### PR TITLE
Fixed 7616: EmptyStreamReader.iter_chunks() never ends

### DIFF
--- a/CHANGES/7616.bugfix
+++ b/CHANGES/7616.bugfix
@@ -1,0 +1,1 @@
+Fix EmptyStreamReader iter_chunks() never ending

--- a/CHANGES/7616.bugfix
+++ b/CHANGES/7616.bugfix
@@ -1,1 +1,1 @@
-Fix EmptyStreamReader iter_chunks() never ending
+Fixed ``EmptyStreamReader.iter_chunks()`` never ending -- by :user:`mind1m`

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -535,11 +535,7 @@ class EmptyStreamReader(StreamReader):  # lgtm [py/missing-call-to-init]
         return b""
 
     async def readchunk(self) -> Tuple[bytes, bool]:
-        # if we return (b"", True) right away
-        # then iter_chunks() will loop forever because it expects (b"", False)
-        # this code makes sure that we yield (b"", False) first
         if not self._read_eof_chunk:
-            # do this only once
             self._read_eof_chunk = True
             return (b"", False)
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -151,7 +151,6 @@ ipv
 IPv
 ish
 isort
-iter
 iterable
 iterables
 javascript

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -151,6 +151,7 @@ ipv
 IPv
 ish
 isort
+iter
 iterable
 iterables
 javascript

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1109,10 +1109,20 @@ async def test_empty_stream_reader() -> None:
     assert await s.read() == b""
     assert await s.readline() == b""
     assert await s.readany() == b""
+    assert await s.readchunk() == (b"", False)
     assert await s.readchunk() == (b"", True)
     with pytest.raises(asyncio.IncompleteReadError):
         await s.readexactly(10)
     assert s.read_nowait() == b""
+
+
+async def test_empty_stream_reader_iter_chunks() -> None:
+    s = streams.EmptyStreamReader()
+
+    # check that iter_chunks() does not cause infinite loop
+    iter_chunks = s.iter_chunks()
+    with pytest.raises(StopAsyncIteration):
+        await iter_chunks.__anext__()
 
 
 @pytest.fixture


### PR DESCRIPTION
## What do these changes do?

Fixes an issue reported in [7616](https://github.com/aio-libs/aiohttp/issues/7616) - An iteration of the chunks of an EmptyStreamReader with iter_chunks() never ends.
## Are there changes in behavior for the user?

- `EmptyStreamReader` `iter_chunks()` does not get stuck
- First call of `EmptyStreamReader` `readchunk()` now returns `(b"", False)`. All the subsequent calls return `(b"", True)`. Before this PR it was always `(b"", True)`.

## Related issue number

[7616](https://github.com/aio-libs/aiohttp/issues/7616)

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
