### PR TITLE
Fix decoding base64 chunk for BodyPartReader

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -302,6 +302,28 @@ class BodyPartReader:
         else:
             chunk = await self._read_chunk_from_stream(size)
 
+        # For the case of base64 data, we must read a fragment of size with a
+        # remainder of 0 by dividing by 4 for string without symbols \n or \r
+        encoding = self.headers.get(CONTENT_TRANSFER_ENCODING)
+        if encoding and encoding.lower() == 'base64':
+            stripped_chunk = b''.join(chunk.split())
+            reminder = len(stripped_chunk) % 4
+
+            while reminder != 0 and not self.at_eof():
+                over_chunk_size = 4 - reminder
+                over_chunk = b''
+
+                if self._prev_chunk:
+                    over_chunk = self._prev_chunk[:over_chunk_size]
+                    self._prev_chunk = self._prev_chunk[len(over_chunk):]
+
+                if len(over_chunk) != over_chunk_size:
+                    over_chunk += await self._content.read(4 - len(over_chunk))
+
+                stripped_chunk += b''.join(over_chunk.split())
+                chunk += over_chunk
+                reminder = len(stripped_chunk) % 4
+
         self._read_bytes += len(chunk)
         if self._read_bytes == self._length:
             self._at_eof = True

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -320,6 +320,9 @@ class BodyPartReader:
                 if len(over_chunk) != over_chunk_size:
                     over_chunk += await self._content.read(4 - len(over_chunk))
 
+                if not over_chunk:
+                    self._at_eof = True
+
                 stripped_chunk += b''.join(over_chunk.split())
                 chunk += over_chunk
                 reminder = len(stripped_chunk) % 4

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -307,10 +307,10 @@ class BodyPartReader:
         encoding = self.headers.get(CONTENT_TRANSFER_ENCODING)
         if encoding and encoding.lower() == 'base64':
             stripped_chunk = b''.join(chunk.split())
-            reminder = len(stripped_chunk) % 4
+            remainder = len(stripped_chunk) % 4
 
-            while reminder != 0 and not self.at_eof():
-                over_chunk_size = 4 - reminder
+            while remainder != 0 and not self.at_eof():
+                over_chunk_size = 4 - remainder
                 over_chunk = b''
 
                 if self._prev_chunk:
@@ -325,7 +325,7 @@ class BodyPartReader:
 
                 stripped_chunk += b''.join(over_chunk.split())
                 chunk += over_chunk
-                reminder = len(stripped_chunk) % 4
+                remainder = len(stripped_chunk) % 4
 
         self._read_bytes += len(chunk)
         if self._read_bytes == self._length:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -369,6 +369,21 @@ class TestPartReader:
         result = await obj.read(decode=True)
         assert b'Time to Relax!' == result
 
+    async def test_decode_with_content_transfer_encoding_base64(
+        self, newline
+    ) -> None:
+
+        obj = aiohttp.BodyPartReader(
+            BOUNDARY, {CONTENT_TRANSFER_ENCODING: 'base64'},
+            Stream(b'VG\r\r\nltZSB0byBSZ\r\nWxheCE=%s--:--' % newline),
+            _newline=newline,
+        )
+        result = b''
+        while not obj.at_eof():
+            chunk = await obj.read_chunk(size=6)
+            result += obj.decode(chunk)
+        assert b'Time to Relax!' == result
+
     async def test_read_with_content_transfer_encoding_quoted_printable(
         self, newline
     ) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Those changes add the additional reading of few bytes in `BodyPartReader.read_chunk` if the size of the chunk is not valid for base64 decoding.  

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Yes, because if someone will try to use `read_chunk` for the body that has transfer encoding equal to base64, can receive more than expected bytes.

## Related issue number

https://github.com/aio-libs/aiohttp/issues/3843

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
