### PR TITLE
Fix stripping of backslashes in multipart filenames

### DIFF
--- a/CHANGES/7070.bugfix
+++ b/CHANGES/7070.bugfix
@@ -1,0 +1,1 @@
+Fix issue where undoubled backslashes in multipart filenames were stripped.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -51,6 +51,7 @@ Arseny Timoniq
 Artem Yushkovskiy
 Arthur Darcet
 Austin Scola
+Barney Gale
 Ben Bader
 Ben Greiner
 Ben Timby

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -35,7 +35,7 @@ from .hdrs import (
     CONTENT_TRANSFER_ENCODING,
     CONTENT_TYPE,
 )
-from .helpers import CHAR, TOKEN, parse_mimetype, reify
+from .helpers import TOKEN, parse_mimetype, reify
 from .http import HeadersParser
 from .payload import (
     JsonPayload,
@@ -93,9 +93,6 @@ def parse_content_disposition(
         substring = string[pos:-1] if string.endswith("*") else string[pos:]
         return substring.isdigit()
 
-    def unescape(text: str, *, chars: str = "".join(map(re.escape, CHAR))) -> str:
-        return re.sub(f"\\\\([{chars}])", "\\1", text)
-
     if not header:
         return None, {}
 
@@ -126,7 +123,7 @@ def parse_content_disposition(
 
         elif is_continuous_param(key):
             if is_quoted(value):
-                value = unescape(value[1:-1])
+                value = value[1:-1]
             elif not is_token(value):
                 warnings.warn(BadContentDispositionParam(item))
                 continue
@@ -149,7 +146,7 @@ def parse_content_disposition(
             failed = True
             if is_quoted(value):
                 failed = False
-                value = unescape(value[1:-1].lstrip("\\/"))
+                value = value[1:-1].lstrip("\\/")
             elif is_token(value):
                 failed = False
             elif parts:
@@ -158,7 +155,7 @@ def parse_content_disposition(
                 _value = f"{value};{parts[0]}"
                 if is_quoted(_value):
                     parts.pop(0)
-                    value = unescape(_value[1:-1].lstrip("\\/"))
+                    value = _value[1:-1].lstrip("\\/")
                     failed = False
 
             if failed:

--- a/tests/test_multipart_helpers.py
+++ b/tests/test_multipart_helpers.py
@@ -87,7 +87,7 @@ class TestParseContentDisposition:
             r'attachment; filename="f\oo.html"'
         )
         assert "attachment" == disptype
-        assert {"filename": "foo.html"} == params
+        assert {"filename": r"f\oo.html"} == params
 
     def test_attwithasciifnescapedquote(self) -> None:
         disptype, params = parse_content_disposition(
@@ -194,7 +194,7 @@ class TestParseContentDisposition:
             r'attachment; filename="foo-%\41.html"'
         )
         assert "attachment" == disptype
-        assert {"filename": r"foo-%41.html"} == params
+        assert {"filename": r"foo-%\41.html"} == params
 
     def test_attwithnamepct(self) -> None:
         disptype, params = parse_content_disposition(
@@ -551,7 +551,7 @@ class TestParseContentDisposition:
             r'attachment; filename*0="foo"; filename*1="\b\a\r.html"'
         )
         assert "attachment" == disptype
-        assert {"filename*0": "foo", "filename*1": "bar.html"} == params
+        assert {"filename*0": "foo", "filename*1": r"\b\a\r.html"} == params
 
     def test_attfncontenc(self) -> None:
         disptype, params = parse_content_disposition(


### PR DESCRIPTION
## What do these changes do?

Adjust `aiohttp.multipart` to not "unescape" backslashes in multipart filenames.

## Are there changes in behavior for the user?

Undoubled backslashes in multipart form data will no longer be stripped. Well-behaved clients will not send these anyway (they send only the basename, not the full path).

## Related issue number

- #7070

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
