### PR TITLE
Patchback/backports/3.9/ecd9c72697ca1529e7cae4693775612987a2a6d2/pr 6559

### DIFF
--- a/CHANGES/2304.feature
+++ b/CHANGES/2304.feature
@@ -1,0 +1,1 @@
+Support setting response header parameters max_line_size and max_field_size.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -170,6 +170,7 @@ class ClientSession:
             "_base_url",
             "_source_traceback",
             "_connector",
+            "requote_redirect_url",
             "_loop",
             "_cookie_jar",
             "_connector_owner",

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -165,30 +165,32 @@ _RetType = TypeVar("_RetType")
 class ClientSession:
     """First-class interface for making HTTP requests."""
 
-    __slots__ = (
-        "_base_url",
-        "_source_traceback",
-        "_connector",
-        "_loop",
-        "_cookie_jar",
-        "_connector_owner",
-        "_default_auth",
-        "_version",
-        "_json_serialize",
-        "_requote_redirect_url",
-        "_timeout",
-        "_raise_for_status",
-        "_auto_decompress",
-        "_trust_env",
-        "_default_headers",
-        "_skip_auto_headers",
-        "_request_class",
-        "_response_class",
-        "_ws_response_class",
-        "_trace_configs",
-        "_read_bufsize",
-        "_max_line_size",
-        "_max_field_size",
+    ATTRS = frozenset(
+        [
+            "_base_url",
+            "_source_traceback",
+            "_connector",
+            "_loop",
+            "_cookie_jar",
+            "_connector_owner",
+            "_default_auth",
+            "_version",
+            "_json_serialize",
+            "_requote_redirect_url",
+            "_timeout",
+            "_raise_for_status",
+            "_auto_decompress",
+            "_trust_env",
+            "_default_headers",
+            "_skip_auto_headers",
+            "_request_class",
+            "_response_class",
+            "_ws_response_class",
+            "_trace_configs",
+            "_read_bufsize",
+            "_max_line_size",
+            "_max_field_size",
+        ]
     )
 
     _source_traceback: Optional[traceback.StackSummary] = None

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -146,6 +146,8 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
         read_timeout: Optional[float] = None,
         read_bufsize: int = 2**16,
         timeout_ceil_threshold: float = 5,
+        max_line_size: int = 8190,
+        max_field_size: int = 8190,
     ) -> None:
         self._skip_payload = skip_payload
 
@@ -162,6 +164,8 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
             response_with_body=not skip_payload,
             read_until_eof=read_until_eof,
             auto_decompress=auto_decompress,
+            max_line_size=max_line_size,
+            max_field_size=max_field_size,
         )
 
         if self._tail:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3079,7 +3079,7 @@ async def test_http_empty_data_text(aiohttp_client) -> None:
         assert resp.headers["Content-Type"] == "text/plain; charset=utf-8"
 
 
-async def test_max_field_size_session_default(aiohttp_client: Any) -> None:
+async def test_max_field_size_session_default(aiohttp_client) -> None:
     async def handler(request):
         return web.Response(headers={"Custom": "x" * 8190})
 
@@ -3092,7 +3092,7 @@ async def test_max_field_size_session_default(aiohttp_client: Any) -> None:
         assert resp.headers["Custom"] == "x" * 8190
 
 
-async def test_max_field_size_session_default_fail(aiohttp_client: Any) -> None:
+async def test_max_field_size_session_default_fail(aiohttp_client) -> None:
     async def handler(request):
         return web.Response(headers={"Custom": "x" * 8191})
 
@@ -3104,7 +3104,7 @@ async def test_max_field_size_session_default_fail(aiohttp_client: Any) -> None:
         await client.get("/")
 
 
-async def test_max_field_size_session_explicit(aiohttp_client: Any) -> None:
+async def test_max_field_size_session_explicit(aiohttp_client) -> None:
     async def handler(request):
         return web.Response(headers={"Custom": "x" * 8191})
 
@@ -3117,7 +3117,7 @@ async def test_max_field_size_session_explicit(aiohttp_client: Any) -> None:
         assert resp.headers["Custom"] == "x" * 8191
 
 
-async def test_max_field_size_request_explicit(aiohttp_client: Any) -> None:
+async def test_max_field_size_request_explicit(aiohttp_client) -> None:
     async def handler(request):
         return web.Response(headers={"Custom": "x" * 8191})
 
@@ -3130,7 +3130,7 @@ async def test_max_field_size_request_explicit(aiohttp_client: Any) -> None:
         assert resp.headers["Custom"] == "x" * 8191
 
 
-async def test_max_line_size_session_default(aiohttp_client: Any) -> None:
+async def test_max_line_size_session_default(aiohttp_client) -> None:
     async def handler(request):
         return web.Response(status=200, reason="x" * 8190)
 
@@ -3143,7 +3143,7 @@ async def test_max_line_size_session_default(aiohttp_client: Any) -> None:
         assert resp.reason == "x" * 8190
 
 
-async def test_max_line_size_session_default_fail(aiohttp_client: Any) -> None:
+async def test_max_line_size_session_default_fail(aiohttp_client) -> None:
     async def handler(request):
         return web.Response(status=200, reason="x" * 8192)
 
@@ -3155,7 +3155,7 @@ async def test_max_line_size_session_default_fail(aiohttp_client: Any) -> None:
         await client.get("/")
 
 
-async def test_max_line_size_session_explicit(aiohttp_client: Any) -> None:
+async def test_max_line_size_session_explicit(aiohttp_client) -> None:
     async def handler(request):
         return web.Response(status=200, reason="x" * 8191)
 
@@ -3168,7 +3168,7 @@ async def test_max_line_size_session_explicit(aiohttp_client: Any) -> None:
         assert resp.reason == "x" * 8191
 
 
-async def test_max_line_size_request_explicit(aiohttp_client: Any) -> None:
+async def test_max_line_size_request_explicit(aiohttp_client) -> None:
     async def handler(request):
         return web.Response(status=200, reason="x" * 8191)
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3077,3 +3077,105 @@ async def test_http_empty_data_text(aiohttp_client) -> None:
         assert resp.status == 200
         assert await resp.text() == "ok"
         assert resp.headers["Content-Type"] == "text/plain; charset=utf-8"
+
+
+async def test_max_field_size_session_default(aiohttp_client: Any) -> None:
+    async def handler(request):
+        return web.Response(headers={"Custom": "x" * 8190})
+
+    app = web.Application()
+    app.add_routes([web.get("/", handler)])
+
+    client = await aiohttp_client(app)
+
+    async with await client.get("/") as resp:
+        assert resp.headers["Custom"] == "x" * 8190
+
+
+async def test_max_field_size_session_default_fail(aiohttp_client: Any) -> None:
+    async def handler(request):
+        return web.Response(headers={"Custom": "x" * 8191})
+
+    app = web.Application()
+    app.add_routes([web.get("/", handler)])
+
+    client = await aiohttp_client(app)
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.get("/")
+
+
+async def test_max_field_size_session_explicit(aiohttp_client: Any) -> None:
+    async def handler(request):
+        return web.Response(headers={"Custom": "x" * 8191})
+
+    app = web.Application()
+    app.add_routes([web.get("/", handler)])
+
+    client = await aiohttp_client(app, max_field_size=8191)
+
+    async with await client.get("/") as resp:
+        assert resp.headers["Custom"] == "x" * 8191
+
+
+async def test_max_field_size_request_explicit(aiohttp_client: Any) -> None:
+    async def handler(request):
+        return web.Response(headers={"Custom": "x" * 8191})
+
+    app = web.Application()
+    app.add_routes([web.get("/", handler)])
+
+    client = await aiohttp_client(app)
+
+    async with await client.get("/", max_field_size=8191) as resp:
+        assert resp.headers["Custom"] == "x" * 8191
+
+
+async def test_max_line_size_session_default(aiohttp_client: Any) -> None:
+    async def handler(request):
+        return web.Response(status=200, reason="x" * 8190)
+
+    app = web.Application()
+    app.add_routes([web.get("/", handler)])
+
+    client = await aiohttp_client(app)
+
+    async with await client.get("/") as resp:
+        assert resp.reason == "x" * 8190
+
+
+async def test_max_line_size_session_default_fail(aiohttp_client: Any) -> None:
+    async def handler(request):
+        return web.Response(status=200, reason="x" * 8192)
+
+    app = web.Application()
+    app.add_routes([web.get("/", handler)])
+
+    client = await aiohttp_client(app)
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.get("/")
+
+
+async def test_max_line_size_session_explicit(aiohttp_client: Any) -> None:
+    async def handler(request):
+        return web.Response(status=200, reason="x" * 8191)
+
+    app = web.Application()
+    app.add_routes([web.get("/", handler)])
+
+    client = await aiohttp_client(app, max_line_size=8191)
+
+    async with await client.get("/") as resp:
+        assert resp.reason == "x" * 8191
+
+
+async def test_max_line_size_request_explicit(aiohttp_client: Any) -> None:
+    async def handler(request):
+        return web.Response(status=200, reason="x" * 8191)
+
+    app = web.Application()
+    app.add_routes([web.get("/", handler)])
+
+    client = await aiohttp_client(app)
+
+    async with await client.get("/", max_line_size=8191) as resp:
+        assert resp.reason == "x" * 8191


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Backporting following these guidelines - https://github.com/aio-libs/aiohttp/pull/6559#issuecomment-1522189057 so we can get configurable header size limits in the next release
