### PR TITLE
Make setup.cfg packages explicit

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -41,7 +41,7 @@ classifiers =
 
 [options]
 python_requires = >=3.8
-packages = find:
+packages = aiohttp
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag
 zip_safe = False
 include_package_data = True


### PR DESCRIPTION
Avoids accidentally including other packages.