### PR TITLE
hint WebSocketWriter methods pong/ping/close to allow bytes or str

### DIFF
--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -661,13 +661,13 @@ class WebSocketWriter:
             raise ConnectionResetError("Cannot write to closing transport")
         self.transport.write(data)
 
-    async def pong(self, message: bytes = b"") -> None:
+    async def pong(self, message: Union[bytes, str] = b"") -> None:
         """Send pong message."""
         if isinstance(message, str):
             message = message.encode("utf-8")
         await self._send_frame(message, WSMsgType.PONG)
 
-    async def ping(self, message: bytes = b"") -> None:
+    async def ping(self, message: Union[bytes, str] = b"") -> None:
         """Send ping message."""
         if isinstance(message, str):
             message = message.encode("utf-8")
@@ -687,7 +687,7 @@ class WebSocketWriter:
         else:
             await self._send_frame(message, WSMsgType.TEXT, compress)
 
-    async def close(self, code: int = 1000, message: bytes = b"") -> None:
+    async def close(self, code: int = 1000, message: Union[bytes, str] = b"") -> None:
         """Close the websocket, sending the specified code and message."""
         if isinstance(message, str):
             message = message.encode("utf-8")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The `message` parameter hints for `WebSocketWriter.pong()`, `.ping()`, and `.close()` are expanded from `bytes` to `Union[bytes, str]`.

## Are there changes in behavior for the user?

This does not change code functionality, but adjust the hinting as would be used by mypy and IDEs to be more accurate to the code behavior.  This was noted in https://github.com/aio-libs/aiohttp/pull/7238/files#r1180780359.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
