### PR TITLE
 Bump vendored llhttp to v8.1.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor/llhttp"]
     path = vendor/llhttp
     url = https://github.com/nodejs/llhttp.git
-    branch = v6.0.6
+    branch = v8.1.1

--- a/CHANGES/7346.feature
+++ b/CHANGES/7346.feature
@@ -1,0 +1,5 @@
+Upgrade the vendored copy of llhttp_ to v8.1.1 -- by :user:`webknjaz`.
+
+Thanks to :user:`sethmlarson` for pointing this out!
+
+.. _llhttp: https://llhttp.org

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -340,6 +340,7 @@ utils
 uvloop
 uWSGI
 vcvarsall
+vendored
 waituntil
 wakeup
 wakeups


### PR DESCRIPTION
It hasn't been updated in two years... It's time to upgrade to the latest version!