### PR TITLE
Update documentation: complete client docs for honoring proxy env vars

### DIFF
--- a/CHANGES/7325.doc
+++ b/CHANGES/7325.doc
@@ -1,0 +1,1 @@
+Complete trust_env parameter description to honor wss_proxy, ws_proxy or no_proxy env

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -593,7 +593,7 @@ Contrary to the ``requests`` library, it won't read environment
 variables by default. But you can do so by passing
 ``trust_env=True`` into :class:`aiohttp.ClientSession`
 constructor for extracting proxy configuration from
-*HTTP_PROXY*, *HTTPS_PROXY*, *WS_PROXY* or *WSS_PROXY* *environment
+*HTTP_PROXY*, *HTTPS_PROXY*, *WS_PROXY*, *WSS_PROXY* or *NO_PROXY* *environment
 variables* (all are case insensitive)::
 
    async with aiohttp.ClientSession(trust_env=True) as session:

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -601,7 +601,7 @@ constructor.::
            print(resp.status)
 
 .. note::
-    ``aiohttp`` uses `urllib.request.getproxies <https://docs.python.org/3/library/urllib.request.html#urllib.request.getproxies>`_
+    aiohttp uses :func:`urllib.request.getproxies`
     for reading the proxy configuration and applies them for the schemas ``http``, ``https``, ``ws`` and ``wss``
 
     Hosts defined in ``no_proxy`` will bypass the proxy.

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -602,7 +602,7 @@ constructor.::
 
 .. note::
     aiohttp uses :func:`urllib.request.getproxies`
-    for reading the proxy configuration and applies them for the schemas ``http``, ``https``, ``ws`` and ``wss``
+    for reading the proxy configuration (e.g. from the *HTTP_PROXY* etc. environment variables) and applies them for the *HTTP*, *HTTPS*, *WS* and *WSS* schemes.
 
     Hosts defined in ``no_proxy`` will bypass the proxy.
 

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -561,6 +561,8 @@ DER with e.g::
    to :class:`TCPConnector` as default, the value from
    :meth:`ClientSession.get` and others override default.
 
+.. _aiohttp-client-proxy-support:
+
 Proxy support
 -------------
 
@@ -592,13 +594,17 @@ Authentication credentials can be passed in proxy URL::
 Contrary to the ``requests`` library, it won't read environment
 variables by default. But you can do so by passing
 ``trust_env=True`` into :class:`aiohttp.ClientSession`
-constructor for extracting proxy configuration from
-*HTTP_PROXY*, *HTTPS_PROXY*, *WS_PROXY*, *WSS_PROXY* or *NO_PROXY* *environment
-variables* (all are case insensitive)::
+constructor.::
 
    async with aiohttp.ClientSession(trust_env=True) as session:
        async with session.get("http://python.org") as resp:
            print(resp.status)
+
+.. note::
+    ``aiohttp`` uses `urllib.request.getproxies <https://docs.python.org/3/library/urllib.request.html#urllib.request.getproxies>`_
+    for reading the proxy configuration and applies them for the schemas ``http``, ``https``, ``ws`` and ``wss``
+
+    Hosts defined in ``no_proxy`` will bypass the proxy.
 
 Proxy credentials are given from ``~/.netrc`` file if present (see
 :class:`aiohttp.ClientSession` for more details).

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -173,9 +173,9 @@ The client session supports the context manager protocol for self closing.
 
       .. versionadded:: 3.7
 
-   :param bool trust_env: Get proxies information from *HTTP_PROXY*, *HTTPS_PROXY*,
-      *WS_PROXY*, *WSS_PROXY* or *NO_PROXY* environment variables if the parameter is ``True``
-      (``False`` by default).
+   :param bool trust_env: Trust environment settings for proxy configuration if the parameter
+      is ``True`` (``False`` by default). See :ref:`aiohttp-client-proxy-support` for
+      more information.
 
       Get proxy credentials from ``~/.netrc`` file if present.
 
@@ -312,8 +312,9 @@ The client session supports the context manager protocol for self closing.
 
    .. attribute:: trust_env
 
-      Should get proxies information from HTTP_PROXY / HTTPS_PROXY environment
-      variables or ~/.netrc file if present
+      Trust environment settings for proxy configuration
+      or ~/.netrc file if present. See :ref:`aiohttp-client-proxy-support` for
+      more information.
 
       :class:`bool` default is ``False``
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -173,8 +173,8 @@ The client session supports the context manager protocol for self closing.
 
       .. versionadded:: 3.7
 
-   :param bool trust_env: Get proxies information from *HTTP_PROXY* /
-      *HTTPS_PROXY* environment variables if the parameter is ``True``
+   :param bool trust_env: Get proxies information from *HTTP_PROXY*, *HTTPS_PROXY*,
+      *WS_PROXY*, *WSS_PROXY* or *NO_PROXY* environment variables if the parameter is ``True``
       (``False`` by default).
 
       Get proxy credentials from ``~/.netrc`` file if present.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

* Update proxy support docs to honor `no_proxy` env
* Complete `trust_env` parameter description to honor `wss_proxy`, `ws_proxy` or `no_proxy` env

## Are there changes in behavior for the user?

No

## Related issue number

Update docs for: https://github.com/aio-libs/aiohttp/issues/4431

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
