### PR TITLE
Replace sync `open()` calls within async functions with `aiofiles.open()` in code examples

### DIFF
--- a/tools/bench-asyncio-write.py
+++ b/tools/bench-asyncio-write.py
@@ -123,10 +123,11 @@ async def main(loop):
         base = await bench(t, writes[0], c)
         for w in writes[1:]:
             await bench("", w, c, base)
-    with open("bench.md", "w") as f:
-        for line in res:
-            f.write("| {} |\n".format(" | ".join(line)))
+    return res
 
 
 loop = asyncio.get_event_loop()
-loop.run_until_complete(main(loop))
+results = loop.run_until_complete(main(loop))
+with open("bench.md", "w") as f:
+    for line in results:
+        f.write("| {} |\n".format(" | ".join(line)))


### PR DESCRIPTION
% [`ruff --select=ASYNC --statistics .`](https://beta.ruff.rs/docs/rules/open-sleep-or-subprocess-in-async-function)

2	ASYNC101	[ ] Async functions should not call `open`, `time.sleep`, or `subprocess` methods

% [`ruff rule ASYNC101`](https://beta.ruff.rs/docs/rules/open-sleep-or-subprocess-in-async-function/)
# open-sleep-or-subprocess-in-async-function (ASYNC101)

Derived from the **flake8-async** linter.

## What it does
Checks that async functions do not contain calls to `open`, `time.sleep`, or `subprocess` methods.

## Why is this bad?
Blocking an async function via a blocking call will block the entire event loop, preventing it from executing other tasks while waiting for the call to complete, negating the benefits of asynchronous programming.

Instead of making a blocking call, use an equivalent asynchronous library or function.

## Example
```python
async def foo():
    time.sleep(1000)
```

Use instead:
```python
async def foo():
    await asyncio.sleep(1000)
```

<!-- Thank you for your contribution! -->

## What do these changes do?
![Screenshot 2023-07-19 at 17 44 51](https://github.com/aio-libs/aiohttp/assets/3709715/be3e50d5-1d6d-405f-8f7b-dd60c6ea927f)
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behavior for the end users. -->

## Related issue number

<!-- Are any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not interesting to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
