### PR TITLE
Update update_query calls to work with latest yarl

### DIFF
--- a/CHANGES/7259.bugfix
+++ b/CHANGES/7259.bugfix
@@ -1,0 +1,1 @@
+Fixed missing query in tracing method URLs when using ``yarl`` 1.9+.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -374,6 +374,7 @@ class ClientSession:
         redirects = 0
         history = []
         version = self._version
+        params = params or {}
 
         # Merge with default headers and transform to CIMultiDict
         headers = self._prepare_headers(headers)
@@ -613,7 +614,7 @@ class ClientSession:
                             headers.pop(hdrs.AUTHORIZATION, None)
 
                         url = parsed_url
-                        params = None
+                        params = {}
                         resp.release()
                         continue
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,4 +11,4 @@ charset-normalizer==2.0.12
 frozenlist==1.3.1
 gunicorn==20.1.0
 uvloop==0.14.0; platform_system!="Windows" and implementation_name=="cpython" and python_version<"3.9" # MagicStack/uvloop#14
-yarl==1.8.1
+yarl==1.9.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -253,7 +253,7 @@ webcolors==1.11.1
     # via blockdiag
 wheel==0.37.0
     # via pip-tools
-yarl==1.8.1
+yarl==1.9.2
     # via -r requirements/base.txt
 zipp==3.8.1
     # via importlib-metadata


### PR DESCRIPTION
This patch pass "{}" when params is "None" to the url.update_query to avoid setting the url params to None.

Related to this change in yarl:
https://github.com/aio-libs/yarl/commit/dd86b3435093b9ca251ecb7831346b92a3f16b25

Fix https://github.com/aio-libs/aiohttp/issues/7259