### PR TITLE
[PR #6002/d66e07c6 backport][3.8] Add xfailing integration tests against ``proxy.py``

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,8 @@ jobs:
         path: ${{ steps.pip-cache.outputs.dir }}
         restore-keys: |
             pip-ci-${{ runner.os }}-${{ matrix.pyver }}-${{ matrix.no-extensions }}-
+    - name: Upgrade wheel  # Needed for proxy.py install not to explode
+      run: pip install -U wheel
     - name: Cythonize
       if: ${{ matrix.no-extensions == '' }}
       run: |

--- a/CHANGES/6002.misc
+++ b/CHANGES/6002.misc
@@ -1,0 +1,2 @@
+Implemented end-to-end testing of sending HTTP and HTTPS requests
+via ``proxy.py``.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -164,6 +164,8 @@ pluggy==0.13.1
     #   pytest
 pre-commit==2.13.0
     # via -r requirements/lint.txt
+proxy.py==2.3.1
+    # via -r requirements/test.txt
 py==1.10.0
     # via
     #   -r requirements/lint.txt
@@ -277,6 +279,7 @@ typing-extensions==3.7.4.3
     #   -r requirements/lint.txt
     #   async-timeout
     #   mypy
+    #   proxy.py
 uritemplate==3.0.1
     # via gidgethub
 urllib3==1.26.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,6 +5,7 @@ cryptography==3.3.1; platform_machine!="i686" and python_version<"3.9" # no 32-b
 freezegun==1.1.0
 mypy==0.910; implementation_name=="cpython"
 mypy-extensions==0.4.3; implementation_name=="cpython"
+proxy.py==2.3.1
 pytest==6.1.2
 pytest-cov==2.12.1
 pytest-mock==3.6.1


### PR DESCRIPTION
**This is a backport of PR #6002 as merged into master (d66e07c652322d280740106ebb9946a3dd7daf5b).**

This patch adds full end-to-end tests for sending requests to HTTP and
HTTPS endpoints through an HTTPS proxy. The first case is currently
supported and the second one is not. This is why the latter test is
marked as expected to fail. The support for TLS-in-TLS in the upstream
stdlib asyncio is currently disabled but is available in Python 3.9
via monkey-patching which is demonstrated in the added tests.

Refs:
* https://bugs.python.org/issue37179
* https://github.com/python/cpython/pull/28073
* https://github.com/aio-libs/aiohttp/pull/5992

Co-authored-by: Sviatoslav Sydorenko <webknjaz@redhat.com>

PR #6002

(cherry picked from commit d66e07c652322d280740106ebb9946a3dd7daf5b)