### PR TITLE
Support using netrc for non-proxy HTTP credentials

### DIFF
--- a/CHANGES/7131.feature
+++ b/CHANGES/7131.feature
@@ -1,1 +1,1 @@
-Support reading HTTP Basic Auth credentials from .netrc file when ``trust_env`` is ``True``.
+Added support for using Basic Auth credentials from :file:`.netrc` file when making HTTP requests with the :py:class:`~aiohttp.ClientSession` ``trust_env`` argument is set to ``True`` -- by :user:`yuvipanda`.

--- a/CHANGES/7131.feature
+++ b/CHANGES/7131.feature
@@ -1,0 +1,1 @@
+Support reading HTTP Basic Auth credentials from .netrc file when ``trust_env`` is ``True``.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -353,6 +353,7 @@ Yury Pliner
 Yury Selivanov
 Yusuke Tsutsumi
 Yuval Ofir
+Yuvi Panda
 Zainab Lawal
 Zeal Wierslee
 Zlatan Sičanica

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -492,6 +492,7 @@ class ClientSession:
                         ssl=ssl,
                         proxy_headers=proxy_headers,
                         traces=traces,
+                        trust_env=self.trust_env,
                     )
 
                     # connection timeout

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -436,8 +436,7 @@ class ClientRequest:
         """Set basic auth."""
         if auth is None:
             auth = self.auth
-        URL_HAS_A_HOST = self.url.host is not None
-        if auth is None and trust_env and URL_HAS_A_HOST:
+        if auth is None and trust_env and self.url.host is not None:
             netrc_obj = netrc_from_env()
             with contextlib.suppress(LookupError):
                 auth = basicauth_from_netrc(netrc_obj, self.url.host)

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -44,6 +44,7 @@ from .helpers import (
     BasicAuth,
     HeadersMixin,
     TimerNoop,
+    basicauth_from_netrc,
     is_expected_content_type,
     netrc_from_env,
     noop,
@@ -440,11 +441,8 @@ class ClientRequest:
 
                 netrc_obj = netrc_from_env()
                 if netrc_obj:
-                    auth_from_netrc = netrc_obj.authenticators(self.url.host)
-                    if auth_from_netrc:
-                        *logins, password = auth_from_netrc
-                        login = logins[0] if logins[0] else logins[-1]
-                        auth = BasicAuth(cast(str, login), cast(str, password))
+                    auth = basicauth_from_netrc(netrc_obj, self.url.host)
+                    if auth:
                         self.headers[hdrs.AUTHORIZATION] = auth.encode()
 
             return

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1,5 +1,6 @@
 import asyncio
 import codecs
+import contextlib
 import dataclasses
 import functools
 import io
@@ -437,7 +438,7 @@ class ClientRequest:
             auth = self.auth
         if auth is None and trust_env:
             netrc_obj = netrc_from_env()
-            if netrc_obj:
+            with contextlib.suppress(LookupError):
                 auth = basicauth_from_netrc(netrc_obj, self.url.host)
         if auth is None:
             return

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -436,7 +436,8 @@ class ClientRequest:
         """Set basic auth."""
         if auth is None:
             auth = self.auth
-        if auth is None and trust_env and self.url.host is not None:
+        URL_HAS_A_HOST = self.url.host is not None
+        if auth is None and trust_env and URL_HAS_A_HOST:
             netrc_obj = netrc_from_env()
             with contextlib.suppress(LookupError):
                 auth = basicauth_from_netrc(netrc_obj, self.url.host)

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -435,7 +435,7 @@ class ClientRequest:
         """Set basic auth."""
         if auth is None:
             auth = self.auth
-        if auth is None and trust_env:
+        if auth is None and trust_env and self.url.host is not None:
             netrc_obj = netrc_from_env()
             if netrc_obj:
                 auth = basicauth_from_netrc(netrc_obj, self.url.host)

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -435,16 +435,11 @@ class ClientRequest:
         """Set basic auth."""
         if auth is None:
             auth = self.auth
+        if auth is None and trust_env:
+            netrc_obj = netrc_from_env()
+            if netrc_obj:
+                auth = basicauth_from_netrc(netrc_obj, self.url.host)
         if auth is None:
-            if trust_env:
-                # If no auth is specified, we read from netrc.
-
-                netrc_obj = netrc_from_env()
-                if netrc_obj:
-                    auth = basicauth_from_netrc(netrc_obj, self.url.host)
-                    if auth:
-                        self.headers[hdrs.AUTHORIZATION] = auth.encode()
-
             return
 
         if not isinstance(auth, helpers.BasicAuth):

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -246,12 +246,25 @@ class ProxyInfo:
 def basicauth_from_netrc(netrc_obj: netrc.netrc, host: str) -> Optional[BasicAuth]:
     auth_from_netrc = netrc_obj.authenticators(host)
     if auth_from_netrc is not None:
-        # auth_from_netrc is a (`user`, `account`, `password`) tuple,
-        # `user` and `account` both can be username,
-        # if `user` is None, use `account`
-        *logins, password = auth_from_netrc
-        login = logins[0] if logins[0] else logins[-1]
-        auth = BasicAuth(login, password)
+        login, account, password = auth_from_netrc
+        if not login:
+            # login is provided, we just use it as username.
+            # If login and account are both provided, only login is used
+            username = login
+        elif account:
+            # login is not provided, but account is
+            username = account
+        else:
+            # neither login nore account are provided, we use blank username
+            # this matches python 3.11 behavior
+            username = ""
+
+        if password is None:
+            # Password is not provided, we use blank string.
+            # this matches python 3.11 behavior
+            password = ""
+
+        auth = BasicAuth(username, password)
         return auth
 
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -243,7 +243,7 @@ class ProxyInfo:
     proxy_auth: Optional[BasicAuth]
 
 
-def basicauth_from_netrc(netrc_obj: netrc.netrc, host: str) -> BasicAuth:
+def basicauth_from_netrc(netrc_obj: Optional[netrc.netrc], host: str) -> BasicAuth:
     """
     Return :py:class:`~aiohttp.BasicAuth` credentials for ``host`` from ``netrc_obj``.
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -262,8 +262,7 @@ def basicauth_from_netrc(netrc_obj: Optional[netrc.netrc], host: str) -> BasicAu
     # Up to python 3.10, account could be None if not specified,
     # and login will be empty string if not specified. From 3.11,
     # login and account will be empty string if not specified.
-    prefer_login_over_account = login or account is None
-    username = login if prefer_login_over_account else account
+    username = login if (login or account is None) else account
 
     # TODO(PY311): Remove this, as password will be empty string
     # if not specified

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -261,8 +261,8 @@ def basicauth_from_netrc(netrc_obj: netrc.netrc, host: str) -> BasicAuth:
     # Up to python 3.10, account could be None if not specified,
     # and login will be empty string if not specified. From 3.11,
     # login and account will be empty string if not specified.
-    # If login is present, we prefer that over account as username
-    username = login if (login or account is None) else account
+    prefer_login_over_account = login or account is None
+    username = login if prefer_login_over_account else account
 
     # TODO(PY311): Remove this, as password will be empty string
     # if not specified

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -251,7 +251,7 @@ def basicauth_from_netrc(netrc_obj: netrc.netrc, host: str) -> Optional[BasicAut
     login, account, password = auth_from_netrc
 
     # TODO(PY311): username = login or account
-    # Upto python 3.10, account could be None if not specified,
+    # Up to python 3.10, account could be None if not specified,
     # and login will be empty string if not specified. From 3.11,
     # login and account will be empty string if not specified.
     # If login is present, we prefer that over account as username

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -245,9 +245,10 @@ class ProxyInfo:
 
 def basicauth_from_netrc(netrc_obj: netrc.netrc, host: str) -> BasicAuth:
     """
-    Return :py:class:`~aiohttp.BasicAuth` tuple with credentials for given ``host`` from ``netrc_obj``.
+    Return :py:class:`~aiohttp.BasicAuth` credentials for ``host`` from ``netrc_obj``.
 
-    :raises LookupError: if ``netrc_obj`` is :py:data:`None` or if no entry is found for the ``host``.
+    :raises LookupError: if ``netrc_obj`` is :py:data:`None` or if no
+            entry is found for the ``host``.
     """
     if netrc_obj is None:
         raise LookupError("No .netrc file found")

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -41,7 +41,6 @@ from typing import (
     Type,
     TypeVar,
     Union,
-    cast,
     overload,
 )
 from urllib.parse import quote
@@ -252,7 +251,7 @@ def basicauth_from_netrc(netrc_obj: netrc.netrc, host: str) -> Optional[BasicAut
         # if `user` is None, use `account`
         *logins, password = auth_from_netrc
         login = logins[0] if logins[0] else logins[-1]
-        auth = BasicAuth(cast(str, login), cast(str, password))
+        auth = BasicAuth(login, password)
         return auth
 
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -245,9 +245,9 @@ class ProxyInfo:
 
 def basicauth_from_netrc(netrc_obj: netrc.netrc, host: str) -> BasicAuth:
     """
-    Return BasicAuth tuple with credentials for given host from netrc_obj.
+    Return :py:class:`~aiohttp.BasicAuth` tuple with credentials for given ``host`` from ``netrc_obj``.
 
-    Raises LookupError if netrc_obj is None or if no entry is found for the host.
+    :raises LookupError: if ``netrc_obj`` is :py:data:`None` or if no entry is found for the ``host``.
     """
     if netrc_obj is None:
         raise LookupError("No .netrc file found")

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -179,6 +179,11 @@ The client session supports the context manager protocol for self closing.
 
       Get proxy credentials from ``~/.netrc`` file if present.
 
+      Get HTTP Basic Auth credentials from ``~/.netrc`` file if present.
+
+      If ``NETRC`` environment variable is set, read from file specified
+      there rather than from ``~/.netrc``
+
       .. seealso::
 
          ``.netrc`` documentation: https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html
@@ -188,6 +193,10 @@ The client session supports the context manager protocol for self closing.
       .. versionchanged:: 3.0
 
          Added support for ``~/.netrc`` file.
+
+      .. versionchanged:: 4.0
+
+         Added support for reading HTTP Basic Auth credentials from ``~/.netrc`` file.
 
    :param bool requote_redirect_url: Apply *URL requoting* for redirection URLs if
                                      automatic redirection is enabled (``True`` by

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -196,7 +196,7 @@ The client session supports the context manager protocol for self closing.
 
       .. versionchanged:: 3.9
 
-         Added support for reading HTTP Basic Auth credentials from ``~/.netrc`` file.
+         Added support for reading HTTP Basic Auth credentials from :file:`~/.netrc` file.
 
    :param bool requote_redirect_url: Apply *URL requoting* for redirection URLs if
                                      automatic redirection is enabled (``True`` by

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -194,7 +194,7 @@ The client session supports the context manager protocol for self closing.
 
          Added support for ``~/.netrc`` file.
 
-      .. versionchanged:: 4.0
+      .. versionchanged:: 3.9
 
          Added support for reading HTTP Basic Auth credentials from ``~/.netrc`` file.
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -179,10 +179,10 @@ The client session supports the context manager protocol for self closing.
 
       Get proxy credentials from ``~/.netrc`` file if present.
 
-      Get HTTP Basic Auth credentials from ``~/.netrc`` file if present.
+      Get HTTP Basic Auth credentials from :file:`~/.netrc` file if present.
 
-      If ``NETRC`` environment variable is set, read from file specified
-      there rather than from ``~/.netrc``
+      If :envvar:`NETRC` environment variable is set, read from file specified
+      there rather than from :file:`~/.netrc`.
 
       .. seealso::
 

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -157,6 +157,9 @@
       https://pypi.python.org/pypi/yarl
 
 
+Enviornment Variables
+=====================
+
 .. envvar:: NETRC
 
    If set, HTTP Basic Auth will be read from the file pointed to by this environment variable,

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -89,6 +89,8 @@
        It makes communication faster by getting rid of connection
        establishment for every request.
 
+
+
    nginx
 
       Nginx [engine x] is an HTTP and reverse proxy server, a mail
@@ -153,3 +155,13 @@
       A library for operating with URL objects.
 
       https://pypi.python.org/pypi/yarl
+
+
+.. envvar:: NETRC
+
+   If set, HTTP Basic Auth will be read from the file pointed to by this environment variable,
+   rather than from :file:`~/.netrc`.
+
+   .. seealso::
+
+      ``.netrc`` documentation: https://www.gnu.org/software/inetutils/manual/html_node/The-_002enetrc-file.html

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -157,7 +157,7 @@
       https://pypi.python.org/pypi/yarl
 
 
-Enviornment Variables
+Environment Variables
 =====================
 
 .. envvar:: NETRC

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,3 +218,5 @@ def netrc_contents(
     netrc_file_path.write_text(netrc_contents)
 
     monkeypatch.setenv("NETRC", str(netrc_file_path))
+
+    return netrc_file_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 # type: ignore
 import asyncio
 import os
+import pathlib
 import socket
 import ssl
 import sys
@@ -197,3 +198,23 @@ def selector_loop() -> None:
     with loop_context(policy.new_event_loop) as _loop:
         asyncio.set_event_loop(_loop)
         yield _loop
+
+
+@pytest.fixture
+def netrc_contents(
+    tmp_path: pathlib.Path,
+    monkeypatch: pytest.MonkeyPatch,
+    request: pytest.FixtureRequest,
+):
+    """
+    Prepare a ``.netrc`` file with given contents.
+
+    monkeypatches the NETRC environment variable to point to created
+    file.
+    """
+    netrc_contents = request.param
+
+    netrc_file_path = tmp_path / ".netrc"
+    netrc_file_path.write_text(netrc_contents)
+
+    monkeypatch.setenv("NETRC", str(netrc_file_path))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 # type: ignore
 import asyncio
 import os
-import pathlib
 import socket
 import ssl
 import sys
@@ -202,7 +201,7 @@ def selector_loop() -> None:
 
 @pytest.fixture
 def netrc_contents(
-    tmp_path: pathlib.Path,
+    tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     request: pytest.FixtureRequest,
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,7 +210,7 @@ def netrc_contents(
 
     Monkey-patches :envvar:`NETRC` to point to created file.
     """
-    netrc_contents = request.param
+    netrc_contents = getattr(request, 'param', None)
 
     netrc_file_path = tmp_path / ".netrc"
     if netrc_contents is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,7 +206,7 @@ def netrc_contents(
     request: pytest.FixtureRequest,
 ):
     """
-    Prepare a ``.netrc`` file with given contents.
+    Prepare :file:`.netrc` with given contents.
 
     Monkey-patches :envvar:`NETRC` to point to created file.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -210,7 +210,7 @@ def netrc_contents(
 
     Monkey-patches :envvar:`NETRC` to point to created file.
     """
-    netrc_contents = getattr(request, 'param', None)
+    netrc_contents = getattr(request, "param", None)
 
     netrc_file_path = tmp_path / ".netrc"
     if netrc_contents is not None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,8 +208,7 @@ def netrc_contents(
     """
     Prepare a ``.netrc`` file with given contents.
 
-    monkeypatches the NETRC environment variable to point to created
-    file.
+    Monkey-patches :envvar:`NETRC` to point to created file.
     """
     netrc_contents = request.param
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,7 +215,8 @@ def netrc_contents(
     netrc_contents = request.param
 
     netrc_file_path = tmp_path / ".netrc"
-    netrc_file_path.write_text(netrc_contents)
+    if netrc_contents is not None:
+        netrc_file_path.write_text(netrc_contents)
 
     monkeypatch.setenv("NETRC", str(netrc_file_path))
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1277,7 +1277,7 @@ def test_basicauth_from_netrc_present(
     indirect=("netrc_contents",),
 )
 @pytest.mark.usefixtures("netrc_contents")
-def test_basicauth_from_netrc_absent(
+def test_basicauth_from_empty_netrc(
     make_request: Any,
 ):
     """Test that no Authorization header is sent when netrc is empty"""

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1255,7 +1255,6 @@ def test_gen_default_accept_encoding(has_brotli: Any, expected: Any) -> None:
 @pytest.mark.usefixtures("netrc_contents")
 def test_basicauth_from_netrc_present(
     make_request: Any,
-    netrc_contents: str,
     hostname: str,
     trust_env: bool,
     expected_auth: Optional[helpers.BasicAuth],

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1274,7 +1274,7 @@ def test_basicauth_from_netrc_present(
 @pytest.mark.parametrize("trust_env", (True, False))
 @pytest.mark.parametrize(
     "netrc_contents",
-    ("", ),
+    ("",),
     indirect=("netrc_contents",),
 )
 @pytest.mark.usefixtures("netrc_contents")

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1273,12 +1273,10 @@ def test_basicauth_from_netrc_present(
         assert req.headers[hdrs.AUTHORIZATION] == expected_auth.encode()
 
 
+@pytest.mark.parametrize("trust_env", (True, False))
 @pytest.mark.parametrize(
-    ["netrc_contents", "hostname", "trust_env", "expected_auth"],
-    [
-        ("", "example.com", True, None),
-        ("", "example.com", False, None),
-    ],
+    "netrc_contents",
+    ("", ),
     indirect=("netrc_contents",),
 )
 @pytest.mark.usefixtures("netrc_contents")

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1233,21 +1233,25 @@ def test_gen_default_accept_encoding(has_brotli: Any, expected: Any) -> None:
 
 
 @pytest.mark.parametrize(
-    ["netrc_contents", "hostname", "trust_env", "expected_auth"],
-    [
-        (
-            "machine example.com login username password pass\n",
-            "example.com",
+    ("trust_env", "expected_auth"),
+    (
+        pytest.param(
             True,
             helpers.BasicAuth("username", "pass"),
+            id='reading netrc requested',
         ),
-        (
-            "machine example.com login username password pass\n",
-            "example.com",
+        pytest.param(
             False,
             None,
+            id='reading netrc disabled',
         ),
-    ],
+    ),
+)
+@pytest.mark.parametrize(
+    "netrc_contents",
+    (
+        "machine example.com login username password pass\n",
+    ),
     indirect=("netrc_contents",),
 )
 @pytest.mark.usefixtures("netrc_contents")

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1238,20 +1238,18 @@ def test_gen_default_accept_encoding(has_brotli: Any, expected: Any) -> None:
         pytest.param(
             True,
             helpers.BasicAuth("username", "pass"),
-            id='reading netrc requested',
+            id="reading netrc requested",
         ),
         pytest.param(
             False,
             None,
-            id='reading netrc disabled',
+            id="reading netrc disabled",
         ),
     ),
 )
 @pytest.mark.parametrize(
     "netrc_contents",
-    (
-        "machine example.com login username password pass\n",
-    ),
+    ("machine example.com login username password pass\n",),
     indirect=("netrc_contents",),
 )
 @pytest.mark.usefixtures("netrc_contents")

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1255,7 +1255,6 @@ def test_gen_default_accept_encoding(has_brotli: Any, expected: Any) -> None:
 @pytest.mark.usefixtures("netrc_contents")
 def test_basicauth_from_netrc_present(
     make_request: Any,
-    hostname: str,
     trust_env: bool,
     expected_auth: Optional[helpers.BasicAuth],
 ):
@@ -1265,12 +1264,13 @@ def test_basicauth_from_netrc_present(
     No authorization header should be sent when trust_env is false, even if
     netrc is not empty.
     """
-    req = make_request("get", f"http://{hostname}", trust_env=trust_env)
+    req = make_request("get", "http://example.com", trust_env=trust_env)
     if trust_env:
         assert req.headers[hdrs.AUTHORIZATION] == expected_auth.encode()
+    else:
+        assert hdrs.AUTHORIZATION not in req.headers
 
 
-@pytest.mark.parametrize("trust_env", (True, False))
 @pytest.mark.parametrize(
     "netrc_contents",
     ("",),
@@ -1279,11 +1279,7 @@ def test_basicauth_from_netrc_present(
 @pytest.mark.usefixtures("netrc_contents")
 def test_basicauth_from_netrc_absent(
     make_request: Any,
-    netrc_contents: str,
-    hostname: str,
-    trust_env: bool,
-    expected_auth: Optional[helpers.BasicAuth],
 ):
     """Test that no Authorization header is sent when netrc is empty"""
-    req = make_request("get", f"http://{hostname}", trust_env=trust_env)
+    req = make_request("get", "http://example.com", trust_env=True)
     assert hdrs.AUTHORIZATION not in req.headers

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1013,7 +1013,7 @@ def test_netrc_from_env(expected_username: str):
     indirect=("netrc_contents",),
 )
 @pytest.mark.usefixtures("netrc_contents")
-def est_basicauth_present_in_netrc(
+def test_basicauth_present_in_netrc(
     expected_auth: helpers.BasicAuth,
 ):
     """Test that netrc file contents are properly parsed into BasicAuth tuples"""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1026,4 +1026,8 @@ def test_basicauth_from_netrc(
     """Test that netrc file contents are properly parsed into BasicAuth tuples"""
     netrc_obj = helpers.netrc_from_env()
 
-    assert expected_auth == helpers.basicauth_from_netrc(netrc_obj, hostname)
+    if expected_auth:
+        assert expected_auth == helpers.basicauth_from_netrc(netrc_obj, hostname)
+    else:
+        with pytest.raises(LookupError):
+            helpers.basicauth_from_netrc(netrc_obj, hostname)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1029,5 +1029,7 @@ def test_basicauth_from_netrc(
     if expected_auth:
         assert expected_auth == helpers.basicauth_from_netrc(netrc_obj, hostname)
     else:
-        with pytest.raises(match=LookupError):
+        with pytest.raises(
+            LookupError, match="No entry for example.com found in the `.netrc` file."
+        ):
             helpers.basicauth_from_netrc(netrc_obj, hostname)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1029,5 +1029,5 @@ def test_basicauth_from_netrc(
     if expected_auth:
         assert expected_auth == helpers.basicauth_from_netrc(netrc_obj, hostname)
     else:
-        with pytest.raises(LookupError):
+        with pytest.raises(match=LookupError):
             helpers.basicauth_from_netrc(netrc_obj, hostname)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -989,7 +989,7 @@ def test_parse_http_date(value, expected):
     indirect=("netrc_contents",),
 )
 @pytest.mark.usefixtures("netrc_contents")
-def test_netrc_from_env(netrc_contents: str, hostname: str, expected_username: str):
+def test_netrc_from_env(hostname: str, expected_username: str):
     """Test that reading netrc files from env works as expected"""
     netrc_obj = helpers.netrc_from_env()
     assert netrc_obj.authenticators(hostname)[0] == expected_username

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -978,57 +978,52 @@ def test_parse_http_date(value, expected):
 
 
 @pytest.mark.parametrize(
-    ["netrc_contents", "hostname", "expected_username"],
+    ["netrc_contents", "expected_username"],
     [
         (
             "machine example.com login username password pass\n",
-            "example.com",
             "username",
         ),
     ],
     indirect=("netrc_contents",),
 )
 @pytest.mark.usefixtures("netrc_contents")
-def test_netrc_from_env(hostname: str, expected_username: str):
+def test_netrc_from_env(expected_username: str):
     """Test that reading netrc files from env works as expected"""
     netrc_obj = helpers.netrc_from_env()
-    assert netrc_obj.authenticators(hostname)[0] == expected_username
+    assert netrc_obj.authenticators("example.com")[0] == expected_username
 
 
 @pytest.mark.parametrize(
-    ["netrc_contents", "hostname", "expected_auth"],
+    ["netrc_contents", "expected_auth"],
     [
         (
             "machine example.com login username password pass\n",
-            "example.com",
             helpers.BasicAuth("username", "pass"),
         ),
         (
             "machine example.com account username password pass\n",
-            "example.com",
             helpers.BasicAuth("username", "pass"),
         ),
         (
             "machine example.com password pass\n",
-            "example.com",
             helpers.BasicAuth("", "pass"),
         ),
-        ("", "example.com", None),
+        ("", None),
     ],
     indirect=("netrc_contents",),
 )
 @pytest.mark.usefixtures("netrc_contents")
 def test_basicauth_from_netrc(
-    hostname: str,
     expected_auth: helpers.BasicAuth,
 ):
     """Test that netrc file contents are properly parsed into BasicAuth tuples"""
     netrc_obj = helpers.netrc_from_env()
 
     if expected_auth:
-        assert expected_auth == helpers.basicauth_from_netrc(netrc_obj, hostname)
+        assert expected_auth == helpers.basicauth_from_netrc(netrc_obj, "example.com")
     else:
         with pytest.raises(
             LookupError, match="No entry for example.com found in the `.netrc` file."
         ):
-            helpers.basicauth_from_netrc(netrc_obj, hostname)
+            helpers.basicauth_from_netrc(netrc_obj, "example.com")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1019,7 +1019,6 @@ def test_netrc_from_env(hostname: str, expected_username: str):
 )
 @pytest.mark.usefixtures("netrc_contents")
 def test_basicauth_from_netrc(
-    netrc_contents: str,
     hostname: str,
     expected_auth: helpers.BasicAuth,
 ):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1009,21 +1009,32 @@ def test_netrc_from_env(expected_username: str):
             "machine example.com password pass\n",
             helpers.BasicAuth("", "pass"),
         ),
-        ("", None),
     ],
     indirect=("netrc_contents",),
 )
 @pytest.mark.usefixtures("netrc_contents")
-def test_basicauth_from_netrc(
+def est_basicauth_present_in_netrc(
     expected_auth: helpers.BasicAuth,
 ):
     """Test that netrc file contents are properly parsed into BasicAuth tuples"""
     netrc_obj = helpers.netrc_from_env()
 
-    if expected_auth:
-        assert expected_auth == helpers.basicauth_from_netrc(netrc_obj, "example.com")
-    else:
-        with pytest.raises(
-            LookupError, match="No entry for example.com found in the `.netrc` file."
-        ):
-            helpers.basicauth_from_netrc(netrc_obj, "example.com")
+    assert expected_auth == helpers.basicauth_from_netrc(netrc_obj, "example.com")
+
+
+@pytest.mark.parametrize(
+    ["netrc_contents"],
+    [
+        ("",),
+    ],
+    indirect=("netrc_contents",),
+)
+@pytest.mark.usefixtures("netrc_contents")
+def test_read_basicauth_from_empty_netrc():
+    """Test that an error is raised if netrc doesn't have an entry for our host"""
+    netrc_obj = helpers.netrc_from_env()
+
+    with pytest.raises(
+        LookupError, match="No entry for example.com found in the `.netrc` file."
+    ):
+        helpers.basicauth_from_netrc(netrc_obj, "example.com")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Currently, setting `trust_env=True` in `ClientSession` will only use the `.netrc`
file if present for authentication to proxies. With this change, the credentials will
also be used for regular HTTP hosts, and Basic Auth will be sent if an appropriate
entry is present in the user's `.netrc` file.

## Are there changes in behavior for the user?

YES! Currently, their .netrc file will be ignored when not making proxy requests. This
will start sending any credentials in netrc files to hosts.

The behavior of this PR seems to have possibly been the suggested behavior when
netrc support was initially added, based on this comment: https://github.com/aio-libs/aiohttp/pull/2584#issuecomment-348935249.

The behavior with this PR applied also matches requests and other libraries. In fact, this
was a deep dive output after trying to figure out why accessing NASA open data with requests
works but aiohttp does not :D  (https://github.com/nsidc/earthaccess/issues/188 has the trail crumbs).

If this is considered a breaking change, I'm happy to instead introduce a *new* param that
toggles this behavior instead. However, `trust_env` is what requests and other libraries use,
so may be ok.

## Related issue number

https://github.com/aio-libs/aiohttp/issues/2581
https://github.com/aio-libs/aiohttp/pull/2584#issuecomment-348935249
(outside aiohttp) https://github.com/nsidc/earthaccess/issues/188

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
