### PR TITLE
Shorten too long test UNIX socket path

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,24 @@
-import hashlib
+import os
+import socket
 import ssl
+import sys
+from hashlib import md5, sha256
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import pytest
 import trustme
 
 pytest_plugins = ['aiohttp.pytest_plugin', 'pytester']
+
+IS_HPUX = sys.platform.startswith('hp-ux')
+"""Specifies whether the current runtime is HP-UX."""
+IS_LINUX = sys.platform.startswith('linux')
+"""Specifies whether the current runtime is HP-UX."""
+IS_UNIX = hasattr(socket, 'AF_UNIX')
+"""Specifies whether the current runtime is *NIX."""
+
+needs_unix = pytest.mark.skipif(not IS_UNIX, reason='requires UNIX sockets')
 
 
 @pytest.fixture
@@ -55,4 +69,82 @@ def tls_certificate_pem_bytes(tls_certificate):
 @pytest.fixture
 def tls_certificate_fingerprint_sha256(tls_certificate_pem_bytes):
     tls_cert_der = ssl.PEM_cert_to_DER_cert(tls_certificate_pem_bytes.decode())
-    return hashlib.sha256(tls_cert_der).digest()
+    return sha256(tls_cert_der).digest()
+
+
+@pytest.fixture
+@needs_unix
+def unix_sockname(tmp_path, tmp_path_factory):
+    """Generate an fs path to the UNIX domain socket for testing.
+
+    N.B. Different OS kernels have different fs path length limitations
+    for it. For Linux, it's 108, for HP-UX it's 92 (or higher) depending
+    on its version. For for most of the BSDs (Open, Free, macOS) it's
+    mostly 104 but sometimes it can be down to 100.
+
+    Ref: https://github.com/aio-libs/aiohttp/issues/3572
+    """
+    max_sock_len = 92 if IS_HPUX else 108 if IS_LINUX else 100
+    """Amount of bytes allocated for the UNIX socket path by OS kernel.
+
+    Ref: https://unix.stackexchange.com/a/367012/27133
+    """
+
+    sock_file_name = 'unix.sock'
+
+    root_tmp_dir = Path('/tmp').resolve()
+    os_tmp_dir = Path(os.getenv('TMPDIR', '/tmp')).resolve()
+    original_base_tmp_path = Path(tmp_path_factory.getbasetemp())
+
+    original_base_tmp_path_hash = md5(
+        str(original_base_tmp_path).encode(),
+    ).hexdigest()
+
+    def make_tmp_dir(base_tmp_dir):
+        return TemporaryDirectory(
+            dir=base_tmp_dir,
+            prefix='pt-',
+            suffix='-{}'.format(original_base_tmp_path_hash),
+        )
+
+    def assert_sock_fits(sock_path):
+        sock_path_len = len(sock_path.encode())
+        # exit-check to verify that it's correct and simplify debugging
+        # in the future
+        assert sock_path_len <= max_sock_len, (
+            'Suggested UNIX socket ({sock_path}) is {sock_path_len} bytes '
+            'long but the current kernel only has {max_sock_len} bytes '
+            'allocated to hold it so it must be shorter. '
+            'See https://github.com/aio-libs/aiohttp/issues/3572 '
+            'for more info.'
+        ).format_map(locals())
+
+    sock_path = str(tmp_path.resolve() / sock_file_name)
+    sock_path_len = len(sock_path.encode())
+
+    if original_base_tmp_path == root_tmp_dir and os_tmp_dir == root_tmp_dir:
+        assert_sock_fits(sock_path)
+
+    if sock_path_len <= max_sock_len:
+        yield sock_path
+        return
+
+    with make_tmp_dir(os_tmp_dir) as tmpd:
+        sock_path = str(tmpd.resolve() / sock_file_name)
+        sock_path_len = len(sock_path.encode())
+
+        if os_tmp_dir == root_tmp_dir:
+            assert_sock_fits(sock_path)
+        # exit-check to verify that it's correct and simplify debugging
+        # in the future
+        if sock_path_len <= max_sock_len:
+            yield sock_path
+            return
+
+    with make_tmp_dir(root_tmp_dir) as tmpd:
+        sock_path = str(tmpd.resolve() / sock_file_name)
+
+        assert_sock_fits(sock_path)
+
+        yield sock_path
+        return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,6 @@ def tls_certificate_fingerprint_sha256(tls_certificate_pem_bytes):
 
 
 @pytest.fixture
-@needs_unix
 def unix_sockname(tmp_path, tmp_path_factory):
     """Generate an fs path to the UNIX domain socket for testing.
 
@@ -85,6 +84,9 @@ def unix_sockname(tmp_path, tmp_path_factory):
 
     Ref: https://github.com/aio-libs/aiohttp/issues/3572
     """
+    if not IS_UNIX:
+        pytest.skip(reason='requires UNIX sockets')
+
     max_sock_len = 92 if IS_HPUX else 108 if IS_LINUX else 100
     """Amount of bytes allocated for the UNIX socket path by OS kernel.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,7 @@ def unix_sockname(tmp_path, tmp_path_factory):
     Ref: https://github.com/aio-libs/aiohttp/issues/3572
     """
     if not IS_UNIX:
-        pytest.skip(reason='requires UNIX sockets')
+        pytest.skip('requires UNIX sockets')
 
     max_sock_len = 92 if IS_HPUX else 108 if IS_LINUX else 100
     """Amount of bytes allocated for the UNIX socket path by OS kernel.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,7 @@ def unix_sockname(tmp_path, tmp_path_factory):
 
     root_tmp_dir = Path('/tmp').resolve()
     os_tmp_dir = Path(os.getenv('TMPDIR', '/tmp')).resolve()
-    original_base_tmp_path = Path(tmp_path_factory.getbasetemp())
+    original_base_tmp_path = Path(str(tmp_path_factory.getbasetemp()))
 
     original_base_tmp_path_hash = md5(
         str(original_base_tmp_path).encode(),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,9 +109,9 @@ def unix_sockname(tmp_path, tmp_path_factory):
 
     def make_tmp_dir(base_tmp_dir):
         return TemporaryDirectory(
-            dir=base_tmp_dir,
+            dir=str(base_tmp_dir),
             prefix='pt-',
-            suffix='-{}'.format(original_base_tmp_path_hash),
+            suffix='-{!s}'.format(original_base_tmp_path_hash),
         )
 
     def assert_sock_fits(sock_path):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def unix_sockname(tmp_path, tmp_path_factory):
 
     sock_file_name = 'unix.sock'
     unique_prefix = '{!s}-'.format(uuid4())
-    unique_prefix_len = len(unique_prefix)
+    unique_prefix_len = len(unique_prefix.encode())
 
     root_tmp_dir = Path('/tmp').resolve()
     os_tmp_dir = Path(os.getenv('TMPDIR', '/tmp')).resolve()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3,12 +3,16 @@
 import asyncio
 import gc
 import hashlib
+import os
 import platform
 import socket
 import ssl
 import sys
 import uuid
 from collections import deque
+from hashlib import md5
+from pathlib import Path
+from tempfile import TemporaryDirectory
 from unittest import mock
 
 import pytest
@@ -53,7 +57,7 @@ def ssl_key():
 
 @pytest.fixture
 @needs_unix
-def unix_sockname(tmp_path):
+def unix_sockname(tmp_path, tmp_path_factory):
     """Generate an fs path to the UNIX domain socket for testing.
 
     N.B. Different OS kernels have different fs path length limitations
@@ -69,20 +73,64 @@ def unix_sockname(tmp_path):
     Ref: https://unix.stackexchange.com/a/367012/27133
     """
 
-    sock_path = str(tmp_path / 'socket.sock')
+    sock_file_name = 'unix.sock'
+
+    root_tmp_dir = Path('/tmp').resolve()
+    os_tmp_dir = Path(os.getenv('TMPDIR', '/tmp')).resolve()
+    original_base_tmp_path = Path(tmp_path_factory.getbasetemp())
+
+    original_base_tmp_path_hash = md5(
+        str(original_base_tmp_path).encode(),
+    ).hexdigest()
+
+    def make_tmp_dir(base_tmp_dir):
+        return TemporaryDirectory(
+            dir=base_tmp_dir,
+            prefix='pt-',
+            suffix='-{}'.format(original_base_tmp_path_hash),
+        )
+
+    def assert_sock_fits(sock_path):
+        sock_path_len = len(sock_path.encode())
+        # exit-check to verify that it's correct and simplify debugging
+        # in the future
+        assert sock_path_len <= max_sock_len, (
+            'Suggested UNIX socket ({sock_path}) is {sock_path_len} bytes '
+            'long but the current kernel only has {max_sock_len} bytes '
+            'allocated to hold it so it must be shorter. '
+            'See https://github.com/aio-libs/aiohttp/issues/3572 '
+            'for more info.'
+        ).format_map(locals())
+
+    sock_path = str(tmp_path.resolve() / sock_file_name)
     sock_path_len = len(sock_path.encode())
 
-    # exit-check to verify that it's correct and simplify debugging
-    # in the future
-    assert sock_path_len <= max_sock_len, (
-        f'Suggested UNIX socket ({sock_path}) is {sock_path_len} bytes '
-        f'long but the current kernel only has {max_sock_len} bytes '
-        'allocated to hold it so it must be shorter. '
-        'See https://github.com/aio-libs/aiohttp/issues/3572 '
-        'for more info.'
-    )
+    if original_base_tmp_path == root_tmp_dir and os_tmp_dir == root_tmp_dir:
+        assert_sock_fits(sock_path)
 
-    return sock_path
+    if sock_path_len <= max_sock_len:
+        yield sock_path
+        return
+
+    with make_tmp_dir(os_tmp_dir) as tmpd:
+        sock_path = str(tmpd.resolve() / sock_file_name)
+        sock_path_len = len(sock_path.encode())
+
+        if os_tmp_dir == root_tmp_dir:
+            assert_sock_fits(sock_path)
+        # exit-check to verify that it's correct and simplify debugging
+        # in the future
+        if sock_path_len <= max_sock_len:
+            yield sock_path
+            return
+
+    with make_tmp_dir(root_tmp_dir) as tmpd:
+        sock_path = str(tmpd.resolve() / sock_file_name)
+
+        assert_sock_fits(sock_path)
+
+        yield sock_path
+        return
 
 
 @pytest.fixture

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -23,7 +23,6 @@ from aiohttp.helpers import PY_37
 from aiohttp.test_utils import make_mocked_coro, unused_port
 from aiohttp.tracing import Trace
 
-
 IS_HPUX = sys.platform.startswith('hp-ux')
 """Specifies whether the current runtime is HP-UX."""
 IS_LINUX = sys.platform.startswith('linux')

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -23,10 +23,7 @@ from aiohttp.helpers import PY_37
 from aiohttp.test_utils import make_mocked_coro, unused_port
 from aiohttp.tracing import Trace
 
-IS_UNIX = hasattr(socket, 'AF_UNIX')
-"""Specifies whether the current runtime is *NIX."""
-
-needs_unix = pytest.mark.skipif(not IS_UNIX, reason='requires UNIX sockets')
+from conftest import needs_unix
 
 
 @pytest.fixture()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -22,7 +22,6 @@ from aiohttp.connector import Connection, _DNSCacheTable
 from aiohttp.helpers import PY_37
 from aiohttp.test_utils import make_mocked_coro, unused_port
 from aiohttp.tracing import Trace
-
 from conftest import needs_unix
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3,16 +3,12 @@
 import asyncio
 import gc
 import hashlib
-import os
 import platform
 import socket
 import ssl
 import sys
 import uuid
 from collections import deque
-from hashlib import md5
-from pathlib import Path
-from tempfile import TemporaryDirectory
 from unittest import mock
 
 import pytest
@@ -27,10 +23,6 @@ from aiohttp.helpers import PY_37
 from aiohttp.test_utils import make_mocked_coro, unused_port
 from aiohttp.tracing import Trace
 
-IS_HPUX = sys.platform.startswith('hp-ux')
-"""Specifies whether the current runtime is HP-UX."""
-IS_LINUX = sys.platform.startswith('linux')
-"""Specifies whether the current runtime is HP-UX."""
 IS_UNIX = hasattr(socket, 'AF_UNIX')
 """Specifies whether the current runtime is *NIX."""
 
@@ -53,84 +45,6 @@ def key2():
 def ssl_key():
     """Connection key"""
     return ConnectionKey('localhost', 80, True, None, None, None, None)
-
-
-@pytest.fixture
-@needs_unix
-def unix_sockname(tmp_path, tmp_path_factory):
-    """Generate an fs path to the UNIX domain socket for testing.
-
-    N.B. Different OS kernels have different fs path length limitations
-    for it. For Linux, it's 108, for HP-UX it's 92 (or higher) depending
-    on its version. For for most of the BSDs (Open, Free, macOS) it's
-    mostly 104 but sometimes it can be down to 100.
-
-    Ref: https://github.com/aio-libs/aiohttp/issues/3572
-    """
-    max_sock_len = 92 if IS_HPUX else 108 if IS_LINUX else 100
-    """Amount of bytes allocated for the UNIX socket path by OS kernel.
-
-    Ref: https://unix.stackexchange.com/a/367012/27133
-    """
-
-    sock_file_name = 'unix.sock'
-
-    root_tmp_dir = Path('/tmp').resolve()
-    os_tmp_dir = Path(os.getenv('TMPDIR', '/tmp')).resolve()
-    original_base_tmp_path = Path(tmp_path_factory.getbasetemp())
-
-    original_base_tmp_path_hash = md5(
-        str(original_base_tmp_path).encode(),
-    ).hexdigest()
-
-    def make_tmp_dir(base_tmp_dir):
-        return TemporaryDirectory(
-            dir=base_tmp_dir,
-            prefix='pt-',
-            suffix='-{}'.format(original_base_tmp_path_hash),
-        )
-
-    def assert_sock_fits(sock_path):
-        sock_path_len = len(sock_path.encode())
-        # exit-check to verify that it's correct and simplify debugging
-        # in the future
-        assert sock_path_len <= max_sock_len, (
-            'Suggested UNIX socket ({sock_path}) is {sock_path_len} bytes '
-            'long but the current kernel only has {max_sock_len} bytes '
-            'allocated to hold it so it must be shorter. '
-            'See https://github.com/aio-libs/aiohttp/issues/3572 '
-            'for more info.'
-        ).format_map(locals())
-
-    sock_path = str(tmp_path.resolve() / sock_file_name)
-    sock_path_len = len(sock_path.encode())
-
-    if original_base_tmp_path == root_tmp_dir and os_tmp_dir == root_tmp_dir:
-        assert_sock_fits(sock_path)
-
-    if sock_path_len <= max_sock_len:
-        yield sock_path
-        return
-
-    with make_tmp_dir(os_tmp_dir) as tmpd:
-        sock_path = str(tmpd.resolve() / sock_file_name)
-        sock_path_len = len(sock_path.encode())
-
-        if os_tmp_dir == root_tmp_dir:
-            assert_sock_fits(sock_path)
-        # exit-check to verify that it's correct and simplify debugging
-        # in the future
-        if sock_path_len <= max_sock_len:
-            yield sock_path
-            return
-
-    with make_tmp_dir(root_tmp_dir) as tmpd:
-        sock_path = str(tmpd.resolve() / sock_file_name)
-
-        assert_sock_fits(sock_path)
-
-        yield sock_path
-        return
 
 
 @pytest.fixture

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -100,8 +100,6 @@ def test_non_app() -> None:
         web.AppRunner(object())
 
 
-@pytest.mark.skipif(platform.system() == "Windows",
-                    reason="Unix socket support is required")
 async def test_addresses(make_runner, unix_sockname) -> None:
     _sock = get_unused_port_socket('127.0.0.1')
     runner = make_runner()

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -102,15 +102,14 @@ def test_non_app() -> None:
 
 @pytest.mark.skipif(platform.system() == "Windows",
                     reason="Unix socket support is required")
-async def test_addresses(make_runner, tmpdir) -> None:
+async def test_addresses(make_runner, unix_sockname) -> None:
     _sock = get_unused_port_socket('127.0.0.1')
     runner = make_runner()
     await runner.setup()
     tcp = web.SockSite(runner, _sock)
     await tcp.start()
-    path = str(tmpdir / 'tmp.sock')
-    unix = web.UnixSite(runner, path)
+    unix = web.UnixSite(runner, unix_sockname)
     await unix.start()
     actual_addrs = runner.addresses
     expected_host, expected_post = _sock.getsockname()[:2]
-    assert actual_addrs == [(expected_host, expected_post), path]
+    assert actual_addrs == [(expected_host, expected_post), unix_sockname]


### PR DESCRIPTION
## What do these changes do?

Make tmp unix sock path fit the kernel limits

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

Fixes #3572

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
