### PR TITLE
Makefile: replace which(1) with more portable `command -v`

### DIFF
--- a/CHANGES/6784.misc
+++ b/CHANGES/6784.misc
@@ -1,0 +1,1 @@
+Remove the dependency on `which(1)` program in favor of the shell built-in `command -v` whose presence is guaranteed by POSIX.

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ FORCE:
 # check_sum.py works perfectly fine but slow when called for every file from $(ALLS)
 # (perhaps even several times for each file).
 # That is why much less readable but faster solution exists
-ifneq (, $(shell which sha256sum))
+ifneq (, $(shell command -v sha256sum))
 %.hash: FORCE
 	$(eval $@_ABS := $(abspath $@))
 	$(eval $@_NAME := $($@_ABS))


### PR DESCRIPTION
## What do these changes do?

The `which(1)` program is not provided by the POSIX base system
and causes the Makefile to misbehave when it is missing on the system.
`command -v` is a portable replacement that is provided by the shell
as a builtin and that is guaranteed to exist by POSIX.

## Are there changes in behavior for the user?

NFC.

## Related issue number

n/a

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
