### PR TITLE
Fix aiohttp client redirection bug with complex URLs

### DIFF
--- a/CHANGES/5319.bugfix
+++ b/CHANGES/5319.bugfix
@@ -1,1 +1,1 @@
-Fix failures with aiohttp web server redirections with complex URLs
+Fix failures with aiohttp web server redirections with complex URLs.

--- a/CHANGES/5319.bugfix
+++ b/CHANGES/5319.bugfix
@@ -1,0 +1,1 @@
+Fix failures with aiohttp web server redirections with complex URLs

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -261,6 +261,7 @@ Pieter van Beek
 Qiao Han
 Rafael Viotti
 Raphael Bialon
+Raphael Géronimi
 Raúl Cumplido
 Required Field
 Robert Lu

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -229,7 +229,7 @@ class HTTPMove(HTTPRedirection):
             headers=headers, reason=reason, text=text, content_type=content_type
         )
         self._location = URL(location)
-        self.headers["Location"] = str(self.location)
+        self.headers["Location"] = str(location)
 
     @property
     def location(self) -> URL:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix
https://github.com/aio-libs/aiohttp/issues/5319

## Are there changes in behavior for the user?

No if their code was correct, i.e. if they didn't use buggy URLs during redirects (that were transparently corrected by yarl). If they did use buggy URLs, this was a bug on their side, that was kept hidden thanks to yarl's reencoding of the URL. This pull request will make these bugs visible.
This is an exotic case that maybe does not exist in practice, but in theory this is possible.

## Related issue number

https://github.com/aio-libs/aiohttp/issues/5319

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."