### PR TITLE
Add error-handling to web-advanced docs

### DIFF
--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -397,6 +397,20 @@ An example of context vars usage::
 
 .. versionadded:: 3.5
 
+.. _aiohttp-web-error-handling:
+
+Error Handling
+--------------
+
+*aiohttp* deliberately doesn't have a built-in error handling
+mechanism.  While the framework does raise :exc:`HTTPException` exceptions,
+it leaves it up to you to handle those errors per your specific requirements.
+
+You can leverage a third-party middleware library such as
+`aiohttp-catcher <https://github.com/yuvalherziger/aiohttp-catcher>`_. to
+handle errors in a centralized way, or alternatively build your own error-handling
+middleware if **aiohttp-catcher** doesn't satisfy your requirements (see the
+**Examples** section in :ref:`aiohttp-web-middlewares`).
 
 .. _aiohttp-web-middlewares:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Following [this gitter discussion](https://gitter.im/aio-libs/Lobby?at=61dd3a6e742c3d4b218fe89c), this PR:

* Adds a new section to the web-advanced documentation page for error handling
* References aiohttp-catcher as a possible third-party candidate library for error handling, as well as a reference to middleware example.

## Are there changes in behavior for the user?

N/A

## Related issue number

N/A

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
