### PR TITLE
fix chunks are not returned at the set size

### DIFF
--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -30,7 +30,7 @@ class EofStream(Exception):
 
 
 class AsyncStreamIterator(Generic[_T]):
-    def __init__(self, read_func: Callable[[], Awaitable[_T]], n) -> None:
+    def __init__(self, read_func: Callable[[], Awaitable[_T]], n = 1024 * 1024) -> None:
         self.read_func = read_func
         self.chunk_size = n
 

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -30,7 +30,7 @@ class EofStream(Exception):
 
 
 class AsyncStreamIterator(Generic[_T]):
-    def __init__(self, read_func: Callable[[], Awaitable[_T]], n = 1024 * 1024) -> None:
+    def __init__(self, read_func: Callable[[], Awaitable[_T]], n=1024 * 1024) -> None:
         self.read_func = read_func
         self.chunk_size = n
 

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -38,8 +38,8 @@ class AsyncStreamIterator(Generic[_T]):
         return self
 
     async def __anext__(self) -> _T:
-        rv = b''
-        last = b' '
+        rv = b""
+        last = b" "
         try:
             while len(rv) != self.chunk_size and len(last) != len(rv):
                 last = rv


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
without this patch, returned chunks by iter_chinked depends of network speed
but with this patch, we try to set chunks size to fixed size and send it for client.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No.
<!-- Outline any notable behaviour for the end users. -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
