### PR TITLE
Fix TLS transport is `None` error

### DIFF
--- a/CHANGES/3355.bugfix
+++ b/CHANGES/3355.bugfix
@@ -1,0 +1,1 @@
+Fixed a transport is ``None`` error. -- by :user:`Dreamsorcerer`

--- a/CHANGES/3355.bugfix
+++ b/CHANGES/3355.bugfix
@@ -1,1 +1,1 @@
-Fixed a transport is ``None`` error. -- by :user:`Dreamsorcerer`
+Fixed a transport is :data:`None` error -- by :user:`Dreamsorcerer`.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1062,6 +1062,9 @@ class TCPConnector(BaseConnector):
                 f"[{type_err!s}]"
             ) from type_err
         else:
+            if tls_transport is None:
+                msg = "Failed to start TLS (possibly caused by closing transport)"
+                raise client_error(req.connection_key, OSError(msg))
             tls_proto.connection_made(
                 tls_transport
             )  # Kick the state machine of the new TLS protocol


### PR DESCRIPTION
Fixes #3355

The type has been fixed in `typeshed` as well, so the bug here would be highlighted in mypy 1.5+.
https://github.com/python/typeshed/pull/10346#issuecomment-1603046653