### PR TITLE
Fix multiple calls to runner shutdown with multiple sites

### DIFF
--- a/CHANGES/4646.bugfix
+++ b/CHANGES/4646.bugfix
@@ -1,0 +1,1 @@
+Fix duplicate calls to shutdown signal handlers when there are multiple sites registered to the app.

--- a/CHANGES/4646.removal
+++ b/CHANGES/4646.removal
@@ -1,0 +1,1 @@
+Move shutdown_timeout arguments from BaseSite to BaseRunner

--- a/CHANGES/4646.removal
+++ b/CHANGES/4646.removal
@@ -1,1 +1,1 @@
-Move shutdown_timeout arguments from BaseSite to BaseRunner
+Move shutdown_timeout argument from BaseSite to BaseRunner

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -308,6 +308,7 @@ async def _run_app(app: Union[Application, Awaitable[Application]], *,
     app = cast(Application, app)
 
     runner = AppRunner(app, handle_signals=handle_signals,
+                       shutdown_timeout=shutdown_timeout,
                        access_log_class=access_log_class,
                        access_log_format=access_log_format,
                        access_log=access_log)
@@ -320,7 +321,6 @@ async def _run_app(app: Union[Application, Awaitable[Application]], *,
         if host is not None:
             if isinstance(host, (str, bytes, bytearray, memoryview)):
                 sites.append(TCPSite(runner, host, port,
-                                     shutdown_timeout=shutdown_timeout,
                                      ssl_context=ssl_context,
                                      backlog=backlog,
                                      reuse_address=reuse_address,
@@ -328,14 +328,12 @@ async def _run_app(app: Union[Application, Awaitable[Application]], *,
             else:
                 for h in host:
                     sites.append(TCPSite(runner, h, port,
-                                         shutdown_timeout=shutdown_timeout,
                                          ssl_context=ssl_context,
                                          backlog=backlog,
                                          reuse_address=reuse_address,
                                          reuse_port=reuse_port))
         elif path is None and sock is None or port is not None:
             sites.append(TCPSite(runner, port=port,
-                                 shutdown_timeout=shutdown_timeout,
                                  ssl_context=ssl_context, backlog=backlog,
                                  reuse_address=reuse_address,
                                  reuse_port=reuse_port))
@@ -343,26 +341,22 @@ async def _run_app(app: Union[Application, Awaitable[Application]], *,
         if path is not None:
             if isinstance(path, (str, bytes, bytearray, memoryview)):
                 sites.append(UnixSite(runner, path,
-                                      shutdown_timeout=shutdown_timeout,
                                       ssl_context=ssl_context,
                                       backlog=backlog))
             else:
                 for p in path:
                     sites.append(UnixSite(runner, p,
-                                          shutdown_timeout=shutdown_timeout,
                                           ssl_context=ssl_context,
                                           backlog=backlog))
 
         if sock is not None:
             if not isinstance(sock, Iterable):
                 sites.append(SockSite(runner, sock,
-                                      shutdown_timeout=shutdown_timeout,
                                       ssl_context=ssl_context,
                                       backlog=backlog))
             else:
                 for s in sock:
                     sites.append(SockSite(runner, s,
-                                          shutdown_timeout=shutdown_timeout,
                                           ssl_context=ssl_context,
                                           backlog=backlog))
         for site in sites:

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -68,9 +68,6 @@ class BaseSite(ABC):
         # named pipes do not have wait_closed property
         if hasattr(self._server, 'wait_closed'):
             await self._server.wait_closed()
-        await self._runner.shutdown()
-        assert self._runner.server
-        await self._runner.server.shutdown(self._shutdown_timeout)
         self._runner._unreg_site(self)
 
 
@@ -255,6 +252,8 @@ class BaseRunner(ABC):
         # still present on failure
         for site in list(self._sites):
             await site.stop()
+        await self.shutdown()
+        await self._server.shutdown(60.0)
         await self._cleanup_server()
         self._server = None
         if self._handle_signals:

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -202,6 +202,10 @@ class BaseRunner(ABC):
         return self._server
 
     @property
+    def shutdown_timeout(self) -> float:
+        return self._shutdown_timeout
+
+    @property
     def addresses(self) -> List[str]:
         ret = []  # type: List[str]
         for site in self._sites:

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2492,6 +2492,12 @@ application on specific TCP or Unix socket, e.g.::
       A read-only :class:`set` of served sites (:class:`TCPSite` /
       :class:`UnixSite` / :class:`NamedPipeSite` / :class:`SockSite` instances).
 
+   .. attribute:: shutdown_timeout
+
+      The timeout for closing opened connections in all served sites upon runner cleanup.
+
+      .. versionadded:: 4.0
+
    .. comethod:: setup()
 
       Initialize the server. Should be called before adding sites.
@@ -2637,7 +2643,7 @@ application on specific TCP or Unix socket, e.g.::
                            supported on Windows.
 
 .. class:: UnixSite(runner, path, *, \
-                   shutdown_timeout=60.0, ssl_context=None, \
+                   ssl_context=None, \
                    backlog=128)
 
    Serve a runner on UNIX socket.
@@ -2645,10 +2651,6 @@ application on specific TCP or Unix socket, e.g.::
    :param runner: a runner to serve.
 
    :param str path: PATH to UNIX socket to listen.
-
-   :param float shutdown_timeout: a timeout for closing opened
-                                  connections on :meth:`BaseSite.stop`
-                                  call.
 
    :param ssl_context: a :class:`ssl.SSLContext` instance for serving
                        SSL/TLS secure server, ``None`` for plain HTTP
@@ -2660,7 +2662,7 @@ application on specific TCP or Unix socket, e.g.::
 
                        ``128`` by default.
 
-.. class:: NamedPipeSite(runner, path, *, shutdown_timeout=60.0)
+.. class:: NamedPipeSite(runner, path, *)
 
    Serve a runner on Named Pipe in Windows.
 
@@ -2668,12 +2670,8 @@ application on specific TCP or Unix socket, e.g.::
 
    :param str path: PATH of named pipe to listen.
 
-   :param float shutdown_timeout: a timeout for closing opened
-                                  connections on :meth:`BaseSite.stop`
-                                  call.
-
 .. class:: SockSite(runner, sock, *, \
-                   shutdown_timeout=60.0, ssl_context=None, \
+                   ssl_context=None, \
                    backlog=128)
 
    Serve a runner on UNIX socket.
@@ -2681,10 +2679,6 @@ application on specific TCP or Unix socket, e.g.::
    :param runner: a runner to serve.
 
    :param sock: :class:`socket.socket` to listen.
-
-   :param float shutdown_timeout: a timeout for closing opened
-                                  connections on :meth:`BaseSite.stop`
-                                  call.
 
    :param ssl_context: a :class:`ssl.SSLContext` instance for serving
                        SSL/TLS secure server, ``None`` for plain HTTP

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2603,7 +2603,7 @@ application on specific TCP or Unix socket, e.g.::
 
 
 .. class:: TCPSite(runner, host=None, port=None, *, \
-                   shutdown_timeout=60.0, ssl_context=None, \
+                   ssl_context=None, \
                    backlog=128, reuse_address=None, \
                    reuse_port=None)
 
@@ -2614,10 +2614,6 @@ application on specific TCP or Unix socket, e.g.::
    :param str host: HOST to listen on, ``'0.0.0.0'`` if ``None`` (default).
 
    :param int port: PORT to listed on, ``8080`` if ``None`` (default).
-
-   :param float shutdown_timeout: a timeout for closing opened
-                                  connections on :meth:`BaseSite.stop`
-                                  call.
 
    :param ssl_context: a :class:`ssl.SSLContext` instance for serving
                        SSL/TLS secure server, ``None`` for plain HTTP

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -77,6 +77,7 @@ def test_run(worker, loop) -> None:
     worker.log = mock.Mock()
     worker.cfg = mock.Mock()
     worker.cfg.access_log_format = ACCEPTABLE_LOG_FORMAT
+    worker.cfg.graceful_timeout = 100
     worker.cfg.is_ssl = False
     worker.sockets = []
 
@@ -91,6 +92,7 @@ def test_run_async_factory(worker, loop) -> None:
     worker.log = mock.Mock()
     worker.cfg = mock.Mock()
     worker.cfg.access_log_format = ACCEPTABLE_LOG_FORMAT
+    worker.cfg.graceful_timeout = 100
     worker.cfg.is_ssl = False
     worker.sockets = []
     app = worker.wsgi


### PR DESCRIPTION
## What do these changes do?

Move invocations to runner shutdown handlers from BaseSite to BaseRunner to avoid multiple (duplicate) shutdowns when there are multiple sites registered to a single runner and application.

Currently startup signal handlers and cleanup contexts are called only once regardless of the number
of registered sites, but the shutdown signal handlers are called multiple times.

## Are there changes in behavior for the user?

`shutdown_timeout` argument is moved from `BaseSite` and all its derivatives to `BaseRunner`.
There are no changes in the high-level API such as `web.run_app()` and the gunicorn worker interface, but if users rely on the low-level APIs they need to move the `shutdown_timeout` argument from sites to runners.

## Example

```python3
import asyncio
from typing import AsyncIterator

from aiohttp import web


async def handle_hello(request: web.Request) -> web.Response:
    return web.Response(text='hello world')


async def my_cleanup_ctx(app: web.Application) -> AsyncIterator[None]:
    print('my_cleanup_ctx: init')
    yield
    print('my_cleanup_ctx: cleanup')


async def my_startup_func(app: web.Application) -> None:
    print('my_startup_func')


async def my_shutdown_func(app: web.Application) -> None:
    print('my_shutdown_func')


async def main() -> None:
    app = web.Application()
    app.add_routes([
        web.get('/', handle_hello)
    ])
    app.cleanup_ctx.append(my_cleanup_ctx)
    app.on_startup.append(my_startup_func)
    app.on_shutdown.append(my_shutdown_func)
    runner = web.AppRunner(app)
    await runner.setup()
    sites = [
        web.TCPSite(runner, 'localhost', 8080),
        web.TCPSite(runner, 'localhost', 8180),
    ]
    print('Starting...')
    for site in sites:
        await site.start()
    try:
        print('Started.')
        while True:
            await asyncio.sleep(1)
    finally:
        print('Terminating...')
        await runner.cleanup()


if __name__ == '__main__':
    try:
        asyncio.run(main())
    except KeyboardInterrupt:
        print('Interrupted!')
```

Before applying this PR (env: Python 3.8.2 installed using pyenv on Ubuntu 18.04):
```
my_cleanup_ctx: init
my_startup_func
Starting...
Started.
^CTerminating...
my_shutdown_func
my_shutdown_func
my_cleanup_ctx: cleanup
Interrupted!
```
Note that `my_shutdown_func` is called ***twice***.

After applying this PR:
```
my_cleanup_ctx: init
my_startup_func
Starting...
Started.
^CTerminating...
my_shutdown_func
my_cleanup_ctx: cleanup
Interrupted!
```

## Related issue number

I have mentioned this issue in the gitter chat.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
