### PR TITLE
Make tests pass after year 2039

### DIFF
--- a/CHANGES/7191.misc
+++ b/CHANGES/7191.misc
@@ -1,0 +1,1 @@
+Made tests pass after the year 2039.

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -31,7 +31,7 @@ def cookies_to_send():
         "path3-cookie=eleventh; Domain=pathtest.com; Path=/one/two; "
         "path4-cookie=twelfth; Domain=pathtest.com; Path=/one/two/; "
         "expires-cookie=thirteenth; Domain=expirestest.com; Path=/;"
-        " Expires=Tue, 1 Jan 2039 12:00:00 GMT; "
+        " Expires=Tue, 1 Jan 2999 12:00:00 GMT; "
         "max-age-cookie=fourteenth; Domain=maxagetest.com; Path=/;"
         " Max-Age=60; "
         "invalid-max-age-cookie=fifteenth; Domain=invalid-values.com; "


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Make tests pass after year 2039

## Are there changes in behavior for the user?

none

## Related issue number

N/A

Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future. The usual offset is +16 years, because that is how long I expect some software will be used in some places. This showed up failing tests in our `python-aiohttp` package build. See https://reproducible-builds.org/ for why this matters.


## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
