### PR TITLE
consume ConnectionResetError in ping tasks

### DIFF
--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -107,7 +107,7 @@ class ClientWebSocketResponse:
             # fire-and-forget a task is not perfect but maybe ok for
             # sending ping. Otherwise we need a long-living heartbeat
             # task in the class.
-            self._loop.create_task(self._writer.ping())
+            self._loop.create_task(self._writer.ping(consume_errors=True))
 
             if self._pong_response_cb is not None:
                 self._pong_response_cb.cancel()

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -667,11 +667,15 @@ class WebSocketWriter:
             message = message.encode("utf-8")
         await self._send_frame(message, WSMsgType.PONG)
 
-    async def ping(self, message: bytes = b"") -> None:
+    async def ping(self, message: bytes = b"", consume_errors: bool = False) -> None:
         """Send ping message."""
         if isinstance(message, str):
             message = message.encode("utf-8")
-        await self._send_frame(message, WSMsgType.PING)
+        try:
+            await self._send_frame(message, WSMsgType.PING)
+        except ConnectionResetError:
+            if not consume_errors:
+                raise
 
     async def send(
         self,

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -142,7 +142,7 @@ class WebSocketResponse(StreamResponse):
             # fire-and-forget a task is not perfect but maybe ok for
             # sending ping. Otherwise we need a long-living heartbeat
             # task in the class.
-            self._loop.create_task(self._writer.ping())  # type: ignore[union-attr]
+            self._loop.create_task(self._writer.ping(consume_errors=True))  # type: ignore[union-attr]
 
             if self._pong_response_cb is not None:
                 self._pong_response_cb.cancel()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The purpose is to avoid uncaught exception tracebacks from ping tasks.

```python-traceback
Task exception was never retrieved
future: <Task finished name='Task-5559' coro=<WebSocketWriter.ping() done, defined at /home/ubuntu/chia-blockchain/venv/lib/python3.10/site-packages/aiohttp/http_websocket.py:672> exception=ConnectionResetError('Cannot write to closing transport')>
Traceback (most recent call last):
  File "/home/ubuntu/chia-blockchain/venv/lib/python3.10/site-packages/aiohttp/http_websocket.py", line 676, in ping
    await self._send_frame(message, WSMsgType.PING)
  File "/home/ubuntu/chia-blockchain/venv/lib/python3.10/site-packages/aiohttp/http_websocket.py", line 646, in _send_frame
    self._write(header + mask + message)
  File "/home/ubuntu/chia-blockchain/venv/lib/python3.10/site-packages/aiohttp/http_websocket.py", line 663, in _write
    raise ConnectionResetError("Cannot write to closing transport")
ConnectionResetError: Cannot write to closing transport
```

## Are there changes in behavior for the user?

The user both does not deal with the tracebacks and also gets the option to request consumption themselves.

## Related issue number

https://github.com/aio-libs/aiohttp/issues/5182

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
