### PR TITLE
[PR #5835 backport][3.9] Fix(doc): ClientResponse.release

### DIFF
--- a/CHANGES/5836.doc
+++ b/CHANGES/5836.doc
@@ -1,0 +1,1 @@
+Fix the `ClientResponse.release`'s type in the doc. Change from `comethod` to `method`.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1274,7 +1274,7 @@ Response object
            assert resp.status == 200
 
    After exiting from ``async with`` block response object will be
-   *released* (see :meth:`release` coroutine).
+   *released* (see :meth:`release` method).
 
    .. attribute:: version
 
@@ -1405,7 +1405,6 @@ Response object
       .. seealso:: :meth:`close`, :meth:`release`.
 
    .. method:: release()
-      :async:
 
       It is not required to call `release` on the response
       object. When the client fully receives the payload, the


### PR DESCRIPTION
## What do these changes do?
Backport changes from #5835 to the `3.9` branch.
`ClientResponse.release` should be marked as method not coroutine.