### PR TITLE
ignore the ResourceWarnings before they become unraisable exceptions

### DIFF
--- a/CHANGES/6872.misc
+++ b/CHANGES/6872.misc
@@ -1,0 +1,1 @@
+Fixed suppression of :py:class:`ResourceWarning`s in the pytest setup -- by :user:`graingert`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -132,11 +132,11 @@ addopts =
 filterwarnings =
     error
     ignore:module 'ssl' has no attribute 'OP_NO_COMPRESSION'. The Python interpreter is compiled against OpenSSL < 1.0.0. Ref. https.//docs.python.org/3/library/ssl.html#ssl.OP_NO_COMPRESSION:UserWarning
-    ignore:Exception ignored in. <function _SSLProtocolTransport.__del__ at.:pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception
-    ignore:Exception ignored in. <coroutine object BaseConnector.close at 0x.:pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception
-    ignore:Exception ignored in. <coroutine object ClientSession._request at 0x.:pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception
-    ignore:Exception ignored in. <function ClientSession.__del__ at 0x.:pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception
-    ignore:Exception ignored in. <_io.FileIO .closed.>:pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception
+    ignore:unclosed transport <_SSLProtocolTransport.*:ResourceWarning
+    ignore:coroutine 'BaseConnector.close' was never awaited:RuntimeWarning
+    ignore:coroutine 'ClientSession._request' was never awaited:RuntimeWarning
+    ignore:Unclosed client session <aiohttp.client.ClientSession object at 0x:ResourceWarning
+    ignore:unclosed file <_io.FileIO.*:ResourceWarning
     ignore:The loop argument is deprecated:DeprecationWarning:asyncio
     ignore:Creating a LegacyVersion has been deprecated and will be removed in the next major release:DeprecationWarning::
     # The following deprecation warning is triggered by importing

--- a/setup.cfg
+++ b/setup.cfg
@@ -132,7 +132,7 @@ addopts =
 filterwarnings =
     error
     ignore:module 'ssl' has no attribute 'OP_NO_COMPRESSION'. The Python interpreter is compiled against OpenSSL < 1.0.0. Ref. https.//docs.python.org/3/library/ssl.html#ssl.OP_NO_COMPRESSION:UserWarning
-    ignore:unclosed transport <_SSLProtocolTransport.*:ResourceWarning
+    ignore:unclosed transport <asyncio.sslproto._SSLProtocolTransport object at 0x.*:ResourceWarning
     ignore:coroutine 'BaseConnector.close' was never awaited:RuntimeWarning
     ignore:coroutine 'ClientSession._request' was never awaited:RuntimeWarning
     ignore:Unclosed client session <aiohttp.client.ClientSession object at 0x:ResourceWarning

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -21,16 +21,15 @@ from aiohttp.web_runner import BaseRunner
 
 _has_unix_domain_socks = hasattr(socket, "AF_UNIX")
 if _has_unix_domain_socks:
-    _abstract_path_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    try:
-        _abstract_path_sock.bind(b"\x00" + uuid4().hex.encode("ascii"))
-    except FileNotFoundError:
-        _abstract_path_failed = True
-    else:
-        _abstract_path_failed = False
-    finally:
-        _abstract_path_sock.close()
-        del _abstract_path_sock
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as _abstract_path_sock:
+        try:
+            _abstract_path_sock.bind(b"\x00" + uuid4().hex.encode("ascii"))
+        except FileNotFoundError:
+            _abstract_path_failed = True
+        else:
+            _abstract_path_failed = False
+        finally:
+            del _abstract_path_sock
 else:
     _abstract_path_failed = True
 
@@ -48,7 +47,8 @@ if HAS_IPV6:
     # support, but the target system still may not have it.
     # So let's ensure that we really have IPv6 support.
     try:
-        socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM):
+            pass
     except OSError:
         HAS_IPV6 = False
 

--- a/tests/test_tcp_helpers.py
+++ b/tests/test_tcp_helpers.py
@@ -11,7 +11,8 @@ if has_ipv6:
     # support, but the target system still may not have it.
     # So let's ensure that we really have IPv6 support.
     try:
-        socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM):
+            pass
     except OSError:
         has_ipv6 = False
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

> @webknjaz:matrix.org btw you're using PytestUnraisableExceptionWarning incorrectly - you need to ignore the ResourceWarning not the PytestUnraisableExceptionWarning. Because pytest will only collect one unraisable per test and if you allow a ResourceWarning to raise then you defer the cleanup of the underlying resource eg:
> ```
> _warn("...", ResourceWarning)  # this raises 
> self._sock.close()  # this never gets called
> ```

## Are there changes in behavior for the user?

nope

## Related issue number

#6872

## Checklist

- [ ] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
