### PR TITLE
Add a graceful shutdown period to allow tasks to complete.

### DIFF
--- a/CHANGES/7188.feature
+++ b/CHANGES/7188.feature
@@ -1,1 +1,1 @@
-Added a graceful shutdown period which allows pending tasks to complete before the application's cleanup is called. The period can be adjusted with the ``shutdown_timeout`` parameter. -- by :user:`Dreamsorcerer`
+Added a graceful shutdown period which allows pending tasks to complete before the application's cleanup is called. The period can be adjusted with the ``shutdown_timeout`` parameter -- by :user:`Dreamsorcerer`.

--- a/CHANGES/7188.feature
+++ b/CHANGES/7188.feature
@@ -1,0 +1,1 @@
+Added a graceful shutdown period which allows pending tasks to complete before the application's cleanup is called. The period can be adjusted with the ``shutdown_timeout`` parameter. -- by :user:`Dreamsorcerer`

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -72,6 +72,7 @@ class StreamWriter(AbstractStreamWriter):
         self.buffer_size += size
         self.output_size += size
 
+        print("FOO", self._transport.__class__, self._transport.is_closing())
         if self._transport is None or self._transport.is_closing():
             raise ConnectionResetError("Cannot write to closing transport")
         self._transport.write(chunk)

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -72,7 +72,6 @@ class StreamWriter(AbstractStreamWriter):
         self.buffer_size += size
         self.output_size += size
 
-        print("FOO", self._transport.__class__, self._transport.is_closing())
         if self._transport is None or self._transport.is_closing():
             raise ConnectionResetError("Cannot write to closing transport")
         self._transport.write(chunk)

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -115,7 +115,7 @@ class BaseTestServer(ABC):
         if self.runner:
             return
         self._ssl = kwargs.pop("ssl", None)
-        self.runner = await self._make_runner(**kwargs)
+        self.runner = await self._make_runner(handler_cancellation=True, **kwargs)
         await self.runner.setup()
         if not self.port:
             self.port = 0

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -283,4 +283,4 @@ class FileResponse(StreamResponse):
         try:
             return await self._sendfile(request, fobj, offset, count)
         finally:
-            await loop.run_in_executor(None, fobj.close)
+            await asyncio.shield(loop.run_in_executor(None, fobj.close))

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -2,6 +2,7 @@ import asyncio
 import signal
 import socket
 from abc import ABC, abstractmethod
+from contextlib import suppress
 from typing import Any, List, Optional, Set, Type
 
 from yarl import URL
@@ -80,10 +81,20 @@ class BaseSite(ABC):
         # named pipes do not have wait_closed property
         if hasattr(self._server, "wait_closed"):
             await self._server.wait_closed()
+
+        # Wait for pending tasks for a given time limit.
+        with suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(self._wait(), timeout=self._shutdown_timeout)
+
         await self._runner.shutdown()
         assert self._runner.server
         await self._runner.server.shutdown(self._shutdown_timeout)
         self._runner._unreg_site(self)
+
+    async def _wait(self) -> None:
+        exclude = self._runner.starting_tasks | {asyncio.current_task()}
+        while tasks := asyncio.all_tasks() - exclude:
+            await asyncio.wait(tasks)
 
 
 class TCPSite(BaseSite):
@@ -247,7 +258,7 @@ class SockSite(BaseSite):
 
 
 class BaseRunner(ABC):
-    __slots__ = ("_handle_signals", "_kwargs", "_server", "_sites")
+    __slots__ = ("starting_tasks", "_handle_signals", "_kwargs", "_server", "_sites")
 
     def __init__(self, *, handle_signals: bool = False, **kwargs: Any) -> None:
         self._handle_signals = handle_signals
@@ -287,6 +298,11 @@ class BaseRunner(ABC):
                 pass
 
         self._server = await self._make_server()
+        # On shutdown we want to avoid waiting on tasks which run forever.
+        # It's very likely that all tasks which run forever will have been created by
+        # the time we have completed the application startup (in self._make_server()),
+        # so we just record all running tasks here and exclude them later.
+        self.starting_tasks = asyncio.all_tasks()
 
     @abstractmethod
     async def shutdown(self) -> None:

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -93,7 +93,7 @@ class BaseSite(ABC):
         await self._runner.server.shutdown(self._shutdown_timeout)
         self._runner._unreg_site(self)
 
-    async def _wait(self, parent_task: asyncio.Task) -> None:
+    async def _wait(self, parent_task: Optional[asyncio.Task[object]]) -> None:
         exclude = self._runner.starting_tasks | {asyncio.current_task(), parent_task}
         # TODO(PY38): while tasks := asyncio.all_tasks() - exclude:
         tasks = asyncio.all_tasks() - exclude

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -93,8 +93,11 @@ class BaseSite(ABC):
 
     async def _wait(self) -> None:
         exclude = self._runner.starting_tasks | {asyncio.current_task()}
-        while tasks := asyncio.all_tasks() - exclude:
+        # TODO(PY38): while tasks := asyncio.all_tasks() - exclude:
+        tasks = asyncio.all_tasks() - exclude
+        while tasks:
             await asyncio.wait(tasks)
+            tasks = asyncio.all_tasks() - exclude
 
 
 class TCPSite(BaseSite):

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -84,7 +84,9 @@ class BaseSite(ABC):
 
         # Wait for pending tasks for a given time limit.
         with suppress(asyncio.TimeoutError):
-            await asyncio.wait_for(self._wait(asyncio.current_task()), timeout=self._shutdown_timeout)
+            await asyncio.wait_for(
+                self._wait(asyncio.current_task()), timeout=self._shutdown_timeout
+            )
 
         await self._runner.shutdown()
         assert self._runner.server

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -93,7 +93,7 @@ class BaseSite(ABC):
         await self._runner.server.shutdown(self._shutdown_timeout)
         self._runner._unreg_site(self)
 
-    async def _wait(self, parent_task: Optional[asyncio.Task[object]]) -> None:
+    async def _wait(self, parent_task: Optional["asyncio.Task[object]"]) -> None:
         exclude = self._runner.starting_tasks | {asyncio.current_task(), parent_task}
         # TODO(PY38): while tasks := asyncio.all_tasks() - exclude:
         tasks = asyncio.all_tasks() - exclude

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -933,7 +933,7 @@ seconds to allow any pending tasks to complete before continuing
 with application shutdown. The timeout can be adjusted with
 ``shutdown_timeout`` in :func:`run_app`.
 
-Another problem is if the application supports :term:`websocket`\s or
+Another problem is if the application supports :term:`websockets <websocket>` or
 *data streaming* it most likely has open connections at server
 shutdown time.
 

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -927,8 +927,14 @@ Graceful shutdown
 Stopping *aiohttp web server* by just closing all connections is not
 always satisfactory.
 
-The problem is: if application supports :term:`websocket`\s or *data
-streaming* it most likely has open connections at server
+The first thing aiohttp will do is to stop listening on the sockets,
+so new connections will be rejected. It will then wait a few
+seconds to allow any pending tasks to complete before continuing
+with application shutdown. The timeout can be adjusted with
+``shutdown_timeout`` in :func:`run_app`.
+
+Another problem is if the application supports :term:`websocket`\s or
+*data streaming* it most likely has open connections at server
 shutdown time.
 
 The *library* has no knowledge how to close them gracefully but

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2863,7 +2863,7 @@ Utilities
 
                                 This is used as a delay to wait for
                                 pending tasks to complete and then
-                                again to close and pending connections.
+                                again to close any pending connections.
 
                                 A system with properly
                                 :ref:`aiohttp-web-graceful-shutdown`

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2688,9 +2688,10 @@ application on specific TCP or Unix socket, e.g.::
 
    :param int port: PORT to listed on, ``8080`` if ``None`` (default).
 
-   :param float shutdown_timeout: a timeout for closing opened
-                                  connections on :meth:`BaseSite.stop`
-                                  call.
+   :param float shutdown_timeout: a timeout used for both waiting on pending
+                                  tasks before application shutdown and for
+                                  closing opened connections on
+                                  :meth:`BaseSite.stop` call.
 
    :param ssl_context: a :class:`ssl.SSLContext` instance for serving
                        SSL/TLS secure server, ``None`` for plain HTTP
@@ -2723,9 +2724,10 @@ application on specific TCP or Unix socket, e.g.::
 
    :param str path: PATH to UNIX socket to listen.
 
-   :param float shutdown_timeout: a timeout for closing opened
-                                  connections on :meth:`BaseSite.stop`
-                                  call.
+   :param float shutdown_timeout: a timeout used for both waiting on pending
+                                  tasks before application shutdown and for
+                                  closing opened connections on
+                                  :meth:`BaseSite.stop` call.
 
    :param ssl_context: a :class:`ssl.SSLContext` instance for serving
                        SSL/TLS secure server, ``None`` for plain HTTP
@@ -2745,9 +2747,10 @@ application on specific TCP or Unix socket, e.g.::
 
    :param str path: PATH of named pipe to listen.
 
-   :param float shutdown_timeout: a timeout for closing opened
-                                  connections on :meth:`BaseSite.stop`
-                                  call.
+   :param float shutdown_timeout: a timeout used for both waiting on pending
+                                  tasks before application shutdown and for
+                                  closing opened connections on
+                                  :meth:`BaseSite.stop` call.
 
 .. class:: SockSite(runner, sock, *, \
                    shutdown_timeout=60.0, ssl_context=None, \
@@ -2759,9 +2762,10 @@ application on specific TCP or Unix socket, e.g.::
 
    :param sock: A :ref:`socket instance <socket-objects>` to listen to.
 
-   :param float shutdown_timeout: a timeout for closing opened
-                                  connections on :meth:`BaseSite.stop`
-                                  call.
+   :param float shutdown_timeout: a timeout used for both waiting on pending
+                                  tasks before application shutdown and for
+                                  closing opened connections on
+                                  :meth:`BaseSite.stop` call.
 
    :param ssl_context: a :class:`ssl.SSLContext` instance for serving
                        SSL/TLS secure server, ``None`` for plain HTTP
@@ -2856,10 +2860,14 @@ Utilities
    :param int shutdown_timeout: a delay to wait for graceful server
                                 shutdown before disconnecting all
                                 open client sockets hard way.
+                                
+                                This is used as a delay to wait for
+                                pending tasks to complete and then
+                                again to close and pending connections.
 
                                 A system with properly
                                 :ref:`aiohttp-web-graceful-shutdown`
-                                implemented never waits for this
+                                implemented never waits for the second
                                 timeout but closes a server in a few
                                 milliseconds.
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2860,7 +2860,7 @@ Utilities
    :param int shutdown_timeout: a delay to wait for graceful server
                                 shutdown before disconnecting all
                                 open client sockets hard way.
-                                
+
                                 This is used as a delay to wait for
                                 pending tasks to complete and then
                                 again to close and pending connections.

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1063,7 +1063,7 @@ class TestShutdown:
 
         async def task() -> None:
             nonlocal finished
-            await asyncio.sleep(2)
+            await asyncio.sleep(3)
             finished = True
 
         async def test(sess: ClientSession) -> None:
@@ -1076,7 +1076,7 @@ class TestShutdown:
                         pass
             assert finished is False
 
-        t = self.run_app(port, 3, task, test)
+        t = self.run_app(port, 4, task, test)
 
         assert finished is True
         assert t.done()

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -943,9 +943,9 @@ class TestShutdown:
         async def test() -> None:
             await asyncio.sleep(1)
             async with ClientSession() as sess:
-                async with sess.get(f"http://localhost:{port}/") as resp:
+                async with sess.get(f"http://localhost:{port}/"):
                     pass
-                async with sess.get(f"http://localhost:{port}/stop") as resp:
+                async with sess.get(f"http://localhost:{port}/stop"):
                     pass
 
                 if extra_test:
@@ -1072,7 +1072,7 @@ class TestShutdown:
             with pytest.raises(ClientConnectorError):
                 # Use a new session to try and open a new connection.
                 async with ClientSession() as sess:
-                    async with sess.get(f"http://localhost:{port}/") as resp:
+                    async with sess.get(f"http://localhost:{port}/"):
                         pass
             assert finished is False
 
@@ -1097,10 +1097,10 @@ class TestShutdown:
                 t = asyncio.create_task(test_resp(sess))
                 await asyncio.sleep(1)
                 # Handler is in-progress while we trigger server shutdown.
-                async with sess.get(f"http://localhost:{port}/stop") as resp:
+                async with sess.get(f"http://localhost:{port}/stop"):
                     pass
 
-                assert finished == False
+                assert finished is False
                 # Handler should still complete and produce a response.
                 await t
 

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -937,7 +937,9 @@ class TestShutdown:
         asyncio.get_running_loop().call_soon(self.raiser)
         return web.Response()
 
-    def run_app(self, port: int, timeout: int, task, extra_test = None, cleanup = None) -> asyncio.Task:
+    def run_app(
+        self, port: int, timeout: int, task, extra_test=None, cleanup=None
+    ) -> asyncio.Task:
         async def test() -> None:
             await asyncio.sleep(1)
             async with ClientSession() as sess:
@@ -972,9 +974,12 @@ class TestShutdown:
         assert test_task.exception() is None
         return t
 
-    def test_shutdown_wait_for_task(self, aiohttp_unused_port: Callable[[], int]) -> None:
+    def test_shutdown_wait_for_task(
+        self, aiohttp_unused_port: Callable[[], int]
+    ) -> None:
         port = aiohttp_unused_port()
         finished = False
+
         async def task():
             nonlocal finished
             await asyncio.sleep(2)
@@ -986,9 +991,12 @@ class TestShutdown:
         assert t.done()
         assert not t.cancelled()
 
-    def test_shutdown_timeout_task(self, aiohttp_unused_port: Callable[[], int]) -> None:
+    def test_shutdown_timeout_task(
+        self, aiohttp_unused_port: Callable[[], int]
+    ) -> None:
         port = aiohttp_unused_port()
         finished = False
+
         async def task():
             nonlocal finished
             await asyncio.sleep(2)
@@ -1000,11 +1008,14 @@ class TestShutdown:
         assert t.done()
         assert t.cancelled()
 
-    def test_shutdown_wait_for_spawned_task(self, aiohttp_unused_port: Callable[[], int]) -> None:
+    def test_shutdown_wait_for_spawned_task(
+        self, aiohttp_unused_port: Callable[[], int]
+    ) -> None:
         port = aiohttp_unused_port()
         finished = False
         finished_sub = False
         sub_t = None
+
         async def sub_task():
             nonlocal finished_sub
             await asyncio.sleep(1.5)
@@ -1012,7 +1023,7 @@ class TestShutdown:
 
         async def task():
             nonlocal finished, sub_t
-            await asyncio.sleep(.5)
+            await asyncio.sleep(0.5)
             sub_t = asyncio.create_task(sub_task())
             finished = True
 
@@ -1025,9 +1036,12 @@ class TestShutdown:
         assert sub_t.done()
         assert not sub_t.cancelled()
 
-    def test_shutdown_timeout_not_reached(self, aiohttp_unused_port: Callable[[], int]) -> None:
+    def test_shutdown_timeout_not_reached(
+        self, aiohttp_unused_port: Callable[[], int]
+    ) -> None:
         port = aiohttp_unused_port()
         finished = False
+
         async def task():
             nonlocal finished
             await asyncio.sleep(1)
@@ -1041,9 +1055,12 @@ class TestShutdown:
         # Verify run_app has not waited for timeout.
         assert time.time() - start_time < 10
 
-    def test_shutdown_new_conn_rejected(self, aiohttp_unused_port: Callable[[], int]) -> None:
+    def test_shutdown_new_conn_rejected(
+        self, aiohttp_unused_port: Callable[[], int]
+    ) -> None:
         port = aiohttp_unused_port()
         finished = False
+
         async def task() -> None:
             nonlocal finished
             await asyncio.sleep(2)
@@ -1064,9 +1081,12 @@ class TestShutdown:
         assert finished is True
         assert t.done()
 
-    def test_shutdown_pending_handler_responds(self, aiohttp_unused_port: Callable[[], int]) -> None:
+    def test_shutdown_pending_handler_responds(
+        self, aiohttp_unused_port: Callable[[], int]
+    ) -> None:
         port = aiohttp_unused_port()
         finished = False
+
         async def test() -> None:
             async def test_resp(sess):
                 async with sess.get(f"http://localhost:{port}/") as resp:

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1063,12 +1063,12 @@ class TestShutdown:
 
         async def task() -> None:
             nonlocal finished
-            await asyncio.sleep(3)
+            await asyncio.sleep(5)
             finished = True
 
         async def test(sess: ClientSession) -> None:
             # Ensure we are in the middle of shutdown (waiting for task()).
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(1)
             with pytest.raises(ClientConnectorError):
                 # Use a new session to try and open a new connection.
                 async with ClientSession() as sess:
@@ -1076,7 +1076,7 @@ class TestShutdown:
                         pass
             assert finished is False
 
-        t = self.run_app(port, 4, task, test)
+        t = self.run_app(port, 6, task, test)
 
         assert finished is True
         assert t.done()

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1068,7 +1068,7 @@ class TestShutdown:
 
         async def test(sess: ClientSession) -> None:
             # Ensure we are in the middle of shutdown (waiting for task()).
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.5)
             with pytest.raises(ClientConnectorError):
                 # Use a new session to try and open a new connection.
                 async with ClientSession() as sess:

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1071,13 +1071,9 @@ class TestShutdown:
             await asyncio.sleep(1)
             with pytest.raises(ClientConnectorError):
                 # Use a new session to try and open a new connection.
-                import time
-
-                print("FOO", time.time())
                 async with ClientSession() as sess:
                     async with sess.get(f"http://localhost:{port}/"):
                         pass
-            print("BAR", time.time())
             assert finished is False
 
         t = self.run_app(port, 10, task, test)

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -938,7 +938,7 @@ class TestShutdown:
         return web.Response()
 
     def run_app(
-        self, port: int, timeout: int, task, extra_test=None, cleanup=None
+        self, port: int, timeout: int, task, extra_test=None
     ) -> asyncio.Task:
         async def test() -> None:
             await asyncio.sleep(1)
@@ -965,8 +965,6 @@ class TestShutdown:
         t = test_task = None
         app = web.Application()
         app.cleanup_ctx.append(run_test)
-        if cleanup:
-            app.on_shutdown.append(cleanup)
         app.router.add_get("/", handler)
         app.router.add_get("/stop", self.stop)
 

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1071,9 +1071,12 @@ class TestShutdown:
             await asyncio.sleep(1)
             with pytest.raises(ClientConnectorError):
                 # Use a new session to try and open a new connection.
+                import time
+                print("FOO", time.time())
                 async with ClientSession() as sess:
                     async with sess.get(f"http://localhost:{port}/"):
                         pass
+                print("BAR", time.time())
             assert finished is False
 
         t = self.run_app(port, 6, task, test)

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1077,7 +1077,7 @@ class TestShutdown:
                 async with ClientSession() as sess:
                     async with sess.get(f"http://localhost:{port}/"):
                         pass
-                print("BAR", time.time())
+            print("BAR", time.time())
             assert finished is False
 
         t = self.run_app(port, 6, task, test)

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1063,7 +1063,7 @@ class TestShutdown:
 
         async def task() -> None:
             nonlocal finished
-            await asyncio.sleep(5)
+            await asyncio.sleep(9)
             finished = True
 
         async def test(sess: ClientSession) -> None:
@@ -1080,7 +1080,7 @@ class TestShutdown:
             print("BAR", time.time())
             assert finished is False
 
-        t = self.run_app(port, 6, task, test)
+        t = self.run_app(port, 10, task, test)
 
         assert finished is True
         assert t.done()

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1072,6 +1072,7 @@ class TestShutdown:
             with pytest.raises(ClientConnectorError):
                 # Use a new session to try and open a new connection.
                 import time
+
                 print("FOO", time.time())
                 async with ClientSession() as sess:
                     async with sess.get(f"http://localhost:{port}/"):

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -9,14 +9,15 @@ import socket
 import ssl
 import subprocess
 import sys
-from typing import Any
+import time
+from typing import Any, Callable, NoReturn
 from unittest import mock
 from uuid import uuid4
 
 import pytest
 from conftest import needs_unix
 
-from aiohttp import web
+from aiohttp import ClientConnectorError, ClientSession, web
 from aiohttp.test_utils import make_mocked_coro
 from aiohttp.web_runner import BaseRunner
 
@@ -926,3 +927,181 @@ def test_run_app_context_vars(patched_loop: Any):
 
     web.run_app(init(), print=stopper(patched_loop), loop=patched_loop)
     assert count == 3
+
+
+class TestShutdown:
+    def raiser(self) -> NoReturn:
+        raise KeyboardInterrupt
+
+    async def stop(self, request: web.Request) -> web.Response:
+        asyncio.get_running_loop().call_soon(self.raiser)
+        return web.Response()
+
+    def run_app(self, port: int, timeout: int, task, extra_test = None, cleanup = None) -> asyncio.Task:
+        async def test() -> None:
+            await asyncio.sleep(1)
+            async with ClientSession() as sess:
+                async with sess.get(f"http://localhost:{port}/") as resp:
+                    pass
+                async with sess.get(f"http://localhost:{port}/stop") as resp:
+                    pass
+
+                if extra_test:
+                    await extra_test(sess)
+
+        async def run_test(app: web.Application) -> None:
+            nonlocal test_task
+            test_task = asyncio.create_task(test())
+            yield
+            await test_task
+
+        async def handler(request: web.Request) -> web.Response:
+            nonlocal t
+            t = asyncio.create_task(task())
+            return web.Response(text="FOO")
+
+        t = test_task = None
+        app = web.Application()
+        app.cleanup_ctx.append(run_test)
+        if cleanup:
+            app.on_shutdown.append(cleanup)
+        app.router.add_get("/", handler)
+        app.router.add_get("/stop", self.stop)
+
+        web.run_app(app, port=port, shutdown_timeout=timeout)
+        assert test_task.exception() is None
+        return t
+
+    def test_shutdown_wait_for_task(self, aiohttp_unused_port: Callable[[], int]) -> None:
+        port = aiohttp_unused_port()
+        finished = False
+        async def task():
+            nonlocal finished
+            await asyncio.sleep(2)
+            finished = True
+
+        t = self.run_app(port, 3, task)
+
+        assert finished is True
+        assert t.done()
+        assert not t.cancelled()
+
+    def test_shutdown_timeout_task(self, aiohttp_unused_port: Callable[[], int]) -> None:
+        port = aiohttp_unused_port()
+        finished = False
+        async def task():
+            nonlocal finished
+            await asyncio.sleep(2)
+            finished = True
+
+        t = self.run_app(port, 1, task)
+
+        assert finished is False
+        assert t.done()
+        assert t.cancelled()
+
+    def test_shutdown_wait_for_spawned_task(self, aiohttp_unused_port: Callable[[], int]) -> None:
+        port = aiohttp_unused_port()
+        finished = False
+        finished_sub = False
+        sub_t = None
+        async def sub_task():
+            nonlocal finished_sub
+            await asyncio.sleep(1.5)
+            finished_sub = True
+
+        async def task():
+            nonlocal finished, sub_t
+            await asyncio.sleep(.5)
+            sub_t = asyncio.create_task(sub_task())
+            finished = True
+
+        t = self.run_app(port, 3, task)
+
+        assert finished is True
+        assert t.done()
+        assert not t.cancelled()
+        assert finished_sub is True
+        assert sub_t.done()
+        assert not sub_t.cancelled()
+
+    def test_shutdown_timeout_not_reached(self, aiohttp_unused_port: Callable[[], int]) -> None:
+        port = aiohttp_unused_port()
+        finished = False
+        async def task():
+            nonlocal finished
+            await asyncio.sleep(1)
+            finished = True
+
+        start_time = time.time()
+        t = self.run_app(port, 15, task)
+
+        assert finished is True
+        assert t.done()
+        # Verify run_app has not waited for timeout.
+        assert time.time() - start_time < 10
+
+    def test_shutdown_new_conn_rejected(self, aiohttp_unused_port: Callable[[], int]) -> None:
+        port = aiohttp_unused_port()
+        finished = False
+        async def task() -> None:
+            nonlocal finished
+            await asyncio.sleep(2)
+            finished = True
+
+        async def test(sess: ClientSession) -> None:
+            # Ensure we are in the middle of shutdown (waiting for task()).
+            await asyncio.sleep(1)
+            with pytest.raises(ClientConnectorError):
+                # Use a new session to try and open a new connection.
+                async with ClientSession() as sess:
+                    async with sess.get(f"http://localhost:{port}/") as resp:
+                        pass
+            assert finished is False
+
+        t = self.run_app(port, 3, task, test)
+
+        assert finished is True
+        assert t.done()
+
+    def test_shutdown_pending_handler_responds(self, aiohttp_unused_port: Callable[[], int]) -> None:
+        port = aiohttp_unused_port()
+        finished = False
+        async def test() -> None:
+            async def test_resp(sess):
+                async with sess.get(f"http://localhost:{port}/") as resp:
+                    assert await resp.text() == "FOO"
+
+            await asyncio.sleep(1)
+            async with ClientSession() as sess:
+                t = asyncio.create_task(test_resp(sess))
+                await asyncio.sleep(1)
+                # Handler is in-progress while we trigger server shutdown.
+                async with sess.get(f"http://localhost:{port}/stop") as resp:
+                    pass
+
+                assert finished == False
+                # Handler should still complete and produce a response.
+                await t
+
+        async def run_test(app: web.Application) -> None:
+            nonlocal t
+            t = asyncio.create_task(test())
+            yield
+            await t
+
+        async def handler(request: web.Request) -> web.Response:
+            nonlocal finished
+            await asyncio.sleep(3)
+            finished = True
+            return web.Response(text="FOO")
+
+        t = None
+        app = web.Application()
+        app.cleanup_ctx.append(run_test)
+        app.router.add_get("/", handler)
+        app.router.add_get("/stop", self.stop)
+
+        web.run_app(app, port=port, shutdown_timeout=5)
+        assert t.exception() is None
+        assert finished is True

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -937,9 +937,7 @@ class TestShutdown:
         asyncio.get_running_loop().call_soon(self.raiser)
         return web.Response()
 
-    def run_app(
-        self, port: int, timeout: int, task, extra_test=None
-    ) -> asyncio.Task:
+    def run_app(self, port: int, timeout: int, task, extra_test=None) -> asyncio.Task:
         async def test() -> None:
             await asyncio.sleep(1)
             async with ClientSession() as sess:


### PR DESCRIPTION
When the server is shutting down gracefully, it should wait on pending tasks before running the application shutdown/cleanup steps and cancelling all remaining tasks.

This helps ensure that tasks have a chance to finish writing to a DB, handlers can finish responding to clients etc.