### PR TITLE
fix: CookieJar quote_cookie / unsafe args lost when input cookies to _request

### DIFF
--- a/CHANGES/6682.bugfix
+++ b/CHANGES/6682.bugfix
@@ -1,0 +1,1 @@
+CookieJar quote_cookie / unsafe args lost when input cookies to _request

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -119,6 +119,7 @@ Eugene Nikolaiev
 Eugene Tolmachev
 Evan Kepner
 Evert Lammerts
+Exherb
 Felix Yan
 Fernanda Guimarães
 FichteFoll

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -13,6 +13,7 @@ from typing import (
     List,
     Optional,
     Tuple,
+    TypeVar,
 )
 
 from multidict import CIMultiDict
@@ -134,10 +135,15 @@ else:
 
 
 ClearCookiePredicate = Callable[["Morsel[str]"], bool]
+_CookieJar = TypeVar("_CookieJar", bound="AbstractCookieJar")
 
 
 class AbstractCookieJar(Sized, IterableBase):
     """Abstract Cookie Jar."""
+
+    @abstractmethod
+    def clone(self: _CookieJar) -> _CookieJar:
+        """Clone."""
 
     @abstractmethod
     def clear(self, predicate: Optional[ClearCookiePredicate] = None) -> None:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -454,7 +454,7 @@ class ClientSession:
                     all_cookies = self._cookie_jar.filter_cookies(url)
 
                     if cookies is not None:
-                        tmp_cookie_jar = CookieJar()
+                        tmp_cookie_jar = self._cookie_jar.clone()
                         tmp_cookie_jar.update_cookies(cookies)
                         req_cookies = tmp_cookie_jar.filter_cookies(url)
                         if req_cookies:

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -92,6 +92,13 @@ class CookieJar(AbstractCookieJar):
         except OverflowError:
             self._max_time = self.MAX_32BIT_TIME
 
+    def clone(self) -> "CookieJar":
+        return self.__class__(
+            unsafe=self._unsafe,
+            quote_cookie=self._quote_cookie,
+            treat_as_secure_origin=self._treat_as_secure_origin,
+        )
+
     def save(self, file_path: PathLike) -> None:
         file_path = pathlib.Path(file_path)
         with file_path.open(mode="wb") as f:
@@ -398,6 +405,9 @@ class DummyCookieJar(AbstractCookieJar):
     It can be used with the ClientSession when no cookie processing is needed.
 
     """
+
+    def clone(self) -> "DummyCookieJar":
+        return self.__class__()
 
     def __iter__(self) -> "Iterator[Morsel[str]]":
         while False:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

the result of those two code blocks are not the same.

```python
import aiohttp
jar = aiohttp.CookieJar(quote_cookie=False)
async with aiohttp.ClientSession(cookie_jar=jar, cookies=cookies) as session:
  async with session.post(url) as r:
    print(await r.json())  
```

```python
import aiohttp
jar = aiohttp.CookieJar(quote_cookie=False)
async with aiohttp.ClientSession(cookie_jar=jar) as session:
  async with session.post(url, cookies=cookies) as r:  # cookies value got quoted even current cookie_jar quote_cookie is False
    print(await r.json())  
```

## Are there changes in behavior for the user?

no

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."