### PR TITLE
Fix incorrect type definitions

### DIFF
--- a/CHANGES/7279.feature
+++ b/CHANGES/7279.feature
@@ -1,0 +1,1 @@
+Fix incorrect type definitions for :meth:`aiohttp.ClientSession.ws_connect` and missing types for :class:`aiohttp.WSMessage`

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -43,6 +43,7 @@ Andrew Svetlov
 Andrew Zhou
 Andrii Soldatenko
 Anes Abismail
+Angelo Kontaxis
 Antoine Pietri
 Anton Kasyanov
 Anton Zhdan-Pushkin

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -131,6 +131,7 @@ if TYPE_CHECKING:
 else:
     SSLContext = None
 
+
 @dataclasses.dataclass(frozen=True)
 class ClientTimeout:
     total: Optional[float] = None

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -12,6 +12,7 @@ import warnings
 from contextlib import suppress
 from types import SimpleNamespace, TracebackType
 from typing import (
+    TYPE_CHECKING,
     Any,
     Awaitable,
     Callable,
@@ -125,12 +126,10 @@ __all__ = (
     "request",
 )
 
-
-try:
+if TYPE_CHECKING:
     from ssl import SSLContext
-except ImportError:  # pragma: no cover
-    SSLContext = object  # type: ignore[misc,assignment]
-
+else:
+    SSLContext = None
 
 @dataclasses.dataclass(frozen=True)
 class ClientTimeout:

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -10,7 +10,18 @@ import sys
 import zlib
 from enum import IntEnum
 from struct import Struct
-from typing import Any, Callable, List, NamedTuple, Optional, Pattern, Set, Tuple, Union, cast
+from typing import (
+    Any,
+    Callable,
+    List,
+    NamedTuple,
+    Optional,
+    Pattern,
+    Set,
+    Tuple,
+    Union,
+    cast,
+)
 
 from typing_extensions import Final
 

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -10,7 +10,7 @@ import sys
 import zlib
 from enum import IntEnum
 from struct import Struct
-from typing import Any, Callable, List, Optional, Pattern, Set, Tuple, Union, cast
+from typing import Any, Callable, List, NamedTuple, Optional, Pattern, Set, Tuple, Union, cast
 
 from typing_extensions import Final
 
@@ -80,10 +80,11 @@ MSG_SIZE: Final[int] = 2**14
 DEFAULT_LIMIT: Final[int] = 2**16
 
 
-_WSMessageBase = collections.namedtuple("_WSMessageBase", ["type", "data", "extra"])
+class WSMessage(NamedTuple):
+    type: WSMsgType
+    data: Any
+    extra: str | None
 
-
-class WSMessage(_WSMessageBase):
     def json(self, *, loads: Callable[[Any], Any] = json.loads) -> Any:
         """Return parsed JSON data.
 


### PR DESCRIPTION
## What do these changes do?

Fixes the type definition for `ws_connect` having `SSLContext` as an unknown type.
Fixes `WSMessage` from not having any type definitions.

## Are there changes in behavior for the user?

Strict mode of type checkers will no longer complain about `ws_connect` being partially unknown.
Better autocomplete for `WSMessage`.

## Related issue number

No

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
