### PR TITLE
Raising RuntimeError when trying to get empty body encoding

### DIFF
--- a/CHANGES/4214.bugfix
+++ b/CHANGES/4214.bugfix
@@ -1,0 +1,1 @@
+Raising RuntimeError when trying to get encoding from not read body

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -267,8 +267,8 @@ Vladimir Kozlovski
 Vladimir Rutsky
 Vladimir Shulyak
 Vladimir Zakharov
-Vladyslav Bondar
 Vladyslav Bohaichuk
+Vladyslav Bondar
 W. Trevor King
 Wei Lin
 Weiwei Wang

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -268,6 +268,7 @@ Vladimir Rutsky
 Vladimir Shulyak
 Vladimir Zakharov
 Vladyslav Bondar
+Vladyslav Bohaichuk
 W. Trevor King
 Wei Lin
 Weiwei Wang

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -938,6 +938,8 @@ class ClientResponse(HeadersMixin):
             if mimetype.type == 'application' and mimetype.subtype == 'json':
                 # RFC 7159 states that the default encoding is UTF-8.
                 encoding = 'utf-8'
+            elif self._body is None:
+                raise RuntimeError("Trying to get encoding of not read body")
             else:
                 encoding = chardet.detect(self._body)['encoding']
         if not encoding:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -939,7 +939,8 @@ class ClientResponse(HeadersMixin):
                 # RFC 7159 states that the default encoding is UTF-8.
                 encoding = 'utf-8'
             elif self._body is None:
-                raise RuntimeError('Cannot guess the encoding of a not yet read body')
+                raise RuntimeError('Cannot guess the encoding of '
+                                   'a not yet read body')
             else:
                 encoding = chardet.detect(self._body)['encoding']
         if not encoding:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -939,7 +939,7 @@ class ClientResponse(HeadersMixin):
                 # RFC 7159 states that the default encoding is UTF-8.
                 encoding = 'utf-8'
             elif self._body is None:
-                raise RuntimeError("Trying to get encoding of not read body")
+                raise RuntimeError('Cannot guess the encoding of a not yet read body')
             else:
                 encoding = chardet.detect(self._body)['encoding']
         if not encoding:

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1305,6 +1305,8 @@ Response object
       decode a response. Some encodings detected by cchardet are not known by
       Python (e.g. VISCII).
 
+      :raise RuntimeError: if body hasn't been read for :term:`cchardet` usage
+
       .. versionadded:: 3.0
 
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1305,7 +1305,8 @@ Response object
       decode a response. Some encodings detected by cchardet are not known by
       Python (e.g. VISCII).
 
-      :raise RuntimeError: if body hasn't been read for :term:`cchardet` usage
+      :raise RuntimeError: if called before the body has been read,
+                           for :term:`cchardet` usage
 
       .. versionadded:: 3.0
 

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -443,7 +443,10 @@ async def test_get_encoding_body_none(loop, session) -> None:
     content = response.content = mock.Mock()
     content.read.side_effect = side_effect
 
-    with pytest.raises(RuntimeError):
+    with pytest.raises(
+        RuntimeError,
+        match='^Cannot guess the encoding of a not yet read body$',
+    ):
         response.get_encoding()
     assert response.closed
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Function get_encoding raise RuntimeError when user is trying to read not present body and header doesn't provide info about encoding

## Are there changes in behavior for the user?

Make error more verbose

## Related issue number

Fixes #4214

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."