### PR TITLE
Replace all tmpdir fixtures with tmp_path (#3551)

### DIFF
--- a/CHANGES/3551.misc
+++ b/CHANGES/3551.misc
@@ -1,0 +1,1 @@
+Replace all tmpdir fixtures with tmp_path in test suite.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -163,6 +163,7 @@ Martin Melka
 Martin Richard
 Mathias Fröjdman
 Mathieu Dugré
+Matt VanEseltine
 Matthieu Hauglustaine
 Matthieu Rigal
 Michael Ihnatenko

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -655,8 +655,8 @@ async def test_pass_falsy_data(loop) -> None:
     await req.close()
 
 
-async def test_pass_falsy_data_file(loop, tmpdir) -> None:
-    testfile = tmpdir.join('tmpfile').open('w+b')
+async def test_pass_falsy_data_file(loop, tmp_path) -> None:
+    testfile = (tmp_path / 'tmpfile').open('w+b')
     testfile.write(b'data')
     testfile.seek(0)
     skip = frozenset([hdrs.CONTENT_TYPE])

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -530,11 +530,11 @@ async def test_proxy_from_env_http_with_auth(proxy_test_server,
 
 
 async def test_proxy_from_env_http_with_auth_from_netrc(
-        proxy_test_server, get_request, tmpdir, mocker):
+        proxy_test_server, get_request, tmp_path, mocker):
     url = 'http://aiohttp.io/path'
     proxy = await proxy_test_server()
     auth = aiohttp.BasicAuth('user', 'pass')
-    netrc_file = tmpdir.join('test_netrc')
+    netrc_file = tmp_path / 'test_netrc'
     netrc_file_data = 'machine 127.0.0.1 login %s password %s' % (
         auth.login, auth.password)
     with open(str(netrc_file), 'w') as f:
@@ -552,11 +552,11 @@ async def test_proxy_from_env_http_with_auth_from_netrc(
 
 
 async def test_proxy_from_env_http_without_auth_from_netrc(
-        proxy_test_server, get_request, tmpdir, mocker):
+        proxy_test_server, get_request, tmp_path, mocker):
     url = 'http://aiohttp.io/path'
     proxy = await proxy_test_server()
     auth = aiohttp.BasicAuth('user', 'pass')
-    netrc_file = tmpdir.join('test_netrc')
+    netrc_file = tmp_path / 'test_netrc'
     netrc_file_data = 'machine 127.0.0.2 login %s password %s' % (
         auth.login, auth.password)
     with open(str(netrc_file), 'w') as f:
@@ -574,11 +574,11 @@ async def test_proxy_from_env_http_without_auth_from_netrc(
 
 
 async def test_proxy_from_env_http_without_auth_from_wrong_netrc(
-        proxy_test_server, get_request, tmpdir, mocker):
+        proxy_test_server, get_request, tmp_path, mocker):
     url = 'http://aiohttp.io/path'
     proxy = await proxy_test_server()
     auth = aiohttp.BasicAuth('user', 'pass')
-    netrc_file = tmpdir.join('test_netrc')
+    netrc_file = tmp_path / 'test_netrc'
     invalid_data = 'machine 127.0.0.1 %s pass %s' % (
         auth.login, auth.password)
     with open(str(netrc_file), 'w') as f:

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -353,10 +353,10 @@ def test_run_app_custom_backlog_unix(patched_loop) -> None:
 
 
 @skip_if_no_unix_socks
-def test_run_app_http_unix_socket(patched_loop, tmpdir) -> None:
+def test_run_app_http_unix_socket(patched_loop, tmp_path) -> None:
     app = web.Application()
 
-    sock_path = str(tmpdir / 'socket.sock')
+    sock_path = str(tmp_path / 'socket.sock')
     printer = mock.Mock(wraps=stopper(patched_loop))
     web.run_app(app, path=sock_path, print=printer)
 
@@ -366,10 +366,10 @@ def test_run_app_http_unix_socket(patched_loop, tmpdir) -> None:
 
 
 @skip_if_no_unix_socks
-def test_run_app_https_unix_socket(patched_loop, tmpdir) -> None:
+def test_run_app_https_unix_socket(patched_loop, tmp_path) -> None:
     app = web.Application()
 
-    sock_path = str(tmpdir / 'socket.sock')
+    sock_path = str(tmp_path / 'socket.sock')
     ssl_context = ssl.create_default_context()
     printer = mock.Mock(wraps=stopper(patched_loop))
     web.run_app(app, path=sock_path, ssl_context=ssl_context, print=printer)

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1560,7 +1560,7 @@ async def test_response_with_bodypart(aiohttp_client) -> None:
                     {'name': 'file', 'filename': 'file', 'filename*': 'file'})
 
 
-async def test_response_with_bodypart_named(aiohttp_client, tmpdir) -> None:
+async def test_response_with_bodypart_named(aiohttp_client, tmp_path) -> None:
 
     async def handler(request):
         reader = await request.multipart()
@@ -1571,7 +1571,7 @@ async def test_response_with_bodypart_named(aiohttp_client, tmpdir) -> None:
     app.router.add_post('/', handler)
     client = await aiohttp_client(app)
 
-    f = tmpdir.join('foobar.txt')
+    f = tmp_path / 'foobar.txt'
     f.write_text('test', encoding='utf8')
     data = {'file': open(str(f), 'rb')}
     resp = await client.post('/', data=data)

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -438,12 +438,12 @@ async def test_web_view(aiohttp_client) -> None:
     await r.release()
 
 
-async def test_static_absolute_url(aiohttp_client, tmpdir) -> None:
+async def test_static_absolute_url(aiohttp_client, tmp_path) -> None:
     # requested url is an absolute name like
     # /static/\\machine_name\c$ or /static/D:\path
     # where the static dir is totally different
     app = web.Application()
-    fname = tmpdir / 'file.txt'
+    fname = tmp_path / 'file.txt'
     fname.write_text('sample text', 'ascii')
     here = pathlib.Path(__file__).parent
     app.router.add_static('/static', here)


### PR DESCRIPTION
tmp_path is the replacement fixture in pytest for tmpdir; tmp_path
uses the builtin pathlib.Path class. As it says on the tin, this
commit replaces every instance of tmpdir in the test suite with
tmp_path. Aside from s/tmpdir/tmp_path/ this also required changing
instances of `tmpdir.join(foo)` to `tmp_path / foo`.

This is intended to comprehensively address and close #3551, and
should have no side effects. This does not affect end users.