### PR TITLE
Bump the `proxy.py` test dep to v3.4.0

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -165,7 +165,7 @@ pluggy==0.13.1
     #   pytest
 pre-commit==2.15.0
     # via -r requirements/lint.txt
-proxy.py==2.3.1
+proxy.py==3.4.0
     # via -r requirements/test.txt
 py==1.10.0
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,7 @@ cryptography==3.3.1; platform_machine!="i686" and python_version<"3.9" # no 32-b
 freezegun==1.1.0
 mypy==0.910; implementation_name=="cpython"
 mypy-extensions==0.4.3; implementation_name=="cpython"
-proxy.py==2.3.1
+proxy.py==3.4.0
 pytest==6.2.5
 pytest-cov==3.0.0
 pytest-mock==3.6.1

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -35,7 +35,7 @@ ASYNCIO_SUPPORTS_TLS_IN_TLS = hasattr(
 
 
 @pytest.fixture
-def secure_proxy_url(monkeypatch, tls_certificate_pem_path):
+def secure_proxy_url(tls_certificate_pem_path):
     """Return the URL of an instance of a running secure proxy.
 
     This fixture also spawns that instance and tears it down after the test.
@@ -54,18 +54,11 @@ def secure_proxy_url(monkeypatch, tls_certificate_pem_path):
         tls_certificate_pem_path,  # contains both key and cert
     ]
 
-    class PatchedAccetorPool(proxy.core.acceptor.AcceptorPool):
-        def listen(self):
-            super().listen()
-            self.socket_host, self.socket_port = self.socket.getsockname()[:2]
-
-    monkeypatch.setattr(proxy.proxy, "AcceptorPool", PatchedAccetorPool)
-
     with proxy.Proxy(input_args=proxypy_args) as proxy_instance:
         yield URL.build(
             scheme="https",
-            host=proxy_instance.acceptors.socket_host,
-            port=proxy_instance.acceptors.socket_port,
+            host=proxy_instance.pool.flags.hostname,
+            port=proxy_instance.pool.flags.port,
         )
 
 


### PR DESCRIPTION
## What do these changes do?

This is the version that started supporting ephemeral port as a
first-class citizen so this patch also uses that.

(Note that this is currently a draft because the recent `proxy.py` has a dependency conflict with us — they put a precise pin on the `typing-extensions` requirement; to be bumped once the upstream issue is solved)

## Are there changes in behavior for the user?

No.

## Related issue number

https://github.com/abhinavsingh/proxy.py/issues/617

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
