### PR TITLE
Fix test utils on Python 3.11.

### DIFF
--- a/CHANGES/6867.misc
+++ b/CHANGES/6867.misc
@@ -1,0 +1,1 @@
+Fix ``test_utils.TestClient`` on Python 3.11.+.

--- a/CHANGES/6867.misc
+++ b/CHANGES/6867.misc
@@ -1,1 +1,1 @@
-Fix ``test_utils.TestClient`` on Python 3.11.+.
+Fix :py:class:`~aiohttp.test_utils.TestClient` compatibility with Python 3.11+, creating a new event loop when there is no active one -- by :user:`felixxm`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -211,6 +211,7 @@ Manuel Miranda
 Marat Sharafutdinov
 Marco Paolini
 Mariano Anaya
+Mariusz Felisiak
 Mariusz Masztalerczuk
 Marko Kohtala
 Martijn Pieters

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -433,7 +433,11 @@ class AioHTTPTestCase(TestCase):
         try:
             self.loop = asyncio.get_running_loop()
         except RuntimeError:
-            self.loop = asyncio.get_event_loop_policy().get_event_loop()
+            try:
+                self.loop = asyncio.get_event_loop()
+            except RuntimeError:
+                self.loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(self.loop)
 
         self.loop.run_until_complete(self.setUpAsync())
 


### PR DESCRIPTION
## What do these changes do?

Fix test utils on Python 3.11

## Are there changes in behavior for the user?

No.

## Related issue number

#6757.
## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] (no need :thinking:) Documentation reflects the changes 
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [X] Add a new news fragment into the `CHANGES` folder