### PR TITLE
tests/test_cookiejar.py: add test

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -72,6 +72,7 @@ Colin Dunklau
 Cong Xu
 Damien Nadé
 Dan Xu
+Daniel Dewberry
 Daniel García
 Daniel Grossmann-Kavanagh
 Daniel Nelson


### PR DESCRIPTION
## What do these changes do?

In accordance with https://github.com/aio-libs/aiohttp/issues/5571, this
commit adds a test to ensure secure cookies are not filtered from an unsafe
cookiejar when given an unsecured endpoint.

Rationale:

According to Mozilla documentation:
> A cookie with the Secure attribute is sent to the server only with an
> encrypted request over the HTTPS protocol, never with unsecured HTTP
> (except on localhost), and therefore can't easily be accessed by a
> man-in-the-middle attacker. Insecure sites (with http: in the URL) can't
> set cookies with the Secure attribute

Note the "(except on localhost)".  In addition, RFC 6265 section-4.1.2.5 states:

> The Secure attribute limits the scope of the cookie to "secure"
> channels (where "secure" is defined by the user agent). When a
> cookie has the Secure attribute, the user agent will include the
> cookie in an HTTP request only if the request is transmitted over a
> secure channel (typically HTTP over Transport Layer Security (TLS)
> [RFC2818]).
> Although seemingly useful for protecting cookies from active network
> attackers, the Secure attribute protects only the cookie's
> confidentiality

Note "(where "secure" is defined by the user agent)".  The behaviour
this commit tests for is therefore an engineer's decision, not an IETF
standard.


## Are there changes in behavior for the user?

An addition to the test suite, adding a failing test


## Related issue number

 https://github.com/aio-libs/aiohttp/issues/5571

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
