### PR TITLE
client: allow for json serializer function which returns bytes

### DIFF
--- a/CHANGES/4482.feature
+++ b/CHANGES/4482.feature
@@ -1,0 +1,1 @@
+Allow Client to accept a json_serialize function which returns bytes

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -287,6 +287,7 @@ Yuriy Shatrov
 Yury Selivanov
 Yusuke Tsutsumi
 Yuval Ofir
+Zachary Smith
 Zlatan Sičanica
 Марк Коренберг
 Семён Марьясин

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -165,7 +165,11 @@ class ClientWebSocketResponse:
     async def send_json(self, data: Any,
                         compress: Optional[int]=None,
                         *, dumps: JSONEncoder=DEFAULT_JSON_ENCODER) -> None:
-        await self.send_str(dumps(data), compress=compress)
+        serialized_data = dumps(data)
+        if isinstance(serialized_data, str):
+            await self.send_str(serialized_data, compress=compress)
+        else:
+            await self.send_bytes(serialized_data, compress=compress)
 
     async def close(self, *, code: int=1000, message: bytes=b'') -> bool:
         # we need to break `receive()` cycle first,

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -384,9 +384,11 @@ class JsonPayload(BytesPayload):
                  dumps: JSONEncoder=json.dumps,
                  *args: Any,
                  **kwargs: Any) -> None:
-
+        serialized_value = dumps(value)
+        if isinstance(serialized_value, str):
+            serialized_value = serialized_value.encode(encoding)
         super().__init__(
-            dumps(value).encode(encoding),
+            serialized_value,
             content_type=content_type, encoding=encoding, *args, **kwargs)
 
 

--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -37,7 +37,7 @@ else:
     _MultiDictProxy = MultiDictProxy
 
 Byteish = Union[bytes, bytearray, memoryview]
-JSONEncoder = Callable[[Any], str]
+JSONEncoder = Callable[[Any], Union[str, bytes]]
 JSONDecoder = Callable[[str], Any]
 LooseHeaders = Union[Mapping[Union[str, istr], str], _CIMultiDict,
                      _CIMultiDictProxy]

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -704,6 +704,7 @@ def json_response(data: Any=sentinel, *,
                   text: str=None,
                   body: bytes=None,
                   status: int=200,
+                  encoding: str = 'utf-8',
                   reason: Optional[str]=None,
                   headers: LooseHeaders=None,
                   content_type: str='application/json',
@@ -714,6 +715,12 @@ def json_response(data: Any=sentinel, *,
                 "only one of data, text, or body should be specified"
             )
         else:
-            text = dumps(data)
+            response_text = dumps(data)
+            if isinstance(response_text, bytes):
+                text = response_text.decode(
+                    encoding
+                )
+            else:
+                text = response_text
     return Response(text=text, body=body, status=status, reason=reason,
                     headers=headers, content_type=content_type)

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -296,7 +296,11 @@ class WebSocketResponse(StreamResponse):
 
     async def send_json(self, data: Any, compress: Optional[bool]=None, *,
                         dumps: JSONEncoder=json.dumps) -> None:
-        await self.send_str(dumps(data), compress=compress)
+        serialized_data = dumps(data)
+        if isinstance(serialized_data, str):
+            await self.send_str(serialized_data, compress=compress)
+        else:
+            await self.send_bytes(serialized_data, compress=compress)
 
     async def write_eof(self) -> None:  # type: ignore
         if self._eof_sent:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Please give a short brief about these changes. -->
Allows a `json_serializer` function passed to the request return either bytes or string.

## Are there changes in behavior for the user?

Should be transparent to users, other than accepting a new format, it should not change existing behavior

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#4482 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
