### PR TITLE
responses are prepared twice

### DIFF
--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -406,7 +406,7 @@ def test_cannot_write_after_eof():
 
 
 @asyncio.coroutine
-def test_repr_after_eof():
+def test___repr___after_eof():
     resp = StreamResponse()
     yield from resp.prepare(make_request('GET', '/'))
 
@@ -416,7 +416,7 @@ def test_repr_after_eof():
     yield from resp.write_eof()
     assert not resp.prepared
     resp_repr = repr(resp)
-    assert resp_repr == '<StreamResponse OK not started>'
+    assert resp_repr == '<StreamResponse OK eof>'
 
 
 @asyncio.coroutine
@@ -578,9 +578,9 @@ def test___repr__():
     assert "<StreamResponse 301 GET /path/to >" == repr(resp)
 
 
-def test___repr__not_started():
+def test___repr___not_prepared():
     resp = StreamResponse(reason=301)
-    assert "<StreamResponse 301 not started>" == repr(resp)
+    assert "<StreamResponse 301 not prepared>" == repr(resp)
 
 
 @asyncio.coroutine


### PR DESCRIPTION
The `prepare` method of `StreamResponse` is called multiple times, and might be called after `write_eof`. Since `StreamReponse.prepared` now go back to False after `write_eof` is called, that means `_start` is also called twice.
This isn't really an issue because when `_start` is called again, the underlying transport is already closed and nothing gets written. But it's still pretty inefficient…

This app for instance triggers two `StreamResponse._start` calls:
```python
from aiohttp import web

async def handle(request):
    resp = web.StreamResponse()
    await resp.prepare(request)
    resp.write(b'Hello')
    await resp.write_eof()
    return resp

app = web.Application()
app.router.add_get('/', handle)
web.run_app(app, port=8080)
```


Also, I think it would make more sense for `StreamResponse.prepared` to stay True even after `write_eof` is called, but I leave that up to you