### PR TITLE
Remove deprecated child watcher

### DIFF
--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -465,19 +465,7 @@ def setup_test_loop(
     once they are done with the loop.
     """
     loop = loop_factory()
-    try:
-        module = loop.__class__.__module__
-        skip_watcher = "uvloop" in module
-    except AttributeError:  # pragma: no cover
-        # Just in case
-        skip_watcher = True
     asyncio.set_event_loop(loop)
-    if sys.platform != "win32" and not skip_watcher:
-        policy = asyncio.get_event_loop_policy()
-        watcher = asyncio.ThreadedChildWatcher()
-        watcher.attach_loop(loop)
-        with contextlib.suppress(NotImplementedError):
-            policy.set_child_watcher(watcher)
     return loop
 
 


### PR DESCRIPTION
It looks like this was added originally to fix some tests (maybe no watcher was set by default in asyncio at the time...?). So, as long as the tests are passing, it should be safe to remove this code.