### PR TITLE
Improve test suite handling of paths, temp files

### DIFF
--- a/CHANGES/3957.misc
+++ b/CHANGES/3957.misc
@@ -1,0 +1,1 @@
+Improve test suite handling of paths and temp files to consistently use pathlib and pytest fixtures.

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -3,7 +3,7 @@
 import asyncio
 import hashlib
 import io
-import os.path
+import pathlib
 import urllib.parse
 import zlib
 from http.cookies import SimpleCookie
@@ -789,15 +789,14 @@ async def test_chunked_transfer_encoding(loop, conn) -> None:
 
 
 async def test_file_upload_not_chunked(loop) -> None:
-    here = os.path.dirname(__file__)
-    fname = os.path.join(here, 'aiohttp.png')
-    with open(fname, 'rb') as f:
+    file_path = pathlib.Path(__file__).parent / 'aiohttp.png'
+    with file_path.open('rb') as f:
         req = ClientRequest(
             'post', URL('http://python.org/'),
             data=f,
             loop=loop)
         assert not req.chunked
-        assert req.headers['CONTENT-LENGTH'] == str(os.path.getsize(fname))
+        assert req.headers['CONTENT-LENGTH'] == str(file_path.stat().st_size)
         await req.close()
 
 
@@ -816,23 +815,21 @@ async def test_precompressed_data_stays_intact(loop) -> None:
 
 
 async def test_file_upload_not_chunked_seek(loop) -> None:
-    here = os.path.dirname(__file__)
-    fname = os.path.join(here, 'aiohttp.png')
-    with open(fname, 'rb') as f:
+    file_path = pathlib.Path(__file__).parent / 'aiohttp.png'
+    with file_path.open('rb') as f:
         f.seek(100)
         req = ClientRequest(
             'post', URL('http://python.org/'),
             data=f,
             loop=loop)
         assert req.headers['CONTENT-LENGTH'] == \
-            str(os.path.getsize(fname) - 100)
+            str(file_path.stat().st_size - 100)
         await req.close()
 
 
 async def test_file_upload_force_chunked(loop) -> None:
-    here = os.path.dirname(__file__)
-    fname = os.path.join(here, 'aiohttp.png')
-    with open(fname, 'rb') as f:
+    file_path = pathlib.Path(__file__).parent / 'aiohttp.png'
+    with file_path.open('rb') as f:
         req = ClientRequest(
             'post', URL('http://python.org/'),
             data=f,

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -1,8 +1,7 @@
 import asyncio
 import datetime
 import itertools
-import os
-import tempfile
+import pathlib
 import unittest
 from http.cookies import SimpleCookie
 from unittest import mock
@@ -144,8 +143,10 @@ async def test_constructor(loop, cookies_to_send, cookies_to_receive) -> None:
     assert jar._loop is loop
 
 
-async def test_save_load(loop, cookies_to_send, cookies_to_receive) -> None:
-    file_path = tempfile.mkdtemp() + '/aiohttp.test.cookie'
+async def test_save_load(
+    tmp_path, loop, cookies_to_send, cookies_to_receive
+) -> None:
+    file_path = pathlib.Path(str(tmp_path)) / 'aiohttp.test.cookie'
 
     # export cookie jar
     jar_save = CookieJar()
@@ -159,7 +160,6 @@ async def test_save_load(loop, cookies_to_send, cookies_to_receive) -> None:
     for cookie in jar_load:
         jar_test[cookie.key] = cookie
 
-    os.unlink(file_path)
     assert jar_test == cookies_to_receive
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -47,7 +47,8 @@ def test_parse_mimetype(mimetype, expected) -> None:
 
 def test_guess_filename_with_tempfile(tmp_path) -> None:
     file_path = tmp_path / 'test_guess_filename'
-    assert (helpers.guess_filename(file_path, 'no-throw') is not None)
+    with file_path.open('w+b') as fp:
+        assert (helpers.guess_filename(fp, 'no-throw') is not None)
 
 
 # ------------------- BasicAuth -----------------------------------

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,7 +3,6 @@ import base64
 import gc
 import os
 import platform
-import tempfile
 from unittest import mock
 
 import pytest
@@ -46,9 +45,9 @@ def test_parse_mimetype(mimetype, expected) -> None:
 
 # ------------------- guess_filename ----------------------------------
 
-def test_guess_filename_with_tempfile() -> None:
-    with tempfile.TemporaryFile() as fp:
-        assert (helpers.guess_filename(fp, 'no-throw') is not None)
+def test_guess_filename_with_tempfile(tmp_path) -> None:
+    file_path = tmp_path / 'test_guess_filename'
+    assert (helpers.guess_filename(file_path, 'no-throw') is not None)
 
 
 # ------------------- BasicAuth -----------------------------------

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -45,10 +45,19 @@ def test_parse_mimetype(mimetype, expected) -> None:
 
 # ------------------- guess_filename ----------------------------------
 
-def test_guess_filename_with_tempfile(tmp_path) -> None:
+def test_guess_filename_with_file_object(tmp_path) -> None:
     file_path = tmp_path / 'test_guess_filename'
     with file_path.open('w+b') as fp:
         assert (helpers.guess_filename(fp, 'no-throw') is not None)
+
+
+def test_guess_filename_with_path(tmp_path) -> None:
+    file_path = tmp_path / 'test_guess_filename'
+    assert (helpers.guess_filename(file_path, 'no-throw') is not None)
+
+
+def test_guess_filename_with_default() -> None:
+    assert (helpers.guess_filename(None, 'no-throw') == 'no-throw')
 
 
 # ------------------- BasicAuth -----------------------------------

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import json
+import pathlib
 import zlib
 from unittest import mock
 
@@ -1266,7 +1267,7 @@ class TestMultipartWriter:
         """
         https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
         """
-        with open(__file__, 'rb') as fobj:
+        with pathlib.Path(__file__).open('rb') as fobj:
             with aiohttp.MultipartWriter('form-data', boundary=':') as writer:
                 part = writer.append(
                     fobj,
@@ -1297,7 +1298,7 @@ class TestMultipartWriter:
         """
         https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
         """
-        with open(__file__, 'rb') as fobj:
+        with pathlib.Path(__file__).open('rb') as fobj:
             with aiohttp.MultipartWriter('form-data', boundary=':') as writer:
                 part = writer.append(
                     fobj,
@@ -1328,7 +1329,7 @@ class TestMultipartWriter:
         """
         https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
         """
-        with open(__file__, 'rb') as fobj:
+        with pathlib.Path(__file__).open('rb') as fobj:
             with aiohttp.MultipartWriter('form-data', boundary=':') as writer:
                 part = writer.append(
                     fobj,

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -537,7 +537,7 @@ async def test_proxy_from_env_http_with_auth_from_netrc(
     netrc_file = tmp_path / 'test_netrc'
     netrc_file_data = 'machine 127.0.0.1 login %s password %s' % (
         auth.login, auth.password)
-    with open(str(netrc_file), 'w') as f:
+    with netrc_file.open('w') as f:
         f.write(netrc_file_data)
     mocker.patch.dict(os.environ, {'http_proxy': str(proxy.url),
                                    'NETRC': str(netrc_file)})
@@ -559,7 +559,7 @@ async def test_proxy_from_env_http_without_auth_from_netrc(
     netrc_file = tmp_path / 'test_netrc'
     netrc_file_data = 'machine 127.0.0.2 login %s password %s' % (
         auth.login, auth.password)
-    with open(str(netrc_file), 'w') as f:
+    with netrc_file.open('w') as f:
         f.write(netrc_file_data)
     mocker.patch.dict(os.environ, {'http_proxy': str(proxy.url),
                                    'NETRC': str(netrc_file)})
@@ -581,7 +581,7 @@ async def test_proxy_from_env_http_without_auth_from_wrong_netrc(
     netrc_file = tmp_path / 'test_netrc'
     invalid_data = 'machine 127.0.0.1 %s pass %s' % (
         auth.login, auth.password)
-    with open(str(netrc_file), 'w') as f:
+    with netrc_file.open('w') as f:
         f.write(invalid_data)
 
     mocker.patch.dict(os.environ, {'http_proxy': str(proxy.url),

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1,4 +1,3 @@
-import os
 import pathlib
 import re
 from collections.abc import Container, Iterable, Mapping, MutableMapping, Sized
@@ -427,7 +426,7 @@ def test_add_static_append_version_follow_symlink(router, tmp_path) -> None:
     """
     symlink_path = tmp_path / 'append_version_symlink'
     symlink_target_path = pathlib.Path(__file__).parent
-    os.symlink(str(symlink_target_path), str(symlink_path), True)
+    pathlib.Path(str(symlink_path)).symlink_to(str(symlink_target_path), True)
 
     # Register global static route:
     resource = router.add_static('/st', str(tmp_path), follow_symlinks=True,
@@ -450,7 +449,7 @@ def test_add_static_append_version_not_follow_symlink(router,
     symlink_path = tmp_path / 'append_version_symlink'
     symlink_target_path = pathlib.Path(__file__).parent
 
-    os.symlink(str(symlink_target_path), str(symlink_path), True)
+    pathlib.Path(str(symlink_path)).symlink_to(str(symlink_target_path), True)
 
     # Register global static route:
     resource = router.add_static('/st', str(tmp_path), follow_symlinks=False,

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -51,7 +51,7 @@ def fill_routes(router):
         route2 = router.add_route('GET', '/variable/{name}',
                                   make_handler())
         resource = router.add_static('/static',
-                                     os.path.dirname(aiohttp.__file__))
+                                     pathlib.Path(aiohttp.__file__).parent)
         return [route1, route2] + list(resource)
     return go
 
@@ -352,7 +352,7 @@ def test_route_dynamic(router) -> None:
 
 def test_add_static(router) -> None:
     resource = router.add_static('/st',
-                                 os.path.dirname(aiohttp.__file__),
+                                 pathlib.Path(aiohttp.__file__).parent,
                                  name='static')
     assert router['static'] is resource
     url = resource.url_for(filename='/dir/a.txt')
@@ -362,7 +362,7 @@ def test_add_static(router) -> None:
 
 def test_add_static_append_version(router) -> None:
     resource = router.add_static('/st',
-                                 os.path.dirname(__file__),
+                                 pathlib.Path(__file__).parent,
                                  name='static')
     url = resource.url_for(filename='/data.unknown_mime_type',
                            append_version=True)
@@ -373,7 +373,7 @@ def test_add_static_append_version(router) -> None:
 
 def test_add_static_append_version_set_from_constructor(router) -> None:
     resource = router.add_static('/st',
-                                 os.path.dirname(__file__),
+                                 pathlib.Path(__file__).parent,
                                  append_version=True,
                                  name='static')
     url = resource.url_for(filename='/data.unknown_mime_type')
@@ -384,7 +384,7 @@ def test_add_static_append_version_set_from_constructor(router) -> None:
 
 def test_add_static_append_version_override_constructor(router) -> None:
     resource = router.add_static('/st',
-                                 os.path.dirname(__file__),
+                                 pathlib.Path(__file__).parent,
                                  append_version=True,
                                  name='static')
     url = resource.url_for(filename='/data.unknown_mime_type',
@@ -395,7 +395,7 @@ def test_add_static_append_version_override_constructor(router) -> None:
 
 def test_add_static_append_version_filename_without_slash(router) -> None:
     resource = router.add_static('/st',
-                                 os.path.dirname(__file__),
+                                 pathlib.Path(__file__).parent,
                                  name='static')
     url = resource.url_for(filename='data.unknown_mime_type',
                            append_version=True)
@@ -406,7 +406,7 @@ def test_add_static_append_version_filename_without_slash(router) -> None:
 
 def test_add_static_append_version_non_exists_file(router) -> None:
     resource = router.add_static('/st',
-                                 os.path.dirname(__file__),
+                                 pathlib.Path(__file__).parent,
                                  name='static')
     url = resource.url_for(filename='/non_exists_file', append_version=True)
     assert '/st/non_exists_file' == str(url)
@@ -415,23 +415,22 @@ def test_add_static_append_version_non_exists_file(router) -> None:
 def test_add_static_append_version_non_exists_file_without_slash(
         router) -> None:
     resource = router.add_static('/st',
-                                 os.path.dirname(__file__),
+                                 pathlib.Path(__file__).parent,
                                  name='static')
     url = resource.url_for(filename='non_exists_file', append_version=True)
     assert '/st/non_exists_file' == str(url)
 
 
-def test_add_static_append_version_follow_symlink(router, tmpdir) -> None:
+def test_add_static_append_version_follow_symlink(router, tmp_path) -> None:
     """
     Tests the access to a symlink, in static folder with apeend_version
     """
-    tmp_dir_path = str(tmpdir)
-    symlink_path = os.path.join(tmp_dir_path, 'append_version_symlink')
-    symlink_target_path = os.path.dirname(__file__)
-    os.symlink(symlink_target_path, symlink_path, True)
+    symlink_path = tmp_path / 'append_version_symlink'
+    symlink_target_path = pathlib.Path(__file__).parent
+    os.symlink(str(symlink_target_path), str(symlink_path), True)
 
     # Register global static route:
-    resource = router.add_static('/st', tmp_dir_path, follow_symlinks=True,
+    resource = router.add_static('/st', str(tmp_path), follow_symlinks=True,
                                  append_version=True)
 
     url = resource.url_for(
@@ -442,17 +441,19 @@ def test_add_static_append_version_follow_symlink(router, tmpdir) -> None:
     assert expect_url == str(url)
 
 
-def test_add_static_append_version_not_follow_symlink(router, tmpdir) -> None:
+def test_add_static_append_version_not_follow_symlink(router,
+                                                      tmp_path) -> None:
     """
     Tests the access to a symlink, in static folder with apeend_version
     """
-    tmp_dir_path = str(tmpdir)
-    symlink_path = os.path.join(tmp_dir_path, 'append_version_symlink')
-    symlink_target_path = os.path.dirname(__file__)
-    os.symlink(symlink_target_path, symlink_path, True)
+
+    symlink_path = tmp_path / 'append_version_symlink'
+    symlink_target_path = pathlib.Path(__file__).parent
+
+    os.symlink(str(symlink_target_path), str(symlink_path), True)
 
     # Register global static route:
-    resource = router.add_static('/st', tmp_dir_path, follow_symlinks=False,
+    resource = router.add_static('/st', str(tmp_path), follow_symlinks=False,
                                  append_version=True)
 
     filename = '/append_version_symlink/data.unknown_mime_type'
@@ -475,7 +476,7 @@ def test_dynamic_not_match(router) -> None:
 
 
 async def test_static_not_match(router) -> None:
-    router.add_static('/pre', os.path.dirname(aiohttp.__file__),
+    router.add_static('/pre', pathlib.Path(aiohttp.__file__).parent,
                       name='name')
     resource = router['name']
     ret = await resource.resolve(
@@ -513,20 +514,20 @@ def test_contains(router) -> None:
 
 
 def test_static_repr(router) -> None:
-    router.add_static('/get', os.path.dirname(aiohttp.__file__),
+    router.add_static('/get', pathlib.Path(aiohttp.__file__).parent,
                       name='name')
     assert re.match(r"<StaticResource 'name' /get", repr(router['name']))
 
 
 def test_static_adds_slash(router) -> None:
     route = router.add_static('/prefix',
-                              os.path.dirname(aiohttp.__file__))
+                              pathlib.Path(aiohttp.__file__).parent)
     assert '/prefix' == route._prefix
 
 
 def test_static_remove_trailing_slash(router) -> None:
     route = router.add_static('/prefix/',
-                              os.path.dirname(aiohttp.__file__))
+                              pathlib.Path(aiohttp.__file__).parent)
     assert '/prefix' == route._prefix
 
 
@@ -797,7 +798,7 @@ def test_named_resources(router) -> None:
     route2 = router.add_route('GET', '/variable/{name}',
                               make_handler(), name='route2')
     route3 = router.add_static('/static',
-                               os.path.dirname(aiohttp.__file__),
+                               pathlib.Path(aiohttp.__file__).parent,
                                name='route3')
     names = {route1.name, route2.name, route3.name}
 
@@ -945,11 +946,11 @@ def test_resources_abc(router) -> None:
 
 def test_static_route_user_home(router) -> None:
     here = pathlib.Path(aiohttp.__file__).parent
-    home = pathlib.Path(os.path.expanduser('~'))
-    if not str(here).startswith(str(home)):  # pragma: no cover
+    try:
+        static_dir = pathlib.Path('~') / here.relative_to(pathlib.Path.home())
+    except ValueError:
         pytest.skip("aiohttp folder is not placed in user's HOME")
-    static_dir = '~/' + str(here.relative_to(home))
-    route = router.add_static('/st', static_dir)
+    route = router.add_static('/st', str(static_dir))
     assert here == route.get_info()['directory']
 
 
@@ -961,7 +962,7 @@ def test_static_route_points_to_file(router) -> None:
 
 async def test_404_for_static_resource(router) -> None:
     resource = router.add_static('/st',
-                                 os.path.dirname(aiohttp.__file__))
+                                 pathlib.Path(aiohttp.__file__).parent)
     ret = await resource.resolve(
         make_mocked_request('GET', '/unknown/path'))
     assert (None, set()) == ret
@@ -969,7 +970,7 @@ async def test_404_for_static_resource(router) -> None:
 
 async def test_405_for_resource_adapter(router) -> None:
     resource = router.add_static('/st',
-                                 os.path.dirname(aiohttp.__file__))
+                                 pathlib.Path(aiohttp.__file__).parent)
     ret = await resource.resolve(
         make_mocked_request('POST', '/st/abc.py'))
     assert (None, {'HEAD', 'GET'}) == ret
@@ -986,13 +987,13 @@ async def test_check_allowed_method_for_found_resource(router) -> None:
 
 def test_url_for_in_static_resource(router) -> None:
     resource = router.add_static('/static',
-                                 os.path.dirname(aiohttp.__file__))
+                                 pathlib.Path(aiohttp.__file__).parent)
     assert URL('/static/file.txt') == resource.url_for(filename='file.txt')
 
 
 def test_url_for_in_static_resource_pathlib(router) -> None:
     resource = router.add_static('/static',
-                                 os.path.dirname(aiohttp.__file__))
+                                 pathlib.Path(aiohttp.__file__).parent)
     assert URL('/static/file.txt') == resource.url_for(
         filename=pathlib.Path('file.txt'))
 
@@ -1162,7 +1163,7 @@ def test_frozen_app_on_subapp(app) -> None:
 
 def test_set_options_route(router) -> None:
     resource = router.add_static('/static',
-                                 os.path.dirname(aiohttp.__file__))
+                                 pathlib.Path(aiohttp.__file__).parent)
     options = None
     for route in resource:
         if route.method == 'OPTIONS':
@@ -1224,7 +1225,7 @@ def test_dynamic_resource_canonical() -> None:
 
 def test_static_resource_canonical() -> None:
     prefix = '/prefix'
-    directory = str(os.path.dirname(aiohttp.__file__))
+    directory = str(pathlib.Path(aiohttp.__file__).parent)
     canonical = prefix
     res = StaticResource(prefix=prefix, directory=directory)
     assert res.canonical == canonical

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1573,7 +1573,7 @@ async def test_response_with_bodypart_named(aiohttp_client, tmp_path) -> None:
 
     f = tmp_path / 'foobar.txt'
     f.write_text('test', encoding='utf8')
-    data = {'file': open(str(f), 'rb')}
+    data = {'file': f.open('rb')}
     resp = await client.post('/', data=data)
 
     assert 200 == resp.status

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -1,7 +1,5 @@
 import os
 import pathlib
-import shutil
-import tempfile
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -9,23 +7,6 @@ import pytest
 
 from aiohttp import web
 from aiohttp.web_urldispatcher import SystemRoute
-
-
-@pytest.fixture(scope='function')
-def tmp_dir_path(request):
-    """
-    Give a path for a temporary directory
-    The directory is destroyed at the end of the test.
-    """
-    # Temporary directory.
-    tmp_dir = tempfile.mkdtemp()
-
-    def teardown():
-        # Delete the whole directory:
-        shutil.rmtree(tmp_dir)
-
-    request.addfinalizer(teardown)
-    return tmp_dir
 
 
 @pytest.mark.parametrize(
@@ -45,7 +26,7 @@ def tmp_dir_path(request):
                   b'<li><a href="/static/my_file">my_file</a></li>\n'
                   b'</ul>\n</body>\n</html>',
                   id="index_static")])
-async def test_access_root_of_static_handler(tmp_dir_path,
+async def test_access_root_of_static_handler(tmp_path,
                                              aiohttp_client,
                                              show_index,
                                              status,
@@ -57,22 +38,21 @@ async def test_access_root_of_static_handler(tmp_dir_path,
     sure that correct HTTP statuses are returned depending if we directory
     index should be shown or not.
     """
-    # Put a file inside tmp_dir_path:
-    my_file_path = os.path.join(tmp_dir_path, 'my_file')
-    with open(my_file_path, 'w') as fw:
+    my_file = tmp_path / 'my_file'
+    my_dir = tmp_path / 'my_dir'
+    my_dir.mkdir()
+    my_file_in_dir = my_dir / 'my_file_in_dir'
+
+    with my_file.open('w') as fw:
         fw.write('hello')
 
-    my_dir_path = os.path.join(tmp_dir_path, 'my_dir')
-    os.mkdir(my_dir_path)
-
-    my_file_path = os.path.join(my_dir_path, 'my_file_in_dir')
-    with open(my_file_path, 'w') as fw:
+    with my_file_in_dir.open('w') as fw:
         fw.write('world')
 
     app = web.Application()
 
     # Register global static route:
-    app.router.add_static(prefix, tmp_dir_path, show_index=show_index)
+    app.router.add_static(prefix, str(tmp_path), show_index=show_index)
     client = await aiohttp_client(app)
 
     # Request the root of the static directory.
@@ -85,26 +65,26 @@ async def test_access_root_of_static_handler(tmp_dir_path,
         assert read_ == data
 
 
-async def test_follow_symlink(tmp_dir_path, aiohttp_client) -> None:
+async def test_follow_symlink(tmp_path, aiohttp_client) -> None:
     """
     Tests the access to a symlink, in static folder
     """
     data = 'hello world'
 
-    my_dir_path = os.path.join(tmp_dir_path, 'my_dir')
-    os.mkdir(my_dir_path)
+    my_dir_path = tmp_path / 'my_dir'
+    my_dir_path.mkdir()
 
-    my_file_path = os.path.join(my_dir_path, 'my_file_in_dir')
-    with open(my_file_path, 'w') as fw:
+    my_file_path = my_dir_path / 'my_file_in_dir'
+    with my_file_path.open('w') as fw:
         fw.write(data)
 
-    my_symlink_path = os.path.join(tmp_dir_path, 'my_symlink')
-    os.symlink(my_dir_path, my_symlink_path)
+    my_symlink_path = tmp_path / 'my_symlink'
+    os.symlink(str(my_dir_path), str(my_symlink_path))
 
     app = web.Application()
 
     # Register global static route:
-    app.router.add_static('/', tmp_dir_path, follow_symlinks=True)
+    app.router.add_static('/', str(tmp_path), follow_symlinks=True)
     client = await aiohttp_client(app)
 
     # Request the root of the static directory.
@@ -117,27 +97,25 @@ async def test_follow_symlink(tmp_dir_path, aiohttp_client) -> None:
     ('', 'test file.txt', 'test text'),
     ('test dir name', 'test dir file .txt', 'test text file folder')
 ])
-async def test_access_to_the_file_with_spaces(tmp_dir_path, aiohttp_client,
+async def test_access_to_the_file_with_spaces(tmp_path, aiohttp_client,
                                               dir_name, filename, data):
     """
     Checks operation of static files with spaces
     """
 
-    my_dir_path = os.path.join(tmp_dir_path, dir_name)
+    my_dir_path = tmp_path / dir_name
+    if my_dir_path != tmp_path:
+        my_dir_path.mkdir()
 
-    if dir_name:
-        os.mkdir(my_dir_path)
-
-    my_file_path = os.path.join(my_dir_path, filename)
-
-    with open(my_file_path, 'w') as fw:
+    my_file_path = my_dir_path / filename
+    with my_file_path.open('w') as fw:
         fw.write(data)
 
     app = web.Application()
 
-    url = os.path.join('/', dir_name, filename)
+    url = '/' + str(pathlib.Path(dir_name, filename))
 
-    app.router.add_static('/', tmp_dir_path)
+    app.router.add_static('/', str(tmp_path))
     client = await aiohttp_client(app)
 
     r = await client.get(url)
@@ -145,7 +123,7 @@ async def test_access_to_the_file_with_spaces(tmp_dir_path, aiohttp_client,
     assert (await r.text()) == data
 
 
-async def test_access_non_existing_resource(tmp_dir_path,
+async def test_access_non_existing_resource(tmp_path,
                                             aiohttp_client) -> None:
     """
     Tests accessing non-existing resource
@@ -155,7 +133,7 @@ async def test_access_non_existing_resource(tmp_dir_path,
     app = web.Application()
 
     # Register global static route:
-    app.router.add_static('/', tmp_dir_path, show_index=True)
+    app.router.add_static('/', str(tmp_path), show_index=True)
     client = await aiohttp_client(app)
 
     # Request the root of the static directory.
@@ -201,15 +179,15 @@ async def test_handler_metadata_persistence() -> None:
             assert route.handler.__doc__ == 'Doc'
 
 
-async def test_unauthorized_folder_access(tmp_dir_path,
+async def test_unauthorized_folder_access(tmp_path,
                                           aiohttp_client) -> None:
     """
     Tests the unauthorized access to a folder of static file server.
     Try to list a folder content of static file server when server does not
     have permissions to do so for the folder.
     """
-    my_dir_path = os.path.join(tmp_dir_path, 'my_dir')
-    os.mkdir(my_dir_path)
+    my_dir = tmp_path / 'my_dir'
+    my_dir.mkdir()
 
     app = web.Application()
 
@@ -221,33 +199,33 @@ async def test_unauthorized_folder_access(tmp_dir_path,
         path_constructor.return_value = path
 
         # Register global static route:
-        app.router.add_static('/', tmp_dir_path, show_index=True)
+        app.router.add_static('/', str(tmp_path), show_index=True)
         client = await aiohttp_client(app)
 
         # Request the root of the static directory.
-        r = await client.get('/my_dir')
+        r = await client.get('/' + my_dir.name)
         assert r.status == 403
 
 
-async def test_access_symlink_loop(tmp_dir_path, aiohttp_client) -> None:
+async def test_access_symlink_loop(tmp_path, aiohttp_client) -> None:
     """
     Tests the access to a looped symlink, which could not be resolved.
     """
-    my_dir_path = os.path.join(tmp_dir_path, 'my_symlink')
-    os.symlink(my_dir_path, my_dir_path)
+    my_dir_path = tmp_path / 'my_symlink'
+    os.symlink(str(my_dir_path), str(my_dir_path))
 
     app = web.Application()
 
     # Register global static route:
-    app.router.add_static('/', tmp_dir_path, show_index=True)
+    app.router.add_static('/', str(tmp_path), show_index=True)
     client = await aiohttp_client(app)
 
     # Request the root of the static directory.
-    r = await client.get('/my_symlink')
+    r = await client.get('/' + my_dir_path.name)
     assert r.status == 404
 
 
-async def test_access_special_resource(tmp_dir_path, aiohttp_client) -> None:
+async def test_access_special_resource(tmp_path, aiohttp_client) -> None:
     """
     Tests the access to a resource that is neither a file nor a directory.
     Checks that if a special resource is accessed (f.e. named pipe or UNIX
@@ -269,7 +247,7 @@ async def test_access_special_resource(tmp_dir_path, aiohttp_client) -> None:
         path_constructor.return_value = path
 
         # Register global static route:
-        app.router.add_static('/', tmp_dir_path, show_index=True)
+        app.router.add_static('/', str(tmp_path), show_index=True)
         client = await aiohttp_client(app)
 
         # Request the root of the static directory.
@@ -443,10 +421,10 @@ async def test_static_absolute_url(aiohttp_client, tmp_path) -> None:
     # /static/\\machine_name\c$ or /static/D:\path
     # where the static dir is totally different
     app = web.Application()
-    fname = tmp_path / 'file.txt'
-    fname.write_text('sample text', 'ascii')
+    file_path = tmp_path / 'file.txt'
+    file_path.write_text('sample text', 'ascii')
     here = pathlib.Path(__file__).parent
     app.router.add_static('/static', here)
     client = await aiohttp_client(app)
-    resp = await client.get('/static/' + str(fname))
+    resp = await client.get('/static/' + str(file_path.resolve()))
     assert resp.status == 403

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -1,4 +1,3 @@
-import os
 import pathlib
 from unittest import mock
 from unittest.mock import MagicMock
@@ -79,7 +78,7 @@ async def test_follow_symlink(tmp_path, aiohttp_client) -> None:
         fw.write(data)
 
     my_symlink_path = tmp_path / 'my_symlink'
-    os.symlink(str(my_dir_path), str(my_symlink_path))
+    pathlib.Path(str(my_symlink_path)).symlink_to(str(my_dir_path), True)
 
     app = web.Application()
 
@@ -212,7 +211,7 @@ async def test_access_symlink_loop(tmp_path, aiohttp_client) -> None:
     Tests the access to a looped symlink, which could not be resolved.
     """
     my_dir_path = tmp_path / 'my_symlink'
-    os.symlink(str(my_dir_path), str(my_dir_path))
+    pathlib.Path(str(my_dir_path)).symlink_to(str(my_dir_path), True)
 
     app = web.Application()
 

--- a/tools/check_changes.py
+++ b/tools/check_changes.py
@@ -12,7 +12,7 @@ ALLOWED_SUFFIXES = ['.feature',
 
 
 def get_root(script_path):
-    folder = script_path.absolute().parent
+    folder = script_path.resolve().parent
     while not (folder / '.git').exists():
         folder = folder.parent
         if folder == folder.anchor:


### PR DESCRIPTION
## What do these changes do?

This updates most uses of `os.path` to instead use `pathlib.Path`.
Relatedly, and following up from #3955 (which replaced pytest's `tmpdir`
fixture with `tmp_path`), this removes most ad-hoc tempfile creation in
favor of the `tmp_path` fixture. Following conversion, unnecessary `os`
and `tempfile` imports were removed.

Most pathlib changes involve straightforward changes from `os` functions
such as `os.mkdir` or `os.path.abspath` to their equivalent methods in
`pathlib.Path`.

Changing ad-hoc temporary path to `tmp_path` involved removing the
`tmp_dir_path` fixture and replacing its functionality with `tmp_path`
in `test_save_load` and `test_guess_filename_with_tempfile`.

On `test_static_route_user_home` function:

* I think that the intention of this test is to ensure that aiohttp
correctly expands the home path if passed in a string. I refactored it
to `pathlib.Path` and cut out duplication of `relative_to()` calls.
But if it's not doing anything but expanding `~`, then it's testing the
functionality of `pathlib.Path`, not aiohttp.

On `unix_sockname` fixture:

This fixture uses `tempfile.TemporaryDirectory`. Because it's a somewhat
complicated fixture used across multiple test modules, I left it as-is
for now.

On `str(tmp_path)` and even `pathlib.Path(str(tmp_path))`:

pytest uses `pathlib2` to provide `tmp_path` for Python 3.5 (only).
This is mostly fine but it fails on a couple of corner cases, such as
`os.symlink()` which blocks all but `str` and `PurePath` via isinstance
type checking. In several cases, this requires conversion to string or
conversion to string and then into `pathlib.Path` to maintain code
compatibility. See: pytest-dev/pytest/issues/5017

## Are there changes in behavior for the user?

These changes only affect the test suite and have no impact on the end user.

## Related issue number

This is intended to address discussion following the simplistic changes from tmpdir to tmp_path of #3955.

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."

