### PR TITLE
Ignore dateutil DeprecationWarning [3.12]

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -153,6 +153,10 @@ filterwarnings =
     # can be dropped with the next release of `certify`, specifically
     # `certify > 2022.06.15`.
     ignore:path is deprecated. Use files.. instead. Refer to https.//importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.:DeprecationWarning:certifi.core
+    # Dateutil deprecation warning already fixed upstream.
+    # Can be dropped with the next release, `dateutil > 2.8.2`
+    # https://github.com/dateutil/dateutil/pull/1285
+    ignore:datetime.utcfromtimestamp\\(\\) is deprecated and scheduled for removal:DeprecationWarning:dateutil.tz.tz
 junit_suite_name = aiohttp_test_suite
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -156,7 +156,7 @@ filterwarnings =
     # Dateutil deprecation warning already fixed upstream.
     # Can be dropped with the next release, `dateutil > 2.8.2`
     # https://github.com/dateutil/dateutil/pull/1285
-    ignore:datetime.utcfromtimestamp\\(\\) is deprecated and scheduled for removal:DeprecationWarning:dateutil.tz.tz
+    ignore:datetime.utcfromtimestamp\(\) is deprecated and scheduled for removal:DeprecationWarning:dateutil.tz.tz
 junit_suite_name = aiohttp_test_suite
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2


### PR DESCRIPTION
## What do these changes do?
Ignore `dateutil` DeprecationWarning on Python 3.12.
It's already fixed on upstream https://github.com/dateutil/dateutil/pull/1285. Just waiting for a new release now.

Requires #7503