### PR TITLE
Allow setting of SSLcontext as env. AIOHTTP_CAFILE

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -19,7 +19,6 @@ from typing import (
     Callable,
     DefaultDict,
     Dict,
-    Final,
     Iterator,
     List,
     Optional,
@@ -29,6 +28,7 @@ from typing import (
     Union,
     cast,
 )
+from typing_extensions import Final
 
 from . import hdrs, helpers
 from .abc import AbstractResolver

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -28,6 +28,7 @@ from typing import (
     Union,
     cast,
 )
+
 from typing_extensions import Final
 
 from . import hdrs, helpers

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -13,10 +13,10 @@ from http.cookies import SimpleCookie
 from itertools import cycle, islice
 from time import monotonic
 from types import TracebackType
-from typing import (  # noqa
+from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
-    cast,
     DefaultDict,
     Dict,
     Final,
@@ -25,9 +25,9 @@ from typing import (  # noqa
     Optional,
     Set,
     Tuple,
-    TYPE_CHECKING,
     Type,
     Union,
+    cast,
 )
 
 from . import hdrs, helpers

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -2,6 +2,7 @@ import asyncio
 import dataclasses
 import functools
 import logging
+import os
 import random
 import sys
 import traceback
@@ -13,20 +14,20 @@ from itertools import cycle, islice
 from time import monotonic
 from types import TracebackType
 from typing import (  # noqa
-    TYPE_CHECKING,
     Any,
-    Awaitable,
     Callable,
+    cast,
     DefaultDict,
     Dict,
+    Final,
     Iterator,
     List,
     Optional,
     Set,
     Tuple,
+    TYPE_CHECKING,
     Type,
     Union,
-    cast,
 )
 
 from . import hdrs, helpers
@@ -66,6 +67,14 @@ if TYPE_CHECKING:  # pragma: no cover
     from .client import ClientTimeout
     from .client_reqrep import ConnectionKey
     from .tracing import Trace
+
+
+# Read SSL from environment variable
+ENV_SSL_CONTEXT: Final[Optional["SSLContext"]] = (
+    ssl.create_default_context(cafile=os.environ.get("AIOHTTP_CAFILE"))
+    if os.environ.get("AIOHTTP_CAFILE") and ssl is not None
+    else None
+)
 
 
 class Connection:
@@ -760,7 +769,7 @@ class TCPConnector(BaseConnector):
                 "ssl should be SSLContext, bool, Fingerprint, "
                 "or None, got {!r} instead.".format(ssl)
             )
-        self._ssl = ssl
+        self._ssl = ssl or ENV_SSL_CONTEXT
         if resolver is None:
             resolver = DefaultResolver()
         self._resolver: AbstractResolver = resolver


### PR DESCRIPTION
## What do these changes do?

Setting `AIOHTTP_CAFILE=<path>` will be used as the fallback SSLContext when using the TCPconnector class. An attempt to get rid of the boilerplate needed to set up custom ca's.

As en example(from [SO](https://stackoverflow.com/questions/41701791/aiohttp-and-client-side-ssl-certificates)).
```python
import ssl
import aiohttp    
conn = aiohttp.TCPConnector(ssl_context=ssl.create_default_context(cafile='/path_to_client_root_ca'))
session = aiohttp.ClientSession(connector=conn)
``` 

## Related issue number
https://github.com/aio-libs/aiohttp/issues/341

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
