### PR TITLE
Increase the upper boundary of the multidict dependency allowing v6

### DIFF
--- a/CHANGES/6950.bugfix
+++ b/CHANGES/6950.bugfix
@@ -1,1 +1,7 @@
-Re-allow multidict version 6 as a dependency.
+Increased the upper boundary of the :doc:`multidict:index` dependency
+to allow for the version 6 -- by :user:`hugovk`.
+
+It used to be limited below version 7 in :doc:`aiohttp <index>` v3.8.1 but
+was lowered in v3.8.2 via :pr:`6550` and never brought back, causing
+the upgrading users problems with their dependency pins. :doc:`aiohttp
+<index>` v3.8.3 fixes that by recovering the original boundary of ``< 7``.

--- a/CHANGES/6950.bugfix
+++ b/CHANGES/6950.bugfix
@@ -1,0 +1,1 @@
+Re-allow multidict version 6 as a dependency.

--- a/CHANGES/6950.bugfix
+++ b/CHANGES/6950.bugfix
@@ -3,5 +3,5 @@ to allow for the version 6 -- by :user:`hugovk`.
 
 It used to be limited below version 7 in :doc:`aiohttp <index>` v3.8.1 but
 was lowered in v3.8.2 via :pr:`6550` and never brought back, causing
-the upgrading users problems with their dependency pins. :doc:`aiohttp
-<index>` v3.8.3 fixes that by recovering the original boundary of ``< 7``.
+problems with dependency pins when upgrading. :doc:`aiohttp <index>` v3.8.3
+fixes that by recovering the original boundary of ``< 7``.

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -196,9 +196,9 @@ class WebSocketResponse(StreamResponse):
         accept_val = base64.b64encode(
             hashlib.sha1(key.encode() + WS_KEY).digest()
         ).decode()
-        response_headers = CIMultiDict(  # type: ignore[var-annotated]
+        response_headers = CIMultiDict(
             {
-                hdrs.UPGRADE: "websocket",  # type: ignore[arg-type]
+                hdrs.UPGRADE: "websocket",
                 hdrs.CONNECTION: "upgrade",
                 hdrs.SEC_WEBSOCKET_ACCEPT: accept_val,
             }

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ include_package_data = True
 install_requires =
   attrs >= 17.3.0
   charset-normalizer >=2.0, < 3.0
-  multidict >=4.5, < 6.0
+  multidict >=4.5, < 7.0
   async_timeout >= 4.0.0a3, < 5.0
   asynctest == 0.13.0; python_version<"3.8"
   yarl >= 1.0, < 2.0


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The multidict dependency used to be `multidict >=4.5, < 7.0` in aiohttp 3.8.1, but was pinned down to `multidict >=4.5, < 6.0` in aiohttp 3.8.2 (https://github.com/aio-libs/aiohttp/pull/6550) in an attempt to help avoid new errors.

However, https://github.com/python/bedevere/ uses `multidict==6.0.2` so the requirements resolution fails with `aiohttp==3.8.2`:

```console
ERROR: Cannot install -r requirements.txt (line 1) and multidict==6.0.2 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested multidict==6.0.2
    aiohttp 3.8.2 depends on multidict<6.0 and >=4.5

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```

https://github.com/hugovk/bedevere/actions/runs/3095794573/jobs/5010600772

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

None that I know of, other than they can install multidict v6 as with aiohttp 3.8.1.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Partially related to closed https://github.com/aio-libs/aiohttp/issues/6600 and merged https://github.com/aio-libs/aiohttp/pull/6550.

## Checklist

- [x] I think the code is well written
- [n/a] Unit tests for the changes exist
- [n/a] Documentation reflects the changes
- [already there] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
