### PR TITLE
Patchback/backports/3.9/e5beaca052434cbf1c1814170917085eb271ba43/pr 3892 implement response check

### DIFF
--- a/CHANGES/3892.feature
+++ b/CHANGES/3892.feature
@@ -1,0 +1,1 @@
+allow ``raise_for_status`` to be a coroutine

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -215,7 +215,7 @@ class ClientSession:
         connector_owner: bool = True,
         raise_for_status: Union[
             bool, Callable[[ClientResponse], Awaitable[None]]
-        ] = False,  # noqa
+        ] = False,
         read_timeout: Union[float, object] = sentinel,
         conn_timeout: Optional[float] = None,
         timeout: Union[object, ClientTimeout] = sentinel,
@@ -384,7 +384,7 @@ class ClientSession:
         expect100: bool = False,
         raise_for_status: Union[
             None, bool, Callable[[ClientResponse], Awaitable[None]]
-        ] = None,  # noqa
+        ] = None,
         read_until_eof: bool = True,
         proxy: Optional[StrOrURL] = None,
         proxy_auth: Optional[BasicAuth] = None,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -213,7 +213,9 @@ class ClientSession:
         version: HttpVersion = http.HttpVersion11,
         cookie_jar: Optional[AbstractCookieJar] = None,
         connector_owner: bool = True,
-        raise_for_status: Union[bool, Callable[[ClientResponse], Awaitable[None]]] = False,  # noqa
+        raise_for_status: Union[
+            bool, Callable[[ClientResponse], Awaitable[None]]
+        ] = False,  # noqa
         read_timeout: Union[float, object] = sentinel,
         conn_timeout: Optional[float] = None,
         timeout: Union[object, ClientTimeout] = sentinel,
@@ -380,7 +382,9 @@ class ClientSession:
         compress: Optional[str] = None,
         chunked: Optional[bool] = None,
         expect100: bool = False,
-        raise_for_status: Union[None, bool, Callable[[ClientResponse], Awaitable[None]]] = None,  # noqa
+        raise_for_status: Union[
+            None, bool, Callable[[ClientResponse], Awaitable[None]]
+        ] = None,  # noqa
         read_until_eof: bool = True,
         proxy: Optional[StrOrURL] = None,
         proxy_auth: Optional[BasicAuth] = None,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -213,7 +213,7 @@ class ClientSession:
         version: HttpVersion = http.HttpVersion11,
         cookie_jar: Optional[AbstractCookieJar] = None,
         connector_owner: bool = True,
-        raise_for_status: bool = False,
+        raise_for_status: Union[bool, Callable[[ClientResponse], Awaitable[None]]] = False,  # noqa
         read_timeout: Union[float, object] = sentinel,
         conn_timeout: Optional[float] = None,
         timeout: Union[object, ClientTimeout] = sentinel,
@@ -380,7 +380,7 @@ class ClientSession:
         compress: Optional[str] = None,
         chunked: Optional[bool] = None,
         expect100: bool = False,
-        raise_for_status: Optional[bool] = None,
+        raise_for_status: Union[None, bool, Callable[[ClientResponse], Awaitable[None]]] = None,  # noqa
         read_until_eof: bool = True,
         proxy: Optional[StrOrURL] = None,
         proxy_auth: Optional[BasicAuth] = None,
@@ -645,7 +645,12 @@ class ClientSession:
             # check response status
             if raise_for_status is None:
                 raise_for_status = self._raise_for_status
-            if raise_for_status:
+
+            if raise_for_status is None:
+                pass
+            elif callable(raise_for_status):
+                await raise_for_status(resp)
+            elif raise_for_status:
                 resp.raise_for_status()
 
             # register connection

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -135,6 +135,22 @@ The client session supports the context manager protocol for self closing.
       requests where you need to handle responses with status 400 or
       higher.
 
+      You can also provide a coroutine which takes the response as an
+      argument and can raise an exception based on custom logic, e.g.::
+
+          async def custom_check(response):
+              if response.status not in {201, 202}:
+                  raise RuntimeError('expected either 201 or 202')
+              text = await response.text()
+              if 'apple pie' not in text:
+                  raise RuntimeError('I wanted to see "apple pie" in response')
+
+          client_session = aiohttp.ClientSession(raise_for_status=custom_check)
+          ...
+
+      As with boolean values, you're free to set this on the session and/or
+      overwrite it on a per-request basis.
+
    :param timeout: a :class:`ClientTimeout` settings structure, 300 seconds (5min)
         total timeout by default.
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2309,6 +2309,56 @@ async def test_request_raise_for_status_enabled(aiohttp_server) -> None:
             assert False, "never executed"  # pragma: no cover
 
 
+async def test_session_raise_for_status_coro(aiohttp_client) -> None:
+
+    async def handle(request):
+        return web.Response(text='ok')
+
+    app = web.Application()
+    app.router.add_route('GET', '/', handle)
+
+    raise_for_status_called = 0
+
+    async def custom_r4s(response):
+        nonlocal raise_for_status_called
+        raise_for_status_called += 1
+        assert response.status == 200
+        assert response.request_info.method == 'GET'
+
+    client = await aiohttp_client(app, raise_for_status=custom_r4s)
+    await client.get('/')
+    assert raise_for_status_called == 1
+    await client.get('/', raise_for_status=True)
+    assert raise_for_status_called == 1  # custom_r4s not called again
+    await client.get('/', raise_for_status=False)
+    assert raise_for_status_called == 1  # custom_r4s not called again
+
+
+async def test_request_raise_for_status_coro(aiohttp_client) -> None:
+
+    async def handle(request):
+        return web.Response(text='ok')
+
+    app = web.Application()
+    app.router.add_route('GET', '/', handle)
+
+    raise_for_status_called = 0
+
+    async def custom_r4s(response):
+        nonlocal raise_for_status_called
+        raise_for_status_called += 1
+        assert response.status == 200
+        assert response.request_info.method == 'GET'
+
+    client = await aiohttp_client(app)
+    await client.get('/', raise_for_status=custom_r4s)
+    assert raise_for_status_called == 1
+    await client.get('/', raise_for_status=True)
+    assert raise_for_status_called == 1  # custom_r4s not called again
+    await client.get('/', raise_for_status=False)
+    assert raise_for_status_called == 1  # custom_r4s not called again
+
+
 async def test_invalid_idna() -> None:
     session = aiohttp.ClientSession()
     try:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2310,12 +2310,11 @@ async def test_request_raise_for_status_enabled(aiohttp_server) -> None:
 
 
 async def test_session_raise_for_status_coro(aiohttp_client) -> None:
-
     async def handle(request):
-        return web.Response(text='ok')
+        return web.Response(text="ok")
 
     app = web.Application()
-    app.router.add_route('GET', '/', handle)
+    app.router.add_route("GET", "/", handle)
 
     raise_for_status_called = 0
 
@@ -2323,24 +2322,23 @@ async def test_session_raise_for_status_coro(aiohttp_client) -> None:
         nonlocal raise_for_status_called
         raise_for_status_called += 1
         assert response.status == 200
-        assert response.request_info.method == 'GET'
+        assert response.request_info.method == "GET"
 
     client = await aiohttp_client(app, raise_for_status=custom_r4s)
-    await client.get('/')
+    await client.get("/")
     assert raise_for_status_called == 1
-    await client.get('/', raise_for_status=True)
+    await client.get("/", raise_for_status=True)
     assert raise_for_status_called == 1  # custom_r4s not called again
-    await client.get('/', raise_for_status=False)
+    await client.get("/", raise_for_status=False)
     assert raise_for_status_called == 1  # custom_r4s not called again
 
 
 async def test_request_raise_for_status_coro(aiohttp_client) -> None:
-
     async def handle(request):
-        return web.Response(text='ok')
+        return web.Response(text="ok")
 
     app = web.Application()
-    app.router.add_route('GET', '/', handle)
+    app.router.add_route("GET", "/", handle)
 
     raise_for_status_called = 0
 
@@ -2348,14 +2346,14 @@ async def test_request_raise_for_status_coro(aiohttp_client) -> None:
         nonlocal raise_for_status_called
         raise_for_status_called += 1
         assert response.status == 200
-        assert response.request_info.method == 'GET'
+        assert response.request_info.method == "GET"
 
     client = await aiohttp_client(app)
-    await client.get('/', raise_for_status=custom_r4s)
+    await client.get("/", raise_for_status=custom_r4s)
     assert raise_for_status_called == 1
-    await client.get('/', raise_for_status=True)
+    await client.get("/", raise_for_status=True)
     assert raise_for_status_called == 1  # custom_r4s not called again
-    await client.get('/', raise_for_status=False)
+    await client.get("/", raise_for_status=False)
     assert raise_for_status_called == 1  # custom_r4s not called again
 
 


### PR DESCRIPTION
## What do these changes do?

Backport for #3892, which allowed `raise_for_status` to optionally be a coroutine.

## Are there changes in behavior for the user?

Should be fully backwards-compatible.

## Related issue number

#3892

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
