### PR TITLE
Fix #7306 - Set ClientWebSocketResponse.close_code correctly in concurrent closing scenario

### DIFF
--- a/CHANGES/7306.bugfix
+++ b/CHANGES/7306.bugfix
@@ -1,0 +1,1 @@
+Fixed an issue where ``ClientWebSocketResponse.close_code`` as erroneously set to None when there were concurrent async tasks receiving data and closing the connection.

--- a/CHANGES/7306.bugfix
+++ b/CHANGES/7306.bugfix
@@ -1,1 +1,1 @@
-Fixed an issue where ``ClientWebSocketResponse.close_code`` as erroneously set to None when there were concurrent async tasks receiving data and closing the connection.
+Fixed ``ClientWebSocketResponse.close_code`` being erroneously set to ``None`` when there are concurrent async tasks receiving data and closing the connection.

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -191,7 +191,8 @@ class ClientWebSocketResponse:
     async def close(self, *, code: int = WSCloseCode.OK, message: bytes = b"") -> bool:
         # we need to break `receive()` cycle first,
         # `close()` may be called from different task
-        if self._waiting is not None and not self._closed:
+        if self._waiting is not None and not self._closing:
+            self._closing = True
             self._reader.feed_data(WS_CLOSING_MESSAGE, 0)
             await self._waiting
 
@@ -210,7 +211,7 @@ class ClientWebSocketResponse:
                 self._response.close()
                 return True
 
-            if self._closing:
+            if self._close_code:
                 self._response.close()
                 return True
 

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -233,6 +233,33 @@ async def test_close(aiohttp_client: Any) -> None:
     assert msg.type == aiohttp.WSMsgType.CLOSED
 
 
+async def test_concurrent_task_close(aiohttp_client: Any) -> None:
+    async def handler(request):
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        await ws.receive()
+        return ws
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+
+    async with aiohttp_client(app) as client:
+        async with client.ws_connect("/") as resp:
+            # wait for the message in a separate task
+            task = asyncio.create_task(resp.receive())
+
+            # Make sure we start to wait on receiving message before closing the connection
+            await asyncio.sleep(0.1)
+
+            closed = await resp.close()
+
+            await task
+
+            assert closed
+            assert resp.closed
+            assert resp.close_code == 1000
+
+
 async def test_concurrent_close(aiohttp_client: Any) -> None:
     client_ws = None
 

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -243,21 +243,21 @@ async def test_concurrent_task_close(aiohttp_client: Any) -> None:
     app = web.Application()
     app.router.add_route("GET", "/", handler)
 
-    async with aiohttp_client(app) as client:
-        async with client.ws_connect("/") as resp:
-            # wait for the message in a separate task
-            task = asyncio.create_task(resp.receive())
+    client = aiohttp_client(app)
+    async with client.ws_connect("/") as resp:
+        # wait for the message in a separate task
+        task = asyncio.create_task(resp.receive())
 
-            # Make sure we start to wait on receiving message before closing the connection
-            await asyncio.sleep(0.1)
+        # Make sure we start to wait on receiving message before closing the connection
+        await asyncio.sleep(0.1)
 
-            closed = await resp.close()
+        closed = await resp.close()
 
-            await task
+        await task
 
-            assert closed
-            assert resp.closed
-            assert resp.close_code == 1000
+        assert closed
+        assert resp.closed
+        assert resp.close_code == 1000
 
 
 async def test_concurrent_close(aiohttp_client: Any) -> None:

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -243,7 +243,7 @@ async def test_concurrent_task_close(aiohttp_client: Any) -> None:
     app = web.Application()
     app.router.add_route("GET", "/", handler)
 
-    client = aiohttp_client(app)
+    client = await aiohttp_client(app)
     async with client.ws_connect("/") as resp:
         # wait for the message in a separate task
         task = asyncio.create_task(resp.receive())


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixes the issue when If one asyncio task is waiting on receiving data and another asyncio task is closing the connection. The ClientWebSocketResponse.close_code will be None after connection closed.

## Related issue number

Fixes #7306 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
