### PR TITLE
Implement BaseRequest.get_extra_info()

### DIFF
--- a/CHANGES/4189.feature
+++ b/CHANGES/4189.feature
@@ -1,0 +1,1 @@
+Implement BaseRequest.get_extra_info() to access a protocol transports' extra info.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -205,6 +205,7 @@ Pepe Osca
 Philipp A.
 Pieter van Beek
 Rafael Viotti
+Raphael Bialon
 Raúl Cumplido
 Required Field
 Robert Lu

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -586,7 +586,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         """Return async iterator to process BODY as multipart."""
         return MultipartReader(self._headers, self._payload)
 
-    async def get_extra_info(self, name: str, default: Any = None):
+    async def get_extra_info(self, name: str, default: Any = None) -> Any:
         """Extra info from protocol transport"""
         protocol = self._protocol
         if protocol is None:

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -586,18 +586,6 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         """Return async iterator to process BODY as multipart."""
         return MultipartReader(self._headers, self._payload)
 
-    async def get_extra_info(self, name: str, default: Any = None) -> Any:
-        """Extra info from protocol transport"""
-        protocol = self._protocol
-        if protocol is None:
-            return default
-
-        transport = protocol.transport
-        if transport is None:
-            return default
-
-        return transport.get_extra_info(name, default)
-
     async def post(self) -> 'MultiDictProxy[Union[str, bytes, FileField]]':
         """Return POST parameters."""
         if self._post is not None:
@@ -684,6 +672,18 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
 
         self._post = MultiDictProxy(out)
         return self._post
+
+    def get_extra_info(self, name: str, default: Any = None) -> Any:
+        """Extra info from protocol transport"""
+        protocol = self._protocol
+        if protocol is None:
+            return default
+
+        transport = protocol.transport
+        if transport is None:
+            return default
+
+        return transport.get_extra_info(name, default)
 
     def __repr__(self) -> str:
         ascii_encodable_path = self.path.encode('ascii', 'backslashreplace') \

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -586,6 +586,18 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         """Return async iterator to process BODY as multipart."""
         return MultipartReader(self._headers, self._payload)
 
+    async def get_extra_info(self, name: str, default: Any = None):
+        """Extra info from protocol transport"""
+        protocol = self._protocol
+        if protocol is None:
+            return default
+
+        transport = protocol.transport
+        if transport is None:
+            return default
+
+        return transport.get_extra_info(name, default)
+
     async def post(self) -> 'MultiDictProxy[Union[str, bytes, FileField]]':
         """Return POST parameters."""
         if self._post is not None:

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -356,6 +356,8 @@ and :ref:`aiohttp-web-signals` handlers.
       :param default: Default value to be used when no value for ``name`` is
                       found (default is ``None``).
 
+      .. versionadded:: 3.7
+
    .. comethod:: read()
 
       Read request body, returns :class:`bytes` object with body content.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -346,6 +346,16 @@ and :ref:`aiohttp-web-signals` handlers.
 
       :return: a cloned :class:`Request` instance.
 
+   .. method:: get_extra_info(name, default=None)
+
+      Reads extra information from the protocol's transport.
+      If no value associated with ``name`` is found, ``default`` is returned.
+
+      :param str name: The key to look up in the transport extra information.
+
+      :param default: Default value to be used when no value for ``name`` is
+                      found (default is ``None``).
+
    .. comethod:: read()
 
       Read request body, returns :class:`bytes` object with body content.

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -694,6 +694,16 @@ def test_url_https_with_closed_transport() -> None:
     assert str(req.url).startswith('https://')
 
 
+async def test_get_extra_info_default() -> None:
+    transp = mock.Mock()
+    transp.get_extra_info.return_value = ('10.10.10.10', 1234)
+    req = make_mocked_request('GET', '/', transport=transp)
+    req._protocol = None
+    default = 'default'
+    extra_info = await req.get_extra_info('test', default)
+    assert extra_info == default
+
+
 def test_eq() -> None:
     req1 = make_mocked_request('GET', '/path/to?a=1&b=2')
     req2 = make_mocked_request('GET', '/path/to?a=1&b=2')

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -1,6 +1,7 @@
 import asyncio
 import socket
 from collections.abc import MutableMapping
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -694,14 +695,29 @@ def test_url_https_with_closed_transport() -> None:
     assert str(req.url).startswith('https://')
 
 
-async def test_get_extra_info_default() -> None:
+async def test_get_extra_info() -> None:
+    valid_key = 'test'
+    valid_value = 'existent'
+    default_value = 'default'
+
+    def get_extra_info(name: str, default: Any = None):
+        return {valid_key: valid_value}.get(name, default)
     transp = mock.Mock()
-    transp.get_extra_info.return_value = ('10.10.10.10', 1234)
+    transp.get_extra_info.side_effect = get_extra_info
     req = make_mocked_request('GET', '/', transport=transp)
+
+    req_extra_info = req.get_extra_info(valid_key, default_value)
+    transp_extra_info = req._protocol.transport.get_extra_info(valid_key,
+                                                               default_value)
+    assert req_extra_info == transp_extra_info
+
+    req._protocol.transport = None
+    extra_info = req.get_extra_info(valid_key, default_value)
+    assert extra_info == default_value
+
     req._protocol = None
-    default = 'default'
-    extra_info = await req.get_extra_info('test', default)
-    assert extra_info == default
+    extra_info = req.get_extra_info(valid_key, default_value)
+    assert extra_info == default_value
 
 
 def test_eq() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This PR introduces the `get_extra_info()` function on `BaseRequest` as suggested in #4189 .
It provides the same functionality as the current `request.transport.get_extra_info()` but is directly associated with `request`.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Users are encouraged to favor `request.get_extra_info()` instead of `request.transport.get_extra_info()`, as `request.transport` is about to be deprecated.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#4189 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
