### PR TITLE
Fix the `ClientWebSocketResponse.receive` stuck for a long time if network is suddenly unavaiable.

### DIFF
--- a/CHANGES/2309.bugfix
+++ b/CHANGES/2309.bugfix
@@ -1,0 +1,1 @@
+Fix the `ClientWebSocketResponse.receive` stuck for a long time if network is suddenly interrupted.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR fix the websocket client will get stuck when a the internect is unavaiable.


## How to reproduce it


Run following code, and turn off the internet after seeing the `Connected` text in the console.

```Python
from asyncio import run
from aiohttp import ClientSession

async def main():
    async with ClientSession() as session:
        async with session.ws_connect('https://echo.websocket.org/',
                                      heartbeat=10) as ws:
            print('Connected', ws)
            print('Received', await ws.receive())

run(main())
```

In my local machine, it will block ablout 8 min and get a `CLOSED` message.

## Explain Why 

`receive` method has a `timeout` argument, and the default value is `None`. It means no timeout for reading from a connection. The websocket pong frame and user data frame uses the same timeout. So if `aiohttp` send a ping frame successfully, then we turn off the network. The `receive` coroutine will be block at the `msg = await self._reader.read()`. Because there are no data comes from the server.

https://github.com/aio-libs/aiohttp/blob/184274d9b28bbfa06ac60e48bf286a761c6a6cb0/aiohttp/client_ws.py#L213-L238


Even if we call `_pong_not_received`, it doesn't cancel the `receive` coroutine.

https://github.com/aio-libs/aiohttp/blob/184274d9b28bbfa06ac60e48bf286a761c6a6cb0/aiohttp/client_ws.py#L101-L106


The `receive` coroutine finished until a `EofStream` error from the TCP Stack.


## What did this PR do 

Add a simple flag(`asyncio.Event`) `_is_heartbeat_failed` in `ClientWebSocketResponse`. And when call `ClientWebSocketResponse.receive`, it both await `self._reader.read()` and this flag by `asyntio.wait` . So if the heartbeat is failed, the `ClientWebSocketResponse.receive` will be awake.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

Fix https://github.com/aio-libs/aiohttp/issues/2309

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
