### PR TITLE
Add note about updating headers in on_response_prepare

### DIFF
--- a/CHANGES/7283.doc
+++ b/CHANGES/7283.doc
@@ -1,0 +1,1 @@
+Added a note about possibly needing to update headers when using ``on_response_prepare`` -- by :user:`Dreamsorcerer`

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1392,6 +1392,13 @@ duplicated like one using :meth:`~aiohttp.web.Application.copy`.
           async def on_prepare(request, response):
               pass
 
+      .. note::
+
+         The headers are written immediately after these callbacks are run.
+         Therefore, if you modify the content of the response, you may need to
+         adjust the `Content-Length` header or similar to match. Aiohttp will
+         not make any updates to the headers at this point.
+
    .. attribute:: on_startup
 
       A :class:`~aiosignal.Signal` that is fired on application start-up.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1397,7 +1397,7 @@ duplicated like one using :meth:`~aiohttp.web.Application.copy`.
          The headers are written immediately after these callbacks are run.
          Therefore, if you modify the content of the response, you may need to
          adjust the `Content-Length` header or similar to match. Aiohttp will
-         not make any updates to the headers at this point.
+         not make any updates to the headers from this point.
 
    .. attribute:: on_startup
 


### PR DESCRIPTION
Fixes #6443.

It seems like it'll be easier just to document this. Only solution that looks like it'd work is to update the Content-Length header every time the body is changed, but that could incur a performance penalty for little reason.