### PR TITLE
Replace cChardet with chardetng_py.

### DIFF
--- a/CHANGES/7559.feature
+++ b/CHANGES/7559.feature
@@ -1,0 +1,1 @@
+Drop use of `cChardet` and replace with `chardetng_py`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -175,6 +175,7 @@ Jesus Cea
 Jian Zeng
 Jinkyu Yi
 Joel Watts
+John Parton
 Jon Nabozny
 Jonas Krüger Svensson
 Jonas Obrist

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -74,7 +74,7 @@ except ImportError:  # pragma: no cover
     SSLContext = object  # type: ignore[misc,assignment]
 
 try:
-    import cchardet as chardet
+    from chardetng_py import compat as chardet
 except ImportError:  # pragma: no cover
     import charset_normalizer as chardet
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -78,7 +78,9 @@ try:
 except ImportError:  # pragma: no cover
     import charset_normalizer as chardet
 
-    def detect_charset(data: bytes, *, tld: Union[bytes, bytearray, None], allow_utf8: bool) -> str:
+    def detect_charset(
+        data: bytes, *, tld: Union[bytes, bytearray, None], allow_utf8: bool
+    ) -> str:
         # tld is ignored because charset_normalizer does not support it
         # allow_utf8 is the only behavior supported by charset_normalizer
         return chardet(data)["encoding"] or "utf-8"
@@ -1023,16 +1025,14 @@ class ClientResponse(HeadersMixin):
                 pass
 
         if mimetype.type == "application" and (
-                mimetype.subtype == "json" or mimetype.subtype == "rdap"
-            ):
-                # RFC 7159 states that the default encoding is UTF-8.
-                # RFC 7483 defines application/rdap+json
-                return "utf-8"
+            mimetype.subtype == "json" or mimetype.subtype == "rdap"
+        ):
+            # RFC 7159 states that the default encoding is UTF-8.
+            # RFC 7483 defines application/rdap+json
+            return "utf-8"
 
         if self._body is None:
-            raise RuntimeError(
-                "Cannot guess the encoding of a not yet read body"
-            )
+            raise RuntimeError("Cannot guess the encoding of a not yet read body")
 
         # TLD parsing should match internal logic for matching charsets in chardetng
         tld = self.url.host.split(".")[-1]

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1020,7 +1020,7 @@ class ClientResponse(HeadersMixin):
         encoding = mimetype.parameters.get("charset")
         if encoding:
             try:
-                return codecs.lookup(encoding)
+                return codecs.lookup(encoding).name
             except LookupError:
                 pass
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,7 +14,7 @@ brotli==1.0.9
     # via -r requirements/runtime-deps.in
 cffi==1.15.1
     # via pycares
-chardetng-py==0.3.0
+chardetng-py==0.3.1
     # via -r requirements/runtime-deps.in
 charset-normalizer==3.2.0
     # via -r requirements/runtime-deps.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,10 +12,10 @@ async-timeout==4.0.3 ; python_version < "3.11"
     # via -r requirements/runtime-deps.in
 brotli==1.0.9
     # via -r requirements/runtime-deps.in
-cchardet==2.1.7 ; python_version < "3.10"
-    # via -r requirements/runtime-deps.in
 cffi==1.15.1
     # via pycares
+chardetng-py==0.3.0
+    # via -r requirements/runtime-deps.in
 charset-normalizer==3.2.0
     # via -r requirements/runtime-deps.in
 frozenlist==1.4.0

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -8,4 +8,4 @@ frozenlist >= 1.1.1
 aiosignal >= 1.1.2
 aiodns >= 1.1; sys_platform=="linux" or sys_platform=="darwin"
 Brotli
-cchardet; python_version < "3.10"
+chardetng_py

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,8 +64,7 @@ speedups =
   # required c-ares (aiodns' backend) will not build on windows
   aiodns >= 1.1; sys_platform=="linux" or sys_platform=="darwin"
   Brotli
-  # cchardet is unmaintained: aio-libs/aiohttp#6819
-  cchardet; python_version < "3.10"
+  chardetng_py
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This removes cChardet as an optional dependency for speeds up and replaces it with chardetng_py, which is a python binding to Mozilla's chartdetng (or chardet Next Generation) library.

Advantages over cChardet:

1. Support for newer versions of python. cChardet is not compatible with the last few versions of Python, but chardetng_py is.
2. Support for CPU architectures other than x86/amd64. In particular, this brings aarch64 support, but also s390x, ppc64le, and armv7l. Full list here: https://pypi.org/project/chardetng-py/#files
3. Support for MacOS 11 (including Arm64 support)
4. Better compatibility with browser implementation by using Firefox's imlementation
5. pypy compatibility

Other notes

i. chardetng is as-fast-or-faster than cchardet in my testing
ii. encoding detection is as-good-or-better than cchardet

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

The exact encoding returned by chardetng might not match what was returned by cchardet, but it is in production use with Firefox. If you have specific questions about the operation of the library, you should read this blog post: https://hsivonen.fi/chardetng/

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

Should close https://github.com/aio-libs/aiohttp/issues/7126

cchardetng_py also support *incremental* encoding detection where the buffer can be fed into the detector in chunks.

Implementing that would solve https://github.com/aio-libs/aiohttp/issues/4112
Docs: https://chardetng-py.readthedocs.io/en/latest/class_reference.html

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
