### PR TITLE
Fix the Python implementation of the HTTP parser

### DIFF
--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -99,9 +99,9 @@ class HttpParser:
                 if pos >= start_pos:
                     # line found
                     self._lines.append(data[start_pos:pos])
+                    start_pos = pos + 2
 
                     # \r\n\r\n found
-                    start_pos = pos + 2
                     if self._lines[-1] == EMPTY:
                         try:
                             msg = self.parse_message(self._lines)
@@ -150,8 +150,6 @@ class HttpParser:
                             payload = EMPTY_PAYLOAD
 
                         messages.append((msg, payload))
-
-                        start_pos = start_pos+2
                 else:
                     self._tail = data[start_pos:]
                     data = EMPTY

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -102,9 +102,7 @@ class HttpParser:
 
                     # \r\n\r\n found
                     start_pos = pos + 2
-                    if data[start_pos:start_pos+2] == SEP:
-                        self._lines.append(EMPTY)
-
+                    if self._lines[-1] == EMPTY:
                         try:
                             msg = self.parse_message(self._lines)
                         finally:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -78,12 +78,22 @@ def test_parse(parser):
     text = b'GET /test HTTP/1.1\r\n\r\n'
     messages, upgrade, tail = parser.feed_data(text)
     assert len(messages) == 1
-    msg = messages[0][0]
+    msg, _ = messages[0]
     assert msg.compression is None
     assert not msg.upgrade
     assert msg.method == 'GET'
     assert msg.path == '/test'
     assert msg.version == (1, 1)
+
+
+@asyncio.coroutine
+def test_parse_body(parser):
+    text = b'GET /test HTTP/1.1\r\nContent-Length: 4\r\n\r\nbody'
+    messages, upgrade, tail = parser.feed_data(text)
+    assert len(messages) == 1
+    _, payload = messages[0]
+    body = yield from payload.read(4)
+    assert body == b'body'
 
 
 def test_parse_delayed(parser):

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -74,6 +74,30 @@ test2: data\r
     assert not msg.upgrade
 
 
+def test_parse(parser):
+    text = b'GET /test HTTP/1.1\r\n\r\n'
+    messages, upgrade, tail = parser.feed_data(text)
+    assert len(messages) == 1
+    msg = messages[0][0]
+    assert msg.compression is None
+    assert not msg.upgrade
+    assert msg.method == 'GET'
+    assert msg.path == '/test'
+    assert msg.version == (1, 1)
+
+
+def test_parse_delayed(parser):
+    text = b'GET /test HTTP/1.1\r\n'
+    messages, upgrade, tail = parser.feed_data(text)
+    assert len(messages) == 0
+    assert not upgrade
+
+    messages, upgrade, tail = parser.feed_data(b'\r\n')
+    assert len(messages) == 1
+    msg = messages[0][0]
+    assert msg.method == 'GET'
+
+
 def test_headers_multi_feed(parser):
     text1 = b'GET /test HTTP/1.1\r\n'
     text2 = b'test: line\r'


### PR DESCRIPTION
The Python version of HttpParser failed if the empty line ending the headers is sent as the first two bytes of a data chunk (ie `GET / HTTP/1.1\r\n` is sent, and then `\r\n` is sent a short while later)

I have also add a failing test checking this case.

--
Nothing to do with this issue, but here are two breaking changes between 1.3 and 2.0 that should probably be documented in a migration doc (it's not really "public" API, so not really an issue but would help anyway):
- `FormData().__call__` does not take an `encoding` arg anymore and its return value changes for an iterator or bytes to a Writer
- `FormData.is_multipart` attribute is gone