### PR TITLE
Fix unsafe .abort() call

### DIFF
--- a/CHANGES/7280.bugfix
+++ b/CHANGES/7280.bugfix
@@ -1,0 +1,1 @@
+Fixed an exception and possible memory leak in Python 3.11.1+ -- by :user:`Dreamsorcerer`

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -354,7 +354,7 @@ class BaseConnector:
             self._cleanup_closed_handle.cancel()
 
         for transport in self._cleanup_closed_transports:
-            if transport is not None:
+            if transport is not None and not transport.is_closing():
                 transport.abort()
 
         self._cleanup_closed_transports = []
@@ -409,7 +409,7 @@ class BaseConnector:
 
             # TODO (A.Yushovskiy, 24-May-2019) collect transp. closing futures
             for transport in self._cleanup_closed_transports:
-                if transport is not None:
+                if transport is not None and not transport.is_closing():
                     transport.abort()
 
             return waiters

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1344,7 +1344,7 @@ async def test_close_cancels_cleanup_handle(loop: Any) -> None:
     assert conn._cleanup_handle is None
 
 
-async def test_close_abort_closed_transports(loop: Any) -> None:
+async def test_close_abort_closed_transports(loop: Any, mocker: Any) -> None:
     tr = mocker.create_autospec(asyncio.Transport, spec_set=True, instance=True)
     tr.is_closing.return_value = True
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1179,7 +1179,7 @@ async def test_cleanup_closed(loop: Any, mocker: Any) -> None:
     mocker.spy(loop, "call_at")
     conn = aiohttp.BaseConnector(enable_cleanup_closed=True)
 
-    tr = mocker.create_autospec(asyncio.Transport, spec_set=True, instance=True)
+    tr = mock.create_autospec(asyncio.Transport, spec_set=True, instance=True)
     tr.is_closing.return_value = False
     conn._cleanup_closed_handle = cleanup_closed_handle = mock.Mock()
     conn._cleanup_closed_transports = [tr]
@@ -1190,10 +1190,10 @@ async def test_cleanup_closed(loop: Any, mocker: Any) -> None:
     assert cleanup_closed_handle.cancel.called
 
 
-async def test_cleanup_closed_disabled(loop: Any, mocker: Any) -> None:
+async def test_cleanup_closed_disabled(loop: Any) -> None:
     conn = aiohttp.BaseConnector(enable_cleanup_closed=False)
 
-    tr = mocker.create_autospec(asyncio.Transport, spec_set=True, instance=True)
+    tr = mock.create_autospec(asyncio.Transport, spec_set=True, instance=True)
     tr.is_closing.return_value = False
     conn._cleanup_closed_transports = [tr]
     conn._cleanup_closed()
@@ -1344,8 +1344,8 @@ async def test_close_cancels_cleanup_handle(loop: Any) -> None:
     assert conn._cleanup_handle is None
 
 
-async def test_close_abort_closed_transports(loop: Any, mocker: Any) -> None:
-    tr = mocker.create_autospec(asyncio.Transport, spec_set=True, instance=True)
+async def test_close_abort_closed_transports(loop: Any) -> None:
+    tr = mock.create_autospec(asyncio.Transport, spec_set=True, instance=True)
     tr.is_closing.return_value = True
 
     conn = aiohttp.BaseConnector()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1179,7 +1179,8 @@ async def test_cleanup_closed(loop: Any, mocker: Any) -> None:
     mocker.spy(loop, "call_at")
     conn = aiohttp.BaseConnector(enable_cleanup_closed=True)
 
-    tr = mock.Mock()
+    tr = mocker.create_autospec(asyncio.Transport, spec_set=True, instance=True)
+    tr.is_closing.return_value = False
     conn._cleanup_closed_handle = cleanup_closed_handle = mock.Mock()
     conn._cleanup_closed_transports = [tr]
     conn._cleanup_closed()
@@ -1192,7 +1193,8 @@ async def test_cleanup_closed(loop: Any, mocker: Any) -> None:
 async def test_cleanup_closed_disabled(loop: Any, mocker: Any) -> None:
     conn = aiohttp.BaseConnector(enable_cleanup_closed=False)
 
-    tr = mock.Mock()
+    tr = mocker.create_autospec(asyncio.Transport, spec_set=True, instance=True)
+    tr.is_closing.return_value = False
     conn._cleanup_closed_transports = [tr]
     conn._cleanup_closed()
     assert tr.abort.called
@@ -1343,14 +1345,15 @@ async def test_close_cancels_cleanup_handle(loop: Any) -> None:
 
 
 async def test_close_abort_closed_transports(loop: Any) -> None:
-    tr = mock.Mock()
+    tr = mocker.create_autospec(asyncio.Transport, spec_set=True, instance=True)
+    tr.is_closing.return_value = True
 
     conn = aiohttp.BaseConnector()
     conn._cleanup_closed_transports.append(tr)
     await conn.close()
 
     assert not conn._cleanup_closed_transports
-    assert tr.abort.called
+    assert not tr.abort.called
     assert conn.closed
 
 


### PR DESCRIPTION
Possibly fixes #7252.
Definite fix for https://github.com/elastic/rally/issues/1714.

`.abort()` is not safe to call if the transport is already closed, since Python 3.11.1:
https://github.com/python/cpython/pull/98540