### PR TITLE
Fix readuntil work 

### DIFF
--- a/CHANGES/6701.bugfix
+++ b/CHANGES/6701.bugfix
@@ -1,1 +1,1 @@
-Fix work of readuntil with delimiter more than one character
+Fix ``readuntil`` to work with a delimiter of more than one character

--- a/CHANGES/6701.bugfix
+++ b/CHANGES/6701.bugfix
@@ -1,0 +1,1 @@
+Fix work of readuntil with delimiter more than one character

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -221,6 +221,7 @@ Mathieu Dugré
 Matt VanEseltine
 Matthieu Hauglustaine
 Matthieu Rigal
+Matvey Tingaev
 Meet Mangukiya
 Michael Ihnatenko
 Michał Górny

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -325,7 +325,9 @@ class StreamReader(AsyncStreamReaderMixin):
                 offset = self._buffer_offset
                 ichar = self._buffer[0].find(separator, offset) + 1
                 # Read from current offset to found separator or to the end.
-                data = self._read_nowait_chunk(ichar - offset if ichar else -1)
+                data = self._read_nowait_chunk(
+                    ichar - offset + seplen - 1 if ichar else -1
+                )
                 chunk += data
                 chunk_size += len(data)
                 if ichar:

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -377,7 +377,7 @@ class TestStreamReader:
         with pytest.raises(ValueError):
             await stream.readline()
 
-    @pytest.mark.parametrize("separator", [b"&", b"&&"])
+    @pytest.mark.parametrize("separator", [b"*", b"**"])
     async def test_readuntil(self, separator: bytes) -> None:
         loop = asyncio.get_event_loop()
         # Read one chunk. 'readuntil' will need to wait for the data
@@ -416,7 +416,7 @@ class TestStreamReader:
         data = await stream.read()
         assert b"line2" + separator == data
 
-    @pytest.mark.parametrize("separator", [b"&", b"&&"])
+    @pytest.mark.parametrize("separator", [b"$", b"$$"])
     async def test_readuntil_limit(self, separator: bytes) -> None:
         loop = asyncio.get_event_loop()
         # Read one chunk. StreamReaders are fed with data after
@@ -436,7 +436,7 @@ class TestStreamReader:
         data = await stream.read()
         assert b"chunk3#" == data
 
-    @pytest.mark.parametrize("separator", [b"&", b"&&"])
+    @pytest.mark.parametrize("separator", [b"!", b"!!"])
     async def test_readuntil_nolimit_nowait(self, separator: bytes) -> None:
         # All needed data for the first 'readuntil' call will be
         # in the buffer.
@@ -453,7 +453,7 @@ class TestStreamReader:
         data = await stream.read()
         assert b"line2" + separator + b"line3" + separator == data
 
-    @pytest.mark.parametrize("separator", [b"&", b"&&"])
+    @pytest.mark.parametrize("separator", [b"@", b"@@"])
     async def test_readuntil_eof(self, separator: bytes) -> None:
         stream = self._make_one()
         stream.feed_data(b"some data")
@@ -462,7 +462,7 @@ class TestStreamReader:
         line = await stream.readuntil(separator)
         assert b"some data" == line
 
-    @pytest.mark.parametrize("separator", [b"&", b"&&"])
+    @pytest.mark.parametrize("separator", [b"@", b"@@"])
     async def test_readuntil_empty_eof(self, separator: bytes) -> None:
         stream = self._make_one()
         stream.feed_eof()
@@ -470,7 +470,7 @@ class TestStreamReader:
         line = await stream.readuntil(separator)
         assert b"" == line
 
-    @pytest.mark.parametrize("separator", [b"&", b"&&"])
+    @pytest.mark.parametrize("separator", [b"!", b"!!"])
     async def test_readuntil_read_byte_count(self, separator: bytes) -> None:
         seplen = len(separator)
         stream = self._make_one()
@@ -487,7 +487,7 @@ class TestStreamReader:
         data = await stream.read()
         assert b"ine3" + separator == data
 
-    @pytest.mark.parametrize("separator", [b"&", b"&&"])
+    @pytest.mark.parametrize("separator", [b"#", b"##"])
     async def test_readuntil_exception(self, separator: bytes) -> None:
         stream = self._make_one()
         stream.feed_data(b"line" + separator)

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -429,7 +429,7 @@ class TestStreamReader:
 
         loop.call_soon(cb)
 
-        with pytest.raises(ValueError, match='Chunk too big'):
+        with pytest.raises(ValueError, match="Chunk too big"):
             await stream.readuntil(b"$")
         data = await stream.read()
         assert b"chunk3#" == data

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -377,7 +377,7 @@ class TestStreamReader:
         with pytest.raises(ValueError):
             await stream.readline()
 
-    @pytest.mark.parametrize("separator", [b"*", b"**"])
+    @pytest.mark.parametrize("separator", [b"&", b"&&"])
     async def test_readuntil(self, separator: bytes) -> None:
         loop = asyncio.get_event_loop()
         # Read one chunk. 'readuntil' will need to wait for the data
@@ -400,7 +400,7 @@ class TestStreamReader:
         data = await stream.read()
         assert b" chunk4" == data
 
-    @pytest.mark.parametrize("separator", [b"*", b"**"])
+    @pytest.mark.parametrize("separator", [b"&", b"&&"])
     async def test_readuntil_limit_with_existing_data(self, separator: bytes) -> None:
         # Read one chunk. The data is in StreamReader's buffer
         # before the event loop is run.
@@ -416,7 +416,7 @@ class TestStreamReader:
         data = await stream.read()
         assert b"line2" + separator == data
 
-    @pytest.mark.parametrize("separator", [b"*", b"**"])
+    @pytest.mark.parametrize("separator", [b"&", b"&&"])
     async def test_readuntil_limit(self, separator: bytes) -> None:
         loop = asyncio.get_event_loop()
         # Read one chunk. StreamReaders are fed with data after
@@ -436,7 +436,7 @@ class TestStreamReader:
         data = await stream.read()
         assert b"chunk3#" == data
 
-    @pytest.mark.parametrize("separator", [b"*", b"**"])
+    @pytest.mark.parametrize("separator", [b"&", b"&&"])
     async def test_readuntil_nolimit_nowait(self, separator: bytes) -> None:
         # All needed data for the first 'readuntil' call will be
         # in the buffer.
@@ -453,7 +453,7 @@ class TestStreamReader:
         data = await stream.read()
         assert b"line2" + separator + b"line3" + separator == data
 
-    @pytest.mark.parametrize("separator", [b"*", b"**"])
+    @pytest.mark.parametrize("separator", [b"&", b"&&"])
     async def test_readuntil_eof(self, separator: bytes) -> None:
         stream = self._make_one()
         stream.feed_data(b"some data")
@@ -462,7 +462,7 @@ class TestStreamReader:
         line = await stream.readuntil(separator)
         assert b"some data" == line
 
-    @pytest.mark.parametrize("separator", [b"*", b"**"])
+    @pytest.mark.parametrize("separator", [b"&", b"&&"])
     async def test_readuntil_empty_eof(self, separator: bytes) -> None:
         stream = self._make_one()
         stream.feed_eof()
@@ -470,7 +470,7 @@ class TestStreamReader:
         line = await stream.readuntil(separator)
         assert b"" == line
 
-    @pytest.mark.parametrize("separator", [b"*", b"**"])
+    @pytest.mark.parametrize("separator", [b"&", b"&&"])
     async def test_readuntil_read_byte_count(self, separator: bytes) -> None:
         seplen = len(separator)
         stream = self._make_one()
@@ -487,7 +487,7 @@ class TestStreamReader:
         data = await stream.read()
         assert b"ine3" + separator == data
 
-    @pytest.mark.parametrize("separator", [b"*", b"**"])
+    @pytest.mark.parametrize("separator", [b"&", b"&&"])
     async def test_readuntil_exception(self, separator: bytes) -> None:
         stream = self._make_one()
         stream.feed_data(b"line" + separator)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix work `readuntil()` with separator length more one character
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
Fixes #6701
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
