### PR TITLE
Allow filename content disposition to have space in accordance with RFC6266 Appendix D

### DIFF
--- a/CHANGES/6826.bugfix
+++ b/CHANGES/6826.bugfix
@@ -1,0 +1,1 @@
+Don't encode ' ' as '%20' in a content-disposition's filename

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -52,6 +52,7 @@ Artem Yushkovskiy
 Arthur Darcet
 Austin Scola
 Ben Bader
+Ben Cutler
 Ben Greiner
 Ben Timby
 Benedikt Reinartz

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -399,7 +399,7 @@ def content_disposition_header(
                 )
             if quote_fields:
                 if key.lower() == "filename":
-                    qval = quote(val, "", encoding=_charset)
+                    qval = quote(val, " ", encoding=_charset)
                     lparams.append((key, '"%s"' % qval))
                 else:
                     try:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -483,6 +483,7 @@ async def test_ceil_timeout_small_with_overriden_threshold(loop) -> None:
         (dict(foo='bär "\\', quote_fields=False), 'attachment; foo="bär \\"\\\\"'),
         (dict(foo="bär", _charset="latin-1"), "attachment; foo*=latin-1''b%E4r"),
         (dict(filename="bär"), 'attachment; filename="b%C3%A4r"'),
+        (dict(filename="bar baz"), 'attachment; filename="bar baz"'),
         (dict(filename="bär", _charset="latin-1"), 'attachment; filename="b%E4r"'),
         (
             dict(filename='bär "\\', quote_fields=False),


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
According to RFC 6266 Appendix D:
https://datatracker.ietf.org/doc/html/rfc6266#appendix-D

```
   o  Avoid including the percent character followed by two hexadecimal
      characters (e.g., %A9) in the filename parameter, since some
      existing implementations consider it to be an escape character,
      while others will pass it through unchanged.
```
The current implementation of aiohttp does encode spaces of the filename, and this implementation should be avoided,.
## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Yes, filenames will no longer be encoded.

This is not exactly a new change for users on aiohttp 3.7 though. The filename was not encoded until this Pr https://github.com/aio-libs/aiohttp/issues/4012 encoded it. 
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [✅] I think the code is well written
- [✅] Unit tests for the changes exist
- [⚠️] Documentation reflects the changes
- [✅] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [✅] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
