### PR TITLE
Add separate non-blocking start_app corountine

### DIFF
--- a/CHANGES/5386.feature
+++ b/CHANGES/5386.feature
@@ -1,0 +1,1 @@
+Add separate non-blocking ``start_app`` corountine.

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -283,7 +283,7 @@ except ImportError:  # pragma: no cover
 HostSequence = TypingIterable[str]
 
 
-async def _run_app(
+async def start_app(
     app: Union[Application, Awaitable[Application]],
     *,
     host: Optional[Union[str, HostSequence]] = None,
@@ -301,8 +301,12 @@ async def _run_app(
     handle_signals: bool = True,
     reuse_address: Optional[bool] = None,
     reuse_port: Optional[bool] = None,
-) -> None:
-    # An internal function to actually do all dirty job for application running
+) -> AppRunner:
+    """Start an app locally.
+
+    Use `run_app` if you do not wish to control and keep the event loop
+    alive yourself, this is non-blocking and returns the runner created.
+    """
     if asyncio.iscoroutine(app):
         app = await app  # type: ignore
 
@@ -478,7 +482,11 @@ def run_app(
     reuse_address: Optional[bool] = None,
     reuse_port: Optional[bool] = None,
 ) -> None:
-    """Run an app locally"""
+    """Run an app locally.
+
+    Use `start_app` if you wish to control and keep the event loop alive
+    yourself, this should be the last line in your file.
+    """
     loop = asyncio.get_event_loop()
     loop.set_debug(debug)
 
@@ -491,7 +499,7 @@ def run_app(
 
     try:
         main_task = loop.create_task(
-            _run_app(
+            start_app(
                 app,
                 host=host,
                 port=port,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
This will add a separate start corountine allowing the user to use a similar half-performant function as `run_app` but if they wish to do the keepalive sleeps themselves.

## Are there changes in behavior for the user?

This has 0 breaking changes, unless someone depends on the previous `_run_app` function which was renamed to `stat_app` and had the keepalive code moved.
## Related issue number

This should close #5386, which I opened confused about the pre-commit hooks failing.
## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."

> - Unit tests for the changes exist

If there is for `run_app` then I guess? I did not add any new unit tests for the new `start_app` function.

> The format is &lt;Name&gt; &lt;Surname&gt;.

I do not want to reveal my real name, looking at the document it doesn't seem as if any aliases are there so I am not gonna add myself there. Which is completely fine by me.

> Please keep alphabetical order, the file is sorted by names.

Not possible considering `run_app` is dependent on `start_app` which means an exception to that rule is made here.