### PR TITLE
[3.8] Make the 3.10 related xfails non-strict

### DIFF
--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -280,6 +280,7 @@ def test_host_header_ipv6_with_port(make_request) -> None:
     reason="No idea why ClientRequest() is constructed out of loop but "
     "it calls `asyncio.get_event_loop()`",
     raises=DeprecationWarning,
+    strict=False,
 )
 def test_default_loop(loop) -> None:
     asyncio.set_event_loop(loop)

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -88,6 +88,7 @@ class TestStreamReader:
         reason="No idea why ClientRequest() is constructed out of loop but "
         "it calls `asyncio.get_event_loop()`",
         raises=DeprecationWarning,
+        strict=False,
     )
     def test_ctor_global_loop(self) -> None:
         loop = asyncio.new_event_loop()

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -44,6 +44,7 @@ async def test_set_loop() -> None:
     reason="No idea why _set_loop() is constructed out of loop "
     "but it calls `asyncio.get_event_loop()`",
     raises=DeprecationWarning,
+    strict=False,
 )
 def test_set_loop_default_loop() -> None:
     loop = asyncio.new_event_loop()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

We see xpasses in Fedora with Python 3.11.1 or 3.10.9:

    =================================== FAILURES ===================================
    __________________________ test_default_loop[pyloop] ___________________________
    [XPASS(strict)] No idea why ClientRequest() is constructed out of loop but it calls `asyncio.get_event_loop()`
    ____________________ TestStreamReader.test_ctor_global_loop ____________________
    [XPASS(strict)] No idea why ClientRequest() is constructed out of loop but it calls `asyncio.get_event_loop()`
    __________________________ test_set_loop_default_loop __________________________
    [XPASS(strict)] No idea why _set_loop() is constructed out of loop but it calls `asyncio.get_event_loop()`

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

No.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [-] Documentation reflects the changes
- [-] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
