### PR TITLE
Add is_multipart parameter to FormData

### DIFF
--- a/CHANGES/6587.feature
+++ b/CHANGES/6587.feature
@@ -1,0 +1,1 @@
+Add is_multipart parameter to FormData

--- a/aiohttp/formdata.py
+++ b/aiohttp/formdata.py
@@ -23,11 +23,12 @@ class FormData:
         quote_fields: bool = True,
         charset: Optional[str] = None,
         boundary: Optional[str] = None,
+        is_multipart: bool = False,
     ) -> None:
         self._boundary = boundary
         self._writer = multipart.MultipartWriter("form-data", boundary=self._boundary)
         self._fields: List[Any] = []
-        self._is_multipart = False
+        self._is_multipart = is_multipart
         self._is_processed = False
         self._quote_fields = quote_fields
         self._charset = charset

--- a/tests/test_formdata.py
+++ b/tests/test_formdata.py
@@ -31,6 +31,22 @@ def test_formdata_multipart(buf: Any, writer: Any) -> None:
     assert form.is_multipart
 
 
+def test_form_data_is_multipart_param(buf: Any, writer: Any) -> None:
+    form = FormData(is_multipart=True)
+    assert form.is_multipart
+
+    form.add_field("test", "test")
+    assert form.is_multipart
+
+
+def test_formdata_multipart(buf: Any, writer: Any) -> None:
+    form = FormData(is_multipart=False)
+    assert not form.is_multipart
+
+    form.add_field("test", b"test", filename="test.txt")
+    assert form.is_multipart  # Adding binary data convert FormData to multpart
+
+
 def test_invalid_formdata_payload() -> None:
     form = FormData()
     form.add_field("test", object(), filename="test.txt")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Allows to set `is_multipart` parameter to `FormData`. It can be helpful in situation when you have only values as a string and whant to send it as multipart/form-data

## Related issue number

Fixes #6587

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
