### PR TITLE
Minor refactor of setting Content-Length in body

### DIFF
--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -576,12 +576,7 @@ class Response(StreamResponse):
         return self._body
 
     @body.setter
-    def body(
-        self,
-        body: bytes,
-        CONTENT_TYPE: istr = hdrs.CONTENT_TYPE,
-        CONTENT_LENGTH: istr = hdrs.CONTENT_LENGTH,
-    ) -> None:
+    def body(self, body: bytes) -> None:
         if body is None:
             self._body: Optional[bytes] = None
             self._body_payload: bool = False
@@ -598,15 +593,9 @@ class Response(StreamResponse):
 
             headers = self._headers
 
-            # set content-length header if needed
-            if not self._chunked and CONTENT_LENGTH not in headers:
-                size = body.size
-                if size is not None:
-                    headers[CONTENT_LENGTH] = str(size)
-
             # set content-type
-            if CONTENT_TYPE not in headers:
-                headers[CONTENT_TYPE] = body.content_type
+            if hdrs.CONTENT_TYPE not in headers:
+                headers[hdrs.CONTENT_TYPE] = body.content_type
 
             # copy payload headers
             if body.headers:
@@ -684,11 +673,8 @@ class Response(StreamResponse):
 
     async def _start(self, request: "BaseRequest") -> AbstractStreamWriter:
         if not self._chunked and hdrs.CONTENT_LENGTH not in self._headers:
-            if not self._body_payload:
-                if self._body is not None:
-                    self._headers[hdrs.CONTENT_LENGTH] = str(len(self._body))
-                else:
-                    self._headers[hdrs.CONTENT_LENGTH] = "0"
+            size = body.size if self._body_payload else len(self._body) if self._body else 0
+            self._headers[hdrs.CONTENT_LENGTH] = str(size)
 
         return await super()._start(request)
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -674,7 +674,7 @@ class Response(StreamResponse):
     async def _start(self, request: "BaseRequest") -> AbstractStreamWriter:
         if not self._chunked and hdrs.CONTENT_LENGTH not in self._headers:
             if self._body_payload:
-                size = self._body.size
+                size = cast(Payload, self._body).size or "0"
             else:
                 size = len(self._body) if self._body else "0"
             self._headers[hdrs.CONTENT_LENGTH] = str(size)

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -678,8 +678,8 @@ class Response(StreamResponse):
                 if size is not None:
                     self._headers[hdrs.CONTENT_LENGTH] = str(size)
             else:
-                size = len(self._body) if self._body else "0"
-                self._headers[hdrs.CONTENT_LENGTH] = str(size)
+                body_len = len(self._body) if self._body else "0"
+                self._headers[hdrs.CONTENT_LENGTH] = str(body_len)
 
         return await super()._start(request)
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -674,10 +674,12 @@ class Response(StreamResponse):
     async def _start(self, request: "BaseRequest") -> AbstractStreamWriter:
         if not self._chunked and hdrs.CONTENT_LENGTH not in self._headers:
             if self._body_payload:
-                size = cast(Payload, self._body).size or "0"
+                size = cast(Payload, self._body).size
+                if size is not None:
+                    self._headers[hdrs.CONTENT_LENGTH] = str(size)
             else:
                 size = len(self._body) if self._body else "0"
-            self._headers[hdrs.CONTENT_LENGTH] = str(size)
+                self._headers[hdrs.CONTENT_LENGTH] = str(size)
 
         return await super()._start(request)
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -673,7 +673,10 @@ class Response(StreamResponse):
 
     async def _start(self, request: "BaseRequest") -> AbstractStreamWriter:
         if not self._chunked and hdrs.CONTENT_LENGTH not in self._headers:
-            size = body.size if self._body_payload else len(self._body) if self._body else 0
+            if self._body_payload:
+                size = self._body.size
+            else:
+                size = len(self._body) if self._body else "0"
             self._headers[hdrs.CONTENT_LENGTH] = str(size)
 
         return await super()._start(request)

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -900,30 +900,15 @@ Response
       Read-write attribute for storing response's content aka BODY,
       :class:`bytes`.
 
-      Setting :attr:`body` also recalculates
-      :attr:`~StreamResponse.content_length` value.
-
       Assigning :class:`str` to :attr:`body` will make the :attr:`body`
       type of :class:`aiohttp.payload.StringPayload`, which tries to encode
       the given data based on *Content-Type* HTTP header, while defaulting
       to ``UTF-8``.
 
-      Resetting :attr:`body` (assigning ``None``) sets
-      :attr:`~StreamResponse.content_length` to ``None`` too, dropping
-      *Content-Length* HTTP header.
-
    .. attribute:: text
 
-      Read-write attribute for storing response's content, represented as
-      string, :class:`str`.
-
-      Setting :attr:`text` also recalculates
-      :attr:`~StreamResponse.content_length` value and
-      :attr:`~aiohttp.StreamResponse.body` value
-
-      Resetting :attr:`text` (assigning ``None``) sets
-      :attr:`~StreamResponse.content_length` to ``None`` too, dropping
-      *Content-Length* HTTP header.
+      Read-write attribute for storing response's
+      :attr:`~aiohttp.StreamResponse.body`, represented as :class:`str`.
 
 
 FileResponse

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -603,7 +603,6 @@ async def test_rm_content_length_if_compression_http11() -> None:
     req = make_request("GET", "/", writer=writer)
     payload = BytesPayload(b"answer", headers={"X-Test-Header": "test"})
     resp = Response(body=payload)
-    assert resp.content_length == 6
     resp.body = payload
     resp.enable_compression(ContentCoding.gzip)
     await resp.prepare(req)


### PR DESCRIPTION
Minor refactor to delay creation of Content-Length until prepare_headers when using payloads.

Updated the docs to reflect reality too.