### PR TITLE
 work around the changes in 3.11, eg asyncio.TimeoutError is an OSError, and IsolatedAsyncioTestCase calls set_event_loop differently

### DIFF
--- a/CHANGES/6757.misc
+++ b/CHANGES/6757.misc
@@ -1,1 +1,3 @@
-work around the changes in 3.11, eg asyncio.TimeoutError is an OSError, and IsolatedAsyncioTestCase calls set_event_loop differently
+Work around the changes in 3.11, e.g. :py:class:`~asyncio.TimeoutError` is an :py:class:`OSError`,
+and :py:class:`~unittest.IsolatedAsyncioTestCase` calls :py:function:`~asyncio.set_event_loop`
+differently -- by :user:`graingert`.

--- a/CHANGES/6757.misc
+++ b/CHANGES/6757.misc
@@ -1,0 +1,1 @@
+work around the changes in 3.11, eg asyncio.TimeoutError is an OSError, and IsolatedAsyncioTestCase calls set_event_loop differently

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -531,6 +531,8 @@ class ClientSession:
                             raise
                     except ClientError:
                         raise
+                    except asyncio.TimeoutError:
+                        raise
                     except OSError as exc:
                         raise ClientOSError(*exc.args) from exc
 

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -531,9 +531,9 @@ class ClientSession:
                             raise
                     except ClientError:
                         raise
-                    except asyncio.TimeoutError:
-                        raise
                     except OSError as exc:
+                        if exc.errno is None and isinstance(exc, asyncio.TimeoutError):
+                            raise
                         raise ClientOSError(*exc.args) from exc
 
                     self._cookie_jar.update_cookies(resp.cookies, resp.url)

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -536,6 +536,8 @@ class ClientRequest:
                     await writer.write(chunk)  # type: ignore[arg-type]
 
             await writer.write_eof()
+        except asyncio.TimeoutError:
+            raise
         except OSError as exc:
             new_exc = ClientOSError(
                 exc.errno, "Can not write request body for %s" % self.url

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -969,6 +969,8 @@ class TCPConnector(BaseConnector):
             raise ClientConnectorCertificateError(req.connection_key, exc) from exc
         except ssl_errors as exc:
             raise ClientConnectorSSLError(req.connection_key, exc) from exc
+        except asyncio.TimeoutError:
+            raise
         except OSError as exc:
             raise client_error(req.connection_key, exc) from exc
 
@@ -1048,6 +1050,8 @@ class TCPConnector(BaseConnector):
             raise ClientConnectorCertificateError(req.connection_key, exc) from exc
         except ssl_errors as exc:
             raise ClientConnectorSSLError(req.connection_key, exc) from exc
+        except asyncio.TimeoutError:
+            raise
         except OSError as exc:
             raise client_error(req.connection_key, exc) from exc
         except TypeError as type_err:
@@ -1098,6 +1102,8 @@ class TCPConnector(BaseConnector):
                     fut.result()
 
             host_resolved.add_done_callback(drop_exception)
+            raise
+        except asyncio.TimeoutError:
             raise
         except OSError as exc:
             # in case of proxy it is not ClientProxyConnectionError
@@ -1292,6 +1298,8 @@ class UnixConnector(BaseConnector):
                 _, proto = await self._loop.create_unix_connection(
                     self._factory, self._path
                 )
+        except asyncio.TimeoutError:
+            raise
         except OSError as exc:
             raise UnixClientConnectorError(self.path, req.connection_key, exc) from exc
 
@@ -1357,6 +1365,8 @@ class NamedPipeConnector(BaseConnector):
                 await asyncio.sleep(0)
                 # other option is to manually set transport like
                 # `proto.transport = trans`
+        except asyncio.TimeoutError:
+            raise
         except OSError as exc:
             raise ClientConnectorError(req.connection_key, exc) from exc
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -969,9 +969,9 @@ class TCPConnector(BaseConnector):
             raise ClientConnectorCertificateError(req.connection_key, exc) from exc
         except ssl_errors as exc:
             raise ClientConnectorSSLError(req.connection_key, exc) from exc
-        except asyncio.TimeoutError:
-            raise
         except OSError as exc:
+            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):
+                raise
             raise client_error(req.connection_key, exc) from exc
 
     def _warn_about_tls_in_tls(
@@ -1050,9 +1050,9 @@ class TCPConnector(BaseConnector):
             raise ClientConnectorCertificateError(req.connection_key, exc) from exc
         except ssl_errors as exc:
             raise ClientConnectorSSLError(req.connection_key, exc) from exc
-        except asyncio.TimeoutError:
-            raise
         except OSError as exc:
+            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):
+                raise
             raise client_error(req.connection_key, exc) from exc
         except TypeError as type_err:
             # Example cause looks like this:
@@ -1103,9 +1103,9 @@ class TCPConnector(BaseConnector):
 
             host_resolved.add_done_callback(drop_exception)
             raise
-        except asyncio.TimeoutError:
-            raise
         except OSError as exc:
+            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):
+                raise
             # in case of proxy it is not ClientProxyConnectionError
             # it is problem of resolving proxy ip itself
             raise ClientConnectorError(req.connection_key, exc) from exc
@@ -1298,9 +1298,9 @@ class UnixConnector(BaseConnector):
                 _, proto = await self._loop.create_unix_connection(
                     self._factory, self._path
                 )
-        except asyncio.TimeoutError:
-            raise
         except OSError as exc:
+            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):
+                raise
             raise UnixClientConnectorError(self.path, req.connection_key, exc) from exc
 
         return cast(ResponseHandler, proto)
@@ -1365,9 +1365,9 @@ class NamedPipeConnector(BaseConnector):
                 await asyncio.sleep(0)
                 # other option is to manually set transport like
                 # `proto.transport = trans`
-        except asyncio.TimeoutError:
-            raise
         except OSError as exc:
+            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):
+                raise
             raise ClientConnectorError(req.connection_key, exc) from exc
 
         return cast(ResponseHandler, proto)

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -429,6 +429,10 @@ class AioHTTPTestCase(TestCase):
         """
         raise RuntimeError("Did you forget to define get_application()?")
 
+    def setUp(self) -> None:
+        if not PY_38:
+            asyncio.get_event_loop().run_until_complete(self.asyncSetUp())
+
     async def asyncSetUp(self) -> None:
         self.loop = asyncio.get_running_loop()
         return await self.setUpAsync()
@@ -439,6 +443,10 @@ class AioHTTPTestCase(TestCase):
         self.client = await self.get_client(self.server)
 
         await self.client.start_server()
+
+    def tearDown(self) -> None:
+        if not PY_38:
+            self.loop.run_until_complete(self.asyncTearDown())
 
     async def asyncTearDown(self) -> None:
         return await self.tearDownAsync()

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -429,7 +429,7 @@ class AioHTTPTestCase(TestCase):
         """
         raise RuntimeError("Did you forget to define get_application()?")
 
-    async def asyncSetUp(self):
+    async def asyncSetUp(self) -> None:
         self.loop = asyncio.get_running_loop()
         return await self.setUpAsync()
 

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -429,13 +429,9 @@ class AioHTTPTestCase(TestCase):
         """
         raise RuntimeError("Did you forget to define get_application()?")
 
-    def setUp(self) -> None:
-        try:
-            self.loop = asyncio.get_running_loop()
-        except RuntimeError:
-            self.loop = asyncio.get_event_loop_policy().get_event_loop()
-
-        self.loop.run_until_complete(self.setUpAsync())
+    async def asyncSetUp(self):
+        self.loop = asyncio.get_running_loop()
+        return await self.setUpAsync()
 
     async def setUpAsync(self) -> None:
         self.app = await self.get_application()
@@ -444,8 +440,8 @@ class AioHTTPTestCase(TestCase):
 
         await self.client.start_server()
 
-    def tearDown(self) -> None:
-        self.loop.run_until_complete(self.tearDownAsync())
+    async def asyncTearDown(self) -> None:
+        return await self.tearDownAsync()
 
     async def tearDownAsync(self) -> None:
         await self.client.close()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixes https://github.com/aio-libs/aiohttp/issues/6757

## Are there changes in behavior for the user?

yeah, if someone overrides asyncSetUp/asyncTearDown in their tests it could cause confusion

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
