### PR TITLE
Only query host address families over DNS that the local network stack supports

### DIFF
--- a/CHANGES/5156.bugfix
+++ b/CHANGES/5156.bugfix
@@ -1,1 +1,1 @@
-Workaround wrong return value of socket.getaddrinfo in rare case
+Fixed querying the address families from DNS that the current host supports.

--- a/CHANGES/5156.bugfix
+++ b/CHANGES/5156.bugfix
@@ -1,0 +1,1 @@
+Workaround wrong return value of socket.getaddrinfo in rare case

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List
 
 from .abc import AbstractResolver
 from .helpers import get_running_loop
+from .log import internal_logger
 
 __all__ = ("ThreadedResolver", "AsyncResolver", "DefaultResolver")
 
@@ -32,15 +33,21 @@ class ThreadedResolver(AbstractResolver):
         )
 
         hosts = []
-        for family, _, proto, _, address in infos:
-            if family == socket.AF_INET6 and address[3]:  # type: ignore
-                # This is essential for link-local IPv6 addresses.
-                # LL IPv6 is a VERY rare case. Strictly speaking, we should use
-                # getnameinfo() unconditionally, but performance makes sense.
-                host, _port = socket.getnameinfo(
-                    address, socket.NI_NUMERICHOST | socket.NI_NUMERICSERV
-                )
-                port = int(_port)
+        for info in infos:
+            family, _, proto, _, address = info
+            if family == socket.AF_INET6:
+                # https://github.com/aio-libs/aiohttp/issues/5156
+                if len(address) != 4:
+                    internal_logger.warning(f"Bad address format in {info}")
+                    continue
+                if address[3]:  # type: ignore
+                    # This is essential for link-local IPv6 addresses.
+                    # LL IPv6 is a VERY rare case. Strictly speaking, we should use
+                    # getnameinfo() unconditionally, but performance makes sense.
+                    host, _port = socket.getnameinfo(
+                        address, socket.NI_NUMERICHOST | socket.NI_NUMERICSERV
+                    )
+                    port = int(_port)
             else:
                 host, port = address[:2]
             hosts.append(

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -28,7 +28,11 @@ class ThreadedResolver(AbstractResolver):
         self, hostname: str, port: int = 0, family: int = socket.AF_INET
     ) -> List[Dict[str, Any]]:
         infos = await self._loop.getaddrinfo(
-            hostname, port, type=socket.SOCK_STREAM, family=family
+            hostname,
+            port,
+            type=socket.SOCK_STREAM,
+            family=family,
+            flags=socket.AI_ADDRCONFIG,
         )
 
         hosts = []

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -35,19 +35,18 @@ class ThreadedResolver(AbstractResolver):
         hosts = []
         for info in infos:
             family, _, proto, _, address = info
-            if family == socket.AF_INET6:
-                # https://github.com/aio-libs/aiohttp/issues/5156
-                if len(address) != 4:
-                    internal_logger.warning(f"Bad address format in {info}")
-                    continue
-                if address[3]:  # type: ignore
-                    # This is essential for link-local IPv6 addresses.
-                    # LL IPv6 is a VERY rare case. Strictly speaking, we should use
-                    # getnameinfo() unconditionally, but performance makes sense.
-                    host, _port = socket.getnameinfo(
-                        address, socket.NI_NUMERICHOST | socket.NI_NUMERICSERV
-                    )
-                    port = int(_port)
+            # https://github.com/aio-libs/aiohttp/issues/5156
+            if family == socket.AF_INET6 and len(address) != 4:
+                internal_logger.warning(f"Bad address format in {info}")
+                continue
+            elif family == socket.AF_INET6 and address[3]:  # type: ignore
+                # This is essential for link-local IPv6 addresses.
+                # LL IPv6 is a VERY rare case. Strictly speaking, we should use
+                # getnameinfo() unconditionally, but performance makes sense.
+                host, _port = socket.getnameinfo(
+                    address, socket.NI_NUMERICHOST | socket.NI_NUMERICSERV
+                )
+                port = int(_port)
             else:
                 host, port = address[:2]
             hosts.append(

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -35,18 +35,19 @@ class ThreadedResolver(AbstractResolver):
         hosts = []
         for info in infos:
             family, _, proto, _, address = info
-            # https://github.com/aio-libs/aiohttp/issues/5156
-            if family == socket.AF_INET6 and len(address) != 4:
-                internal_logger.warning(f"Bad address format in {info}")
-                continue
-            elif family == socket.AF_INET6 and address[3]:  # type: ignore
-                # This is essential for link-local IPv6 addresses.
-                # LL IPv6 is a VERY rare case. Strictly speaking, we should use
-                # getnameinfo() unconditionally, but performance makes sense.
-                host, _port = socket.getnameinfo(
-                    address, socket.NI_NUMERICHOST | socket.NI_NUMERICSERV
-                )
-                port = int(_port)
+            if family == socket.AF_INET6:
+                # https://github.com/aio-libs/aiohttp/issues/5156
+                if len(address) != 4:
+                    internal_logger.warning(f"Bad address format in {info}")
+                    continue
+                if address[3]:  # type: ignore
+                    # This is essential for link-local IPv6 addresses.
+                    # LL IPv6 is a VERY rare case. Strictly speaking, we should use
+                    # getnameinfo() unconditionally, but performance makes sense.
+                    host, _port = socket.getnameinfo(
+                        address, socket.NI_NUMERICHOST | socket.NI_NUMERICSERV
+                    )
+                    port = int(_port)
             else:
                 host, port = address[:2]
             hosts.append(

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -34,14 +34,18 @@ async def fake_query_result(result):
     return [FakeQueryResult(host=h) for h in result]
 
 
-def fake_addrinfo(hosts):
+def fake_addrinfo_raw(return_value):
     async def fake(*args, **kwargs):
-        if not hosts:
+        if not return_value:
             raise socket.gaierror
 
-        return list([(None, None, None, None, [h, 0]) for h in hosts])
+        return return_value
 
     return fake
+
+
+def fake_addrinfo(hosts):
+    return fake_addrinfo_raw(list([(None, None, None, None, [h, 0]) for h in hosts]))
 
 
 @pytest.mark.skipif(not gethostbyname, reason="aiodns 1.1 required")
@@ -160,3 +164,17 @@ def test_default_resolver() -> None:
     # else:
     #     assert DefaultResolver is ThreadedResolver
     assert DefaultResolver is ThreadedResolver
+
+
+async def test_threaded_resolver_5156() -> None:
+    loop = Mock()
+    loop.getaddrinfo = fake_addrinfo_raw(
+        [
+            (2, 1, 6, "", ("151.101.188.223", 443)),
+            (10, 1, 6, "", (10, b"\x01\xbb\x00\x00\x00\x00*\x04NB\x00-\x00\x00")),
+        ]
+    )
+    resolver = ThreadedResolver()
+    resolver._loop = loop
+
+    await resolver.resolve("foo")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Workaround for incorrect socket.getaddrinfo return value in rare case

## Are there changes in behavior for the user?

No

## Related issue number

Fixes #5156 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
