### PR TITLE
Add a Request.wait_for_disconnection() method

### DIFF
--- a/CHANGES/2492.feature
+++ b/CHANGES/2492.feature
@@ -1,0 +1,1 @@
+Add a Request.wait_for_disconnection() method, as means of allowing request handlers to be notified of premature client disconnections.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -560,6 +560,7 @@ class RequestHandler(BaseProtocol):
         can get exception information. Returns True if the client disconnects
         prematurely.
         """
+        request._finish()
         if self._request_parser is not None:
             self._request_parser.set_upgraded(False)
             self._upgrade = False

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -703,13 +703,6 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
             fut.cancel()
 
     async def wait_for_disconnection(self) -> None:
-        """Returns when the connection that sent this request closes
-
-        This can be used in handlers as a means to receive a notification of
-        premature client disconnection.
-
-        .. versionadded:: 4.0
-        """
         fut = asyncio.Future()  # type: asyncio.Future[None]
         self._disconnection_waiters.add(fut)
         try:

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -703,7 +703,8 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
             fut.cancel()
 
     async def wait_for_disconnection(self) -> None:
-        fut = asyncio.Future()  # type: asyncio.Future[None]
+        loop = asyncio.get_event_loop()
+        fut = loop.create_future()  # type: asyncio.Future[None]
         self._disconnection_waiters.add(fut)
         try:
             await fut

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -698,6 +698,10 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         for fut in self._disconnection_waiters:
             set_result(fut, None)
 
+    def _finish(self) -> None:
+        for fut in self._disconnection_waiters:
+            fut.cancel()
+
     async def wait_for_disconnection(self) -> None:
         """Returns when the connection that sent this request closes
 

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -17,6 +17,7 @@ from typing import (  # noqa
     Mapping,
     MutableMapping,
     Optional,
+    Set,
     Tuple,
     Union,
     cast,
@@ -35,6 +36,7 @@ from .helpers import (
     is_expected_content_type,
     reify,
     sentinel,
+    set_result,
 )
 from .http_parser import RawRequestMessage
 from .multipart import BodyPartReader, MultipartReader
@@ -110,7 +112,9 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         '_message', '_protocol', '_payload_writer', '_payload', '_headers',
         '_method', '_version', '_rel_url', '_post', '_read_bytes',
         '_state', '_cache', '_task', '_client_max_size', '_loop',
-        '_transport_sslcontext', '_transport_peername')
+        '_transport_sslcontext', '_transport_peername',
+        '_disconnection_waiters',
+    )
 
     def __init__(self, message: RawRequestMessage,
                  payload: StreamReader, protocol: 'RequestHandler',
@@ -142,6 +146,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         self._task = task
         self._client_max_size = client_max_size
         self._loop = loop
+        self._disconnection_waiters = set()  # type: Set[asyncio.Future[None]]
 
         transport = self._protocol.transport
         assert transport is not None
@@ -690,6 +695,23 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
 
     def _cancel(self, exc: BaseException) -> None:
         self._payload.set_exception(exc)
+        for fut in self._disconnection_waiters:
+            set_result(fut, None)
+
+    async def wait_for_disconnection(self) -> None:
+        """Returns when the connection that sent this request closes
+
+        This can be used in handlers as a means to receive a notification of
+        premature client disconnection.
+
+        .. versionadded:: 4.0
+        """
+        fut = asyncio.Future()  # type: asyncio.Future[None]
+        self._disconnection_waiters.add(fut)
+        try:
+            await fut
+        finally:
+            self._disconnection_waiters.remove(fut)
 
 
 class Request(BaseRequest):

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -446,6 +446,10 @@ and :ref:`aiohttp-web-signals` handlers.
 
       Returns when the connection that sent this request closes
 
+      If there is no client disconnection during request handling, this
+      coroutine gets cancelled automatically at the end of this request being
+      handled.
+
       This can be used in handlers as a means of receiving a notification of
       premature client disconnection.
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -442,6 +442,14 @@ and :ref:`aiohttp-web-signals` handlers.
           required work will be processed by :mod:`aiohttp.web`
           internal machinery.
 
+   .. comethod:: wait_for_disconnection()
+
+      Returns when the connection that sent this request closes
+
+      This can be used in handlers as a means of receiving a notification of
+      premature client disconnection.
+
+      .. versionadded:: 4.0
 
 .. class:: Request
 


### PR DESCRIPTION
as means of allowing request handlers to be notified of premature client
disconnections.

<!-- Thank you for your contribution! -->

## What do these changes do?

Adds a new async method `Request.wait_for_disconnection()`.  This method does nothing except to wait until the connection that sent a request to be disconnected.

This may be useful, in certain cases, now that aiohttp no longer automatically cancels request handlers upon client disconnection.  E.g., if there is a slow DB query, it is beneficial to be able to cancel that DB query as soon as the client disconnects, to avoid the DB doing useless work.

This async method provides the needed "signal" for that.  Although making use of it is not pretty, it can be simplified by a utility function/wrapper, probably outside the scope of aiohttp (and outside the scope of this PR).

## Are there changes in behavior for the user?

A new method was added, as described above.  It is opt-in, so should not affect existing code.

## Related issue number

#2492 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
