### PR TITLE
Add documentation section on client authentication

### DIFF
--- a/CHANGES/6998.doc
+++ b/CHANGES/6998.doc
@@ -1,0 +1,1 @@
+Added documentation on client authentication and updating headers. -- by :user:`faph`

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -122,6 +122,7 @@ Evert Lammerts
 Felix Yan
 Fernanda Guimarães
 FichteFoll
+Florenz A.P. Hollebrandse
 Florian Scheffler
 Franek Magiera
 Frederik Gladhorn

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -122,7 +122,6 @@ Evert Lammerts
 Felix Yan
 Fernanda Guimarães
 FichteFoll
-Florenz A.P. Hollebrandse
 Florian Scheffler
 Franek Magiera
 Frederik Gladhorn

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -46,11 +46,6 @@ You also can set default headers for all session requests::
             assert json_body['headers']['Authorization'] == \
                 'Basic bG9naW46cGFzcw=='
 
-The default headers for a session may be modified as and when required.
-For example::
-
-    session.headers["Authorization"] = "Basic bG9naW46c2VjcmV0"
-
 Typical use case is sending JSON body. You can specify content type
 directly as shown above, but it is more convenient to use special keyword
 ``json``::
@@ -71,6 +66,39 @@ For *text/plain* ::
 
    Started keeping the ``Authorization`` header during ``HTTP -> HTTPS``
    redirects when the host remains the same.
+
+Authentication
+--------------
+
+Instead of setting the ``Authorization`` header directly,
+:class:`ClientSession` and individual request methods provide an ``auth``
+argument. An instance of :class:`BasicAuth` can be passed in like this::
+
+    auth = BasicAuth(login="...", password="...")
+    async with ClientSession(auth=auth) as session:
+        ...
+
+For other authentication flows, the ``Authorization`` header can be set
+directly::
+
+    headers = {"Authorization": "Bearer eyJh...0M30"}
+    async with ClientSession(headers=headers) as session:
+        ...
+
+The authentication header for a session may be updated as and when required.
+For example::
+
+    session.headers["Authorization"] = "Bearer eyJh...1OH0"
+
+Note that a *copy* of the original headers dictionary is set on the
+:class:`ClientSession` instance as a :class:`CIMultiDict` object. Updating the
+original dictionary does not have any effect. Instead, the
+:attr:`ClientSession.headers` property can be updated like a standard
+dictionary.
+
+In cases where the authentication header value expires periodically, an
+:mod:`asyncio` task may be used to update the session's default headers in the
+background.
 
 Custom Cookies
 --------------

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -52,7 +52,7 @@ directly as shown above, but it is more convenient to use special keyword
 
     await session.post(url, json={'example': 'text'})
 
-For *text/plain* ::
+For ``text/plain``::
 
     await session.post(url, data='Привет, Мир!')
 

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -56,17 +56,6 @@ For *text/plain* ::
 
     await session.post(url, data='Привет, Мир!')
 
-.. note::
-
-   ``Authorization`` header will be removed if you get redirected
-   to a different host or protocol, except the case when  ``HTTP -> HTTPS``
-   redirect is performed on the same host.
-
-.. versionchanged:: 4.0
-
-   Started keeping the ``Authorization`` header during ``HTTP -> HTTPS``
-   redirects when the host remains the same.
-
 Authentication
 --------------
 
@@ -99,6 +88,17 @@ dictionary.
 In cases where the authentication header value expires periodically, an
 :mod:`asyncio` task may be used to update the session's default headers in the
 background.
+
+.. note::
+
+   The ``Authorization`` header will be removed if you get redirected
+   to a different host or protocol, except the case when  HTTP to HTTPS
+   redirect is performed on the same host.
+
+.. versionchanged:: 4.0
+
+   Started keeping the ``Authorization`` header during HTTP to HTTPS
+   redirects when the host remains the same.
 
 Custom Cookies
 --------------

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -80,10 +80,8 @@ For example::
     session.headers["Authorization"] = "Bearer eyJh...1OH0"
 
 Note that a *copy* of the headers dictionary is set as an attribute when
-creating a :class:`ClientSession` instance (as a :class:`CIMultiDict` object).
-Updating the original dictionary does not have any effect. Instead, the
-:attr:`ClientSession.headers` property should be updated like a standard
-dictionary.
+creating a :class:`ClientSession` instance (as a :class:`multidict.CIMultiDict`
+object). Updating the original dictionary does not have any effect.
 
 In cases where the authentication header value expires periodically, an
 :mod:`asyncio` task may be used to update the session's default headers in the
@@ -92,12 +90,12 @@ background.
 .. note::
 
    The ``Authorization`` header will be removed if you get redirected
-   to a different host or protocol, except the case when  HTTP to HTTPS
+   to a different host or protocol, except the case when  HTTP → HTTPS
    redirect is performed on the same host.
 
 .. versionchanged:: 4.0
 
-   Started keeping the ``Authorization`` header during HTTP to HTTPS
+   Started keeping the ``Authorization`` header during HTTP → HTTPS
    redirects when the host remains the same.
 
 Custom Cookies

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -80,7 +80,7 @@ For example::
     session.headers["Authorization"] = "Bearer eyJh...1OH0"
 
 Note that a *copy* of the headers dictionary is set as an attribute when
-creating an :class:`ClientSession` instance (as a :class:`CIMultiDict` object).
+creating a :class:`ClientSession` instance (as a :class:`CIMultiDict` object).
 Updating the original dictionary does not have any effect. Instead, the
 :attr:`ClientSession.headers` property should be updated like a standard
 dictionary.

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -46,6 +46,11 @@ You also can set default headers for all session requests::
             assert json_body['headers']['Authorization'] == \
                 'Basic bG9naW46cGFzcw=='
 
+The default headers for a session may be modified as and when required.
+For example::
+
+    session.headers["Authorization"] = "Basic bG9naW46c2VjcmV0"
+
 Typical use case is sending JSON body. You can specify content type
 directly as shown above, but it is more convenient to use special keyword
 ``json``::

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -79,10 +79,10 @@ For example::
 
     session.headers["Authorization"] = "Bearer eyJh...1OH0"
 
-Note that a *copy* of the original headers dictionary is set on the
-:class:`ClientSession` instance as a :class:`CIMultiDict` object. Updating the
-original dictionary does not have any effect. Instead, the
-:attr:`ClientSession.headers` property can be updated like a standard
+Note that a *copy* of the headers dictionary is set as an attribute when
+creating an :class:`ClientSession` instance (as a :class:`CIMultiDict` object).
+Updating the original dictionary does not have any effect. Instead, the
+:attr:`ClientSession.headers` property should be updated like a standard
 dictionary.
 
 In cases where the authentication header value expires periodically, an


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds a dedicated section on client authentication using the `auth` argument for HTTP Basic Auth. Also explains how to configure other authentication flows including periodic renewal of credentials.

## Are there changes in behavior for the user?

No. Just makes it easier for developers to access authentication `aiohttp` features. Avoids users asking questions like this: https://github.com/aio-libs/aiohttp/discussions/6908

## Related issue number

Issue #6915 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
