### PR TITLE
#7297 Add tests for closed keepalive connections

### DIFF
--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -155,6 +155,7 @@ async def test_keepalive_timeout_async_sleep() -> None:
         await asyncio.gather(runner.shutdown(), site.stop())
 
 
+@pytest.mark.xfail(reason="Reproducer for #7297")
 async def test_keepalive_timeout_sync_sleep() -> None:
     async def handler(request):
         body = await request.read()


### PR DESCRIPTION
## What do these changes do?

Tests for the bug discussed in #7297 (ClientSession tries to reuse a closed keepalive connection). The new tests are not passing due to the bug. Interestingly, the one with `asyncio.sleep` passes, as the `connection_lost` gets called before the request is made and a new connection is established. The one with `time.sleep` doesn't, `connection_lost` doesn't get called "early enough", nor is `transport.is_closing()` True.

## Are there changes in behavior for the user?

No

## Related issue number

#7297

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
