### PR TITLE
Permit empty reason strings in ClientResponse.raise_for_status()

### DIFF
--- a/CHANGES/3532.bugfix
+++ b/CHANGES/3532.bugfix
@@ -1,0 +1,2 @@
+Raise a ClientResponseError instead of an AssertionError for a blank
+HTTP Reason Phrase.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -120,6 +120,7 @@ Joel Watts
 Jon Nabozny
 Joongi Kim
 Josep Cugat
+Joshu Coats
 Julia Tsemusheva
 Julien Duponchelle
 Jungkook Park

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -931,8 +931,10 @@ class ClientResponse(HeadersMixin):
         return noop()
 
     def raise_for_status(self) -> None:
+        # self.reason is only None if self.start() hasn't been called:
+        if self.reason is None:
+            raise TypeError("Expected a Reason-Phrase as a string")
         if 400 <= self.status:
-            assert self.reason  # always not None for started response
             self.release()
             raise ClientResponseError(
                 self.request_info,

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -931,10 +931,9 @@ class ClientResponse(HeadersMixin):
         return noop()
 
     def raise_for_status(self) -> None:
-        # self.reason is only None if self.start() hasn't been called:
-        if self.reason is None:
-            raise TypeError("Expected a Reason-Phrase as a string")
         if 400 <= self.status:
+            # reason should always be not None for a started response
+            assert self.reason is not None
             self.release()
             raise ClientResponseError(
                 self.request_info,

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -669,6 +669,24 @@ def test_raise_for_status_4xx() -> None:
     assert response.closed
 
 
+def test_raise_for_status_4xx_without_reason() -> None:
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
+    response.status = 404
+    response.reason = ''
+    with pytest.raises(aiohttp.ClientResponseError) as cm:
+        response.raise_for_status()
+    assert str(cm.value.status) == '404'
+    assert str(cm.value.message) == ''
+    assert response.closed
+
+
 def test_resp_host() -> None:
     response = ClientResponse('get', URL('http://del-cl-resp.org'),
                               request_info=mock.Mock(),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

* Allows `ClientResponse.raise_for_status` to raise a `ClientResponseError` in the case of an HTTP Reason-Phrase that is an empty string
* Raises a `TypeError` if the `ClientResponse.reason` is `None` (since we can’t make a `ClientResponseError` with a message of `None`)
* Fixes https://github.com/aio-libs/aiohttp/issues/3532
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

* Calling `raise_for_status` on a status with a reason phrase that’s an empty string will raise a `ClientResponseError` now instead of an `AssertionError`
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

https://github.com/aio-libs/aiohttp/issues/3532

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
