### PR TITLE
Fix PermissionError when loading .netrc (#7237)

### DIFF
--- a/CHANGES/7237.bugfix
+++ b/CHANGES/7237.bugfix
@@ -1,0 +1,1 @@
+Fixed ``PermissionError`` when .netrc is unreadable due to permissions.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -163,6 +163,7 @@ Jake Davis
 Jakob Ackermann
 Jakub Wilk
 Jan Buchar
+Jan Gosmann
 Jarno Elonen
 Jashandeep Sohi
 Jean-Baptiste Estival

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 import binascii
+import contextlib
 import dataclasses
 import datetime
 import enum
@@ -213,8 +214,11 @@ def netrc_from_env() -> Optional[netrc.netrc]:
     except netrc.NetrcParseError as e:
         client_logger.warning("Could not parse .netrc file: %s", e)
     except OSError as e:
+        netrc_exists = False
+        with contextlib.suppress(OSError):
+            netrc_exists = netrc_path.is_file()
         # we couldn't read the file (doesn't exist, permissions, etc.)
-        if netrc_env or netrc_path.is_file():
+        if netrc_env or netrc_exists:
             # only warn if the environment wanted us to load it,
             # or it appears like the default file does actually exist
             client_logger.warning("Could not read .netrc file: %s", e)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,6 +6,7 @@ import gc
 import platform
 import weakref
 from math import ceil, modf
+from pathlib import Path
 from unittest import mock
 from urllib.request import getproxies_environment
 
@@ -991,6 +992,26 @@ def test_netrc_from_env(expected_username: str):
     """Test that reading netrc files from env works as expected"""
     netrc_obj = helpers.netrc_from_env()
     assert netrc_obj.authenticators("example.com")[0] == expected_username
+
+
+@pytest.fixture
+def protected_dir(tmp_path: Path):
+    protected_dir = tmp_path / "protected"
+    protected_dir.mkdir()
+    try:
+        protected_dir.chmod(0o600)
+        yield protected_dir
+    finally:
+        protected_dir.rmdir()
+
+
+def test_netrc_from_home_does_not_raise_if_access_denied(
+    protected_dir: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(Path, "home", lambda: protected_dir)
+    monkeypatch.delenv("NETRC", raising=False)
+
+    helpers.netrc_from_env()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What do these changes do?

If no NETRC environment variable is provided and the .netrc path cannot be accessed due to missing permission, a PermissionError was raised instead of returning None. See issue #7237. This PR fixes the issue.

If the changes look good, I can also prepare backports.

## Are there changes in behavior for the user?

If the .netrc cannot be accessed due to a permission problem (and the `NETRC` environment variable is unset), no `PermissionError` will be raised. Instead it will be silently ignored.

## Related issue number

Fixes #7237 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes (<- I think no changes were necessary as it is a pure bugfix.)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
