### PR TITLE
GunicornWebWorker subclasses can config AppRunner

### DIFF
--- a/CHANGES/2988.feature
+++ b/CHANGES/2988.feature
@@ -1,0 +1,2 @@
+Allow `GunicornWebWorker` subclasses to configure its `ApplicationRunner` by introducing the
+`GunicornWebWorker._get_application_runner_instance` method.

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -73,13 +73,7 @@ class GunicornWebWorker(base.Worker):
             raise RuntimeError("wsgi app should be either Application or "
                                "async function returning Application, got {}"
                                .format(self.wsgi))
-        access_log = self.log.access_log if self.cfg.accesslog else None
-        runner = web.AppRunner(app,
-                               logger=self.log,
-                               keepalive_timeout=self.cfg.keepalive,
-                               access_log=access_log,
-                               access_log_format=self._get_valid_log_format(
-                                   self.cfg.access_log_format))
+        runner = self._get_application_runner_instance(app)
         await runner.setup()
 
         ctx = self._create_ssl_context(self.cfg) if self.cfg.is_ssl else None
@@ -206,6 +200,17 @@ class GunicornWebWorker(base.Worker):
             )
         else:
             return source_format
+
+    def _get_application_runner_instance(self, app, **kwargs):
+        access_log = self.log.access_log if self.cfg.accesslog else None
+        runner = web.AppRunner(app,
+                               logger=self.log,
+                               keepalive_timeout=self.cfg.keepalive,
+                               access_log=access_log,
+                               access_log_format=self._get_valid_log_format(
+                                   self.cfg.access_log_format),
+                               **kwargs)
+        return runner
 
 
 class GunicornUVLoopWebWorker(GunicornWebWorker):


### PR DESCRIPTION
Currently there is no way to configure the Application Runner created by
the `aiohttp.GunicornWebWorker`.

This allows `GunicornWebWorker` subclasses to configure its
`ApplicationRunner` by introducing the
`GunicornWebWorker._get_application_runner_instance` method.

<!-- Thank you for your contribution! -->

## What do these changes do?

This implements Design 1 from this request for comment, comment https://github.com/aio-libs/aiohttp/issues/2988#issuecomment-611124997

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

https://github.com/aio-libs/aiohttp/issues/2988

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
