### PR TITLE
Fix readexactly eof

### DIFF
--- a/CHANGES/6878.bugfix
+++ b/CHANGES/6878.bugfix
@@ -1,0 +1,1 @@
+fix ``readexaclty`` last chunk eof and make the user decide between ``read`` and ``readexactly`` in ``iter_chunked``

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -267,6 +267,7 @@ Robert Lu
 Robert Nikolich
 Roman Markeloff
 Roman Podoliaka
+Safa Safari
 Samir Akarioh
 Samuel Colvin
 Sean Hunt


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
fix readexactly last chunk with eof and make the user decide to select between readexactly and read
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
maybe yes
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
