### PR TITLE
Support supplying `FileField` objects as `FormData` field values

### DIFF
--- a/aiohttp/formdata.py
+++ b/aiohttp/formdata.py
@@ -7,6 +7,7 @@ from multidict import MultiDict, MultiDictProxy
 from . import hdrs, multipart, payload
 from .helpers import guess_filename
 from .payload import Payload
+from .web_request import FileField
 
 __all__ = ("FormData",)
 
@@ -52,6 +53,12 @@ class FormData:
         content_transfer_encoding: Optional[str] = None,
     ) -> None:
 
+        if isinstance(value, FileField):
+            if filename is None:
+                filename = value.filename
+            if content_type is None:
+                content_type = value.content_type
+            value = value.file
         if isinstance(value, io.IOBase):
             self._is_multipart = True
         elif isinstance(value, (bytes, bytearray, memoryview)):


### PR DESCRIPTION
This makes it easier to proxy multi-part requests:

    data = await request.post()
    resp = await session.post(..., data=FormData(data))

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
