### PR TITLE
Skip default headers

### DIFF
--- a/CHANGES/7552.feature
+++ b/CHANGES/7552.feature
@@ -1,0 +1,1 @@
+Add `skip_default_headers` to client session requests

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -251,6 +251,7 @@ Nándor Mátravölgyi
 Oisin Aylward
 Olaf Conradi
 Oleg Höfling
+Owen Drysdale
 Pahaz Blinov
 Panagiotis Kolokotronis
 Pankaj Pandey

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -908,7 +908,9 @@ class ClientSession:
                 client_notakeover=notakeover,
             )
 
-    def _prepare_headers(self, headers: Optional[LooseHeaders], skip_default_headers: bool = False) -> "CIMultiDict[str]":
+    def _prepare_headers(
+        self, headers: Optional[LooseHeaders], skip_default_headers: bool = False
+    ) -> "CIMultiDict[str]":
         """Add default headers and transform it to CIMultiDict"""
         # Convert headers to MultiDict
         if skip_default_headers:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -355,6 +355,7 @@ class ClientSession:
         auto_decompress: Optional[bool] = None,
         max_line_size: Optional[int] = None,
         max_field_size: Optional[int] = None,
+        skip_default_headers: Optional[bool] = None,
     ) -> ClientResponse:
         # NOTE: timeout clamps existing connect and read timeouts.  We cannot
         # set the default to None because we need to detect if the user wants
@@ -382,8 +383,8 @@ class ClientSession:
         params = params or {}
 
         # Merge with default headers and transform to CIMultiDict
-        headers = self._prepare_headers(headers)
-        proxy_headers = self._prepare_headers(proxy_headers)
+        headers = self._prepare_headers(headers, skip_default_headers)
+        proxy_headers = self._prepare_headers(proxy_headers, skip_default_headers)
 
         try:
             url = self._build_url(str_or_url)
@@ -907,10 +908,13 @@ class ClientSession:
                 client_notakeover=notakeover,
             )
 
-    def _prepare_headers(self, headers: Optional[LooseHeaders]) -> "CIMultiDict[str]":
+    def _prepare_headers(self, headers: Optional[LooseHeaders], skip_default_headers: bool = False) -> "CIMultiDict[str]":
         """Add default headers and transform it to CIMultiDict"""
         # Convert headers to MultiDict
-        result = CIMultiDict(self._default_headers)
+        if skip_default_headers:
+            result = CIMultiDict()
+        else:
+            result = CIMultiDict(self._default_headers)
         if headers:
             if not isinstance(headers, (MultiDictProxy, MultiDict)):
                 headers = CIMultiDict(headers)

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -347,7 +347,8 @@ The client session supports the context manager protocol for self closing.
                          timeout=sentinel, ssl=None, \
                          verify_ssl=None, fingerprint=None, \
                          ssl_context=None, proxy_headers=None, \
-                         server_hostname=None, auto_decompress=None)
+                         server_hostname=None, auto_decompress=None, \
+                         skip_default_headers = False)
       :async:
       :noindexentry:
 
@@ -531,6 +532,8 @@ The client session supports the context manager protocol for self closing.
       :param bool auto_decompress: Automatically decompress response body.
          Overrides :attr:`ClientSession.auto_decompress`.
          May be used to enable/disable auto decompression on a per-request basis.
+
+      :param bool skip_default_headers: Skip adding the default headers set in :attr:`ClientSession.headers`.
 
       :return ClientResponse: a :class:`client response <ClientResponse>`
          object.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
These changes allows users to specify whether or not the `ClientSession.headers` are included in this request.
I added this because I was writing a library where I add an `Authorization` header in `ClientSession.headers`, however I needed 
to do another request where I didn't want to pass that `Authorization` header. I've added a simple boolean to turn it on and off.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No significant changes, the default behaviour is still the same.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
