### PR TITLE
Stop installing cchardet speedup under >Python 3.9

### DIFF
--- a/CHANGES/6857.misc
+++ b/CHANGES/6857.misc
@@ -1,0 +1,2 @@
+Excluded :term:`cchardet` from the ``speedups`` extra in the package
+metadata under Python 3.10 or higher -- by :user:`webknjaz`.

--- a/docs/_snippets/cchardet-unmaintained-admonition.rst
+++ b/docs/_snippets/cchardet-unmaintained-admonition.rst
@@ -1,0 +1,5 @@
+.. warning::
+
+   Note that the :term:`cchardet` project is known not to support
+   Python 3.10 or higher. See :issue:`6819` and
+   :gh:`PyYoshi/cChardet/issues/77` for more details.

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -59,6 +59,8 @@
 
        https://pypi.python.org/pypi/cchardet/
 
+       .. include:: _snippets/cchardet-unmaintained-admonition.rst
+
    gunicorn
 
        Gunicorn 'Green Unicorn' is a Python WSGI HTTP Server for

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,6 +40,8 @@ replacement for :term:`charset-normalizer`:
 
    $ pip install cchardet
 
+.. include:: _snippets/cchardet-unmaintained-admonition.rst
+
 For speeding up DNS resolving by client API you may install
 :term:`aiodns` as well.
 This option is highly recommended:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ aiosignal==1.2.0
 async-timeout==4.0.2
 asynctest==0.13.0; python_version<"3.8"
 Brotli==1.0.9
-cchardet==2.1.7
+cchardet==2.1.7; python_version < "3.10"  # Unmaintained: aio-libs/aiohttp#6819
 charset-normalizer==2.0.12
 frozenlist==1.3.1
 gunicorn==20.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,7 +65,7 @@ install_requires =
 speedups =
   aiodns >= 1.1
   Brotli
-  cchardet
+  cchardet; python_version < "3.10"
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
## What do these changes do?
`cchardet` stopped being maintained a while ago so this patch removes
it from the `speedups` extra to keep it helpful. It also makes the
same adjustment in the CI under the most recent CPython versions to
keep the testing going.

## Are there changes in behavior for the user?

`pip install aiohttp[speedups]` will only request `cchardet` under CPython < 3.10

## Related issue number

* https://github.com/aio-libs/aiohttp/issues/6819#issuecomment-1181603136
* https://github.com/PyYoshi/cChardet/issues/77

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
