### PR TITLE
Add `auto_decompress` parameter to `ClientSession.request()`

### DIFF
--- a/CHANGES/3751.feature
+++ b/CHANGES/3751.feature
@@ -1,0 +1,1 @@
+Added ``auto_decompress`` parameter to ``ClientSession.request`` to override ``ClientSession._auto_decompress``. -- by :user:`Daste745`

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -351,6 +351,7 @@ class ClientSession:
         proxy_headers: Optional[LooseHeaders] = None,
         trace_request_ctx: Optional[SimpleNamespace] = None,
         read_bufsize: Optional[int] = None,
+        auto_decompress: Optional[bool] = None,
     ) -> ClientResponse:
 
         # NOTE: timeout clamps existing connect and read timeouts.  We cannot
@@ -410,6 +411,9 @@ class ClientSession:
 
         if read_bufsize is None:
             read_bufsize = self._read_bufsize
+
+        if auto_decompress is None:
+            auto_decompress = self._auto_decompress
 
         traces = [
             Trace(
@@ -512,7 +516,7 @@ class ClientSession:
                         timer=timer,
                         skip_payload=method.upper() == "HEAD",
                         read_until_eof=read_until_eof,
-                        auto_decompress=self._auto_decompress,
+                        auto_decompress=auto_decompress,
                         read_timeout=real_timeout.sock_read,
                         read_bufsize=read_bufsize,
                         timeout_ceil_threshold=self._connector._timeout_ceil_threshold,

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -512,7 +512,7 @@ The client session supports the context manager protocol for self closing.
 
       :param bool auto_decompress: Automatically decompress response body.
          Overrides :attr:`ClientSession.auto_decompress`.
-         May be used to disable auto decompression on a per-request basis.
+         May be used to enable/disable auto decompression on a per-request basis.
 
       :return ClientResponse: a :class:`client response <ClientResponse>`
          object.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -164,8 +164,7 @@ The client session supports the context manager protocol for self closing.
       connection pool between sessions without sharing session state:
       cookies etc.
 
-   :param bool auto_decompress: Automatically decompress response body,
-       ``True`` by default
+   :param bool auto_decompress: Automatically decompress response body (``True`` by default).
 
       .. versionadded:: 2.3
 
@@ -338,7 +337,8 @@ The client session supports the context manager protocol for self closing.
                          proxy=None, proxy_auth=None,\
                          timeout=sentinel, ssl=None, \
                          verify_ssl=None, fingerprint=None, \
-                         ssl_context=None, proxy_headers=None)
+                         ssl_context=None, proxy_headers=None, \
+                         auto_decompress=None)
       :async-with:
       :coroutine:
       :noindexentry:
@@ -509,6 +509,10 @@ The client session supports the context manager protocol for self closing.
         tracers that is only available at request time.
 
          .. versionadded:: 3.0
+
+      :param bool auto_decompress: Automatically decompress response body.
+         Overrides :attr:`ClientSession.auto_decompress`.
+         May be used to disable auto decompression on a per-request basis.
 
       :return ClientResponse: a :class:`client response <ClientResponse>`
          object.


### PR DESCRIPTION
## What do these changes do?

Added a parameter to `ClientSession.request()` method to override the `ClientSession.auto_decompress` attribute.

Implements changes proposed in 

## Are there changes in behavior for the user?

As discussed in #3751, the user is now able to enable/disable `auto_decompress` on a per-request basis.

## Related issue number

#3751

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
