### PR TITLE
Cover ttl=0 (expire always) _DNSCacheTable case

### DIFF
--- a/CHANGES/7014.bugfix
+++ b/CHANGES/7014.bugfix
@@ -1,0 +1,1 @@
+Fixed bug when using TCPConnector with ttl_dns_cache=0.

--- a/CHANGES/7014.bugfix
+++ b/CHANGES/7014.bugfix
@@ -1,1 +1,1 @@
-Fixed bug when using TCPConnector with ttl_dns_cache=0.
+Fixed bug when using ``TCPConnector`` with ``ttl_dns_cache=0``.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -153,6 +153,7 @@ Illia Volochii
 Ilya Chichak
 Ilya Gruzinov
 Ingmar Steen
+Ivan Lakovic
 Ivan Larin
 Jacob Champion
 Jaesung Lee

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -678,13 +678,13 @@ class _DNSCacheTable:
     def add(self, key: Tuple[str, int], addrs: List[Dict[str, Any]]) -> None:
         self._addrs_rr[key] = (cycle(addrs), len(addrs))
 
-        if self._ttl:
+        if self._ttl is not None:
             self._timestamps[key] = monotonic()
 
     def remove(self, key: Tuple[str, int]) -> None:
         self._addrs_rr.pop(key, None)
 
-        if self._ttl:
+        if self._ttl is not None:
             self._timestamps.pop(key, None)
 
     def clear(self) -> None:
@@ -701,8 +701,6 @@ class _DNSCacheTable:
     def expired(self, key: Tuple[str, int]) -> bool:
         if self._ttl is None:
             return False
-        elif self._ttl == 0:
-            return True
 
         return self._timestamps[key] + self._ttl < monotonic()
 
@@ -719,7 +717,6 @@ class TCPConnector(BaseConnector):
         resolver
     use_dns_cache - Use memory cache for DNS lookups.
     ttl_dns_cache - Max seconds having cached a DNS entry, None forever.
-        0 expire immediately (use use_dns_cache=False instead). 10 by default.
     family - socket address family
     local_addr - local tuple of (host, port) to bind socket to
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -701,6 +701,8 @@ class _DNSCacheTable:
     def expired(self, key: Tuple[str, int]) -> bool:
         if self._ttl is None:
             return False
+        elif self._ttl == 0:
+            return True
 
         return self._timestamps[key] + self._ttl < monotonic()
 
@@ -717,6 +719,7 @@ class TCPConnector(BaseConnector):
         resolver
     use_dns_cache - Use memory cache for DNS lookups.
     ttl_dns_cache - Max seconds having cached a DNS entry, None forever.
+        0 expire immediately (use use_dns_cache=False instead). 10 by default.
     family - socket address family
     local_addr - local tuple of (host, port) to bind socket to
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2190,7 +2190,9 @@ class TestDNSCacheTable:
 
     def test_never_expire(self) -> None:
         dns_cache_table = _DNSCacheTable(ttl=None)
+        monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 1)
         dns_cache_table.add("localhost", ["127.0.0.1"])
+        monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 10000000)
         assert not dns_cache_table.expired("localhost")
 
     def test_always_expire(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2195,9 +2195,11 @@ class TestDNSCacheTable:
         monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 10000000)
         assert not dns_cache_table.expired("localhost")
 
-    def test_always_expire(self) -> None:
+    def test_always_expire(self, monkeypatch: pytest.MonkeyPatch) -> None:
         dns_cache_table = _DNSCacheTable(ttl=0)
+        monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 1)
         dns_cache_table.add("localhost", ["127.0.0.1"])
+        monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 1.00001)
         assert dns_cache_table.expired("localhost")
 
     def test_next_addrs(self, dns_cache_table: Any) -> None:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2179,21 +2179,23 @@ class TestDNSCacheTable:
         dns_cache_table.add("localhost", ["127.0.0.1"])
         assert not dns_cache_table.expired("localhost")
 
-    async def test_expired_ttl(self, loop: Any, monkeypatch: Any) -> None:
-        dns_cache_table = _DNSCacheTable(ttl=0.01)
+    def test_expired_ttl(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        dns_cache_table = _DNSCacheTable(ttl=1)
         monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 1)
         dns_cache_table.add("localhost", ["127.0.0.1"])
-        monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 1.02)
+        monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 2)
+        assert not dns_cache_table.expired("localhost")
+        monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 3)
         assert dns_cache_table.expired("localhost")
 
-    async def test_never_expire(self, loop: Any, monkeypatch: Any) -> None:
+    def test_never_expire(self, monkeypatch: pytest.MonkeyPatch) -> None:
         dns_cache_table = _DNSCacheTable(ttl=None)
         monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 1)
         dns_cache_table.add("localhost", ["127.0.0.1"])
         monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 10000000)
         assert not dns_cache_table.expired("localhost")
 
-    async def test_always_expire(self, loop: Any) -> None:
+    def test_always_expire(self) -> None:
         dns_cache_table = _DNSCacheTable(ttl=0)
         dns_cache_table.add("localhost", ["127.0.0.1"])
         assert dns_cache_table.expired("localhost")

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2179,16 +2179,18 @@ class TestDNSCacheTable:
         dns_cache_table.add("localhost", ["127.0.0.1"])
         assert not dns_cache_table.expired("localhost")
 
-    async def test_expired_ttl(self, loop: Any) -> None:
+    async def test_expired_ttl(self, loop: Any, monkeypatch: Any) -> None:
         dns_cache_table = _DNSCacheTable(ttl=0.01)
+        monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 1)
         dns_cache_table.add("localhost", ["127.0.0.1"])
-        await asyncio.sleep(0.02)
+        monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 1.02)
         assert dns_cache_table.expired("localhost")
 
-    async def test_never_expire(self, loop: Any) -> None:
+    async def test_never_expire(self, loop: Any, monkeypatch: Any) -> None:
         dns_cache_table = _DNSCacheTable(ttl=None)
+        monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 1)
         dns_cache_table.add("localhost", ["127.0.0.1"])
-        await asyncio.sleep(0.02)
+        monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 10000000)
         assert not dns_cache_table.expired("localhost")
 
     async def test_always_expire(self, loop: Any) -> None:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2188,7 +2188,7 @@ class TestDNSCacheTable:
         monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 3)
         assert dns_cache_table.expired("localhost")
 
-    def test_never_expire(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_never_expire(self) -> None:
         dns_cache_table = _DNSCacheTable(ttl=None)
         dns_cache_table.add("localhost", ["127.0.0.1"])
         assert not dns_cache_table.expired("localhost")

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2185,6 +2185,17 @@ class TestDNSCacheTable:
         await asyncio.sleep(0.02)
         assert dns_cache_table.expired("localhost")
 
+    async def test_never_expire(self, loop: Any) -> None:
+        dns_cache_table = _DNSCacheTable(ttl=None)
+        dns_cache_table.add("localhost", ["127.0.0.1"])
+        await asyncio.sleep(0.02)
+        assert not dns_cache_table.expired("localhost")
+
+    async def test_always_expire(self, loop: Any) -> None:
+        dns_cache_table = _DNSCacheTable(ttl=0)
+        dns_cache_table.add("localhost", ["127.0.0.1"])
+        assert dns_cache_table.expired("localhost")
+
     def test_next_addrs(self, dns_cache_table: Any) -> None:
         dns_cache_table.add("foo", ["127.0.0.1", "127.0.0.2", "127.0.0.3"])
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2190,9 +2190,7 @@ class TestDNSCacheTable:
 
     def test_never_expire(self, monkeypatch: pytest.MonkeyPatch) -> None:
         dns_cache_table = _DNSCacheTable(ttl=None)
-        monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 1)
         dns_cache_table.add("localhost", ["127.0.0.1"])
-        monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 10000000)
         assert not dns_cache_table.expired("localhost")
 
     def test_always_expire(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2188,7 +2188,7 @@ class TestDNSCacheTable:
         monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 3)
         assert dns_cache_table.expired("localhost")
 
-    def test_never_expire(self) -> None:
+    def test_never_expire(self, monkeypatch: pytest.MonkeyPatch) -> None:
         dns_cache_table = _DNSCacheTable(ttl=None)
         monkeypatch.setattr("aiohttp.connector.monotonic", lambda: 1)
         dns_cache_table.add("localhost", ["127.0.0.1"])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Fix bug when using ttl_dns_cache=0

<!-- Please give a short brief about these changes. -->
When using `ttl_dns_cache=0`, hostname is added to cache and on expire check there is a KeyError as it is never added into _timestamp dictionary.
Added a short description to docs ClientSession advising to use `use_dns_cache` instead of `ttl_dns_cache=0` for always expiring cache. 

Alternative to this change is to enforce user to use positive none 0 float or None for `ttl_dns_cache` during init time and in case of using 0 implicitly change `use_dns_cache` to False or raise exception.
## Are there changes in behavior for the user?
No.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
