### PR TITLE
fix chunks are not returned at the set size

### DIFF
--- a/CHANGES/6871.bugfix
+++ b/CHANGES/6871.bugfix
@@ -1,0 +1,1 @@
+Fix size of output chunks in ``read`` function into streams.py

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -267,6 +267,7 @@ Robert Lu
 Robert Nikolich
 Roman Markeloff
 Roman Podoliaka
+Safa Safari
 Samir Akarioh
 Samuel Colvin
 Sean Hunt

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -431,10 +431,12 @@ class StreamReader(AsyncStreamReaderMixin):
         if self._exception is not None:
             raise self._exception
 
-        blocks: List[bytes] = []
+        blocks = []  # type: List[bytes]
         while n > 0:
             block = await self.read(n)
             if not block:
+                if self.at_eof():
+                    break
                 partial = b"".join(blocks)
                 raise asyncio.IncompleteReadError(partial, len(partial) + n)
             blocks.append(block)

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -65,7 +65,8 @@ class AsyncStreamReaderMixin:
         return AsyncStreamIterator(self.readline)  # type: ignore[attr-defined]
 
     def iter_chunked(self, n: int, exactly: bool = True) -> AsyncStreamIterator[bytes]:
-        """Returns an asynchronous iterator that yields chunks of size n (exactly n by default so you can change "exactly" parameter to False to set chunks size as max n).
+        """Returns an asynchronous iterator that yields chunks of size n
+        exactly n by default so you can change "exactly" parameter to False to set chunks size as max n
 
         Python-3.5 available for Python 3.5+ only
         """

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -365,10 +365,13 @@ class StreamReader(AsyncStreamReaderMixin):
         # TODO: should be `if` instead of `while`
         # because waiter maybe triggered on chunk end,
         # without feeding any data
-        while not self._buffer and not self._eof:
-            await self._wait("read")
+        ret = b""
+        while len(ret) != n:
+            while not self._buffer and not self._eof:
+                await self._wait("read")
+            ret += self._read_nowait(n - len(ret))
 
-        return self._read_nowait(n)
+        return ret
 
     async def readany(self) -> bytes:
         if self._exception is not None:

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -66,7 +66,10 @@ class AsyncStreamReaderMixin:
 
     def iter_chunked(self, n: int, exactly: bool = True) -> AsyncStreamIterator[bytes]:
         """Returns an asynchronous iterator that yields chunks of size n
-        exactly n by default so you can change "exactly" parameter to False to set chunks size as max n
+        
+        exactly n by default
+        you can change "exactly" parameter to False
+        to set chunks size as max n
 
         Python-3.5 available for Python 3.5+ only
         """
@@ -431,7 +434,7 @@ class StreamReader(AsyncStreamReaderMixin):
         if self._exception is not None:
             raise self._exception
 
-        blocks = []  # type: List[bytes]
+        blocks: List[bytes] = []
         while n > 0:
             block = await self.read(n)
             if not block:

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -66,7 +66,7 @@ class AsyncStreamReaderMixin:
 
     def iter_chunked(self, n: int, exactly: bool = True) -> AsyncStreamIterator[bytes]:
         """Returns an asynchronous iterator that yields chunks of size n
-        
+
         exactly n by default
         you can change "exactly" parameter to False
         to set chunks size as max n

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -64,8 +64,15 @@ class AsyncStreamReaderMixin:
     def __aiter__(self) -> AsyncStreamIterator[bytes]:
         return AsyncStreamIterator(self.readline)  # type: ignore[attr-defined]
 
-    def iter_chunked(self, n: int) -> AsyncStreamIterator[bytes]:
-        """Returns an asynchronous iterator that yields chunks of size n."""
+    def iter_chunked(self, n: int, exactly: bool = True) -> AsyncStreamIterator[bytes]:
+        """Returns an asynchronous iterator that yields chunks of size n (exactly n by default so you can change "exactly" parameter to False to set chunks size as max n).
+
+        Python-3.5 available for Python 3.5+ only
+        """
+        if exactly:
+            return AsyncStreamIterator(
+                lambda: self.readexactly(n)  # type: ignore[attr-defined,no-any-return]
+            )
         return AsyncStreamIterator(
             lambda: self.read(n)  # type: ignore[attr-defined,no-any-return]
         )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
without this patch, returned chunks by iter_chinked depends of network speed
but with this patch, we try to set chunks size to fixed size and send it for client.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No.
<!-- Outline any notable behaviour for the end users. -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
