### PR TITLE
Emit UserWarning when accessing Application items by str

### DIFF
--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -150,6 +150,13 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
         ...
 
     def __getitem__(self, key: Union[str, AppKey[_T]]) -> Any:
+        if not isinstance(key, AppKey):
+            warnings.warn(
+                "It is recommended to use web.AppKey instances for keys.\n"
+                + "https://docs.aiohttp.org/en/stable/web_advanced.html"
+                + "#application-s-config",
+                stacklevel=2,
+            )
         return self._state[key]
 
     def _check_frozen(self) -> None:
@@ -200,6 +207,13 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
         ...
 
     def get(self, key: Union[str, AppKey[_T]], default: Any = None) -> Any:
+        if not isinstance(key, AppKey):
+            warnings.warn(
+                "It is recommended to use web.AppKey instances for keys.\n"
+                + "https://docs.aiohttp.org/en/stable/web_advanced.html"
+                + "#application-s-config",
+                stacklevel=2,
+            )
         return self._state.get(key, default)
 
     ########

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -147,10 +147,22 @@ def test_app_str_keys() -> None:
     with pytest.warns(
         UserWarning, match=r"web_advanced\.html#application-s-config"
     ) as checker:
+        # Warning for __setitem__
         app["key"] = "value"
         # Check that the error is emitted at the call site (stacklevel=2)
         assert checker[0].filename == __file__
-    assert app["key"] == "value"
+    with pytest.warns(
+        UserWarning, match=r"web_advanced\.html#application-s-config"
+    ) as checker:
+        # Warning for __getitem__
+        assert app["key"] == "value"
+        assert checker[0].filename == __file__
+    with pytest.warns(
+        UserWarning, match=r"web_advanced\.html#application-s-config"
+    ) as checker:
+        # Warning for get
+        assert app.get("key") == "value"
+        assert checker[0].filename == __file__
 
 
 def test_app_get() -> None:


### PR DESCRIPTION
## What do these changes do?
In addition to emitting a `UserWarning` when setting a `str` key for Application items, also emit a warning when accessing it. Either via `get` or `__getitem__`. This will help users to update their code more easily.

_I haven't added a CHANGES entry yet. Since the feature hasn't been shipped yet, it should still be covered with the original message. Please let me know if I should add one regardless._
https://github.com/aio-libs/aiohttp/blob/cf97e5b0a20de31aeb51684add61b7dad4e92375/CHANGES/5864.feature#L1

/CC @Dreamsorcerer 


## Are there changes in behavior for the user?
The `UserWarning` will be emitted in more cases. Not just here
https://github.com/aio-libs/aiohttp/blob/cf97e5b0a20de31aeb51684add61b7dad4e92375/aiohttp/web_app.py#L169-L178
