### PR TITLE
support all the Content-Transfer-Encoding in the rfc1341

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -455,7 +455,7 @@ class BodyPartReader(object):
             return base64.b64decode(data)
         elif encoding == 'quoted-printable':
             return binascii.a2b_qp(data)
-        elif encoding == 'binary':
+        elif encoding in ('binary', '8bit', '7bit'):
             return data
         else:
             raise RuntimeError('unknown content transfer encoding: {}'

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -363,14 +363,17 @@ class PartReaderTestCase(TestCase):
         self.assertEqual(b'\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82,'
                          b' \xd0\xbc\xd0\xb8\xd1\x80!', result)
 
+    @pytest.mark.parametrize('encoding', [])
     def test_read_with_content_transfer_encoding_binary(self):
-        obj = aiohttp.multipart.BodyPartReader(
-            self.boundary, {CONTENT_TRANSFER_ENCODING: 'binary'},
-            Stream(b'\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82,'
-                   b' \xd0\xbc\xd0\xb8\xd1\x80!\r\n--:--'))
-        result = yield from obj.read(decode=True)
-        self.assertEqual(b'\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82,'
-                         b' \xd0\xbc\xd0\xb8\xd1\x80!', result)
+        data = b'\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82,' \
+               b' \xd0\xbc\xd0\xb8\xd1\x80!'
+        for encoding in ('binary', '8bit', '7bit'):
+            with self.subTest(encoding):
+                obj = aiohttp.multipart.BodyPartReader(
+                    self.boundary, {CONTENT_TRANSFER_ENCODING: encoding},
+                    Stream(data + b'\r\n--:--'))
+                result = yield from obj.read(decode=True)
+                self.assertEqual(data, result)
 
     def test_read_with_content_transfer_encoding_unknown(self):
         obj = aiohttp.multipart.BodyPartReader(


### PR DESCRIPTION
Support all the `Content-Transfer-Encoding` defined in the RFC (see https://www.w3.org/Protocols/rfc1341/5_Content-Transfer-Encoding.html )


According to RFC1341:
> The difference between "8bit" (or any other conceivable bit-width token) and the "binary" token is that "binary" does not require adherence to any limits on line length or to the SMTP CRLF semantics

so we could do additional checks to validate the body here if the encoding is `8bit` or `7bit`, but imo it wouldn't bring much anyway.
