### PR TITLE
Make AioHTTPTestCase.get_application() abstract

### DIFF
--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -405,7 +405,7 @@ class TestClient:
         await self.close()
 
 
-class AioHTTPTestCase(TestCase):
+class AioHTTPTestCase(TestCase, ABC):
     """A base class to allow for unittest web applications using aiohttp.
 
     Provides the following:
@@ -418,14 +418,13 @@ class AioHTTPTestCase(TestCase):
     execute function on the test client using asynchronous methods.
     """
 
+    @abstractmethod
     async def get_application(self) -> Application:
         """Get application.
 
-        This method should be overridden
-        to return the aiohttp.web.Application
+        This method should be overridden to return the aiohttp.web.Application
         object to test.
         """
-        raise RuntimeError("Did you forget to define get_application()?")
 
     def setUp(self) -> None:
         if not PY_38:

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -282,7 +282,7 @@ def test_testcase_no_app(testdir: Any, loop: Any) -> None:
         """
     )
     result = testdir.runpytest()
-    result.stdout.fnmatch_lines(["*RuntimeError*"])
+    result.stdout.fnmatch_lines(["*TypeError*"])
 
 
 async def test_server_context_manager(app: Any, loop: Any) -> None:


### PR DESCRIPTION
Make it abstract to error on instantiation, rather than throwing an error when the test case is run.