### PR TITLE
Fix pip reinstallation on windows due to constraints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ endif
 	@python -m pip install --upgrade pip
 
 .install-cython: .update-pip $(call to-hash,requirements/cython.txt)
-	@pip install -r requirements/cython.txt -c requirements/constraints.txt
+	@python -m pip install -r requirements/cython.txt -c requirements/constraints.txt
 	@touch .install-cython
 
 aiohttp/_find_header.c: $(call to-hash,aiohttp/hdrs.py ./tools/gen.py)
@@ -74,7 +74,7 @@ generate-llhttp: .llhttp-gen
 cythonize: .install-cython $(PYXS:.pyx=.c)
 
 .install-deps: .install-cython $(PYXS:.pyx=.c) $(call to-hash,$(CYS) $(REQS))
-	@pip install -r requirements/dev.txt -c requirements/constraints.txt
+	@python -m pip install -r requirements/dev.txt -c requirements/constraints.txt
 	@touch .install-deps
 
 .PHONY: lint
@@ -89,7 +89,7 @@ mypy:
 	mypy
 
 .develop: .install-deps generate-llhttp $(call to-hash,$(PYS) $(CYS) $(CS))
-	pip install -e . -c requirements/constraints.txt
+	python -m pip install -e . -c requirements/constraints.txt
 	@touch .develop
 
 .PHONY: test
@@ -189,7 +189,7 @@ compile-deps: .update-pip $(REQS)
 
 .PHONY: install
 install: .update-pip
-	@pip install -r requirements/dev.txt -c requirements/constraints.txt
+	@python -m pip install -r requirements/dev.txt -c requirements/constraints.txt
 
 .PHONY: install-dev
 install-dev: .develop


### PR DESCRIPTION
## What do these changes do?

Fix for constantly failing CI on windows agents.

## Description

We have pinned pip version in constraints.txt file:
https://github.com/aio-libs/aiohttp/blob/08ca779e9abdb6d558cdd1647fdca17cfe979711/requirements/constraints.txt#L260

So when you call `pip install ... -c constraints.txt` it will downgrade/upgrade pip depending on the currently installed version. This works fine on all platforms except windows, which forces you to explicitly use `python -m pip install ...` when dealing with the pip package itself.

Since `python -m pip install ...` command is a completely legit replacement for `pip install ...` ([examples ](https://pip.pypa.io/en/latest/getting-started/)from the pip wiki), I decided to update `Makefile` with it.