### PR TITLE
[3.6] Fix the dependabot app name @ Chronographer config

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,6 @@
+chronographer:
+  exclude:
+    bots:
+    - dependabot-preview
+    humans:
+    - pyup-bot


### PR DESCRIPTION
This was causing an issue because it's been renamed
when GitHub bought them..
(cherry picked from commit e99607bd27ff4fb2c54e35d934936c39aef66f07)

Co-authored-by: Sviatoslav Sydorenko <wk@sydorenko.org.ua>
