### PR TITLE
🐛 Fix RST in changelog template before links

### DIFF
--- a/CHANGES/.TEMPLATE.rst
+++ b/CHANGES/.TEMPLATE.rst
@@ -12,8 +12,8 @@
 
 {% if definitions[category]['showcontent'] %}
 {% for text, values in sections[section][category].items() %}
-- {{ text }}
-  {{ values|join(',\n  ') }}
+- {{ text + '\n' }}
+  {{ values|join(',\n  ') + '\n' }}
 {% endfor %}
 
 {% else %}


### PR DESCRIPTION
In corner cases, changelog fragments with things like detached link definitions (example: #7346) cause RST rendering errors. This patch corrects this by injecting empty lines between the changelog entry bodies and their reference lists.