### PR TITLE
Multipart base64 encoding as  RFC 2045

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -915,7 +915,7 @@ class MultipartPayloadWriter:
                 enc_chunk, self._encoding_buffer = (
                     buffer[:div * 3], buffer[div * 3:])
                 if enc_chunk:
-                    enc_chunk = base64.b64encode(enc_chunk)
+                    enc_chunk = base64.encodebytes(enc_chunk)
                     yield from self._writer.write(enc_chunk)
         elif self._encoding == 'quoted-printable':
             yield from self._writer.write(binascii.b2a_qp(chunk))

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -876,7 +876,6 @@ class MultipartPayloadWriter:
     def enable_encoding(self, encoding):
         if encoding == 'base64':
             self._encoding = encoding
-            self._encoding_buffer = bytearray()
         elif encoding == 'quoted-printable':
             self._encoding = 'quoted-printable'
 
@@ -893,11 +892,6 @@ class MultipartPayloadWriter:
                 self._compress = None
                 yield from self.write(chunk)
 
-        if self._encoding == 'base64':
-            if self._encoding_buffer:
-                yield from self._writer.write(base64.b64encode(
-                    self._encoding_buffer))
-
     @asyncio.coroutine
     def write(self, chunk):
         if self._compress is not None:
@@ -907,16 +901,14 @@ class MultipartPayloadWriter:
                     return
 
         if self._encoding == 'base64':
-            self._encoding_buffer.extend(chunk)
+            if chunk:
+                enc_chunk = base64.encodebytes(chunk)
+                # eol convertion needed because python API returns simple \n
+                # and RFC 2045 needs \r\n. It's safe because base64 doesn't
+                # produce \n inside a payload
+                enc_chunk = enc_chunk.replace(b"\n", b"\r\n")
+                yield from self._writer.write(enc_chunk)
 
-            if self._encoding_buffer:
-                buffer = self._encoding_buffer
-                div, mod = divmod(len(buffer), 3)
-                enc_chunk, self._encoding_buffer = (
-                    buffer[:div * 3], buffer[div * 3:])
-                if enc_chunk:
-                    enc_chunk = base64.encodebytes(enc_chunk)
-                    yield from self._writer.write(enc_chunk)
         elif self._encoding == 'quoted-printable':
             yield from self._writer.write(binascii.b2a_qp(chunk))
         else:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -914,6 +914,19 @@ def test_writer_with_content_transfer_encoding_base64(buf, stream, writer):
 
 
 @asyncio.coroutine
+def test_writer_with_content_te_base64_no_long_lines(buf, stream, writer):
+    writer.append('Time to write long lines!' * 10,
+                  {CONTENT_TRANSFER_ENCODING: 'base64'}
+    )
+    yield from writer.write(stream)
+    headers, message = bytes(buf).split(b'\r\n\r\n', 1)
+
+    line0 = message.split(b'\r\n')
+    assert len(line0) < 80
+
+
+
+@asyncio.coroutine
 def test_writer_content_transfer_encoding_quote_printable(buf, stream, writer):
     writer.append('Привет, мир!',
                   {CONTENT_TRANSFER_ENCODING: 'quoted-printable'})

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -923,6 +923,7 @@ def test_writer_with_content_te_base64_no_long_lines(buf, stream, writer):
     line0 = message.split(b'\r\n')
     assert len(line0) < 80
 
+
 @asyncio.coroutine
 def test_writer_content_transfer_encoding_quote_printable(buf, stream, writer):
     writer.append('Привет, мир!',

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -916,15 +916,12 @@ def test_writer_with_content_transfer_encoding_base64(buf, stream, writer):
 @asyncio.coroutine
 def test_writer_with_content_te_base64_no_long_lines(buf, stream, writer):
     writer.append('Time to write long lines!' * 10,
-                  {CONTENT_TRANSFER_ENCODING: 'base64'}
-    )
+                  {CONTENT_TRANSFER_ENCODING: 'base64'})
     yield from writer.write(stream)
     headers, message = bytes(buf).split(b'\r\n\r\n', 1)
 
     line0 = message.split(b'\r\n')
     assert len(line0) < 80
-
-
 
 @asyncio.coroutine
 def test_writer_content_transfer_encoding_quote_printable(buf, stream, writer):

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import functools
 import io
 import unittest
@@ -922,6 +923,47 @@ def test_writer_with_content_te_base64_no_long_lines(buf, stream, writer):
 
     line0 = message.split(b'\r\n')
     assert len(line0) < 80
+
+
+class MockedIO(io.IOBase):
+    """A mock tht simulate a reader that provides chunks of data (once per read).
+
+        contents is a list of each chunk to provide on read call
+    """
+    def __init__(self, contents):
+        self.idx = 0
+        self.contents = contents
+
+    def read(self, *args):
+        if self.idx >= len(self.contents):
+            return b""
+        v = self.contents[self.idx]
+        self.idx += 1
+        return v
+
+
+@asyncio.coroutine
+def test_writer_multiple_write_base64_output(buf, stream, writer):
+    # we expect a complete buffer with each completly filled
+    # independently of the write sequence.
+    expected = base64.encodebytes((
+        'Time to write long lines!' * 10 +
+        'More big content' * 10
+    ).replace("\n", "\r\n").encode("ascii"))
+
+    mock_reader = MockedIO([
+        b'Time to write long lines!' * 10,
+        b'More big content' * 10
+    ])
+
+    writer.append(mock_reader,
+                  {CONTENT_TRANSFER_ENCODING: 'base64'})
+
+    yield from writer.write(stream)
+
+    headers, message = bytes(buf).split(b'\r\n\r\n', 1)
+
+    assert message == expected
 
 
 @asyncio.coroutine


### PR DESCRIPTION

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?
Fixes #2087 
Trivial, but need discussion.

https://docs.python.org/3/library/base64.html#base64.encodebytes
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No affected for user, but can broke some side apps:

Maybe unexpected '\n' because http exprcts '\r\n' .

Lose performance 
```
>>> timeit.timeit('base64.b64encode(data)','import base64;data= b"i"*1000')
3.0879702609963715
>>> timeit.timeit('base64.encodebytes(data)','import base64;data= b"i"*1000')
15.915579186999821

```

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#2087 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
