### PR TITLE
Fix a bug in creating proxy connection of TCPConnector.

### DIFF
--- a/CHANGES/6239.bugfix
+++ b/CHANGES/6239.bugfix
@@ -1,0 +1,1 @@
+Fix a bug in creating a proxy connection.

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -105,6 +105,14 @@ class ClientHttpProxyError(ClientResponseError):
     """
 
 
+class ClientProxyClosedError(ClientResponseError):
+    """Proxy server is closed.
+
+    Raised in :class:`aiohttp.connector.TCPConnector` if
+    proxy server is closed on ``CONNECT`` request.
+    """
+
+
 class TooManyRedirects(ClientResponseError):
     """Client was redirected too many times."""
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -37,6 +37,7 @@ from .client_exceptions import (
     ClientConnectorError,
     ClientConnectorSSLError,
     ClientHttpProxyError,
+    ClientProxyClosedError,
     ClientProxyConnectionError,
     ServerFingerprintMismatch,
     UnixClientConnectorError,
@@ -1227,6 +1228,14 @@ class TCPConnector(BaseConnector):
                             resp.history,
                             status=resp.status,
                             message=message,
+                            headers=resp.headers,
+                        )
+                    elif resp.method == hdrs.METH_CONNECT and resp.closed:
+                        raise ClientProxyClosedError(
+                            proxy_resp.request_info,
+                            resp.history,
+                            status=resp.status,
+                            message="Proxy server is closed.",
                             headers=resp.headers,
                         )
                 except BaseException:


### PR DESCRIPTION
This fix addresses the issue where an AttributeError is raised when a
proxy response is closed due to EOF.

<!-- Thank you for your contribution! -->

## What do these changes do?
 Fix the issue #6239.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
Add ClientProxyClosedError handler.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#6239 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
