### PR TITLE
Update version constraint in GHA workflows

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.3.2
+        uses: dependabot/fetch-metadata@v1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       with:
         python-version: 3.8
     - name: Cache PyPI
-      uses: actions/cache@v3.0.4
+      uses: actions/cache@v3
       with:
         key: pip-lint-${{ hashFiles('requirements/*.txt') }}
         path: ~/.cache/pip
@@ -97,7 +97,7 @@ jobs:
       with:
         submodules: true
     - name: Cache llhttp generated files
-      uses: actions/cache@v3.0.4
+      uses: actions/cache@v3
       id: cache
       with:
         key: llhttp-${{ hashFiles('vendor/llhttp/package.json', 'vendor/llhttp/src/**/*') }}
@@ -123,7 +123,7 @@ jobs:
     needs: gen_llhttp
     strategy:
       matrix:
-        pyver: [3.7, 3.8, 3.9, '3.10']
+        pyver: ['3.7', '3.8', '3.9', '3.10']
         no-extensions: ['', 'Y']
         os: [ubuntu, macos, windows]
         experimental: [false]
@@ -171,7 +171,7 @@ jobs:
       run: |
         echo "::set-output name=dir::$(pip cache dir)"    # - name: Cache
     - name: Cache PyPI
-      uses: actions/cache@v3.0.4
+      uses: actions/cache@v3
       with:
         key: pip-ci-${{ runner.os }}-${{ matrix.pyver }}-${{ matrix.no-extensions }}-${{ hashFiles('requirements/*.txt') }}
         path: ${{ steps.pip-cache.outputs.dir }}
@@ -343,7 +343,7 @@ jobs:
       run: |
         make cythonize
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.10.1
+      uses: pypa/cibuildwheel@v2.11.1
       env:
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
     - uses: actions/upload-artifact@v3

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v4
     - name: Cache PyPI
-      uses: actions/cache@v3.0.4
+      uses: actions/cache@v3
       with:
         key: post-update
         path: ~/.cache/pip

--- a/.github/workflows/update-pre-commit.yml
+++ b/.github/workflows/update-pre-commit.yml
@@ -19,12 +19,12 @@ jobs:
     - name: Run pre-commit autoupdate
       run: pre-commit autoupdate
     - id: generate_token
-      uses: tibdex/github-app-token@v1.5
+      uses: tibdex/github-app-token@v1
       with:
         app_id: ${{ secrets.BOT_APP_ID }}
         private_key: ${{ secrets.BOT_PRIVATE_KEY }}
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v4.0.4
+      uses: peter-evans/create-pull-request@v4
       with:
         token: ${{ steps.generate_token.outputs.token }}
         branch: update/pre-commit-autoupdate

--- a/CHANGES/7046.misc
+++ b/CHANGES/7046.misc
@@ -1,0 +1,1 @@
+Update version constraint in GHA workflows

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -126,6 +126,7 @@ Florian Scheffler
 Franek Magiera
 Frederik Gladhorn
 Frederik Peter Aalund
+Gabriel Machado
 Gabriel Tremblay
 Gary Wilson Jr.
 Gennady Andreyev


### PR DESCRIPTION
## What do these changes do?

Attempt to reduce the set-output and save-state deprecation warn
over time by updating the actions wherever is possible to use the
latest major release for a given action (i.e. using a v3 release instead v3.x.y)

## Are there changes in behavior for the user?

No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
