### PR TITLE
[3.6] switch noop from function to class (#4322)

### DIFF
--- a/CHANGES/4282.bugfix
+++ b/CHANGES/4282.bugfix
@@ -1,0 +1,1 @@
+Remove warning messages from noop.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -24,6 +24,7 @@ from typing import (  # noqa
     Any,
     Callable,
     Dict,
+    Generator,
     Iterable,
     Iterator,
     List,
@@ -99,12 +100,11 @@ TOKEN = CHAR ^ CTL ^ SEPARATORS
 coroutines = asyncio.coroutines
 old_debug = coroutines._DEBUG  # type: ignore
 
-# prevent "coroutine noop was never awaited" warning.
-coroutines._DEBUG = False  # type: ignore
 
+class noop:
+    def __await__(self) -> Generator[None, None, None]:
+        yield
 
-async def noop(*args: Any, **kwargs: Any) -> None:
-    return
 
 noop2 = noop
 

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -252,21 +252,6 @@ async def test_bad_method(srv, buf) -> None:
     assert buf.startswith(b'HTTP/1.0 400 Bad Request\r\n')
 
 
-async def test_data_received_error(srv, buf) -> None:
-    transport = srv.transport
-    srv._request_parser = mock.Mock()
-    srv._request_parser.feed_data.side_effect = TypeError
-
-    srv.data_received(
-        b'!@#$ / HTTP/1.0\r\n'
-        b'Host: example.com\r\n\r\n')
-
-    await asyncio.sleep(0)
-    assert buf.startswith(b'HTTP/1.0 500 Internal Server Error\r\n')
-    assert transport.close.called
-    assert srv._error_handler is None
-
-
 async def test_line_too_long(srv, buf) -> None:
     srv.data_received(b''.join([b'a' for _ in range(10000)]) + b'\r\n\r\n')
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

They remove the `RuntimeWarning` for noop function by turning it into class with `__await__`. It's a backport of #4322 to aiohttp 3.6

## Are there changes in behavior for the user?

No

## Related issue number

#4282 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
