### PR TITLE
Fix chunked eof

### DIFF
--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -823,7 +823,7 @@ class HttpPayloadParser:
                     if head == SEP:
                         # end of stream
                         self.payload.feed_eof()
-                        return True, chunk[2:]
+                        return True, chunk[-2:]
                     # Both CR and LF, or only LF may not be received yet. It is
                     # expected that CRLF or LF will be shown at the very first
                     # byte next time, otherwise trailers should come. The last


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

I found some web sites whose last chunk is "/r/n0/r/n/r/n". The parser matches the head "/r/n" but returns chunk[2:], which is "0/r/n/r/n", throwing at last a 400 error.
Given the fact we do know it's the last chunk, this can be easily solved by making sure we return "/r/n". I used last 2 bytes of data (which works) just to highlight badly configured services, but you could well use directly SEP if you think its better.
I tested it against some websites which were giving 400 error and with this fix the work fine.

## Are there changes in behavior for the user?

None

## Related issue number

None

## Checklist

- [X] I think the code is well written
- [-] Unit tests for the changes exist
- [-] Documentation reflects the changes
- [-] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
