### PR TITLE
Ignore new deprecation message from setuptools.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -143,6 +143,9 @@ filterwarnings =
     # `gunicorn.util`. Hopefully, it'll get fixed in the future. See
     # https://github.com/benoitc/gunicorn/issues/2840 for detail.
     ignore:module 'sre_constants' is deprecated:DeprecationWarning:pkg_resources._vendor.pyparsing
+    # Deprecation warning emitted by setuptools v67.5.0+ triggered by importing
+    # `gunicorn.util`.
+    ignore:pkg_resources is deprecated as an API:DeprecationWarning
     # The deprecation warning below is happening under Python 3.11 and
     # is fixed by https://github.com/certifi/python-certifi/pull/199. It
     # can be dropped with the next release of `certify`, specifically

--- a/tests/test_circular_imports.py
+++ b/tests/test_circular_imports.py
@@ -104,6 +104,10 @@ def test_no_warnings(import_path: str) -> None:
         "-W", "ignore:Creating a LegacyVersion has been deprecated and "
         "will be removed in the next major release:"
         "DeprecationWarning:",
+        # Deprecation warning emitted by setuptools v67.5.0+ triggered by importing
+        # `gunicorn.util`.
+        "-W", "ignore:pkg_resources is deprecated as an API:"
+        "DeprecationWarning",
         "-c", f"import {import_path!s}",
         # fmt: on
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

In setuptools 67.5.0+ (since https://github.com/pypa/setuptools/commit/a1aeda391a0c462ea53627bcdf50dd4c0daadaed), a new DeprecationWarning is emitted whenever `pkg_resources` is imported, which we need to ignore during tests.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
