### PR TITLE
Turn RawResponseMessage into a NamedTuple

### DIFF
--- a/CHANGES/7365.feature
+++ b/CHANGES/7365.feature
@@ -1,0 +1,1 @@
+Added typing information to ``RawResponseMessage`` -- by :user:`Gobot1234`

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -76,20 +76,16 @@ class RawRequestMessage(NamedTuple):
     url: URL
 
 
-RawResponseMessage = collections.namedtuple(
-    "RawResponseMessage",
-    [
-        "version",
-        "code",
-        "reason",
-        "headers",
-        "raw_headers",
-        "should_close",
-        "compression",
-        "upgrade",
-        "chunked",
-    ],
-)
+class RawResponseMessage(NamedTuple):
+    version: HttpVersion
+    code: int
+    reason: str
+    headers: CIMultiDictProxy[str]
+    raw_headers: RawHeaders
+    should_close: bool
+    compression: Optional[str]
+    upgrade: bool
+    chunked: bool
 
 
 _MsgT = TypeVar("_MsgT", RawRequestMessage, RawResponseMessage)

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -1,6 +1,5 @@
 import abc
 import asyncio
-import collections
 import re
 import string
 from contextlib import suppress


### PR DESCRIPTION
## What do these changes do?

This makes pyright happier when accessing the fields on the class 

## Are there changes in behavior for the user?

No complaints from pyright with regards to it thinking the fields are unknown.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
