### PR TITLE
Add --aiohttp-skip-watcher flag for tests which don't create subprocess

### DIFF
--- a/CHANGES/5865.feature
+++ b/CHANGES/5865.feature
@@ -1,0 +1,1 @@
+Add --aiohttp-skip-watcher flag for tests which don't create subprocess

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -163,9 +163,9 @@ def _runtime_warning_context():  # type: ignore[no-untyped-def]
 
 
 @contextlib.contextmanager
-def _passthrough_loop_context(
+def _passthrough_loop_context(  # type: ignore[no-untyped-def]
     loop, fast=False, skip_watcher=False
-):  # type: ignore[no-untyped-def]
+):
     """
     setups and tears down a loop unless one is passed in via the loop
     argument when it's passed straight through.

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -49,7 +49,7 @@ def pytest_addoption(parser):  # type: ignore[no-untyped-def]
         "--aiohttp-skip-watcher",
         action="store_true",
         default=False,
-        help="skip adding child process watcher when not calling asyncio.create_subprocess_*",
+        help="skip adding child process watcher when not using asyncio subprocess",
     )
     parser.addoption(
         "--aiohttp-enable-loop-debug",
@@ -163,7 +163,9 @@ def _runtime_warning_context():  # type: ignore[no-untyped-def]
 
 
 @contextlib.contextmanager
-def _passthrough_loop_context(loop, fast=False, skip_watcher=False):  # type: ignore[no-untyped-def]
+def _passthrough_loop_context(
+    loop, fast=False, skip_watcher=False
+):  # type: ignore[no-untyped-def]
     """
     setups and tears down a loop unless one is passed in via the loop
     argument when it's passed straight through.

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -12,6 +12,7 @@ from aiohttp.test_utils import AioHTTPTestCase
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="the test is not valid for Windows"
 )
+@pytest.mark.use_aio_subprocess
 async def test_subprocess_co(loop: Any) -> None:
     assert threading.current_thread() is threading.main_thread()
     proc = await asyncio.create_subprocess_shell(

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -54,8 +54,8 @@ def _create_example_app():
 
 # these exist to test the pytest scenario
 @pytest.fixture
-def loop() -> None:
-    with loop_context() as loop:
+def loop(skip_watcher) -> None:
+    with loop_context(skip_watcher=skip_watcher) as loop:
         yield loop
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Currently, the child process watcher is added to event loop in unit tests regardless of whether the tests actually call `asyncio.create_subprocess_*`. This is not always a good idea because 

1. The `MultiLoopChildWatcher` implementations in cpython is still flakey: https://bugs.python.org/issue38323
2. The stable ones either incur performance costs, ie. `ThreadedChildWatcher`, or only works when ran on main thread, ie. `SafeChildWatcher`.
3. Windows platform does not support signals so the child watcher has to be conditionally added anyway.

This PR adds `--aiohttp-skip-watcher` flag to pytest plugin so that loops without child process watcher can be created on demand. It follows the zero-overhead principle of "you don't pay for what you don't use".

In addition, it also allows users to safely run tests using `pytest-xdist` by marking those which use `asyncio.create_subprocess_*` as skipped.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No breaking chagnes as child watchers are added by default for backwards compatibility.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/aio-libs/aiohttp/pull/5852

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
