### PR TITLE
Fix #4097: misleading message in the string representation of `ClientConnectorError`

### DIFF
--- a/CHANGES/4097.bugfix
+++ b/CHANGES/4097.bugfix
@@ -1,0 +1,1 @@
+Fix misleading message in the string representation of `ClientConnectorError`; `self.ssl == None` means certification checks relaxed, not SSL disabled

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -136,8 +136,9 @@ class ClientConnectorError(ClientOSError):
         return self._conn_key.ssl
 
     def __str__(self) -> str:
-        return ('Cannot connect to host {0.host}:{0.port} ssl:{0.ssl} [{1}]'
-                .format(self, self.strerror))
+        return ('Cannot connect to host {0.host}:{0.port} ssl:{1} [{2}]'
+                .format(self, self.ssl if self.ssl is not None else 'default',
+                        self.strerror))
 
     # OSError.__reduce__ does too much black magick
     __reduce__ = BaseException.__reduce__

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -123,8 +123,8 @@ class TestClientConnectorError:
         err = client.ClientConnectorError(
             connection_key=self.connection_key,
             os_error=OSError(errno.ENOENT, 'No such file'))
-        assert str(err) == ("Cannot connect to host example.com:8080 ssl:None "
-                            "[No such file]")
+        assert str(err) == ("Cannot connect to host example.com:8080 ssl:"
+                            "default [No such file]")
 
 
 class TestClientConnectorCertificateError:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Trivial change; according to https://docs.aiohttp.org/en/stable/client_advanced.html#ssl-control-for-tcp-sockets the `ssl=False` argument is to disable the default behavior which is to throw exception if SSL verifcation fails such as with self-signed certificates, not for enabling or disabling SSL

## Related issue number
#4097
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."