### PR TITLE
Skip uvloop install on Python 3.12

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,4 +2,4 @@
 -r runtime-deps.in
 
 gunicorn
-uvloop; platform_system != "Windows" and implementation_name == "cpython"  # MagicStack/uvloop#14
+uvloop; platform_system != "Windows" and implementation_name == "cpython" and python_version < "3.12"  # MagicStack/uvloop#14  # MagicStack/uvloop#547

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,7 +38,7 @@ pycparser==2.21
     # via cffi
 typing-extensions==4.7.1
     # via -r requirements/typing-extensions.in
-uvloop==0.17.0 ; platform_system != "Windows" and implementation_name == "cpython"
+uvloop==0.17.0 ; platform_system != "Windows" and implementation_name == "cpython" and python_version < "3.12"
     # via -r requirements/base.in
 yarl==1.9.2
     # via -r requirements/runtime-deps.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -243,8 +243,10 @@ uritemplate==4.1.1
     # via gidgethub
 urllib3==2.0.4
     # via requests
-uvloop==0.17.0 ; platform_system != "Windows"
-    # via -r requirements/lint.in
+uvloop==0.17.0 ; platform_system != "Windows" and python_version < "3.12"
+    # via
+    #   -r requirements/base.in
+    #   -r requirements/lint.in
 virtualenv==20.24.2
     # via pre-commit
 wait-for-it==2.2.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -238,7 +238,7 @@ uritemplate==4.1.1
     # via gidgethub
 urllib3==2.0.4
     # via requests
-uvloop==0.17.0 ; platform_system != "Windows" and implementation_name == "cpython"
+uvloop==0.17.0 ; platform_system != "Windows" and implementation_name == "cpython" and python_version < "3.12"
     # via
     #   -r requirements/base.in
     #   -r requirements/lint.in

--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -5,4 +5,4 @@ mypy; implementation_name == "cpython"
 pre-commit
 pytest
 slotscheck
-uvloop; platform_system != "Windows"
+uvloop; platform_system != "Windows" and python_version < "3.12"

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -52,7 +52,7 @@ typing-extensions==4.7.1
     #   -r requirements/typing-extensions.in
     #   aioredis
     #   mypy
-uvloop==0.17.0 ; platform_system != "Windows"
+uvloop==0.17.0 ; platform_system != "Windows" and python_version < "3.12"
     # via -r requirements/lint.in
 virtualenv==20.24.2
     # via pre-commit

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -118,7 +118,7 @@ typing-extensions==4.7.1
     #   typer
 urllib3==2.0.4
     # via requests
-uvloop==0.17.0 ; platform_system != "Windows" and implementation_name == "cpython"
+uvloop==0.17.0 ; platform_system != "Windows" and implementation_name == "cpython" and python_version < "3.12"
     # via -r requirements/base.in
 wait-for-it==2.2.2
     # via -r requirements/test.in


### PR DESCRIPTION
## What do these changes do?

Skip `uvloop` install on Python 3.12.
MagicStack/uvloop#547

Let's see if that unblocks the [failing 3.12 tests](https://github.com/aio-libs/aiohttp/actions/runs/5779615304/job/15662155865#step:7:210).