### PR TITLE
 Add runner.serve_forever()

### DIFF
--- a/CHANGES/2746.feature
+++ b/CHANGES/2746.feature
@@ -1,0 +1,1 @@
+Add method `BaseRunner.serve_forever()` that waits forever until being cancelled.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -215,6 +215,7 @@ Ludovic Gasc
 Luis Pedrosa
 Lukasz Marcin Dobrzanski
 Makc Belousow
+Maksim Vasilev
 Manuel Miranda
 Marat Sharafutdinov
 Marc Mueller

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -261,7 +261,11 @@ class SockSite(BaseSite):
 
 class BaseRunner(ABC):
     __slots__ = (
-        "starting_tasks", "_handle_signals", "_kwargs", "_server", "_sites",
+        "starting_tasks",
+        "_handle_signals",
+        "_kwargs",
+        "_server",
+        "_sites",
         "_serve_forever_fut",
     )
 
@@ -312,19 +316,15 @@ class BaseRunner(ABC):
 
     async def serve_forever(self) -> None:
         if self._serve_forever_fut is not None:
-            raise RuntimeError(
-                'Concurrent calls to serve_forever() are not allowed'
-            )
+            raise RuntimeError("Concurrent calls to serve_forever() are not allowed")
         if self._server is None:
-            raise RuntimeError('Call setup() first')
+            raise RuntimeError("Call setup() first")
 
         loop = asyncio.get_event_loop()
         self._serve_forever_fut = loop.create_future()
+
         try:
             await self._serve_forever_fut
-        except asyncio.CancelledError:
-            await self.cleanup()
-            raise
         finally:
             self._serve_forever_fut = None
 

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -260,13 +260,17 @@ class SockSite(BaseSite):
 
 
 class BaseRunner(ABC):
-    __slots__ = ("starting_tasks", "_handle_signals", "_kwargs", "_server", "_sites")
+    __slots__ = (
+        "starting_tasks", "_handle_signals", "_kwargs", "_server", "_sites",
+        "_serve_forever_fut",
+    )
 
     def __init__(self, *, handle_signals: bool = False, **kwargs: Any) -> None:
         self._handle_signals = handle_signals
         self._kwargs = kwargs
         self._server: Optional[Server] = None
         self._sites: List[BaseSite] = []
+        self._serve_forever_fut: Optional[asyncio.Future[None]] = None
 
     @property
     def server(self) -> Optional[Server]:
@@ -305,6 +309,24 @@ class BaseRunner(ABC):
         # the time we have completed the application startup (in self._make_server()),
         # so we just record all running tasks here and exclude them later.
         self.starting_tasks = asyncio.all_tasks()
+
+    async def serve_forever(self) -> None:
+        if self._serve_forever_fut is not None:
+            raise RuntimeError(
+                'Concurrent calls to serve_forever() are not allowed'
+            )
+        if self._server is None:
+            raise RuntimeError('Call setup() first')
+
+        loop = asyncio.get_event_loop()
+        self._serve_forever_fut = loop.create_future()
+        try:
+            await self._serve_forever_fut
+        except asyncio.CancelledError:
+            await self.cleanup()
+            raise
+        finally:
+            self._serve_forever_fut = None
 
     @abstractmethod
     async def shutdown(self) -> None:

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -909,9 +909,7 @@ The simple startup code for serving HTTP site on ``'localhost'``, port
     await runner.setup()
     site = web.TCPSite(runner, 'localhost', 8080)
     await site.start()
-
-    while True:
-        await asyncio.sleep(3600)  # sleep forever
+    await runner.serve_forever()
 
 To stop serving call :meth:`AppRunner.cleanup`::
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2555,10 +2555,10 @@ application on specific TCP or Unix socket, e.g.::
       Stop handling all registered sites and cleanup used resources.
 
    .. method:: serve_forever()
+      :async:
 
-      Wait forever. Cancellation of serve_forever task causes the runner to be closed.
-      This method can be called only if the runner is already initialized.
-      Only one serve_forever task can exist per one runner object.
+      Wait forever. Make sure to call :meth:`setup` prior calling this method.
+      Only one :meth:`serve_forever` task is allowed per one runner object.
 
 
 .. class:: AppRunner(app, *, handle_signals=False, **kwargs)

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2511,7 +2511,7 @@ application on specific TCP or Unix socket, e.g.::
     site = web.TCPSite(runner, 'localhost', 8080)
     await site.start()
     # wait for finish signal
-    await runner.cleanup()
+    await runner.serve_forever()
 
 
 .. versionadded:: 3.0
@@ -2553,6 +2553,12 @@ application on specific TCP or Unix socket, e.g.::
       :async:
 
       Stop handling all registered sites and cleanup used resources.
+
+   .. method:: serve_forever()
+
+      Wait forever. Cancellation of serve_forever task causes the runner to be closed.
+      This method can be called only if the runner is already initialized.
+      Only one serve_forever task can exist per one runner object.
 
 
 .. class:: AppRunner(app, *, handle_signals=False, **kwargs)

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -2,7 +2,7 @@
 import asyncio
 import platform
 import signal
-from typing import Any
+from typing import Any, Optional
 from unittest.mock import patch
 
 import pytest
@@ -22,8 +22,8 @@ def make_runner(loop: Any, app: Any):
     asyncio.set_event_loop(loop)
     runners = []
 
-    def go(**kwargs):
-        runner = web.AppRunner(app, **kwargs)
+    def go(app_param: Optional[web.AppRunner] = None, **kwargs):
+        runner = web.AppRunner(app_param or app, **kwargs)
         runners.append(runner)
         return runner
 
@@ -265,3 +265,55 @@ def test_run_after_asyncio_run() -> None:
 
     web.run_app(app)
     assert spy.called, "run_app() should work after asyncio.run()."
+
+async def test_app_runner_serve_forever_uninitialized(
+        make_runner, loop) -> None:
+    runner = make_runner()
+    with pytest.raises(RuntimeError):
+        await runner.serve_forever()
+
+
+async def test_app_runner_serve_forever_concurrent_call(
+        make_runner, loop) -> None:
+    runner = make_runner()
+    task = loop.create_task(runner.serve_forever())
+    await asyncio.sleep(0.01)
+    with pytest.raises(RuntimeError):
+        await runner.serve_forever()
+    task.cancel()
+
+
+async def test_app_runner_serve_forever_multiple_times(
+        make_runner, loop) -> None:
+    runner = make_runner()
+    for i in range(3):
+        await runner.setup()
+        task = loop.create_task(runner.serve_forever())
+        await asyncio.sleep(0.01)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+async def test_app_runner_serve_forever_cleanup_called(
+        make_runner, app, loop) -> None:
+
+    called = False
+
+    async def on_cleanup(app_param):
+        nonlocal called
+        assert app is app_param
+        called = True
+
+    app.on_cleanup.append(on_cleanup)
+    app.freeze()
+    runner = make_runner(app)
+    await runner.setup()
+
+    task = loop.create_task(runner.serve_forever())
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert called


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
This is a continuation of work from #4378. I've dropped `cleanup` call on `serve_forever()` task cancellation 
and updated the documentation accordingly. 

## Are there changes in behavior for the user?
No.

## Related issue number
#2746 

Original attempt from asvetlov: https://github.com/aio-libs/aiohttp/compare/master...server_forever

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
