### PR TITLE
Allow linking to request()

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -341,7 +341,7 @@ The client session supports the context manager protocol for self closing.
                          ssl_context=None, proxy_headers=None)
       :async-with:
       :coroutine:
-      :noindex:
+      :noindexentry:
 
       Performs an asynchronous HTTP request. Returns a response object.
 


### PR DESCRIPTION
noindex actually removes the anchor, so there is no way to create a link to this method in the documentation.