### PR TITLE
Make `ClientSession.headers` a settable property

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -267,12 +267,7 @@ class ClientSession:
         self._requote_redirect_url = requote_redirect_url
         self._read_bufsize = read_bufsize
 
-        # Convert to list of tuples
-        if headers:
-            real_headers: CIMultiDict[str] = CIMultiDict(headers)
-        else:
-            real_headers = CIMultiDict()
-        self._default_headers: CIMultiDict[str] = real_headers
+        self.headers = headers  # See `headers` property setter function
         if skip_auto_headers is not None:
             self._skip_auto_headers = frozenset(istr(i) for i in skip_auto_headers)
         else:
@@ -1014,6 +1009,12 @@ class ClientSession:
     def headers(self) -> "CIMultiDict[str]":
         """The default headers of the client session."""
         return self._default_headers
+
+    @headers.setter
+    def headers(self, value: Optional[LooseHeaders] = None) -> None:
+        """Set or update the default headers of the client session."""
+        value = value or {}
+        self._default_headers = CIMultiDict(value)
 
     @property
     def skip_auto_headers(self) -> FrozenSet[istr]:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -267,7 +267,10 @@ class ClientSession:
         self._requote_redirect_url = requote_redirect_url
         self._read_bufsize = read_bufsize
 
-        self.headers = headers  # See `headers` property setter function
+        # See `headers` property setter function. Mypy struggling with the property
+        # returning a stricter type than the setter function allows.
+        # https://github.com/python/mypy/issues/3004
+        self.headers = headers  # type: ignore
         if skip_auto_headers is not None:
             self._skip_auto_headers = frozenset(istr(i) for i in skip_auto_headers)
         else:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -124,8 +124,10 @@ async def test_init_cookies_with_list_of_tuples(create_session: Any) -> None:
 async def test_headers_can_be_updated(create_session: Any) -> None:
     session = await create_session()
     session.headers = {"h1": "header1", "h2": "header2"}
-    assert session.headers == session._default_headers == CIMultiDict(
-        [("h1", "header1"), ("h2", "header2")]
+    assert (
+        session.headers
+        == session._default_headers
+        == CIMultiDict([("h1", "header1"), ("h2", "header2")])
     )
 
 

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -121,6 +121,14 @@ async def test_init_cookies_with_list_of_tuples(create_session: Any) -> None:
     assert cookies["c2"].value == "cookie2"
 
 
+async def test_headers_can_be_updated(create_session: Any) -> None:
+    session = await create_session()
+    session.headers = {"h1": "header1", "h2": "header2"}
+    assert session.headers == session._default_headers == CIMultiDict(
+        [("h1", "header1"), ("h2", "header2")]
+    )
+
+
 async def test_merge_headers(create_session: Any) -> None:
     # Check incoming simple dict
     session = await create_session(headers={"h1": "header1", "h2": "header2"})


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

After a client session has been initialized, default session-wide headers may be updated. This allows application developers to update authorization headers periodically, for example.

## Are there changes in behavior for the user?

No, except that in addition to reading `ClientSession.headers`, users may now set this property. Existing behavior does not change.

## Related issue number

Issue #6954 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
