### PR TITLE
Make max 32-bit timestamp aware

### DIFF
--- a/CHANGES/7302.bugfix
+++ b/CHANGES/7302.bugfix
@@ -1,0 +1,1 @@
+Make max 32-bit timestamp an aware datetime object, for consistency with the non-32-bit one, and to avoid a DeprecationWarning on Python 3.12.

--- a/CHANGES/7302.bugfix
+++ b/CHANGES/7302.bugfix
@@ -1,1 +1,1 @@
-Make max 32-bit timestamp an aware datetime object, for consistency with the non-32-bit one, and to avoid a DeprecationWarning on Python 3.12.
+Changed max 32-bit timestamp to an aware datetime object, for consistency with the non-32-bit one, and to avoid a DeprecationWarning on Python 3.12.

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -54,7 +54,7 @@ class CookieJar(AbstractCookieJar):
 
     MAX_TIME = datetime.datetime.max.replace(tzinfo=datetime.timezone.utc)
 
-    MAX_32BIT_TIME = datetime.datetime.utcfromtimestamp(2**31 - 1)
+    MAX_32BIT_TIME = datetime.datetime.fromtimestamp(2**31 - 1, datetime.timezone.utc)
 
     def __init__(
         self,


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Make the max 32-bit timestamp an aware one. For consistency with the non-32-bit one, and to avoid a `DeprecationWarning` with Python 3.12.

https://docs.python.org/3.12/library/datetime.html#datetime.datetime.utcfromtimestamp

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

`aiohttp.cookiejar.MAX_32BIT_TIME` is now aware. I suppose that's not something directly used much at all though.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
