### PR TITLE
Fix example code in client quickstart.

### DIFF
--- a/CHANGES/3376.doc
+++ b/CHANGES/3376.doc
@@ -1,0 +1,1 @@
+Fix example code in client quickstart

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -19,17 +19,23 @@ Let's get started with some simple examples.
 Make a Request
 ==============
 
-Begin by importing the aiohttp module::
+Begin by importing the aiohttp module, and asyncio::
 
     import aiohttp
+    import asyncio
 
 Now, let's try to get a web-page. For example let's query
 ``http://httpbin.org/get``::
 
-    async with aiohttp.ClientSession() as session:
-        async with session.get('http://httpbin.org/get') as resp:
-            print(resp.status)
-            print(await resp.text())
+    async def main():
+        async with aiohttp.ClientSession() as session:
+            async with session.get('http://httpbin.org/get') as resp:
+                print(resp.status)
+                print(await resp.text())
+
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(main())
 
 Now, we have a :class:`ClientSession` called ``session`` and a
 :class:`ClientResponse` object called ``resp``. We can get all the
@@ -88,7 +94,7 @@ following code::
     params = {'key1': 'value1', 'key2': 'value2'}
     async with session.get('http://httpbin.org/get',
                            params=params) as resp:
-        expect = 'http://httpbin.org/get?key2=value2&key1=value1'
+        expect = 'http://httpbin.org/get?key1=value1&key2=value2'
         assert str(resp.url) == expect
 
 You can see that the URL has been correctly encoded by printing the URL.


### PR DESCRIPTION
The quickstart client examples throw an error. I did not find a solution until reaching this page:
https://github.com/aio-libs/aiohttp/issues/3376

I propose that it should be runnable for starters on the first example.

<!-- Thank you for your contribution! -->

## What do these changes do?

Make the docs page more user-friendly by providing working examples.

## Related issue number

https://github.com/aio-libs/aiohttp/issues/3376

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
