### PR TITLE
Fix GunicornWebWorker max_requests_jitter not work

### DIFF
--- a/CHANGES/7518.bugfix
+++ b/CHANGES/7518.bugfix
@@ -1,0 +1,1 @@
+Fix GunicornWebWorker max_requests_jitter not work

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -110,7 +110,7 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
                 self.notify()
 
                 cnt = server.requests_count
-                if self.cfg.max_requests and cnt > self.cfg.max_requests:
+                if self.max_requests and cnt > self.max_requests:
                     self.alive = False
                     self.log.info("Max requests, shutting down: %s", self)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -214,8 +214,8 @@ async def test__run_ok_parent_changed(
     worker.sockets = [sock]
     worker.log = mock.Mock()
     worker.loop = loop
+    worker.max_requests = 0
     worker.cfg.access_log_format = ACCEPTABLE_LOG_FORMAT
-    worker.cfg.max_requests = 0
     worker.cfg.is_ssl = False
 
     await worker._run()
@@ -237,8 +237,8 @@ async def test__run_exc(
     worker.sockets = [sock]
     worker.log = mock.Mock()
     worker.loop = loop
+    worker.max_requests = 0
     worker.cfg.access_log_format = ACCEPTABLE_LOG_FORMAT
-    worker.cfg.max_requests = 0
     worker.cfg.is_ssl = False
 
     def raiser() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

`GunicornWebWorker` use `self.cfg.max_requests` which is not add jitter, from https://github.com/benoitc/gunicorn/blob/master/gunicorn/workers/base.py#L56-L60, the correct way is to use `sef.max_requests`

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

After the PR is merged, the max-requests-jitter parameter of Gunicorn can take effect.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
