### PR TITLE
Remove Extra Spaces

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ To get something from the web:
               html = await response.text()
               print("Body:", html[:15], "...")
 
-    asyncio.run(main())
+  asyncio.run(main())
 
 This prints:
 


### PR DESCRIPTION
- Remove extra spaces in README files
- When the user copies this code will cause the user to remove the extra spaces