### PR TITLE
Return a readily processed `FormData` instead of raising an exception

### DIFF
--- a/CHANGES/5577.bugfix
+++ b/CHANGES/5577.bugfix
@@ -1,0 +1,1 @@
+Instead of raising ClientPayloadError, return already processed FormData.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -231,6 +231,7 @@ Pau Freixes
 Paul Colomiets
 Paulius Šileikis
 Paulus Schoutsen
+Pavel Filatov
 Pavel Kamaev
 Pavel Polyakov
 Pavel Sapezhko

--- a/aiohttp/formdata.py
+++ b/aiohttp/formdata.py
@@ -129,7 +129,7 @@ class FormData:
     def _gen_form_data(self) -> multipart.MultipartWriter:
         """Encode a list of fields using the multipart/form-data MIME format"""
         if self._is_processed:
-            raise RuntimeError("Form data has been processed already")
+            return self._writer
         for dispparams, headers, value in self._fields:
             try:
                 if hdrs.CONTENT_TYPE in headers:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -987,40 +987,15 @@ async def test_HTTP_308_PERMANENT_REDIRECT_POST(aiohttp_client: Any) -> None:
     resp.close()
 
 
-async def test_HTTP_307_REDIRECT_POST_FORMDATA(aiohttp_client: Any) -> None:
+@pytest.mark.xfail
+@pytest.mark.parametrize("redirect_type", [web.HTTPPermanentRedirect, web.HTTPTemporaryRedirect])
+async def test_HTTP_REDIRECT_POST_FORMDATA(redirect_type, aiohttp_client: Any) -> None:
     async def handler(request):
         return web.Response(text=request.method)
 
     async def redirect(request):
         await request.read()
-        raise web.HTTPTemporaryRedirect(location="/")
-
-    app = web.Application()
-    app.router.add_post("/", handler)
-    app.router.add_post("/redirect", redirect)
-    client = await aiohttp_client(app)
-
-    data = FormData()
-    data.add_field(
-        'file',
-        io.BytesIO(),
-        filename='bytes_file',
-    )
-    resp = await client.post("/redirect", data=data)
-    assert 200 == resp.status
-    assert 1 == len(resp.history)
-    txt = await resp.text()
-    assert txt == "POST"
-    resp.close()
-
-
-async def test_HTTP_308_PERMANENT_REDIRECT_POST_FORMDATA(aiohttp_client: Any) -> None:
-    async def handler(request):
-        return web.Response(text=request.method)
-
-    async def redirect(request):
-        await request.read()
-        raise web.HTTPPermanentRedirect(location="/")
+        raise redirect_type(location="/")
 
     app = web.Application()
     app.router.add_post("/", handler)

--- a/tests/test_formdata.py
+++ b/tests/test_formdata.py
@@ -97,5 +97,6 @@ async def test_mark_formdata_as_processed() -> None:
         await session.post(url, data=data)
         assert len(data._writer._parts) == 1
 
-        with pytest.raises(RuntimeError):
-            await session.post(url, data=data)
+        # second request doesn't append values to existing FormData
+        await session.post(url, data=data)
+        assert len(data._writer._parts) == 1


### PR DESCRIPTION
## What do these changes do?

This changes the behavior of already processed data. Instead of raising an exception when trying to access already processed data -- return the data.

## Are there changes in behavior for the user?

The POST redirects with FormData no longer raise exception.

## Related issue number

This commit fixes #5577 issue

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
