### PR TITLE
add address size checking (#4556)

### DIFF
--- a/CHANGES/4556.bugfix
+++ b/CHANGES/4556.bugfix
@@ -1,0 +1,1 @@
+Do not check fourth item of address tuple if it's not there

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -233,6 +233,7 @@ Paulius Šileikis
 Paulus Schoutsen
 Pavel Kamaev
 Pavel Polyakov
+Pavel Sadikov
 Pawel Kowalski
 Pawel Miech
 Pepe Osca

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -37,7 +37,9 @@ class ThreadedResolver(AbstractResolver):
 
         hosts = []
         for family, _, proto, _, address in infos:
-            if family == socket.AF_INET6 and address[3]:  # type: ignore
+            if (
+                family == socket.AF_INET6 and len(address) >= 4 and address[3]
+            ):  # type: ignore
                 # This is essential for link-local IPv6 addresses.
                 # LL IPv6 is a VERY rare case. Strictly speaking, we should use
                 # getnameinfo() unconditionally, but performance makes sense.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Checks if link-local IPv6 address tuple has four items, so it wouldn't fall if it has not.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#4556
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
