### PR TITLE
Minor fix

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -343,11 +343,8 @@ class ClientRequest:
                     self.headers.add(key, value)
 
     def update_auto_headers(self, skip_auto_headers: Iterable[str]) -> None:
-        self.skip_auto_headers = CIMultiDict(
-            (hdr, None) for hdr in sorted(skip_auto_headers)
-        )
-        used_headers = self.headers.copy()
-        used_headers.extend(self.skip_auto_headers)  # type: ignore[arg-type]
+        self.skip_auto_headers = set(skip_auto_headers)
+        used_headers = self.skip_auto_headers | self.headers.keys()
 
         for hdr, val in self.DEFAULT_HEADERS.items():
             if hdr not in used_headers:


### PR DESCRIPTION
There is a type error here, but I see no reason to be using a dict here, all references to it only use an `in` test. The same name attribute in client.py is also a set().