### PR TITLE
Add missing __repr__ to streams.EmptyStreamReader

### DIFF
--- a/CHANGES/6916.bugfix
+++ b/CHANGES/6916.bugfix
@@ -1,0 +1,1 @@
+Add __repr__ to EmptyStreamReader to avoid AttributeErrors.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -160,6 +160,7 @@ Jake Davis
 Jakob Ackermann
 Jakub Wilk
 Jan Buchar
+Jarno Elonen
 Jashandeep Sohi
 Jean-Baptiste Estival
 Jens Steinhauser

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -492,6 +492,9 @@ class EmptyStreamReader(StreamReader):  # lgtm [py/missing-call-to-init]
     def __init__(self) -> None:
         pass
 
+    def __repr__(self) -> str:
+        return "<%s>" % self.__class__.__name__
+
     def exception(self) -> Optional[BaseException]:
         return None
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1062,6 +1062,7 @@ class TestStreamReader:
 
 async def test_empty_stream_reader() -> None:
     s = streams.EmptyStreamReader()
+    assert str(s) is not None
     assert s.set_exception(ValueError()) is None
     assert s.exception() is None
     assert s.feed_eof() is None


### PR DESCRIPTION
**EmptyStreamReader** currently inherits `__repr__` from **StreamReader** , which then tries to access non-existing fields, causing AttributeErrors. The bug causes issues like this in upstream code: https://github.com/miguelgrinberg/python-socketio/issues/1032

This PR adds a custom `__repr__` to EmptyStreamReader to fix the problem.
