### PR TITLE
Increase stacklevel for UserWarning about AppKey usage

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -215,6 +215,7 @@ Lukasz Marcin Dobrzanski
 Makc Belousow
 Manuel Miranda
 Marat Sharafutdinov
+Marc Mueller
 Marco Paolini
 Mariano Anaya
 Mariusz Masztalerczuk

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -173,7 +173,8 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
             warnings.warn(
                 "It is recommended to use web.AppKey instances for keys.\n"
                 + "https://docs.aiohttp.org/en/stable/web_advanced.html"
-                + "#application-s-config"
+                + "#application-s-config",
+                stacklevel=2,
             )
         self._state[key] = value
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -144,8 +144,12 @@ def test_appkey_repr_annotated() -> None:
 
 def test_app_str_keys() -> None:
     app = web.Application()
-    with pytest.warns(UserWarning, match=r"web_advanced\.html#application-s-config"):
+    with pytest.warns(
+        UserWarning, match=r"web_advanced\.html#application-s-config"
+    ) as checker:
         app["key"] = "value"
+        # Check that the error is emitted at the call site (stacklevel=2)
+        assert checker[0].filename == __file__
     assert app["key"] == "value"
 
 


### PR DESCRIPTION
## What do these changes do?

The `UserWarning` to use `web.AppKey` should be emitted on the call site.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
