### PR TITLE
Drop Python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
     needs: gen_llhttp
     strategy:
       matrix:
-        pyver: [3.6, 3.7, 3.8, 3.9, '3.10']
+        pyver: [3.7, 3.8, 3.9, '3.10']
         no-extensions: ['', 'Y']
         os: [ubuntu, macos, windows]
         exclude:


### PR DESCRIPTION
Think we've created a clash here by adding 3.11 support. But, the pinned version of frozenlist no longer supports Python 3.6.

Maybe we can switch versions conditionally to pass the tests, without dropping it in the 3.8 branch.