### PR TITLE
[PR #6843/f90cb195 backport][3.9] Add type Path on web app run

### DIFF
--- a/CHANGES/6839.feature
+++ b/CHANGES/6839.feature
@@ -1,0 +1,1 @@
+``web.run_app()`` now accept a ``Path`` object for the path parameter.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -256,6 +256,7 @@ Required Field
 Robert Lu
 Robert Nikolich
 Roman Podoliaka
+Samir Akarioh
 Samuel Colvin
 Sean Hunt
 Sebastian Acuna

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -5,6 +5,7 @@ import sys
 from argparse import ArgumentParser
 from collections.abc import Iterable
 from importlib import import_module
+from pathlib import Path
 from typing import (
     Any,
     Awaitable,
@@ -292,7 +293,7 @@ async def _run_app(
     *,
     host: Optional[Union[str, HostSequence]] = None,
     port: Optional[int] = None,
-    path: Optional[str] = None,
+    path: Optional[Union[str, Path]] = None,
     sock: Optional[Union[socket.socket, TypingIterable[socket.socket]]] = None,
     shutdown_timeout: float = 60.0,
     keepalive_timeout: float = 75.0,
@@ -368,7 +369,7 @@ async def _run_app(
             )
 
         if path is not None:
-            if isinstance(path, (str, bytes, bytearray, memoryview)):
+            if isinstance(path, (str, bytes, bytearray, memoryview, Path)):
                 sites.append(
                     UnixSite(
                         runner,
@@ -465,7 +466,7 @@ def run_app(
     *,
     host: Optional[Union[str, HostSequence]] = None,
     port: Optional[int] = None,
-    path: Optional[str] = None,
+    path: Optional[Union[str, Path]] = None,
     sock: Optional[Union[socket.socket, TypingIterable[socket.socket]]] = None,
     shutdown_timeout: float = 60.0,
     keepalive_timeout: float = 75.0,

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -3,7 +3,7 @@ import signal
 import socket
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, List, Optional, Set, Type, Union
+from typing import Any, List, Optional, Set, Union
 
 from yarl import URL
 

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -2,7 +2,8 @@ import asyncio
 import signal
 import socket
 from abc import ABC, abstractmethod
-from typing import Any, List, Optional, Set
+from pathlib import Path
+from typing import Any, List, Optional, Set, Type, Union
 
 from yarl import URL
 
@@ -135,7 +136,7 @@ class UnixSite(BaseSite):
     def __init__(
         self,
         runner: "BaseRunner",
-        path: str,
+        path: Union[str, Path],
         *,
         shutdown_timeout: float = 60.0,
         ssl_context: Optional[SSLContext] = None,
@@ -160,7 +161,10 @@ class UnixSite(BaseSite):
         server = self._runner.server
         assert server is not None
         self._server = await loop.create_unix_server(
-            server, self._path, ssl=self._ssl_context, backlog=self._backlog
+            server,
+            self._path,  # type: ignore[arg-type]
+            ssl=self._ssl_context,
+            backlog=self._backlog,
         )
 
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2930,10 +2930,10 @@ Utilities
                     text HTTP and ``8443`` for HTTP via SSL (when
                     *ssl_context* parameter is specified).
 
-   :param str path: file system path for HTTP server Unix domain socket.
+   :param path: file system path for HTTP server Unix domain socket.
                     A sequence of file system paths can be used to bind
                     multiple domain sockets. Listening on Unix domain
-                    sockets is not supported by all operating systems.
+                    sockets is not supported by all operating systems, :class:`str` or :class:`pathlib.Path` .
 
    :param socket.socket sock: a preexisting socket object to accept connections on.
                        A sequence of socket objects can be passed.


### PR DESCRIPTION
**This is a backport of PR #6843 as merged into master (f90cb1952c272936845b93a8f424b32e703d545c).**

(cherry picked from commit f90cb19)

<!-- Thank you for your contribution! -->

## What do these changes do?

I modify the web.py file and add Union[str,pathlib.Path] for path

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

For the option of path, we can have str or pathlib.path

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#6839 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."