### PR TITLE
Implement `aiohttp.ClientResponse.ok` property

### DIFF
--- a/CHANGES/4711.feature
+++ b/CHANGES/4711.feature
@@ -1,0 +1,1 @@
+Add ClientResponse.ok property for checking status code under 400.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -100,6 +100,7 @@ Eugene Ershov
 Eugene Naydenov
 Eugene Nikolaiev
 Eugene Tolmachev
+Evan Kepner
 Evert Lammerts
 Felix Yan
 Fernanda Guimarães

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -876,6 +876,19 @@ class ClientResponse(HeadersMixin):
         self._cleanup_writer()
         return noop()
 
+    @property
+    def ok(self) -> bool:
+        """Returns ``True`` if ``status`` is less than ``400``, ``False`` if not.
+
+        This is **not** a check for ``200 OK`` but a check that the response
+        status is under 400.
+        """
+        try:
+            self.raise_for_status()
+        except ClientResponseError:
+            return False
+        return True
+
     def raise_for_status(self) -> None:
         if 400 <= self.status:
             # reason should always be not None for a started response

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1091,6 +1091,11 @@ Response object
 
       HTTP status reason of response (:class:`str`), e.g. ``"OK"``.
 
+   .. attribute:: ok
+
+      Boolean representation of HTTP status code (:class:`bool`).
+      ``True`` if ``status`` is less than ``400``; otherwise, ``False``.
+
    .. attribute:: method
 
       Request's method (:class:`str`).

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2202,8 +2202,9 @@ async def test_redirect_without_location_header(aiohttp_client) -> None:
     assert data == body
 
 
-@pytest.mark.parametrize("status", [200, 201, 301, 400, 403, 500],
-                         ids= lambda x: f"status_code: {x}")
+@pytest.mark.parametrize(
+    "status", [200, 201, 301, 400, 403, 500], ids=lambda x: f"status_code: {x}"
+)
 async def test_ok_from_status(aiohttp_client, status) -> None:
 
     async def handler(request):

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2203,7 +2203,7 @@ async def test_redirect_without_location_header(aiohttp_client) -> None:
 
 
 @pytest.mark.parametrize(
-    ("status", "expected_ok"),
+    "status, expected_ok",
     (
         (200, True),
         (201, True),
@@ -2211,8 +2211,7 @@ async def test_redirect_without_location_header(aiohttp_client) -> None:
         (400, False),
         (403, False),
         (500, False),
-    ),
-    ids=lambda tc: f"HTTP status code {tc[0]} is{' ' if tc[1] else ' not'} ok",
+    )
 )
 async def test_ok_from_status(aiohttp_client, status, expected_ok) -> None:
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2203,7 +2203,7 @@ async def test_redirect_without_location_header(aiohttp_client) -> None:
 
 
 @pytest.mark.parametrize(
-    "status, expected_ok",
+    ("status", "expected_ok"),
     (
         (200, True),
         (201, True),

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2202,6 +2202,23 @@ async def test_redirect_without_location_header(aiohttp_client) -> None:
     assert data == body
 
 
+@pytest.mark.parametrize("status", [200, 201, 301, 400, 403, 500],
+                         ids= lambda x: f"status_code: {x}")
+async def test_ok_from_status(aiohttp_client, status) -> None:
+
+    async def handler(request):
+        return web.Response(status=status, body=b'')
+
+    app = web.Application()
+    app.router.add_route('GET', '/endpoint', handler)
+    client = await aiohttp_client(app, raise_for_status=False)
+    resp = await client.get('/endpoint')
+
+    if resp.status < 400:
+        assert resp.ok
+    else:
+        assert not resp.ok
+
 async def test_raise_for_status(aiohttp_client) -> None:
 
     async def handler(request):

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2212,7 +2212,7 @@ async def test_redirect_without_location_header(aiohttp_client) -> None:
         (403, False),
         (500, False),
     ),
-    ids=lambda c, y: f"HTTP status code {c} is{' ' if o else ' not'} ok",
+    ids=lambda c, o: f"HTTP status code {c} is{' ' if o else ' not'} ok",
 )
 async def test_ok_from_status(aiohttp_client, status, expected_ok) -> None:
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2203,9 +2203,18 @@ async def test_redirect_without_location_header(aiohttp_client) -> None:
 
 
 @pytest.mark.parametrize(
-    "status", [200, 201, 301, 400, 403, 500], ids=lambda x: f"status_code: {x}"
+    ("status", "expected_ok"),
+    (
+        (200, True),
+        (201, True),
+        (301, True),
+        (400, False),
+        (403, False),
+        (500, False),
+    ),
+    ids=lambda c, y: f"HTTP status code {c} is{' ' if o else ' not'} ok",
 )
-async def test_ok_from_status(aiohttp_client, status) -> None:
+async def test_ok_from_status(aiohttp_client, status, expected_ok) -> None:
 
     async def handler(request):
         return web.Response(status=status, body=b'')
@@ -2215,10 +2224,7 @@ async def test_ok_from_status(aiohttp_client, status) -> None:
     client = await aiohttp_client(app, raise_for_status=False)
     resp = await client.get('/endpoint')
 
-    if resp.status < 400:
-        assert resp.ok
-    else:
-        assert not resp.ok
+    assert resp.ok is expected_ok
 
 async def test_raise_for_status(aiohttp_client) -> None:
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2212,7 +2212,7 @@ async def test_redirect_without_location_header(aiohttp_client) -> None:
         (403, False),
         (500, False),
     ),
-    ids=lambda c, o: f"HTTP status code {c} is{' ' if o else ' not'} ok",
+    ids=lambda tc: f"HTTP status code {tc[0]} is{' ' if tc[1] else ' not'} ok",
 )
 async def test_ok_from_status(aiohttp_client, status, expected_ok) -> None:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This adds `ClientResponse.ok` as a property, similar to `requests.Response.ok` to help people moving code to async.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Not directly. Users will get a new property for `ok` to check if the `status` is under 400.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
