### PR TITLE
No Content-Length header for 1xx 204

### DIFF
--- a/CHANGES/4901.bugfix
+++ b/CHANGES/4901.bugfix
@@ -1,0 +1,1 @@
+Server doesn't send Content-Length for 1xx or 204

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -426,6 +426,10 @@ class StreamResponse(BaseClass, HeadersMixin):
                         del headers[hdrs.CONTENT_LENGTH]
                 else:
                     keep_alive = False
+            # HTTP 1.1: https://tools.ietf.org/html/rfc7230#section-3.3.2
+            # HTTP 1.0: https://tools.ietf.org/html/rfc1945#section-10.4
+            elif version >= HttpVersion11 and self.status in (100, 101, 102, 103, 204):
+                del headers[hdrs.CONTENT_LENGTH]
 
         headers.setdefault(hdrs.CONTENT_TYPE, "application/octet-stream")
         headers.setdefault(hdrs.DATE, rfc822_formatted_time())


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Remove Content-Length header for 1xx or 204 according to [rfc7230](https://tools.ietf.org/html/rfc7230#section-3.3.2)

## Are there changes in behavior for the user?

No

## Related issue number

Fixes #4901 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
