### PR TITLE
Fix invalid utf8 decoding error handler in HeadersParser

### DIFF
--- a/CHANGES/6614.bugfix
+++ b/CHANGES/6614.bugfix
@@ -1,0 +1,1 @@
+Fix issue with using invalid error handler for decoding utf8 in :py:class:`~aiohttp.http_parser.HeadersParser`

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -240,6 +240,7 @@ Nándor Mátravölgyi
 Oisin Aylward
 Olaf Conradi
 Oleg Höfling
+Otto Winter
 Pahaz Blinov
 Panagiotis Kolokotronis
 Pankaj Pandey

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -156,7 +156,7 @@ class HeadersParser:
             if len(bname) > self.max_field_size:
                 raise LineTooLong(
                     "request header name {}".format(
-                        bname.decode("utf8", "xmlcharrefreplace")
+                        bname.decode("utf8", "surrogateescape")
                     ),
                     str(self.max_field_size),
                     str(len(bname)),
@@ -178,7 +178,7 @@ class HeadersParser:
                     if header_length > self.max_field_size:
                         raise LineTooLong(
                             "request header field {}".format(
-                                bname.decode("utf8", "xmlcharrefreplace")
+                                bname.decode("utf8", "surrogateescape")
                             ),
                             str(self.max_field_size),
                             str(header_length),
@@ -199,7 +199,7 @@ class HeadersParser:
                 if header_length > self.max_field_size:
                     raise LineTooLong(
                         "request header field {}".format(
-                            bname.decode("utf8", "xmlcharrefreplace")
+                            bname.decode("utf8", "surrogateescape")
                         ),
                         str(self.max_field_size),
                         str(header_length),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The [`xmlcharrefreplace`](https://docs.python.org/3/library/codecs.html#error-handlers) error handler is invalid for `decode` operations (only `encode`):

```
In [1]: b = b"\xc3\x28"  # invalid utf8

In [2]: b.decode("utf8", "xmlcharrefreplace")
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-6-0fb1f7b80b46> in <module>
----> 1 b.decode("utf8", "xmlcharrefreplace")

TypeError: don't know how to handle UnicodeDecodeError in error callback

In [3]: b.decode("utf8", "surrogateescape")
Out[3]: '\udcc3('
```

When these `LineTooLong` exceptions are triggered with non-utf8 input, a `TypeError` exception was raised

_This was found by [`atheris`](https://github.com/google/atheris)_

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
