### PR TITLE
Fixed __repr__ call in EmptyStreamReader

### DIFF
--- a/CHANGES/6655.bugfix
+++ b/CHANGES/6655.bugfix
@@ -1,0 +1,1 @@
+Fixed EmptyStreamReader instances throwing an exception during __repr__ call

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -274,6 +274,7 @@ Sebastian Hanula
 Sebastian Hüther
 Sebastien Geffroy
 SeongSoo Cho
+Sergey Chudov
 Sergey Ninua
 Sergey Skripnick
 Serhii Charykov

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -492,6 +492,9 @@ class EmptyStreamReader(StreamReader):  # lgtm [py/missing-call-to-init]
     def __init__(self) -> None:
         pass
 
+    def __repr__(self) -> str:
+        return f"<{self.__class__.__name__}>"
+
     def exception(self) -> Optional[BaseException]:
         return None
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1075,6 +1075,7 @@ async def test_empty_stream_reader() -> None:
     with pytest.raises(asyncio.IncompleteReadError):
         await s.readexactly(10)
     assert s.read_nowait() == b""
+    assert "<EmptyStreamReader>" == repr(s)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixed an error when calling the \_\_repr\_\_ method on an **EmptyStreamReader**

**Briefly about the solution:**

Removes the problem associated with calling the \_\_repr\_\_ method on the super class. 
The problem comes from missing methods in the child class. 
So the decision was made to override the lower class's \_\_repr\_\_ method

## Are there changes in behavior for the user?

The user will no longer get an error when calling \_\_repr\_\_ on an **EmptyStreamReader**

## Related issue number

#6655

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
