### PR TITLE
Document web.FileResponse

### DIFF
--- a/CHANGES/3958.doc
+++ b/CHANGES/3958.doc
@@ -1,0 +1,1 @@
+Add documentation for ``aiohttp.web.FileResponse``.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -850,6 +850,33 @@ Response
       *Content-Length* HTTP header.
 
 
+FileResponse
+^^^^^^^^^^^^^^
+
+.. class:: FileResponse(*, path, chunk_size=256*1024, status=200, reason=None, headers=None)
+
+   The response class used to send files, inherited from :class:`StreamResponse`.
+
+   Supports the ``Content-Range`` and ``If-Range`` HTTP Headers in requests.
+
+   The actual :attr:`body` sending happens in overridden :meth:`~StreamResponse.prepare`.
+
+   :param path: Path to file. Accepts both :class:`str` and :class:`pathlib.Path`.
+   :param int chunk_size: Chunk size in bytes which will be passed into
+                          :meth:`io.RawIOBase.read` in the event that the
+                          ``sendfile`` system call is not supported.
+
+   :param int status: HTTP status code, ``200`` by default.
+
+   :param str reason: HTTP reason. If param is ``None`` reason will be
+                      calculated basing on *status*
+                      parameter. Otherwise pass :class:`str` with
+                      arbitrary *status* explanation..
+
+   :param collections.abc.Mapping headers: HTTP headers that should be added to
+                           response's ones. The ``Content-Type`` response header
+                           will be overridden if provided.
+
 WebSocketResponse
 ^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Adds `FileResponse` constructor parameters to the documentation, based on the parent `StreamResponse` class documentation.
## Related issue number
<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #3958 

## Checklist

- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
