### PR TITLE
Enforce URL for cookie_jar.filter_cookies() call

### DIFF
--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -4,6 +4,7 @@ import os  # noqa
 import pathlib
 import pickle
 import re
+import warnings
 from collections import defaultdict
 from http.cookies import BaseCookie, Morsel, SimpleCookie  # noqa
 from math import ceil
@@ -188,7 +189,11 @@ class CookieJar(AbstractCookieJar):
     def filter_cookies(self, request_url: URL=URL()) -> 'BaseCookie[str]':
         """Returns this jar's cookies filtered by their attributes."""
         self._do_expiration()
-        request_url = URL(request_url)
+        if not isinstance(request_url, URL):
+            warnings.warn("The method accepts yarl.URL instances only, got {}"
+                          .format(type(request_url)),
+                          DeprecationWarning)
+            request_url = URL(request_url)
         filtered = SimpleCookie()
         hostname = request_url.raw_host or ""
         is_not_secure = request_url.scheme not in ("https", "wss")

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -81,7 +81,7 @@ between multiple requests::
         await session.get(
             'http://httpbin.org/cookies/set?my_cookie=my_value')
         filtered = session.cookie_jar.filter_cookies(
-            'http://httpbin.org')
+            URL('http://httpbin.org'))
         assert filtered['my_cookie'].value == 'my_value'
         async with session.get('http://httpbin.org/cookies') as r:
             json_body = await r.json()

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -189,6 +189,12 @@ async def test_filter_cookie_with_unicode_domain(loop) -> None:
     assert len(jar.filter_cookies(URL("http://xn--9caa.com"))) == 1
 
 
+async def test_filter_cookies_str_deprecated(loop) -> None:
+    jar = CookieJar()
+    with pytest.warns(DeprecationWarning):
+        jar.filter_cookies("http://éé.com")
+
+
 async def test_domain_filter_ip_cookie_send(loop) -> None:
     jar = CookieJar(loop=loop)
     cookies = SimpleCookie(


### PR DESCRIPTION
CookieJar technically supports both `str` and `URL`.
But only `URL` is pointed as an acceptable type in type hints information.
Moreover, the Jar is a kind of *internal* class. User can provide a custom implementation but the caller is always `aiohttp` itself.
The method is called with URL only by aiohttp.

Deprecation for `str` is added.
We can drop `str` eventually with a deprecation period.