### PR TITLE
Re-introduce `pytest-xdist` in supported envs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -220,14 +220,15 @@ jobs:
         COLOR: yes
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
       run: >-  # `exit 1` makes sure that the job remains red with flaky runs
-        pytest --no-cov -vvvvv --lf && exit 1
+        pytest --no-cov --numprocesses=0 -vvvvv --lf && exit 1
       shell: bash
     - name: Run dev_mode tests
       env:
         COLOR: yes
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
         PIP_USER: 1
-      run: python -X dev -m pytest -m dev_mode --cov-append
+        PYTHONDEVMODE: 1
+      run: pytest -m dev_mode --cov-append --numprocesses=0
       shell: bash
     - name: Turn coverage into xml
       env:
@@ -292,7 +293,7 @@ jobs:
       uses: CodSpeedHQ/action@v3
       with:
         token: ${{ secrets.CODSPEED_TOKEN }}
-        run: python -Im pytest --no-cov -vvvvv --codspeed
+        run: python -Im pytest --no-cov --numprocesses=0 -vvvvv --codspeed
 
 
   check:  # This job does nothing and is only used for the branch protection

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,6 +18,8 @@ alabaster==0.7.13
     # via sphinx
 annotated-types==0.7.0
     # via pydantic
+apipkg==1.5
+    # via execnet
 async-timeout==4.0.3 ; python_version < "3.11"
     # via
     #   -r requirements/runtime-deps.in
@@ -69,6 +71,8 @@ filelock==3.16.1
     # via
     #   pytest-codspeed
     #   virtualenv
+execnet==2.1.1
+    # via pytest-xdist
 freezegun==1.5.1
     # via
     #   -r requirements/lint.in
@@ -145,6 +149,8 @@ proxy-py==2.4.9
     # via
     #   -r requirements/lint.in
     #   -r requirements/test.in
+py==1.11.0
+    # via pytest
 pycares==4.4.0
     # via aiodns
 pycparser==2.22
@@ -174,7 +180,20 @@ pytest==8.1.1
     #   pytest-codspeed
     #   pytest-cov
     #   pytest-mock
+    #   pytest-xdist
 pytest-codspeed==3.0.0
+    # via
+    #   -r requirements/lint.in
+    #   -r requirements/test.in
+pytest-cov==5.0.0
+    # via -r requirements/test.in
+pytest-mock==3.14.0
+    # via -r requirements/test.in
+pytest-xdist==3.6.1
+    # via -r requirements/test.txt
+python-dateutil==2.8.2
+    # via freezegun
+python-on-whales==0.71.0
     # via
     #   -r requirements/lint.in
     #   -r requirements/test.in

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,10 +3,11 @@
 coverage
 freezegun
 mypy; implementation_name == "cpython"
-proxy.py >= 2.4.4rc4
+proxy.py >= 2.4.4rc5
 pytest
 pytest-cov
 pytest-mock
+pytest-xdist
 pytest_codspeed
 python-on-whales
 setuptools-git

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -37,6 +37,8 @@ cryptography==43.0.3
     # via trustme
 exceptiongroup==1.2.2
     # via pytest
+execnet==2.1.1
+    # via pytest-xdist
 filelock==3.16.1
     # via pytest-codspeed
 freezegun==1.5.1
@@ -78,6 +80,8 @@ propcache==0.2.0
     #   yarl
 proxy-py==2.4.9
     # via -r requirements/test.in
+py==1.11.0
+    # via pytest
 pycares==4.4.0
     # via aiodns
 pycparser==2.22
@@ -95,10 +99,14 @@ pytest==8.1.1
     #   pytest-cov
     #   pytest-mock
 pytest-codspeed==3.0.0
-    # via -r requirements/test.in
+    # via
+    #   -r requirements/test.in
+    #   pytest-xdist
 pytest-cov==5.0.0
     # via -r requirements/test.in
 pytest-mock==3.14.0
+    # via -r requirements/test.in
+pytest-xdist==3.6.1
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via freezegun

--- a/setup.cfg
+++ b/setup.cfg
@@ -124,6 +124,9 @@ exclude_lines =
 
 [tool:pytest]
 addopts =
+    # `pytest-xdist`:
+    --numprocesses=auto
+
     # show 10 slowest invocations:
     --durations=10
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -736,7 +736,8 @@ async def test_urlencoded_formdata_charset(
         data=aiohttp.FormData({"hey": "you"}, charset="koi8-r"),
         loop=loop,
     )
-    await req.send(conn)
+    async with await req.send(conn):
+        await asyncio.sleep(0)
     assert "application/x-www-form-urlencoded; charset=koi8-r" == req.headers.get(
         "CONTENT-TYPE"
     )
@@ -755,7 +756,8 @@ async def test_formdata_boundary_from_headers(
             headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
             loop=loop,
         )
-        await req.send(conn)
+        async with await req.send(conn):
+            await asyncio.sleep(0)
         assert req.body._boundary == boundary.encode()
 
 
@@ -1088,13 +1090,13 @@ async def test_data_stream_exc(
 
     t = loop.create_task(throw_exc())
 
-    await req.send(conn)
-    assert req._writer is not None
-    await req._writer
-    await t
-    # assert conn.close.called
-    assert conn.protocol is not None
-    assert conn.protocol.set_exception.called
+    async with await req.send(conn):
+        assert req._writer is not None
+        await req._writer
+        await t
+        # assert conn.close.called
+        assert conn.protocol is not None
+        assert conn.protocol.set_exception.called
     await req.close()
 
 
@@ -1118,9 +1120,9 @@ async def test_data_stream_exc_chain(
 
     t = loop.create_task(throw_exc())
 
-    await req.send(conn)
-    assert req._writer is not None
-    await req._writer
+    async with await req.send(conn):
+        assert req._writer is not None
+        await req._writer
     await t
     # assert conn.close.called
     assert conn.protocol.set_exception.called

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -28,8 +28,18 @@ def test_web___all__(pytester: pytest.Pytester) -> None:
     result.assert_outcomes(passed=0, errors=0)
 
 
+_IS_CI_ENV = os.getenv("CI") == "true"
+_XDIST_WORKER_COUNT = int(os.getenv("PYTEST_XDIST_WORKER_COUNT", 0))
+_IS_XDIST_RUN = _XDIST_WORKER_COUNT > 1
+
 _TARGET_TIMINGS_BY_PYTHON_VERSION = {
-    "3.12": 250,  # 3.12 is expected to be a bit slower due to performance trade-offs
+    "3.12": (
+        # 3.12 is expected to be a bit slower due to performance trade-offs,
+        # and even slower under pytest-xdist, especially in CI
+        _XDIST_WORKER_COUNT * 100 * (1 if _IS_CI_ENV else 1.53)
+        if _IS_XDIST_RUN
+        else 250
+    ),
 }
 
 

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -139,6 +139,7 @@ async def web_server_endpoint_url(
 # Filter out the warning from
 # https://github.com/abhinavsingh/proxy.py/blob/30574fd0414005dfa8792a6e797023e862bdcf43/proxy/common/utils.py#L226
 # otherwise this test will fail because the proxy will die with an error.
+@pytest.mark.usefixtures("loop")
 async def test_secure_https_proxy_absolute_path(
     client_ssl_ctx: ssl.SSLContext,
     secure_proxy_url: URL,
@@ -159,6 +160,7 @@ async def test_secure_https_proxy_absolute_path(
 
     await sess.close()
     await conn.close()
+    await asyncio.sleep(0.1)
 
 
 @pytest.mark.parametrize("web_server_endpoint_type", ("https",))
@@ -231,6 +233,8 @@ async def test_https_proxy_unsupported_tls_in_tls(
 
     await sess.close()
     await conn.close()
+
+    await asyncio.sleep(0.1)
 
 
 @pytest.fixture


### PR DESCRIPTION
## What do these changes do?

This change resurrects parallel test execution in most of the test envs. On my laptop, the full test run is almost 3x faster: 36.04s vs 105.53s (0:01:45).

Refs:
  * https://github.com/pytest-dev/pytest-xdist/issues/620
  * https://stackoverflow.com/a/58614689/595220
  * https://bugs.python.org/issue35621
  * https://github.com/python/cpython/pull/14344

## Are there changes in behavior for the user?

Nope.

## Related issue number

https://github.com/aio-libs/aiohttp/pull/3419 + https://github.com/aio-libs/aiohttp/issues/3450

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
