### PR TITLE
[PR #5992/c29e5fb5 backport][3.8] Add secure proxy support in the client

### DIFF
--- a/CHANGES/5992.feature
+++ b/CHANGES/5992.feature
@@ -1,0 +1,3 @@
+Added support for HTTPS proxies to the extent CPython's
+:py:mod:`asyncio` supports it -- by :user:`bmbouter`,
+:user:`jborean93` and :user:`webknjaz`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -55,6 +55,7 @@ Bob Haddleton
 Boris Feld
 Boyi Chen
 Brett Cannon
+Brian Bouterse
 Brian C. Lane
 Brian Muller
 Bruce Merry
@@ -159,6 +160,7 @@ Jonas Obrist
 Jonathan Wright
 Jonny Tan
 Joongi Kim
+Jordan Borean
 Josep Cugat
 Josh Junon
 Joshu Coats

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -547,8 +547,6 @@ class ClientRequest:
         proxy_auth: Optional[BasicAuth],
         proxy_headers: Optional[LooseHeaders],
     ) -> None:
-        if proxy and not proxy.scheme == "http":
-            raise ValueError("Only http proxies are supported")
         if proxy_auth and not isinstance(proxy_auth, helpers.BasicAuth):
             raise ValueError("proxy_auth must be None or BasicAuth() tuple")
         self.proxy = proxy

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -54,6 +54,9 @@ from .typedefs import PathLike, Protocol  # noqa
 
 __all__ = ("BasicAuth", "ChainMapProxy", "ETag")
 
+IS_MACOS = platform.system() == "Darwin"
+IS_WINDOWS = platform.system() == "Windows"
+
 PY_36 = sys.version_info >= (3, 6)
 PY_37 = sys.version_info >= (3, 7)
 PY_38 = sys.version_info >= (3, 8)
@@ -213,9 +216,7 @@ def netrc_from_env() -> Optional[netrc.netrc]:
             )
             return None
 
-        netrc_path = home_dir / (
-            "_netrc" if platform.system() == "Windows" else ".netrc"
-        )
+        netrc_path = home_dir / ("_netrc" if IS_WINDOWS else ".netrc")
 
     try:
         return netrc.netrc(str(netrc_path))

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -526,9 +526,11 @@ DER with e.g::
 Proxy support
 -------------
 
-aiohttp supports plain HTTP proxies and HTTP proxies that can be upgraded to HTTPS
-via the HTTP CONNECT method. aiohttp does not support proxies that must be
-connected to via ``https://``. To connect, use the *proxy* parameter::
+aiohttp supports plain HTTP proxies and HTTP proxies that can be
+upgraded to HTTPS via the HTTP CONNECT method. aiohttp has a limited
+support for proxies that must be connected to via ``https://`` — see
+the info box below for more details.
+To connect, use the *proxy* parameter::
 
    async with aiohttp.ClientSession() as session:
        async with session.get("http://python.org",
@@ -562,6 +564,33 @@ insensitive)::
 
 Proxy credentials are given from ``~/.netrc`` file if present (see
 :class:`aiohttp.ClientSession` for more details).
+
+.. attention::
+
+   CPython has introduced the support for TLS in TLS around Python 3.7.
+   But, as of now (Python 3.10), it's disabled for the transports that
+   :py:mod:`asyncio` uses. If the further release of Python (say v3.11)
+   toggles one attribute, it'll *just work™*.
+
+   aiohttp v3.8 and higher is ready for this to happen and has code in
+   place supports TLS-in-TLS, hence sending HTTPS requests over HTTPS
+   proxy tunnels.
+
+   ⚠️ For as long as your Python runtime doesn't declare the support for
+   TLS-in-TLS, please don't file bugs with aiohttp but rather try to
+   help the CPython upstream enable this feature. Meanwhile, if you
+   *really* need this to work, there's a patch that may help you make
+   it happen, include it into your app's code base:
+   https://github.com/aio-libs/aiohttp/discussions/6044#discussioncomment-1432443.
+
+.. important::
+
+   When supplying a custom :py:class:`ssl.SSLContext` instance, bear in
+   mind that it will be used not only to establish a TLS session with
+   the HTTPS endpoint you're hitting but also to establish a TLS tunnel
+   to the HTTPS proxy. To avoid surprises, make sure to set up the trust
+   chain that would recognize TLS certificates used by both the endpoint
+   and the proxy.
 
 Graceful Shutdown
 -----------------

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -120,11 +120,6 @@ def test_version_err(make_request) -> None:
         make_request("get", "http://python.org/", version="1.c")
 
 
-def test_https_proxy(make_request) -> None:
-    with pytest.raises(ValueError):
-        make_request("get", "http://python.org/", proxy=URL("https://proxy.org"))
-
-
 def test_keep_alive(make_request) -> None:
     req = make_request("get", "http://python.org/", version=(0, 9))
     assert not req.keep_alive()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -221,6 +221,7 @@ class TestProxy(unittest.TestCase):
 
         tr, proto = mock.Mock(), mock.Mock()
         self.loop.create_connection = make_mocked_coro((tr, proto))
+        self.loop.start_tls = make_mocked_coro(mock.Mock())
 
         req = ClientRequest(
             "GET",
@@ -235,8 +236,6 @@ class TestProxy(unittest.TestCase):
         self.assertEqual(req.url.path, "/")
         self.assertEqual(proxy_req.method, "CONNECT")
         self.assertEqual(proxy_req.url, URL("https://www.python.org"))
-        tr.close.assert_called_once_with()
-        tr.get_extra_info.assert_called_with("socket", default=None)
 
         self.loop.run_until_complete(proxy_req.close())
         proxy_resp.close()
@@ -280,22 +279,10 @@ class TestProxy(unittest.TestCase):
             ]
         )
 
-        seq = 0
-
-        async def create_connection(*args, **kwargs):
-            nonlocal seq
-            seq += 1
-
-            # connection to http://proxy.example.com
-            if seq == 1:
-                return mock.Mock(), mock.Mock()
-            # connection to https://www.python.org
-            elif seq == 2:
-                raise ssl.CertificateError
-            else:
-                assert False
-
-        self.loop.create_connection = create_connection
+        # Called on connection to http://proxy.example.com
+        self.loop.create_connection = make_mocked_coro((mock.Mock(), mock.Mock()))
+        # Called on connection to https://www.python.org
+        self.loop.start_tls = make_mocked_coro(raise_exception=ssl.CertificateError)
 
         req = ClientRequest(
             "GET",
@@ -346,22 +333,12 @@ class TestProxy(unittest.TestCase):
             ]
         )
 
-        seq = 0
-
-        async def create_connection(*args, **kwargs):
-            nonlocal seq
-            seq += 1
-
-            # connection to http://proxy.example.com
-            if seq == 1:
-                return mock.Mock(), mock.Mock()
-            # connection to https://www.python.org
-            elif seq == 2:
-                raise ssl.SSLError
-            else:
-                assert False
-
-        self.loop.create_connection = create_connection
+        # Called on connection to http://proxy.example.com
+        self.loop.create_connection = make_mocked_coro(
+            (mock.Mock(), mock.Mock()),
+        )
+        # Called on connection to https://www.python.org
+        self.loop.start_tls = make_mocked_coro(raise_exception=ssl.SSLError)
 
         req = ClientRequest(
             "GET",
@@ -373,65 +350,6 @@ class TestProxy(unittest.TestCase):
             self.loop.run_until_complete(
                 connector._create_connection(req, None, aiohttp.ClientTimeout())
             )
-
-    @mock.patch("aiohttp.connector.ClientRequest")
-    def test_https_connect_runtime_error(self, ClientRequestMock) -> None:
-        proxy_req = ClientRequest(
-            "GET", URL("http://proxy.example.com"), loop=self.loop
-        )
-        ClientRequestMock.return_value = proxy_req
-
-        proxy_resp = ClientResponse(
-            "get",
-            URL("http://proxy.example.com"),
-            request_info=mock.Mock(),
-            writer=mock.Mock(),
-            continue100=None,
-            timer=TimerNoop(),
-            traces=[],
-            loop=self.loop,
-            session=mock.Mock(),
-        )
-        proxy_req.send = make_mocked_coro(proxy_resp)
-        proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
-
-        async def make_conn():
-            return aiohttp.TCPConnector()
-
-        connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
-                {
-                    "hostname": "hostname",
-                    "host": "127.0.0.1",
-                    "port": 80,
-                    "family": socket.AF_INET,
-                    "proto": 0,
-                    "flags": 0,
-                }
-            ]
-        )
-
-        tr, proto = mock.Mock(), mock.Mock()
-        tr.get_extra_info.return_value = None
-        self.loop.create_connection = make_mocked_coro((tr, proto))
-
-        req = ClientRequest(
-            "GET",
-            URL("https://www.python.org"),
-            proxy=URL("http://proxy.example.com"),
-            loop=self.loop,
-        )
-        with self.assertRaisesRegex(
-            RuntimeError, "Transport does not expose socket instance"
-        ):
-            self.loop.run_until_complete(
-                connector._create_connection(req, None, aiohttp.ClientTimeout())
-            )
-
-        self.loop.run_until_complete(proxy_req.close())
-        proxy_resp.close()
-        self.loop.run_until_complete(req.close())
 
     @mock.patch("aiohttp.connector.ClientRequest")
     def test_https_connect_http_proxy_error(self, ClientRequestMock) -> None:
@@ -643,6 +561,7 @@ class TestProxy(unittest.TestCase):
 
         tr, proto = mock.Mock(), mock.Mock()
         self.loop.create_connection = make_mocked_coro((tr, proto))
+        self.loop.start_tls = make_mocked_coro(mock.Mock())
 
         req = ClientRequest(
             "GET",
@@ -654,18 +573,17 @@ class TestProxy(unittest.TestCase):
             connector._create_connection(req, None, aiohttp.ClientTimeout())
         )
 
-        self.loop.create_connection.assert_called_with(
+        self.loop.start_tls.assert_called_with(
             mock.ANY,
-            ssl=connector._make_ssl_context(True),
-            sock=mock.ANY,
+            mock.ANY,
+            connector._make_ssl_context(True),
             server_hostname="www.python.org",
+            ssl_handshake_timeout=mock.ANY,
         )
 
         self.assertEqual(req.url.path, "/")
         self.assertEqual(proxy_req.method, "CONNECT")
         self.assertEqual(proxy_req.url, URL("https://www.python.org"))
-        tr.close.assert_called_once_with()
-        tr.get_extra_info.assert_called_with("socket", default=None)
 
         self.loop.run_until_complete(proxy_req.close())
         proxy_resp.close()
@@ -714,6 +632,7 @@ class TestProxy(unittest.TestCase):
 
         tr, proto = mock.Mock(), mock.Mock()
         self.loop.create_connection = make_mocked_coro((tr, proto))
+        self.loop.start_tls = make_mocked_coro(mock.Mock())
 
         self.assertIn("AUTHORIZATION", proxy_req.headers)
         self.assertNotIn("PROXY-AUTHORIZATION", proxy_req.headers)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -5,11 +5,12 @@ import ssl
 import unittest
 from unittest import mock
 
+import pytest
 from yarl import URL
 
 import aiohttp
 from aiohttp.client_reqrep import ClientRequest, ClientResponse
-from aiohttp.helpers import TimerNoop
+from aiohttp.helpers import PY_37, TimerNoop
 from aiohttp.test_utils import make_mocked_coro
 
 
@@ -350,6 +351,70 @@ class TestProxy(unittest.TestCase):
             self.loop.run_until_complete(
                 connector._create_connection(req, None, aiohttp.ClientTimeout())
             )
+
+    @pytest.mark.skipif(
+        PY_37,
+        reason="The tested code path is only reachable below Python 3.7 because those "
+        "versions don't yet have `asyncio.loop.start_tls()` implemeneted",
+    )
+    @mock.patch("aiohttp.connector.ClientRequest")
+    def test_https_connect_runtime_error(self, ClientRequestMock) -> None:
+        proxy_req = ClientRequest(
+            "GET", URL("http://proxy.example.com"), loop=self.loop
+        )
+        ClientRequestMock.return_value = proxy_req
+
+        proxy_resp = ClientResponse(
+            "get",
+            URL("http://proxy.example.com"),
+            request_info=mock.Mock(),
+            writer=mock.Mock(),
+            continue100=None,
+            timer=TimerNoop(),
+            traces=[],
+            loop=self.loop,
+            session=mock.Mock(),
+        )
+        proxy_req.send = make_mocked_coro(proxy_resp)
+        proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
+
+        async def make_conn():
+            return aiohttp.TCPConnector()
+
+        connector = self.loop.run_until_complete(make_conn())
+        connector._resolve_host = make_mocked_coro(
+            [
+                {
+                    "hostname": "hostname",
+                    "host": "127.0.0.1",
+                    "port": 80,
+                    "family": socket.AF_INET,
+                    "proto": 0,
+                    "flags": 0,
+                }
+            ]
+        )
+
+        tr, proto = mock.Mock(), mock.Mock()
+        tr.get_extra_info.return_value = None
+        self.loop.create_connection = make_mocked_coro((tr, proto))
+
+        req = ClientRequest(
+            "GET",
+            URL("https://www.python.org"),
+            proxy=URL("http://proxy.example.com"),
+            loop=self.loop,
+        )
+        with self.assertRaisesRegex(
+            RuntimeError, "Transport does not expose socket instance"
+        ):
+            self.loop.run_until_complete(
+                connector._create_connection(req, None, aiohttp.ClientTimeout())
+            )
+
+        self.loop.run_until_complete(proxy_req.close())
+        proxy_resp.close()
+        self.loop.run_until_complete(req.close())
 
     @mock.patch("aiohttp.connector.ClientRequest")
     def test_https_connect_http_proxy_error(self, ClientRequestMock) -> None:

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -162,14 +162,14 @@ async def test_https_proxy_unsupported_tls_in_tls(
         r"An HTTPS request is being sent through an HTTPS proxy\. "
         "This support for TLS in TLS is known to be disabled "
         r"in the stdlib asyncio\. This is why you'll probably see "
-        r"an error in the log below.\n\n"
+        r"an error in the log below\.\n\n"
         "It is possible to enable it via monkeypatching under "
         r"Python 3\.7 or higher\. For more details, see:\n"
-        r"* https://bugs\.python\.org/issue37179\n"
-        r"* https://github\.com/python/cpython/pull/28073\n\n"
+        r"\* https://bugs\.python\.org/issue37179\n"
+        r"\* https://github\.com/python/cpython/pull/28073\n\n"
         r"You can temporarily patch this as follows:\n"
-        r"* https://docs\.aiohttp\.org/en/stable/client_advanced\.html#proxy-support\n",
-        r"* https://github\.com/aio-libs/aiohttp/discussions/6044\n$",
+        r"\* https://docs\.aiohttp\.org/en/stable/client_advanced\.html#proxy-support\n"
+        r"\* https://github\.com/aio-libs/aiohttp/discussions/6044\n$"
     )
     type_err = (
         r"transport <asyncio\.sslproto\._SSLProtocolTransport object at "
@@ -184,13 +184,10 @@ async def test_https_proxy_unsupported_tls_in_tls(
         r"$"
     )
 
-    with pytest.raises(
+    with pytest.warns(RuntimeWarning, match=expected_warning_text,), pytest.raises(
         ClientConnectionError,
         match=expected_exception_reason,
-    ) as conn_err, pytest.warns(
-        RuntimeWarning,
-        match=expected_warning_text,
-    ):
+    ) as conn_err:
         await sess.get(url, proxy=secure_proxy_url, ssl=client_ssl_ctx)
 
     assert type(conn_err.value.__cause__) == TypeError

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -12,6 +12,7 @@ from yarl import URL
 import aiohttp
 from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionError
+from aiohttp.helpers import IS_MACOS, IS_WINDOWS, PY_37
 
 ASYNCIO_SUPPORTS_TLS_IN_TLS = hasattr(
     asyncio.sslproto._SSLProtocolTransport,
@@ -26,7 +27,6 @@ def secure_proxy_url(monkeypatch, tls_certificate_pem_path):
     This fixture also spawns that instance and tears it down after the test.
     """
     proxypy_args = [
-        "--threadless",  # use asyncio
         "--num-workers",
         "1",  # the tests only send one query anyway
         "--hostname",
@@ -38,6 +38,8 @@ def secure_proxy_url(monkeypatch, tls_certificate_pem_path):
         "--key-file",
         tls_certificate_pem_path,  # contains both key and cert
     ]
+    if not IS_MACOS and not IS_WINDOWS:
+        proxypy_args.append("--threadless")  # use asyncio
 
     class PatchedAccetorPool(proxy.core.acceptor.AcceptorPool):
         def listen(self):
@@ -111,7 +113,20 @@ def _pretend_asyncio_supports_tls_in_tls(
     )
 
 
-@pytest.mark.parametrize("web_server_endpoint_type", ("http", "https"))
+@pytest.mark.parametrize(
+    "web_server_endpoint_type",
+    (
+        "http",
+        pytest.param(
+            "https",
+            marks=pytest.mark.xfail(
+                not PY_37,
+                raises=RuntimeError,
+                reason="`asyncio.loop.start_tls()` is only implemeneted in Python 3.7",
+            ),
+        ),
+    ),
+)
 @pytest.mark.usefixtures("_pretend_asyncio_supports_tls_in_tls", "loop")
 async def test_secure_https_proxy_absolute_path(
     client_ssl_ctx,
@@ -137,6 +152,11 @@ async def test_secure_https_proxy_absolute_path(
     await conn.close()
 
 
+@pytest.mark.xfail(
+    not PY_37,
+    raises=RuntimeError,
+    reason="`asyncio.loop.start_tls()` is only implemeneted in Python 3.7",
+)
 @pytest.mark.parametrize("web_server_endpoint_type", ("https",))
 @pytest.mark.usefixtures("loop")
 async def test_https_proxy_unsupported_tls_in_tls(
@@ -195,6 +215,49 @@ async def test_https_proxy_unsupported_tls_in_tls(
 
     await sess.close()
     await conn.close()
+
+
+@pytest.mark.skipif(
+    PY_37,
+    reason="This test checks an error we emit below Python 3.7",
+)
+@pytest.mark.usefixtures("loop")
+async def test_https_proxy_missing_start_tls() -> None:
+    """Ensure error is raised for TLS-in-TLS w/ no ``start_tls()``."""
+    conn = aiohttp.TCPConnector()
+    sess = aiohttp.ClientSession(connector=conn)
+
+    expected_exception_reason = (
+        r"^"
+        r"An HTTPS request is being sent through an HTTPS proxy\. "
+        "This needs support for TLS in TLS but it is not implemented "
+        r"in your runtime for the stdlib asyncio\.\n\n"
+        r"Please upgrade to Python 3\.7 or higher\. For more details, "
+        r"please see:\n"
+        r"\* https://bugs\.python\.org/issue37179\n"
+        r"\* https://github\.com/python/cpython/pull/28073\n"
+        r"\* https://docs\.aiohttp\.org/en/stable/client_advanced\.html#proxy-support\n"
+        r"\* https://github\.com/aio-libs/aiohttp/discussions/6044\n"
+        r"$"
+    )
+
+    with pytest.raises(
+        RuntimeError,
+        match=expected_exception_reason,
+    ) as runtime_err:
+        await sess.get("https://python.org", proxy="https://proxy")
+
+    await sess.close()
+    await conn.close()
+
+    assert type(runtime_err.value.__cause__) is AttributeError
+
+    selector_event_loop_type = "Windows" if IS_WINDOWS else "Unix"
+    attr_err = (
+        f"^'_{selector_event_loop_type}SelectorEventLoop' object "
+        "has no attribute 'start_tls'$"
+    )
+    assert match_regex(attr_err, str(runtime_err.value.__cause__))
 
 
 @pytest.fixture

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -1,7 +1,9 @@
 import asyncio
 import os
 import pathlib
+from re import match as match_regex
 from unittest import mock
+from uuid import uuid4
 
 import proxy
 import pytest
@@ -9,6 +11,7 @@ from yarl import URL
 
 import aiohttp
 from aiohttp import web
+from aiohttp.client_exceptions import ClientConnectionError
 
 ASYNCIO_SUPPORTS_TLS_IN_TLS = hasattr(
     asyncio.sslproto._SSLProtocolTransport,
@@ -53,7 +56,7 @@ def secure_proxy_url(monkeypatch, tls_certificate_pem_path):
 
 @pytest.fixture
 def web_server_endpoint_payload():
-    return "Test message"
+    return str(uuid4())
 
 
 @pytest.fixture(params=("http", "https"))
@@ -108,10 +111,6 @@ def _pretend_asyncio_supports_tls_in_tls(
     )
 
 
-@pytest.mark.xfail(
-    reason="https://github.com/aio-libs/aiohttp/pull/5992",
-    raises=ValueError,
-)
 @pytest.mark.parametrize("web_server_endpoint_type", ("http", "https"))
 @pytest.mark.usefixtures("_pretend_asyncio_supports_tls_in_tls", "loop")
 async def test_secure_https_proxy_absolute_path(
@@ -120,7 +119,7 @@ async def test_secure_https_proxy_absolute_path(
     web_server_endpoint_url,
     web_server_endpoint_payload,
 ) -> None:
-    """Test urls can be requested through a secure proxy."""
+    """Ensure HTTP(S) sites are accessible through a secure proxy."""
     conn = aiohttp.TCPConnector()
     sess = aiohttp.ClientSession(connector=conn)
 
@@ -134,6 +133,69 @@ async def test_secure_https_proxy_absolute_path(
     assert await response.text() == web_server_endpoint_payload
 
     response.close()
+    await sess.close()
+    await conn.close()
+
+
+@pytest.mark.parametrize("web_server_endpoint_type", ("https",))
+@pytest.mark.usefixtures("loop")
+async def test_https_proxy_unsupported_tls_in_tls(
+    client_ssl_ctx,
+    secure_proxy_url,
+    web_server_endpoint_type,
+) -> None:
+    """Ensure connecting to TLS endpoints w/ HTTPS proxy needs patching.
+
+    This also checks that a helpful warning on how to patch the env
+    is displayed.
+    """
+    url = URL.build(scheme=web_server_endpoint_type, host="python.org")
+
+    escaped_host_port = ":".join((url.host.replace(".", r"\."), str(url.port)))
+    escaped_proxy_url = str(secure_proxy_url).replace(".", r"\.")
+
+    conn = aiohttp.TCPConnector()
+    sess = aiohttp.ClientSession(connector=conn)
+
+    expected_warning_text = (
+        r"^"
+        r"An HTTPS request is being sent through an HTTPS proxy\. "
+        "This support for TLS in TLS is known to be disabled "
+        r"in the stdlib asyncio\. This is why you'll probably see "
+        r"an error in the log below.\n\n"
+        "It is possible to enable it via monkeypatching under "
+        r"Python 3\.7 or higher\. For more details, see:\n"
+        r"* https://bugs\.python\.org/issue37179\n"
+        r"* https://github\.com/python/cpython/pull/28073\n\n"
+        r"You can temporarily patch this as follows:\n"
+        r"* https://docs\.aiohttp\.org/en/stable/client_advanced\.html#proxy-support\n",
+        r"* https://github\.com/aio-libs/aiohttp/discussions/6044\n$",
+    )
+    type_err = (
+        r"transport <asyncio\.sslproto\._SSLProtocolTransport object at "
+        r"0x[\d\w]+> is not supported by start_tls\(\)"
+    )
+    expected_exception_reason = (
+        r"^"
+        "Cannot initialize a TLS-in-TLS connection to host "
+        f"{escaped_host_port!s} through an underlying connection "
+        f"to an HTTPS proxy {escaped_proxy_url!s} ssl:{client_ssl_ctx!s} "
+        f"[{type_err!s}]"
+        r"$"
+    )
+
+    with pytest.raises(
+        ClientConnectionError,
+        match=expected_exception_reason,
+    ) as conn_err, pytest.warns(
+        RuntimeWarning,
+        match=expected_warning_text,
+    ):
+        await sess.get(url, proxy=secure_proxy_url, ssl=client_ssl_ctx)
+
+    assert type(conn_err.value.__cause__) == TypeError
+    assert match_regex(f"^{type_err!s}$", str(conn_err.value.__cause__))
+
     await sess.close()
     await conn.close()
 


### PR DESCRIPTION
**This is a backport of PR #5992 as merged into master (c29e5fb58efb65c6198ea75b95805ab972e98adc).** It also includes https://github.com/aio-libs/aiohttp/pull/6072.

Note: `--threadless` in `proxy.py` is disabled under Windows and macOS because of https://github.com/abhinavsingh/proxy.py/issues/492.

## What do these changes do?

This patch opens up the code path and adds the implementation that allows end-users to start sending HTTPS requests through HTTPS proxies.

The support for TLS-in-TLS (needed for this to work) in the stdlib is kinda available since Python 3.7 but is disabled for `asyncio` with an attribute/flag/toggle. When the upstream CPython enables it finally, aiohttp v3.8+ will be able to work with it out of the box.

Currently the tests monkey-patch `asyncio` in order to verify that this works. The users who are willing to do the same, will be able to take advantage of it right now. Eventually (hopefully starting Python 3.11), the need for monkey-patching should be eliminated.

Refs:
* https://bugs.python.org/issue37179
* https://github.com/python/cpython/pull/28073
* https://docs.aiohttp.org/en/stable/client_advanced.html#proxy-support
* https://github.com/aio-libs/aiohttp/discussions/6044

<details>
<summary>
  Original details
</summary>

I test with this script:

```python
import aiohttp
import asyncio


url = "http://example.com"
url = "https://example.com"

proxy_url = "http://localhost:3128/"
proxy_url = "https://localhost:3130/"

async def main():
    import pydevd_pycharm
    # pydevd_pycharm.settrace('localhost', port=29437, stdoutToServer=True, stderrToServer=True, suspend=False)
    async with aiohttp.ClientSession(headers={"Cache-Control": "no-cache"}) as session:
        async with session.get(url, proxy=proxy_url, verify_ssl=False) as resp:
            print(resp.status)
            print(resp)
            print(await resp.text())


loop = asyncio.get_event_loop()
loop.run_until_complete(main())
```

And I get

```python-traceback
Traceback (most recent call last):
  File "/home/vagrant/devel/aiohttp_proxy_test.py", line 22, in <module>
    loop.run_until_complete(main())
  File "/usr/lib64/python3.9/asyncio/base_events.py", line 642, in run_until_complete
    return future.result()
  File "/home/vagrant/devel/aiohttp_proxy_test.py", line 15, in main
    async with session.get(url, proxy=proxy_url, verify_ssl=False) as resp:
  File "/home/vagrant/devel/aiohttp/aiohttp/client.py", line 1117, in __aenter__
    self._resp = await self._coro
  File "/home/vagrant/devel/aiohttp/aiohttp/client.py", line 520, in _request
    conn = await self._connector.connect(
  File "/home/vagrant/devel/aiohttp/aiohttp/connector.py", line 535, in connect
    proto = await self._create_connection(req, traces, timeout)
  File "/home/vagrant/devel/aiohttp/aiohttp/connector.py", line 890, in _create_connection
    _, proto = await self._create_proxy_connection(req, traces, timeout)
  File "/home/vagrant/devel/aiohttp/aiohttp/connector.py", line 1139, in _create_proxy_connection
    transport, proto = await self._wrap_create_connection(
  File "/home/vagrant/devel/aiohttp/aiohttp/connector.py", line 969, in _wrap_create_connection
    return await self._loop.create_connection(*args, **kwargs)  # type: ignore  # noqa
  File "/usr/lib64/python3.9/asyncio/base_events.py", line 1081, in create_connection
    transport, protocol = await self._create_connection_transport(
  File "/usr/lib64/python3.9/asyncio/base_events.py", line 1111, in _create_connection_transport
    await waiter
ConnectionResetError
```

The squid proxy does show `1631129861.057     45 ::1 TCP_TUNNEL/200 39 CONNECT example.com:443 - HIER_DIRECT/93.184.216.34 -` and I can see the 200 OK from the direct connection.

What fails is when taking the TCP socket from the direct connection and TLS wrapping it I get a `ConnectionResetError`.

</details>


## Are there changes in behavior for the user?

They get the ability to send out HTTPS queries through HTTPS proxies if they monkey-patch the stdlib `asyncio`.


## Related issue number

Resolves #3816
Resolves #4268


## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."