### PR TITLE
Support brotlicffi alternatively to brotli

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -35,6 +35,9 @@ ignore_missing_imports = True
 [mypy-brotli]
 ignore_missing_imports = True
 
+[mypy-brotlicffi]
+ignore_missing_imports = True
+
 [mypy-gunicorn.*]
 ignore_missing_imports = True
 

--- a/CHANGES/7611.feature
+++ b/CHANGES/7611.feature
@@ -1,0 +1,1 @@
+Support using ``brotlicffi`` Python package alternatively to ``brotli``, as the latter does not work on PyPy.

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -4,7 +4,10 @@ from concurrent.futures import Executor
 from typing import Optional, cast
 
 try:
-    import brotli
+    try:
+        import brotlicffi as brotli
+    except ImportError:
+        import brotli
 
     HAS_BROTLI = True
 except ImportError:  # pragma: no cover

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -187,7 +187,8 @@ The ``gzip`` and ``deflate`` transfer-encodings are automatically
 decoded for you.
 
 You can enable ``brotli`` transfer-encodings support,
-just install  `Brotli <https://pypi.org/project/Brotli>`_.
+just install `Brotli <https://pypi.org/project/Brotli/>`_
+or `brotlicffi <https://pypi.org/project/brotlicffi/>`_.
 
 JSON Request
 ============

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -40,6 +40,13 @@
 
       https://pypi.org/project/Brotli/
 
+   brotlicffi
+
+      An alternative implementation of :term:`Brotli` built using the CFFI
+      library. This implementation supports PyPy correctly.
+
+      https://pypi.org/project/brotlicffi/
+
    callable
 
       Any object that can be called. Use :func:`callable` to check

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -158,7 +158,8 @@ Dependencies
 
      $ pip install aiodns
 
-- *Optional* :term:`Brotli` for brotli (:rfc:`7932`) client compression support.
+- *Optional* :term:`Brotli` or :term:`brotlicffi` for brotli (:rfc:`7932`)
+  client compression support.
 
   .. code-block:: bash
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -40,6 +40,7 @@ boolean
 botocore
 brotli
 Brotli
+brotlicffi
 brotlipy
 bugfix
 Bugfixes

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -6,4 +6,5 @@ yarl >= 1.0, < 2.0
 frozenlist >= 1.1.1
 aiosignal >= 1.1.2
 aiodns >= 1.1; sys_platform=="linux" or sys_platform=="darwin"
-Brotli
+Brotli; platform_python_implementation == 'CPython'
+brotlicffi; platform_python_implementation != 'CPython'

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,8 @@ install_requires =
 speedups =
   # required c-ares (aiodns' backend) will not build on windows
   aiodns >= 1.1; sys_platform=="linux" or sys_platform=="darwin"
-  Brotli
+  Brotli; platform_python_implementation == 'CPython'
+  brotlicffi; platform_python_implementation != 'CPython'
 
 [options.packages.find]
 exclude =

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -22,7 +22,10 @@ from aiohttp.http_parser import (
 )
 
 try:
-    import brotli
+    try:
+        import brotlicffi as brotli
+    except ImportError:
+        import brotli
 except ImportError:
     brotli = None
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -8,7 +8,6 @@ import zlib
 from typing import Any, Optional
 from unittest import mock
 
-import brotli
 import pytest
 from multidict import CIMultiDictProxy, MultiDict
 from yarl import URL
@@ -18,6 +17,11 @@ from aiohttp import FormData, HttpVersion10, HttpVersion11, TraceConfig, multipa
 from aiohttp.hdrs import CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING
 from aiohttp.test_utils import make_mocked_coro
 from aiohttp.typedefs import Handler
+
+try:
+    import brotlicffi as brotli
+except ImportError:
+    import brotli
 
 try:
     import ssl


### PR DESCRIPTION
## What do these changes do?

Support the brotlicffi implementation as an alternative to brotli. This is necessary since the current version of brotli (as of 1.1.0) does not work on PyPy.  This uses the approach of preferring brotlicffi over brotli in imports, and listing brotli or brotlicffi depending on the Python implementation in dependencies, as recommended in brotlicffi documentation:
https://pypi.org/project/brotlicffi/1.1.0.0/#using-brotlicffi-in-projects

## Are there changes in behavior for the user?

No.

## Related issue number

https://github.com/aio-libs/aiohttp/discussions/7610

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
