### PR TITLE
Authentication header removed although same origin host #7381

### DIFF
--- a/CHANGES/7636.bugfix
+++ b/CHANGES/7636.bugfix
@@ -1,0 +1,1 @@
+Authentication header shouldn't disappear in same host redirection

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -608,9 +608,7 @@ class ClientSession:
                             parsed_url = url.join(parsed_url)
 
                         is_same_host_https_redirect = (
-                            url.host == parsed_url.host
-                            and parsed_url.scheme == "https"
-                            and url.scheme in ("http", "https")
+                            url.host == parsed_url.host and parsed_url.scheme == "https"
                         )
 
                         if (

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -610,7 +610,7 @@ class ClientSession:
                         is_same_host_https_redirect = (
                             url.host == parsed_url.host
                             and parsed_url.scheme == "https"
-                            and url.scheme == "http"
+                            and url.scheme in ("http", "https")
                         )
 
                         if (


### PR DESCRIPTION
Adding to is_same_host_https_redirect check case both origin and redirect are same host on https, as one might include port and the other not, or the different port

Also adding test_dont_drop_auth_on_redirect_to_same_host_https_scheme to check this

<!-- Thank you for your contribution! -->

## What do these changes do?
change is_same_host_https_redirect to support if previous scheme was "https" - this way the port itself doesn't matter

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
Adding to is_same_host_https_redirect check case both origin and redirect are same host on https, as one might include port and the other not, or the different port

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#7381 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
