### PR TITLE
Grammar improvements around backwards-compatibility policy.

### DIFF
--- a/CHANGES/6979.doc
+++ b/CHANGES/6979.doc
@@ -1,1 +1,1 @@
-Improve grammar and brevity in communication in the Policy for Backward Incompatible Changes section of docs/index.rst -- :user:`Paarth`.
+Improve grammar and brevity in communication in the Policy for Backward Incompatible Changes section of ``docs/index.rst`` -- :user:`Paarth`.

--- a/CHANGES/6979.doc
+++ b/CHANGES/6979.doc
@@ -1,0 +1,1 @@
+Improve grammar and brevity in communication in the Policy for Backward Incompatible Changes section of docs/index.rst -- :user:`Paarth`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -213,18 +213,17 @@ Policy for Backward Incompatible Changes
 
 *aiohttp* keeps backward compatibility.
 
-After deprecating some *Public API* (method, class, function argument,
-etc.) the library guarantees the usage of *deprecated API* is still
-allowed at least for a year and half after publishing new release with
-deprecation.
+When a new release is published that deprecates a *Public API* (method, class,
+function argument, etc.), the library will guarantee its usage for at least
+a year and half from the date of release.
 
-All deprecations are reflected in documentation and raises
+Deprecated APIs are reflected in their documentation, and their use will raise
 :exc:`DeprecationWarning`.
 
-Sometimes we are forced to break our own rule for the sake of very strong
-reason.  Most likely the reason is a critical bug which cannot be
-solved without major API change, but we are working hard for keeping
-these changes as rare as possible.
+However, if there is a strong reason, we may be forced to break this guarantee.
+The most likely reason would be a critical bug, such as a security issue, which
+cannot be solved without a major API change. We are working hard to keep these
+breaking changes as rare as possible.
 
 
 Table Of Contents


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Improve grammar and brevity in communication in the `Policy for Backward Incompatible Changes` section of `docs/index.rst` 

## Are there changes in behavior for the user?

No functional changes. Will improve introductory communication on https://docs.aiohttp.org

## Related issue number
N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
