### PR TITLE
Replace typing-extensions imports

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -18,6 +18,7 @@ from typing import (
     Callable,
     Collection,
     Coroutine,
+    Final,
     FrozenSet,
     Generator,
     Generic,
@@ -31,10 +32,10 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    final,
 )
 
 from multidict import CIMultiDict, MultiDict, MultiDictProxy, istr
-from typing_extensions import Final, final
 from yarl import URL
 
 from . import hdrs, http, payload

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -2,10 +2,9 @@
 
 import asyncio
 import dataclasses
-from typing import Any, Optional, cast
+from typing import Any, Final, Optional, cast
 
 import async_timeout
-from typing_extensions import Final
 
 from .client_exceptions import ClientError
 from .client_reqrep import ClientResponse

--- a/aiohttp/hdrs.py
+++ b/aiohttp/hdrs.py
@@ -2,10 +2,9 @@
 
 # After changing the file content call ./tools/gen.py
 # to regenerate the headers parser
-from typing import Set
+from typing import Final, Set
 
 from multidict import istr
-from typing_extensions import Final
 
 METH_ANY: Final[str] = "*"
 METH_CONNECT: Final[str] = "CONNECT"

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -38,10 +38,12 @@ from typing import (
     Mapping,
     Optional,
     Pattern,
+    Protocol,
     Tuple,
     Type,
     TypeVar,
     Union,
+    final,
     get_args,
     overload,
 )
@@ -50,7 +52,6 @@ from urllib.request import getproxies, proxy_bypass
 
 import async_timeout
 from multidict import CIMultiDict, MultiDict, MultiDictProxy
-from typing_extensions import Protocol, final
 from yarl import URL
 
 from . import hdrs

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -5,6 +5,7 @@ import string
 from contextlib import suppress
 from enum import IntEnum
 from typing import (
+    Final,
     Generic,
     List,
     NamedTuple,
@@ -18,7 +19,6 @@ from typing import (
 )
 
 from multidict import CIMultiDict, CIMultiDictProxy, istr
-from typing_extensions import Final
 from yarl import URL
 
 from . import hdrs

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -12,6 +12,7 @@ from struct import Struct
 from typing import (
     Any,
     Callable,
+    Final,
     List,
     NamedTuple,
     Optional,
@@ -21,8 +22,6 @@ from typing import (
     Union,
     cast,
 )
-
-from typing_extensions import Final
 
 from .base_protocol import BaseProtocol
 from .compression_utils import ZLibCompressor, ZLibDecompressor

--- a/aiohttp/locks.py
+++ b/aiohttp/locks.py
@@ -1,11 +1,6 @@
 import asyncio
 import collections
-from typing import Any, Optional
-
-try:
-    from typing import Deque
-except ImportError:
-    from typing_extensions import Deque
+from typing import Any, Deque, Optional
 
 
 class EventResultOrError:

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -13,6 +13,7 @@ from typing import (
     Any,
     ByteString,
     Dict,
+    Final,
     Iterable,
     Optional,
     TextIO,
@@ -22,7 +23,6 @@ from typing import (
 )
 
 from multidict import CIMultiDict
-from typing_extensions import Final
 
 from . import hdrs
 from .abc import AbstractStreamWriter

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -1,18 +1,21 @@
 import asyncio
 import collections
 import warnings
-from typing import Awaitable, Callable, Generic, List, Optional, Tuple, TypeVar
-
-from typing_extensions import Final
+from typing import (
+    Awaitable,
+    Callable,
+    Deque,
+    Final,
+    Generic,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+)
 
 from .base_protocol import BaseProtocol
 from .helpers import BaseTimerContext, TimerNoop, set_exception, set_result
 from .log import internal_logger
-
-try:  # pragma: no cover
-    from typing import Deque
-except ImportError:
-    from typing_extensions import Deque
 
 __all__ = (
     "EMPTY_PAYLOAD",

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -1,6 +1,6 @@
 import dataclasses
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Awaitable, Optional, Type, TypeVar
+from typing import TYPE_CHECKING, Awaitable, Optional, Protocol, Type, TypeVar
 
 from aiosignal import Signal
 from multidict import CIMultiDict
@@ -9,8 +9,6 @@ from yarl import URL
 from .client_reqrep import ClientResponse
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing_extensions import Protocol
-
     from .client import ClientSession
 
     _ParamT_contra = TypeVar("_ParamT_contra", contravariant=True)

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import warnings
 from functools import partial, update_wrapper
-from typing import (  # noqa
+from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
@@ -16,17 +16,16 @@ from typing import (  # noqa
     MutableMapping,
     Optional,
     Sequence,
-    Tuple,
     Type,
     TypeVar,
     Union,
     cast,
+    final,
     overload,
 )
 
 from aiosignal import Signal
 from frozenlist import FrozenList
-from typing_extensions import final
 
 from . import hdrs
 from .helpers import AppKey

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -2,21 +2,17 @@ import asyncio
 import mimetypes
 import os
 import pathlib
-from typing import (  # noqa
+from typing import (
     IO,
     TYPE_CHECKING,
     Any,
     Awaitable,
     Callable,
-    Iterator,
-    List,
+    Final,
     Optional,
     Tuple,
-    Union,
     cast,
 )
-
-from typing_extensions import Final
 
 from . import hdrs
 from .abc import AbstractStreamWriter

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -13,6 +13,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Dict,
+    Final,
     Iterator,
     Mapping,
     MutableMapping,
@@ -26,7 +27,6 @@ from typing import (
 from urllib.parse import parse_qsl
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
-from typing_extensions import Final
 from yarl import URL
 
 from . import hdrs

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -15,6 +15,7 @@ from typing import (
     Callable,
     Container,
     Dict,
+    Final,
     Generator,
     Iterable,
     Iterator,
@@ -27,11 +28,11 @@ from typing import (
     Sized,
     Tuple,
     Type,
+    TypedDict,
     Union,
     cast,
 )
 
-from typing_extensions import Final, TypedDict
 from yarl import URL, __version__ as yarl_version  # type: ignore[attr-defined]
 
 from . import hdrs

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -4,11 +4,10 @@ import binascii
 import dataclasses
 import hashlib
 import json
-from typing import Any, Iterable, Optional, Tuple, cast
+from typing import Any, Final, Iterable, Optional, Tuple, cast
 
 import async_timeout
 from multidict import CIMultiDict
-from typing_extensions import Final
 
 from . import hdrs
 from .abc import AbstractStreamWriter


### PR DESCRIPTION
## What do these changes do?
Replace import from `typing_extensions` with `typing` now that Python 3.8 is the oldest supported version.

## Are there changes in behavior for the user?
_No_

Technically, this removes the need for the `typing_extension` dependency. However, it isn't even listed as a direct dependency at the moment.
https://github.com/aio-libs/aiohttp/blob/c9176acb672b90717914d232ecca24e22ed42325/setup.cfg#L49-L56 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
