### PR TITLE
bug(trace): Expose TraceRequestHeadersSentParams

### DIFF
--- a/CHANGES/7113.bugfix
+++ b/CHANGES/7113.bugfix
@@ -1,0 +1,1 @@
+TraceRequestHeadersSentParams is not exposed to clients. Exposing it by updating `aiohttp/__init__.py`.

--- a/CHANGES/7113.bugfix
+++ b/CHANGES/7113.bugfix
@@ -1,1 +1,0 @@
-TraceRequestHeadersSentParams is not exposed to clients. Exposing it by updating `aiohttp/__init__.py`.

--- a/CHANGES/7113.feature
+++ b/CHANGES/7113.feature
@@ -1,0 +1,1 @@
+Export ``TraceRequestHeadersSentParams``.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -68,6 +68,7 @@ Bruno Souza Cabral
 Bryan Kok
 Bryce Drennan
 Carl George
+Casey Howard
 Cecile Tonglet
 Chien-Wei Huang
 Chih-Yuan Chen

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -101,6 +101,7 @@ from .tracing import (
     TraceRequestRedirectParams as TraceRequestRedirectParams,
     TraceRequestStartParams as TraceRequestStartParams,
     TraceResponseChunkReceivedParams as TraceResponseChunkReceivedParams,
+    TraceRequestHeadersSentParams as TraceRequestHeadersSentParams,
 )
 
 if TYPE_CHECKING:
@@ -210,6 +211,7 @@ __all__: Tuple[str, ...] = (
     "TraceRequestRedirectParams",
     "TraceRequestStartParams",
     "TraceResponseChunkReceivedParams",
+    "TraceRequestHeadersSentParams",
     # workers (imported lazily with __getattr__)
     "GunicornUVLoopWebWorker",
     "GunicornWebWorker",

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -98,10 +98,10 @@ from .tracing import (
     TraceRequestChunkSentParams as TraceRequestChunkSentParams,
     TraceRequestEndParams as TraceRequestEndParams,
     TraceRequestExceptionParams as TraceRequestExceptionParams,
+    TraceRequestHeadersSentParams as TraceRequestHeadersSentParams,
     TraceRequestRedirectParams as TraceRequestRedirectParams,
     TraceRequestStartParams as TraceRequestStartParams,
     TraceResponseChunkReceivedParams as TraceResponseChunkReceivedParams,
-    TraceRequestHeadersSentParams as TraceRequestHeadersSentParams,
 )
 
 if TYPE_CHECKING:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

TraceRequestHeadersSentParams is not exposed to clients. Exposing it by updating `__init__.py`.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Yes, it lets them use TraceRequestHeadersSentParams.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
