### PR TITLE
refactor: Extract zlib-related logic into a single module

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -37,6 +37,7 @@ from .client_exceptions import (
     InvalidURL,
     ServerFingerprintMismatch,
 )
+from .compression_utils import HAS_BROTLI
 from .formdata import FormData
 from .hdrs import CONTENT_TYPE
 from .helpers import (
@@ -51,7 +52,6 @@ from .helpers import (
     set_result,
 )
 from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11, StreamWriter
-from .compression_utils import HAS_BROTLI
 from .log import client_logger
 from .streams import StreamReader
 from .typedefs import (

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -51,7 +51,7 @@ from .helpers import (
     set_result,
 )
 from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11, StreamWriter
-from .http_parser import HAS_BROTLI
+from .compression_utils import HAS_BROTLI
 from .log import client_logger
 from .streams import StreamReader
 from .typedefs import (

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -57,9 +57,7 @@ class ZLibCompressor(ZlibBaseHandler):
             self._compressor = zlib.compressobj(wbits=self._mode, strategy=strategy)
         else:
             self._compressor = zlib.compressobj(
-                wbits=self._mode,
-                strategy=strategy,
-                level=level
+                wbits=self._mode, strategy=strategy, level=level
             )
 
     def compress_sync(self, data: bytes) -> bytes:

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -19,7 +19,7 @@ def encoding_to_mode(
 ) -> int:
     if encoding == "gzip":
         return 16 + zlib.MAX_WBITS
-    # deflate
+
     return -zlib.MAX_WBITS if suppress_deflate_header else zlib.MAX_WBITS
 
 

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -129,7 +129,7 @@ class BrotliDecompressor:
     # Supports both 'brotlipy' and 'Brotli' packages
     # since they share an import name. The top branches
     # are for 'brotlipy' and bottom branches for 'Brotli'
-    def __init__(self):
+    def __init__(self) -> None:
         if not HAS_BROTLI:
             raise RuntimeError(
                 "The brotli decompression is not available. "

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -53,11 +53,14 @@ class ZLibCompressor(ZlibBaseHandler):
             executor=executor,
             max_sync_chunk_size=max_sync_chunk_size,
         )
-        self._compressor = zlib.compressobj(
-            wbits=self._mode,
-            strategy=strategy,
-            **({"level": level} if level is not None else {})  # type: ignore
-        )
+        if level is None:
+            self._compressor = zlib.compressobj(wbits=self._mode, strategy=strategy)
+        else:
+            self._compressor = zlib.compressobj(
+                wbits=self._mode,
+                strategy=strategy,
+                level=level
+            )
 
     def compress_sync(self, data: bytes) -> bytes:
         return self._compressor.compress(data)

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -4,7 +4,6 @@ from concurrent.futures import Executor
 from typing import Optional, cast
 
 try:
-    # noinspection PyPackageRequirements,PyUnresolvedReferences
     import brotli
 
     HAS_BROTLI = True

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -902,7 +902,7 @@ class DeflateBuffer:
             self.out.feed_data(chunk, len(chunk))
             if (
                 self.encoding == "deflate"
-                and isinstance(self.decompressor, ZLibDecompressor)
+                and hasattr(self.decompressor, 'eof')
                 and not self.decompressor.eof
             ):
                 raise ContentEncodingError("deflate")

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -902,7 +902,7 @@ class DeflateBuffer:
             self.out.feed_data(chunk, len(chunk))
             if (
                 self.encoding == "deflate"
-                and hasattr(self.decompressor, 'eof')
+                and hasattr(self.decompressor, "eof")
                 and not self.decompressor.eof
             ):
                 raise ContentEncodingError("deflate")

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -902,8 +902,7 @@ class DeflateBuffer:
             self.out.feed_data(chunk, len(chunk))
             if (
                 self.encoding == "deflate"
-                and hasattr(self.decompressor, "eof")
-                and not self.decompressor.eof
+                and not self.decompressor.eof  # type: ignore
             ):
                 raise ContentEncodingError("deflate")
 

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -6,7 +6,6 @@ import string
 from contextlib import suppress
 from enum import IntEnum
 from typing import (
-    Any,
     Generic,
     List,
     NamedTuple,
@@ -21,7 +20,7 @@ from typing import (
 )
 
 from multidict import CIMultiDict, CIMultiDictProxy, istr
-from typing_extensions import Final
+from typing_extensions import Final, Protocol
 from yarl import URL
 
 from . import hdrs
@@ -49,22 +48,17 @@ try:
 except ImportError:  # pragma: no cover
     HAS_BROTLI = False
 
-try:
-    # Protocol has been added to Python 3.8
-    # noinspection PyUnresolvedReferences
-    from typing import Protocol
 
-    class Decompressor(Protocol):
-        eof: bool
+class Decompressor(Protocol):
+    @property
+    def eof(self) -> bool:
+        ...
 
-        def decompress_sync(self, data: bytes, max_length: int = ...) -> bytes:
-            ...
+    def decompress_sync(self, data: bytes, max_length: int = ...) -> bytes:
+        ...
 
-        def flush(self, length: int = ...) -> bytes:
-            ...
-
-except ImportError:
-    Decompressor = Any
+    def flush(self, length: int = ...) -> bytes:
+        ...
 
 
 __all__ = (

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -924,7 +924,9 @@ class DeflateBuffer:
         ):
             # Change the decoder to decompress incorrectly compressed data
             # Actually we should issue a warning about non-RFC-compliant data.
-            self.decompressor = ZLibDecompressor(encoding=self.encoding)
+            self.decompressor = ZLibDecompressor(
+                encoding=self.encoding, suppress_deflate_header=True
+            )
 
         try:
             chunk = self.decompressor.decompress_sync(chunk)

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -24,6 +24,7 @@ from yarl import URL
 
 from . import hdrs
 from .base_protocol import BaseProtocol
+from .compression_utils import HAS_BROTLI, BrotliDecompressor, ZLibDecompressor
 from .helpers import NO_EXTENSIONS, BaseTimerContext
 from .http_exceptions import (
     BadHttpMessage,
@@ -38,8 +39,6 @@ from .http_writer import HttpVersion, HttpVersion10
 from .log import internal_logger
 from .streams import EMPTY_PAYLOAD, StreamReader
 from .typedefs import RawHeaders
-from .compression_utils import ZLibDecompressor, BrotliDecompressor, HAS_BROTLI
-
 
 __all__ = (
     "HeadersParser",

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -56,8 +56,13 @@ try:
 
     class Decompressor(Protocol):
         eof: bool
-        def decompress_sync(self, data: bytes, max_length: int = ...) -> bytes: ...
-        def flush(self, length: int = ...) -> bytes: ...
+
+        def decompress_sync(self, data: bytes, max_length: int = ...) -> bytes:
+            ...
+
+        def flush(self, length: int = ...) -> bytes:
+            ...
+
 except ImportError:
     Decompressor = Any
 

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -900,10 +900,7 @@ class DeflateBuffer:
 
         if chunk or self.size > 0:
             self.out.feed_data(chunk, len(chunk))
-            if (
-                self.encoding == "deflate"
-                and not self.decompressor.eof  # type: ignore
-            ):
+            if self.encoding == "deflate" and not self.decompressor.eof:  # type: ignore
                 raise ContentEncodingError("deflate")
 
         self.out.feed_eof()

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -17,7 +17,7 @@ from typing_extensions import Final
 from .base_protocol import BaseProtocol
 from .helpers import NO_EXTENSIONS
 from .streams import DataQueue
-from .zlib_utils import ZLibDecompressor, ZLibCompressor
+from .zlib_utils import ZLibCompressor, ZLibDecompressor
 
 __all__ = (
     "WS_CLOSED_MESSAGE",

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -291,7 +291,7 @@ class WebSocketReader:
     def _feed_data(self, data: bytes) -> Tuple[bool, bytes]:
         for fin, opcode, payload, compressed in self.parse_frame(data):
             if compressed and not self._decompressobj:
-                self._decompressobj = ZLibDecompressor(mode=-zlib.MAX_WBITS)
+                self._decompressobj = ZLibDecompressor(suppress_deflate_header=True)
             if opcode == WSMsgType.CLOSE:
                 if len(payload) >= 2:
                     close_code = UNPACK_CLOSE_CODE(payload[:2])[0]
@@ -606,11 +606,11 @@ class WebSocketWriter:
         if (compress or self.compress) and opcode < 8:
             if compress:
                 # Do not set self._compress if compressing is for this frame
-                compressobj = ZLibCompressor(level=zlib.Z_BEST_SPEED, mode=-compress)
+                compressobj = ZLibCompressor(level=zlib.Z_BEST_SPEED, wbits=-compress)
             else:  # self.compress
                 if not self._compressobj:
                     self._compressobj = ZLibCompressor(
-                        level=zlib.Z_BEST_SPEED, mode=-self.compress
+                        level=zlib.Z_BEST_SPEED, wbits=-self.compress
                     )
                 compressobj = self._compressobj
 

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -15,9 +15,9 @@ from typing import Any, Callable, List, Optional, Pattern, Set, Tuple, Union, ca
 from typing_extensions import Final
 
 from .base_protocol import BaseProtocol
+from .compression_utils import ZLibCompressor, ZLibDecompressor
 from .helpers import NO_EXTENSIONS
 from .streams import DataQueue
-from .compression_utils import ZLibCompressor, ZLibDecompressor
 
 __all__ = (
     "WS_CLOSED_MESSAGE",

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -376,8 +376,9 @@ class WebSocketReader:
                     # Decompress process must to be done after all packets
                     # received.
                     if compressed:
+                        assert self._decompressobj is not None
                         self._partial.extend(_WS_DEFLATE_TRAILING)
-                        payload_merged = self._decompressobj.decompress(
+                        payload_merged = self._decompressobj.decompress_sync(
                             self._partial, self._max_msg_size
                         )
                         if self._decompressobj.unconsumed_tail:

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -17,7 +17,7 @@ from typing_extensions import Final
 from .base_protocol import BaseProtocol
 from .helpers import NO_EXTENSIONS
 from .streams import DataQueue
-from .zlib_utils import ZLibCompressor, ZLibDecompressor
+from .compression_utils import ZLibCompressor, ZLibDecompressor
 
 __all__ = (
     "WS_CLOSED_MESSAGE",

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -8,8 +8,8 @@ from multidict import CIMultiDict
 
 from .abc import AbstractStreamWriter
 from .base_protocol import BaseProtocol
-from .helpers import NO_EXTENSIONS
 from .compression_utils import ZLibCompressor
+from .helpers import NO_EXTENSIONS
 
 __all__ = ("StreamWriter", "HttpVersion", "HttpVersion10", "HttpVersion11")
 

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -9,7 +9,7 @@ from multidict import CIMultiDict
 from .abc import AbstractStreamWriter
 from .base_protocol import BaseProtocol
 from .helpers import NO_EXTENSIONS
-from .zlib_utils import ZLibCompressor
+from .compression_utils import ZLibCompressor
 
 __all__ = ("StreamWriter", "HttpVersion", "HttpVersion10", "HttpVersion11")
 

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -46,7 +46,7 @@ from .payload import (
     payload_type,
 )
 from .streams import StreamReader
-from .zlib_utils import ZLibCompressor, ZLibDecompressor
+from .compression_utils import ZLibCompressor, ZLibDecompressor
 
 __all__ = (
     "MultipartReader",

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -494,7 +494,7 @@ class BodyPartReader:
         encoding = self.headers.get(CONTENT_ENCODING, "").lower()
         if encoding == "identity":
             return data
-        if encoding in ("deflate", "gzip"):
+        if encoding in {"deflate", "gzip"}:
             return ZLibDecompressor(
                 encoding=encoding,
                 suppress_deflate_header=True,

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -27,6 +27,7 @@ from urllib.parse import parse_qsl, unquote, urlencode
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiMapping
 
+from .compression_utils import ZLibCompressor, ZLibDecompressor
 from .hdrs import (
     CONTENT_DISPOSITION,
     CONTENT_ENCODING,
@@ -46,7 +47,6 @@ from .payload import (
     payload_type,
 )
 from .streams import StreamReader
-from .compression_utils import ZLibCompressor, ZLibDecompressor
 
 __all__ = (
     "MultipartReader",

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -495,7 +495,10 @@ class BodyPartReader:
         if encoding == "identity":
             return data
         if encoding in ("deflate", "gzip"):
-            return ZLibDecompressor(encoding=encoding).decompress_sync(data)
+            return ZLibDecompressor(
+                encoding=encoding,
+                suppress_deflate_header=True,
+            ).decompress_sync(data)
 
         raise RuntimeError(f"unknown content encoding: {encoding}")
 
@@ -987,7 +990,11 @@ class MultipartPayloadWriter:
     def enable_compression(
         self, encoding: str = "deflate", strategy: int = zlib.Z_DEFAULT_STRATEGY
     ) -> None:
-        self._compress = ZLibCompressor(encoding=encoding, strategy=strategy)
+        self._compress = ZLibCompressor(
+            encoding=encoding,
+            suppress_deflate_header=True,
+            strategy=strategy,
+        )
 
     async def write_eof(self) -> None:
         if self._compress is not None:

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -46,7 +46,7 @@ from .payload import (
     payload_type,
 )
 from .streams import StreamReader
-from .zlib_utils import ZLibDecompressor, ZLibCompressor
+from .zlib_utils import ZLibCompressor, ZLibDecompressor
 
 __all__ = (
     "MultipartReader",

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -719,7 +719,9 @@ class Response(StreamResponse):
                     "might block the async event loop. Consider providing a custom value to zlib_executor_size/"
                     "zlib_executor response properties or disabling compression on it."
                 )
-            self._compressed_body = await compressor.compress(self._body) + compressor.flush()
+            self._compressed_body = (
+                await compressor.compress(self._body) + compressor.flush()
+            )
             assert self._compressed_body is not None
 
             self._headers[hdrs.CONTENT_ENCODING] = coding.value

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -24,6 +24,7 @@ from multidict import CIMultiDict, istr
 
 from . import hdrs, payload
 from .abc import AbstractStreamWriter
+from .compression_utils import ZLibCompressor
 from .helpers import (
     ETAG_ANY,
     PY_38,
@@ -40,7 +41,6 @@ from .helpers import (
 from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11
 from .payload import Payload
 from .typedefs import JSONEncoder, LooseHeaders
-from .compression_utils import ZLibCompressor
 
 __all__ = ("ContentCoding", "StreamResponse", "Response", "json_response")
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -40,7 +40,7 @@ from .helpers import (
 from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11
 from .payload import Payload
 from .typedefs import JSONEncoder, LooseHeaders
-from .zlib_utils import ZLibCompressor
+from .compression_utils import ZLibCompressor
 
 __all__ = ("ContentCoding", "StreamResponse", "Response", "json_response")
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -6,7 +6,6 @@ import json
 import math
 import time
 import warnings
-import zlib
 from concurrent.futures import Executor
 from http import HTTPStatus
 from http.cookies import Morsel
@@ -692,13 +691,6 @@ class Response(StreamResponse):
                     self._headers[hdrs.CONTENT_LENGTH] = "0"
 
         return await super()._start(request)
-
-    def _compress_body(self, zlib_mode: int) -> None:
-        assert zlib_mode > 0
-        compressobj = zlib.compressobj(wbits=zlib_mode)
-        body_in = self._body
-        assert body_in is not None
-        self._compressed_body = compressobj.compress(body_in) + compressobj.flush()
 
     async def _do_start_compression(self, coding: ContentCoding) -> None:
         if self._body_payload or self._chunked:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -715,8 +715,9 @@ class Response(StreamResponse):
             assert self._body is not None
             if self._zlib_executor_size is None and len(self._body) > 1024 * 1024:
                 warnings.warn(
-                    f"Synchronous compression of large response bodies ({len(self._body)} bytes) "
-                    "might block the async event loop. Consider providing a custom value to zlib_executor_size/"
+                    "Synchronous compression of large response bodies "
+                    f"({len(self._body)} bytes) might block the async event loop. "
+                    "Consider providing a custom value to zlib_executor_size/"
                     "zlib_executor response properties or disabling compression on it."
                 )
             self._compressed_body = (

--- a/aiohttp/zlib_utils.py
+++ b/aiohttp/zlib_utils.py
@@ -45,6 +45,7 @@ class ZlibBaseHandler:
         if encoding == "gzip":
             self._mode = 16 + zlib.MAX_WBITS
         else:
+            # deflate
             self._mode = -zlib.MAX_WBITS if suppress_deflate_header else zlib.MAX_WBITS
         self._executor = executor
         self._max_sync_chunk_size = max_sync_chunk_size
@@ -61,9 +62,6 @@ class ZLibCompressor(ZlibBaseHandler):
         executor: Optional[Executor] = None,
         max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE,
     ):
-        assert not (
-            encoding is None and wbits is None
-        ), "Either encoding or wbits must be provided"
         super().__init__(
             encoding=encoding,
             suppress_deflate_header=suppress_deflate_header,
@@ -75,7 +73,7 @@ class ZLibCompressor(ZlibBaseHandler):
         self._compressor: Compressor = zlib.compressobj(
             wbits=self._mode,
             strategy=strategy,
-            **({"level": level} if level is not None else {})
+            **({"level": level} if level is not None else {})  # type: ignore
         )
 
     def compress_sync(self, data: bytes) -> bytes:
@@ -100,7 +98,7 @@ class ZLibCompressor(ZlibBaseHandler):
 class ZLibDecompressor(ZlibBaseHandler):
     def __init__(
         self,
-        encoding: str = "deflate",
+        encoding: Optional[str],
         suppress_deflate_header: bool = False,
         executor: Optional[Executor] = None,
         max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE,

--- a/aiohttp/zlib_utils.py
+++ b/aiohttp/zlib_utils.py
@@ -5,8 +5,8 @@ from typing import Optional
 
 from typing_extensions import Protocol
 
-
 MAX_SYNC_CHUNK_SIZE = 1024
+
 
 class Compressor(Protocol):
     def compress(self, data: bytes) -> bytes:

--- a/aiohttp/zlib_utils.py
+++ b/aiohttp/zlib_utils.py
@@ -80,7 +80,8 @@ class ZLibCompressor(ZlibBaseHandler):
             self._max_sync_chunk_size is not None
             and len(data) > self._max_sync_chunk_size
         ):
-            # TODO: Replace with asyncio.to_thread as soon as we drop Python 3.8 and below
+            # TODO: Replace with asyncio.to_thread as soon as we
+            # TODO: drop Python 3.8 and below
             return await asyncio.get_event_loop().run_in_executor(
                 self._executor, self.compress_sync, data
             )

--- a/aiohttp/zlib_utils.py
+++ b/aiohttp/zlib_utils.py
@@ -40,7 +40,9 @@ class ZLibCompressor(ZlibBaseHandler):
         max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE,
     ):
         super().__init__(
-            mode=encoding_to_mode(encoding, suppress_deflate_header) if wbits is None else wbits,
+            mode=encoding_to_mode(encoding, suppress_deflate_header)
+            if wbits is None
+            else wbits,
             executor=executor,
             max_sync_chunk_size=max_sync_chunk_size,
         )

--- a/aiohttp/zlib_utils.py
+++ b/aiohttp/zlib_utils.py
@@ -98,7 +98,7 @@ class ZLibCompressor(ZlibBaseHandler):
 class ZLibDecompressor(ZlibBaseHandler):
     def __init__(
         self,
-        encoding: Optional[str],
+        encoding: Optional[str] = None,
         suppress_deflate_header: bool = False,
         executor: Optional[Executor] = None,
         max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE,

--- a/aiohttp/zlib_utils.py
+++ b/aiohttp/zlib_utils.py
@@ -61,7 +61,9 @@ class ZLibCompressor(ZlibBaseHandler):
         executor: Optional[Executor] = None,
         max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE,
     ):
-        assert not (encoding is None and wbits is None), "Either encoding or wbits must be provided"
+        assert not (
+            encoding is None and wbits is None
+        ), "Either encoding or wbits must be provided"
         super().__init__(
             encoding=encoding,
             suppress_deflate_header=suppress_deflate_header,
@@ -73,7 +75,7 @@ class ZLibCompressor(ZlibBaseHandler):
         self._compressor: Compressor = zlib.compressobj(
             wbits=self._mode,
             strategy=strategy,
-            **({'level': level} if level is not None else {})
+            **({"level": level} if level is not None else {})
         )
 
     def compress_sync(self, data: bytes) -> bytes:

--- a/aiohttp/zlib_utils.py
+++ b/aiohttp/zlib_utils.py
@@ -1,0 +1,106 @@
+import asyncio
+import zlib
+from concurrent.futures import Executor
+from typing import Any, Optional
+
+try:
+    # Protocol has been added to Python 3.8
+    # noinspection PyUnresolvedReferences
+    from typing import Protocol
+
+    class Compressor(Protocol):
+        def compress(self, data: bytes) -> bytes: ...
+        def flush(self, mode: int = ...) -> bytes: ...
+        def copy(self) -> 'Compressor': ...
+
+
+    class Decompressor(Protocol):
+        unused_data: bytes
+        unconsumed_tail: bytes
+        eof: bool
+        def decompress(self, data: bytes, max_length: int = ...) -> bytes: ...
+        def flush(self, length: int = ...) -> bytes: ...
+        def copy(self) -> 'Decompressor': ...
+except ImportError:
+    Compressor = Any
+    Decompressor = Any
+
+MAX_SYNC_CHUNK_SIZE = 1024
+
+
+class ZlibBaseHandler:
+    def __init__(
+        self,
+        encoding: Optional[str] = None,
+        mode: Optional[int] = None,
+        executor: Optional[Executor] = None,
+        max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE
+    ):
+        assert encoding is not None or mode is not None, "Either encoding or mode must be provided"
+        if mode is not None:
+            self._mode = mode
+        elif encoding == "gzip":
+            self._mode = 16 + zlib.MAX_WBITS
+        elif encoding == "deflate":
+            self._mode = -zlib.MAX_WBITS
+        else:
+            self._mode = zlib.MAX_WBITS
+        self._executor = executor
+        self._max_sync_chunk_size = max_sync_chunk_size
+
+
+class ZLibCompressor(ZlibBaseHandler):
+    def __init__(
+        self,
+        encoding: Optional[str] = None,
+        mode: Optional[int] = None,
+        level: int = -1,
+        strategy: int = zlib.Z_DEFAULT_STRATEGY,
+        executor: Optional[Executor] = None,
+        max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE
+    ):
+        super().__init__(encoding, mode, executor, max_sync_chunk_size)
+        self._compressor: Compressor = zlib.compressobj(wbits=self._mode, level=level, strategy=strategy)
+
+    def compress_sync(self, data: bytes) -> bytes:
+        return self._compressor.compress(data)
+
+    async def compress(self, data: bytes) -> bytes:
+        if self._max_sync_chunk_size is not None and len(data) > self._max_sync_chunk_size:
+            # TODO: Replace with asyncio.to_thread as soon as we drop Python 3.8 and below
+            return await asyncio.get_event_loop().run_in_executor(
+                self._executor, self.compress_sync, data
+            )
+        return self.compress_sync(data)
+
+    def flush(self, mode: int = zlib.Z_FINISH) -> bytes:
+        return self._compressor.flush(mode)
+
+
+class ZLibDecompressor(ZlibBaseHandler):
+    def __init__(
+        self,
+        encoding: Optional[str] = None,
+        mode: Optional[int] = None,
+        executor: Optional[Executor] = None,
+        max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE
+    ):
+        super().__init__(encoding, mode, executor, max_sync_chunk_size)
+        self._decompressor: Decompressor = zlib.decompressobj(wbits=self._mode)
+
+    def decompress_sync(self, data: bytes, max_length: int = 0) -> bytes:
+        return self._decompressor.decompress(data, max_length)
+
+    async def decompress(self, data: bytes, max_length: int = 0) -> bytes:
+        if self._max_sync_chunk_size is not None and len(data) > self._max_sync_chunk_size:
+            return await asyncio.get_event_loop().run_in_executor(
+                self._executor, self.decompress_sync, data, max_length
+            )
+        return self.decompress_sync(data, max_length)
+
+    def flush(self, length: int = 0) -> bytes:
+        return self._decompressor.flush(length) if length > 0 else self._decompressor.flush()
+
+    @property
+    def eof(self) -> bool:
+        return self._decompressor.eof

--- a/aiohttp/zlib_utils.py
+++ b/aiohttp/zlib_utils.py
@@ -1,42 +1,37 @@
 import asyncio
 import zlib
 from concurrent.futures import Executor
-from typing import Any, Optional
+from typing import Optional
 
-try:
-    # Protocol has been added to Python 3.8
-    # noinspection PyUnresolvedReferences
-    from typing import Protocol
+from typing_extensions import Protocol
 
-    class Compressor(Protocol):
-        def compress(self, data: bytes) -> bytes:
-            ...
-
-        def flush(self, mode: int = ...) -> bytes:
-            ...
-
-        def copy(self) -> "Compressor":
-            ...
-
-    class Decompressor(Protocol):
-        unused_data: bytes
-        unconsumed_tail: bytes
-        eof: bool
-
-        def decompress(self, data: bytes, max_length: int = ...) -> bytes:
-            ...
-
-        def flush(self, length: int = ...) -> bytes:
-            ...
-
-        def copy(self) -> "Decompressor":
-            ...
-
-except ImportError:
-    Compressor = Any
-    Decompressor = Any
 
 MAX_SYNC_CHUNK_SIZE = 1024
+
+class Compressor(Protocol):
+    def compress(self, data: bytes) -> bytes:
+        ...
+
+    def flush(self, mode: int = ...) -> bytes:
+        ...
+
+    def copy(self) -> "Compressor":
+        ...
+
+
+class Decompressor(Protocol):
+    unused_data: bytes
+    unconsumed_tail: bytes
+    eof: bool
+
+    def decompress(self, data: bytes, max_length: int = ...) -> bytes:
+        ...
+
+    def flush(self, length: int = ...) -> bytes:
+        ...
+
+    def copy(self) -> "Decompressor":
+        ...
 
 
 class ZlibBaseHandler:
@@ -129,3 +124,11 @@ class ZLibDecompressor(ZlibBaseHandler):
     @property
     def eof(self) -> bool:
         return self._decompressor.eof
+
+    @property
+    def unconsumed_tail(self) -> bytes:
+        return self._decompressor.unconsumed_tail
+
+    @property
+    def unused_data(self) -> bytes:
+        return self._decompressor.unused_data

--- a/aiohttp/zlib_utils.py
+++ b/aiohttp/zlib_utils.py
@@ -9,18 +9,29 @@ try:
     from typing import Protocol
 
     class Compressor(Protocol):
-        def compress(self, data: bytes) -> bytes: ...
-        def flush(self, mode: int = ...) -> bytes: ...
-        def copy(self) -> 'Compressor': ...
+        def compress(self, data: bytes) -> bytes:
+            ...
 
+        def flush(self, mode: int = ...) -> bytes:
+            ...
+
+        def copy(self) -> "Compressor":
+            ...
 
     class Decompressor(Protocol):
         unused_data: bytes
         unconsumed_tail: bytes
         eof: bool
-        def decompress(self, data: bytes, max_length: int = ...) -> bytes: ...
-        def flush(self, length: int = ...) -> bytes: ...
-        def copy(self) -> 'Decompressor': ...
+
+        def decompress(self, data: bytes, max_length: int = ...) -> bytes:
+            ...
+
+        def flush(self, length: int = ...) -> bytes:
+            ...
+
+        def copy(self) -> "Decompressor":
+            ...
+
 except ImportError:
     Compressor = Any
     Decompressor = Any
@@ -34,9 +45,11 @@ class ZlibBaseHandler:
         encoding: Optional[str] = None,
         mode: Optional[int] = None,
         executor: Optional[Executor] = None,
-        max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE
+        max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE,
     ):
-        assert encoding is not None or mode is not None, "Either encoding or mode must be provided"
+        assert (
+            encoding is not None or mode is not None
+        ), "Either encoding or mode must be provided"
         if mode is not None:
             self._mode = mode
         elif encoding == "gzip":
@@ -57,16 +70,21 @@ class ZLibCompressor(ZlibBaseHandler):
         level: int = -1,
         strategy: int = zlib.Z_DEFAULT_STRATEGY,
         executor: Optional[Executor] = None,
-        max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE
+        max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE,
     ):
         super().__init__(encoding, mode, executor, max_sync_chunk_size)
-        self._compressor: Compressor = zlib.compressobj(wbits=self._mode, level=level, strategy=strategy)
+        self._compressor: Compressor = zlib.compressobj(
+            wbits=self._mode, level=level, strategy=strategy
+        )
 
     def compress_sync(self, data: bytes) -> bytes:
         return self._compressor.compress(data)
 
     async def compress(self, data: bytes) -> bytes:
-        if self._max_sync_chunk_size is not None and len(data) > self._max_sync_chunk_size:
+        if (
+            self._max_sync_chunk_size is not None
+            and len(data) > self._max_sync_chunk_size
+        ):
             # TODO: Replace with asyncio.to_thread as soon as we drop Python 3.8 and below
             return await asyncio.get_event_loop().run_in_executor(
                 self._executor, self.compress_sync, data
@@ -83,7 +101,7 @@ class ZLibDecompressor(ZlibBaseHandler):
         encoding: Optional[str] = None,
         mode: Optional[int] = None,
         executor: Optional[Executor] = None,
-        max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE
+        max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE,
     ):
         super().__init__(encoding, mode, executor, max_sync_chunk_size)
         self._decompressor: Decompressor = zlib.decompressobj(wbits=self._mode)
@@ -92,14 +110,21 @@ class ZLibDecompressor(ZlibBaseHandler):
         return self._decompressor.decompress(data, max_length)
 
     async def decompress(self, data: bytes, max_length: int = 0) -> bytes:
-        if self._max_sync_chunk_size is not None and len(data) > self._max_sync_chunk_size:
+        if (
+            self._max_sync_chunk_size is not None
+            and len(data) > self._max_sync_chunk_size
+        ):
             return await asyncio.get_event_loop().run_in_executor(
                 self._executor, self.decompress_sync, data, max_length
             )
         return self.decompress_sync(data, max_length)
 
     def flush(self, length: int = 0) -> bytes:
-        return self._decompressor.flush(length) if length > 0 else self._decompressor.flush()
+        return (
+            self._decompressor.flush(length)
+            if length > 0
+            else self._decompressor.flush()
+        )
 
     @property
     def eof(self) -> bool:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1119,7 +1119,7 @@ class TestDeflateBuffer:
         dbuf = DeflateBuffer(buf, "deflate")
 
         dbuf.decompressor = mock.Mock()
-        dbuf.decompressor.decompress.return_value = b"line"
+        dbuf.decompressor.decompress_sync.return_value = b"line"
 
         # First byte should be b'x' in order code not to change the decoder.
         dbuf.feed_data(b"xxxx", 4)
@@ -1133,7 +1133,7 @@ class TestDeflateBuffer:
 
         exc = ValueError()
         dbuf.decompressor = mock.Mock()
-        dbuf.decompressor.decompress.side_effect = exc
+        dbuf.decompressor.decompress_sync.side_effect = exc
 
         with pytest.raises(http_exceptions.ContentEncodingError):
             # Should be more than 4 bytes to trigger deflate FSM error.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Addresses issue https://github.com/aio-libs/aiohttp/issues/7192
Refactors the logic to have the zlib-related stuff concentrated into a single module

## Are there changes in behavior for the user?

No

## Related issue number

https://github.com/aio-libs/aiohttp/issues/7192

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
