### PR TITLE
CookieJar - return 'best-match' and not LIFO

### DIFF
--- a/CHANGES/7577.bugfix
+++ b/CHANGES/7577.bugfix
@@ -1,1 +1,1 @@
-Fix filter_cookies return 'best-mach' (instead of lifo) cookie -- by :user:`marq24`.
+Fix sorting in filter_cookies to use cookie with longest path -- by :user:`marq24`.

--- a/CHANGES/7577.bugfix
+++ b/CHANGES/7577.bugfix
@@ -1,0 +1,1 @@
+Fix filter_cookies return 'best-mach' (instead of lifo) cookie -- by :user:`marq24`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -228,6 +228,7 @@ Martin Richard
 Mathias Fröjdman
 Mathieu Dugré
 Matt VanEseltine
+Matthias Marquardt
 Matthieu Hauglustaine
 Matthieu Rigal
 Matvey Tingaev

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -256,6 +256,7 @@ class CookieJar(AbstractCookieJar):
             and request_origin not in self._treat_as_secure_origin
         )
 
+        # Point 2: https://www.rfc-editor.org/rfc/rfc6265.html#section-5.4
         for cookie in sorted(self, key=lambda c: len(c["path"])):
             name = cookie.key
             domain = cookie["domain"]

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -282,12 +282,10 @@ class CookieJar(AbstractCookieJar):
 
             # we need to check, if the found cookie is a better match then the
             # previously found
-            if name in filtered:
-                existing_cookie = filtered[name]
-                if len(existing_cookie.get("path")) < len(cookie.get("path")):
-                    filtered[name] = cookie
-            else:
-                filtered[name] = cookie
+            if name in filtered and len(cookie["path"]) < len(filtered[name]["path"]):
+                continue
+
+            filtered[name] = cookie
 
         # It's critical we use the Morsel so the coded_value
         # (based on cookie version) is preserved

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -256,7 +256,7 @@ class CookieJar(AbstractCookieJar):
             and request_origin not in self._treat_as_secure_origin
         )
 
-        for cookie in self:
+        for cookie in sorted(self, key=lambda c: len(c["path"])):
             name = cookie.key
             domain = cookie["domain"]
 
@@ -280,23 +280,10 @@ class CookieJar(AbstractCookieJar):
             if is_not_secure and cookie["secure"]:
                 continue
 
-            # we need to check, if the found cookie is a better match then the
-            # previously found
-            if name in filtered and len(cookie["path"]) < len(filtered[name]["path"]):
-                continue
-
-            filtered[name] = cookie
-
-        # It's critical we use the Morsel so the coded_value
-        # (based on cookie version) is preserved
-        for name in filtered:
-            filtered_cookie = filtered[name]
-            mrsl_val = cast(
-                "Morsel[str]", filtered_cookie.get(filtered_cookie.key, Morsel())
-            )
-            mrsl_val.set(
-                filtered_cookie.key, filtered_cookie.value, filtered_cookie.coded_value
-            )
+            # It's critical we use the Morsel so the coded_value
+            # (based on cookie version) is preserved
+            mrsl_val = cast("Morsel[str]", cookie.get(cookie.key, Morsel()))
+            mrsl_val.set(cookie.key, cookie.value, cookie.coded_value)
             filtered[name] = mrsl_val
 
         return filtered

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -284,7 +284,7 @@ class CookieJar(AbstractCookieJar):
             # previously found
             if name in filtered:
                 existing_cookie = filtered[name]
-                if len(existing_cookie.get('path')) < len(cookie.get('path')):
+                if len(existing_cookie.get("path")) < len(cookie.get("path")):
                     filtered[name] = cookie
             else:
                 filtered[name] = cookie
@@ -293,8 +293,12 @@ class CookieJar(AbstractCookieJar):
         # (based on cookie version) is preserved
         for name in filtered:
             filtered_cookie = filtered[name]
-            mrsl_val = cast("Morsel[str]", filtered_cookie.get(filtered_cookie.key, Morsel()))
-            mrsl_val.set(filtered_cookie.key, filtered_cookie.value, filtered_cookie.coded_value)
+            mrsl_val = cast(
+                "Morsel[str]", filtered_cookie.get(filtered_cookie.key, Morsel())
+            )
+            mrsl_val.set(
+                filtered_cookie.key, filtered_cookie.value, filtered_cookie.coded_value
+            )
             filtered[name] = mrsl_val
 
         return filtered

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -280,10 +280,21 @@ class CookieJar(AbstractCookieJar):
             if is_not_secure and cookie["secure"]:
                 continue
 
-            # It's critical we use the Morsel so the coded_value
-            # (based on cookie version) is preserved
-            mrsl_val = cast("Morsel[str]", cookie.get(cookie.key, Morsel()))
-            mrsl_val.set(cookie.key, cookie.value, cookie.coded_value)
+            # we need to check, if the found cookie is a better match then the
+            # previously found
+            if name in filtered:
+                existing_cookie = filtered[name]
+                if len(existing_cookie.get('path')) < len(cookie.get('path')):
+                    filtered[name] = cookie
+            else:
+                filtered[name] = cookie
+
+        # It's critical we use the Morsel so the coded_value
+        # (based on cookie version) is preserved
+        for name in filtered:
+            filtered_cookie = filtered[name]
+            mrsl_val = cast("Morsel[str]", filtered_cookie.get(filtered_cookie.key, Morsel()))
+            mrsl_val.set(filtered_cookie.key, filtered_cookie.value, filtered_cookie.coded_value)
             filtered[name] = mrsl_val
 
         return filtered

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -704,6 +704,34 @@ class TestCookieJarSafe(TestCookieJarBase):
         self.assertEqual(len(jar_filtered), 1)
         self.assertEqual(jar_filtered["path-cookie"].value, "one")
 
+    def test_path_filter_diff_folder_same_name_return_best_match_independent_from_put_order(self) -> None:
+        async def make_jar():
+            return CookieJar(unsafe=True)
+
+        jar = self.loop.run_until_complete(make_jar())
+        jar.update_cookies(
+            SimpleCookie("path-cookie=one; Domain=pathtest.com; Path=/one; ")
+        )
+        jar.update_cookies(
+            SimpleCookie("path-cookie=zero; Domain=pathtest.com; Path=/; ")
+        )
+        jar.update_cookies(
+            SimpleCookie("path-cookie=two; Domain=pathtest.com; Path=/second; ")
+        )
+        self.assertEqual(len(jar), 3)
+
+        jar_filtered = jar.filter_cookies(URL("http://pathtest.com/"))
+        self.assertEqual(len(jar_filtered), 1)
+        self.assertEqual(jar_filtered["path-cookie"].value, "zero")
+
+        jar_filtered = jar.filter_cookies(URL("http://pathtest.com/second"))
+        self.assertEqual(len(jar_filtered), 1)
+        self.assertEqual(jar_filtered["path-cookie"].value, "two")
+
+        jar_filtered = jar.filter_cookies(URL("http://pathtest.com/one"))
+        self.assertEqual(len(jar_filtered), 1)
+        self.assertEqual(jar_filtered["path-cookie"].value, "one")
+
 
 async def test_dummy_cookie_jar() -> None:
     cookie = SimpleCookie("foo=bar; Domain=example.com;")

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -704,7 +704,9 @@ class TestCookieJarSafe(TestCookieJarBase):
         self.assertEqual(len(jar_filtered), 1)
         self.assertEqual(jar_filtered["path-cookie"].value, "one")
 
-    def test_path_filter_diff_folder_same_name_return_best_match_independent_from_put_order(self) -> None:
+    def test_path_filter_diff_folder_same_name_return_best_match_independent_from_put_order(
+        self,
+    ) -> None:
         async def make_jar():
             return CookieJar(unsafe=True)
 


### PR DESCRIPTION
## What do these changes do?
The CookieJAR can contain multiple cookies with the identical name (e.g. JSESSIONID) for different paths of the same domain

the `filter_cookies` have to make sure that the cookie with the best-matching path will be returned. In the current implementation that last matching cookie that was inserted into the JAR will return... 

I came across this issue in the situation, that a request to `/auth` set a SESSION_A, then redirected to `/` set another (different SESSION_B), redirected me again to `/auth` where the current implementation returned the SESSION_B for `/` (instead of the SESSION_A for `/auth`

I might do things here completely wrong - please excuse - I am far from being a python expert (I consider myself more a newbie)

## Tests?
I added an additional test in the cookiejar.py `test_path_filter_diff_folder_same_name_return_best_match_independent_from_put_order` that fail with the current implementation, but with the change/fix it test is passed

## Are there changes in behavior for the user?
IMHO - nope

## Related issue number
PRNUM: #7577

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
