### PR TITLE
Stop using the cgi module, deprecated in Python 3.11 per PEP 594

### DIFF
--- a/CHANGES/6708.misc
+++ b/CHANGES/6708.misc
@@ -1,0 +1,1 @@
+Replace deprecated cgi module usage with email.parser.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -3,7 +3,6 @@
 import asyncio
 import base64
 import binascii
-import cgi
 import dataclasses
 import datetime
 import enum
@@ -19,6 +18,7 @@ import warnings
 import weakref
 from collections import namedtuple
 from contextlib import suppress
+from email.parser import HeaderParser
 from email.utils import parsedate
 from http.cookies import SimpleCookie
 from math import ceil
@@ -748,7 +748,11 @@ class HeadersMixin:
             self._content_type = "application/octet-stream"
             self._content_dict = {}
         else:
-            self._content_type, self._content_dict = cgi.parse_header(raw)
+            msg = HeaderParser().parsestr("Content-Type: " + raw)
+            self._content_type = msg.get_content_type()
+            params = msg.get_params()
+            del params[0]  # content type duplicated here
+            self._content_dict = dict(params)
 
     @property
     def content_type(self) -> str:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -751,8 +751,7 @@ class HeadersMixin:
             msg = HeaderParser().parsestr("Content-Type: " + raw)
             self._content_type = msg.get_content_type()
             params = msg.get_params()
-            del params[0]  # content type duplicated here
-            self._content_dict = dict(params)
+            self._content_dict = dict(params[1:])  # First element is content type again
 
     @property
     def content_type(self) -> str:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Removes use of the `cgi` module which is deprecated in 3.11+ per https://peps.python.org/pep-0594/#cgi

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
No

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
