### PR TITLE
Make AppKey compatible with string keys

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -8,7 +8,6 @@ import dataclasses
 import datetime
 import enum
 import functools
-import inspect
 import netrc
 import os
 import platform
@@ -817,19 +816,15 @@ class AppKey(Generic[_T]):
     __orig_class__: Type[object]
 
     def __init__(self, name: str, t: Optional[Type[_T]] = None):
-        # Prefix with module name to help deduplicate key names.
-        frame = inspect.currentframe()
-        while frame:
-            if frame.f_code.co_name == "<module>":
-                module: str = frame.f_globals["__name__"]
-                break
-            frame = frame.f_back
-        else:
-            raise RuntimeError("Failed to get module name.")
-
-        # https://github.com/python/mypy/issues/14209
-        self._name = module + "." + name  # type: ignore[possibly-undefined]
+        self._name = name
         self._t = t
+
+    # Add __hash__ and __eq__ to make AppKey compatible with string keys
+    def __hash__(self) -> int:
+        return hash(self._name)
+
+    def __eq__(self, other: object) -> bool:
+        return hash(self) == hash(other)
 
     def __lt__(self, other: object) -> bool:
         if isinstance(other, AppKey):

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,4 +1,5 @@
 import asyncio
+import warnings
 from typing import Any, AsyncIterator, Callable, Iterator, NoReturn
 from unittest import mock
 
@@ -112,34 +113,35 @@ def test_appkey() -> None:
 
 def test_appkey_repr_concrete() -> None:
     key = web.AppKey("key", int)
-    assert repr(key) in (
-        "<AppKey(__channelexec__.key, type=int)>",  # pytest-xdist
-        "<AppKey(__main__.key, type=int)>",
-    )
+    assert repr(key) == "<AppKey(key, type=int)>"
     key2 = web.AppKey("key", web.Request)
-    assert repr(key2) in (
-        # pytest-xdist:
-        "<AppKey(__channelexec__.key, type=aiohttp.web_request.Request)>",
-        "<AppKey(__main__.key, type=aiohttp.web_request.Request)>",
-    )
+    assert repr(key2) == "<AppKey(key, type=aiohttp.web_request.Request)>"
 
 
 def test_appkey_repr_nonconcrete() -> None:
     key = web.AppKey("key", Iterator[int])
-    assert repr(key) in (
-        # pytest-xdist:
-        "<AppKey(__channelexec__.key, type=typing.Iterator[int])>",
-        "<AppKey(__main__.key, type=typing.Iterator[int])>",
-    )
+    assert repr(key) == "<AppKey(key, type=typing.Iterator[int])>"
 
 
 def test_appkey_repr_annotated() -> None:
     key = web.AppKey[Iterator[int]]("key")
-    assert repr(key) in (
-        # pytest-xdist:
-        "<AppKey(__channelexec__.key, type=typing.Iterator[int])>",
-        "<AppKey(__main__.key, type=typing.Iterator[int])>",
-    )
+    assert repr(key) == "<AppKey(key, type=typing.Iterator[int])>"
+
+
+def test_appkey_str_compatibility() -> None:
+    app = web.Application()
+    key = web.AppKey("key", int)
+    key2 = web.AppKey("key2", int)
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            ".*web.AppKey.*\n.*web_advanced.html#application-s-config",
+            UserWarning,
+        )
+        app[key] = 1
+        assert app["key"] == 1
+        app["key2"] = 2
+        assert app[key2] == 2
 
 
 def test_app_str_keys() -> None:


### PR DESCRIPTION
## What do these changes do?
Allow the simultaneous use of `AppKey` and string keys. During my early testing for [Home Assistant](https://github.com/home-assistant/core) I found it quite challenging to start using `AppKey`. At least in this particular case, a variable was stored once but read all throughout the code base. Just missing one update, would cause a test failure. By making both compatible, users will be able to update them gradually.

_The only downside being that the names of `AppKey` will no longer be able to contain the module name and loose some of their uniqueness. However, I don't believe that is an issue with the current string keys so it should be fine. It might even help avoid some additional confusions if AppKey instances have the same name + same variable name but are in different modules -> so not compatible._

Overall, I found that without this change, I wasn't able to introduce `AppKey` during testing in a larger code base.

/CC @Dreamsorcerer 

## Are there changes in behavior for the user?
The feature hasn't been shipped yet.