### PR TITLE
Implement WebSocketResponse.get_extra_info method to avoid using private member

### DIFF
--- a/CHANGES/7078.feature
+++ b/CHANGES/7078.feature
@@ -1,0 +1,1 @@
+Implement ``WebSocketResponse.get_extra_info`` method to avoid accessing the private member ``_writer``

--- a/CHANGES/7078.feature
+++ b/CHANGES/7078.feature
@@ -1,1 +1,1 @@
-Implement ``WebSocketResponse.get_extra_info`` method to avoid accessing the private member ``_writer``
+Added ``WebSocketResponse.get_extra_info()`` to access a protocol transport's extra info.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -317,6 +317,7 @@ Tolga Tezel
 Tomasz Trebski
 Toshiaki Tanaka
 Trinh Hoang Nhu
+Tymofii Tsiapa
 Vadim Suharnikov
 Vaibhav Sagar
 Vamsi Krishna Avula

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -324,7 +324,10 @@ class WebSocketResponse(StreamResponse):
         return self._compress
 
     def get_extra_info(self, name: str, default: Any = None) -> Any:
-        """extra info from writer transport"""
+        """Get optional transport information.
+
+        If no value associated with ``name`` is found, ``default`` is returned.
+        """
         writer = self._writer
         if writer is None:
             return default

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -323,6 +323,16 @@ class WebSocketResponse(StreamResponse):
     def compress(self) -> bool:
         return self._compress
 
+    def get_extra_info(self, name: str, default: Any = None) -> Any:
+        """extra info from writer transport"""
+        writer = self._writer
+        if writer is None:
+            return default
+        transport = writer.transport
+        if transport is None:
+            return default
+        return transport.get_extra_info(name, default)
+
     def exception(self) -> Optional[BaseException]:
         return self._exception
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1508,7 +1508,15 @@ manually.
 
    .. method:: get_extra_info(name, default=None)
 
-      Reads extra info from connection's transport
+      Reads optional extra information from the connection's transport.
+      If no value associated with ``name`` is found, ``default`` is returned.
+
+      See :meth:`asyncio.BaseTransport.get_extra_info`
+
+      :param str name: The key to look up in the transport extra information.
+
+      :param default: Default value to be used when no value for ``name`` is
+                      found (default is ``None``).
 
    .. method:: exception()
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1049,6 +1049,10 @@ and :ref:`aiohttp-web-signals` handlers::
       May be ``None`` if server and client protocols are
       not overlapping.
 
+   .. method:: get_extra_info(name, default=None)
+
+      Reads extra info from writer's transport
+
    .. method:: exception()
 
       Returns last occurred exception or None.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -379,6 +379,8 @@ and :ref:`aiohttp-web-signals` handlers.
       Reads extra information from the protocol's transport.
       If no value associated with ``name`` is found, ``default`` is returned.
 
+      See :meth:`asyncio.BaseTransport.get_extra_info`
+
       :param str name: The key to look up in the transport extra information.
 
       :param default: Default value to be used when no value for ``name`` is
@@ -1054,13 +1056,12 @@ and :ref:`aiohttp-web-signals` handlers::
       Reads optional extra information from the writer's transport.
       If no value associated with ``name`` is found, ``default`` is returned.
 
-      Can be used, for example, for getting IP address of client's peer::
-
-         peername = response.get_extra_info('peername')
-         if peername is not None:
-             host, port = peername
-
       See :meth:`asyncio.BaseTransport.get_extra_info`
+
+      :param str name: The key to look up in the transport extra information.
+
+      :param default: Default value to be used when no value for ``name`` is
+                      found (default is ``None``).
 
    .. method:: exception()
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1051,7 +1051,16 @@ and :ref:`aiohttp-web-signals` handlers::
 
    .. method:: get_extra_info(name, default=None)
 
-      Reads extra info from writer's transport
+      Reads optional extra information from the writer's transport.
+      If no value associated with ``name`` is found, ``default`` is returned.
+
+      Can be used, for example, for getting IP address of client's peer::
+
+         peername = response.get_extra_info('peername')
+         if peername is not None:
+             host, port = peername
+
+      See :meth:`asyncio.BaseTransport.get_extra_info`
 
    .. method:: exception()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This change introduces new method to access get_extra_info from a WebSocketResponse, like its possible in ClientWebSocketResponse to avoid accessing the private member like in

`response._writer.transport.get_extra_info("the info")`


## Related issue number

https://github.com/aio-libs/aiohttp/issues/7078

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
