### PR TITLE
feature: allow link argument to be set to None/empty in HTTP 451 exception

### DIFF
--- a/CHANGES/7689.bugfix
+++ b/CHANGES/7689.bugfix
@@ -1,1 +1,1 @@
-Handle invalid ``link`` argument values in HTTP 451 exception.
+Make ``link`` argument optional and handle invalid values in HTTP 451 exception.

--- a/CHANGES/7689.bugfix
+++ b/CHANGES/7689.bugfix
@@ -1,0 +1,1 @@
+Handle invalid ``link`` argument values in HTTP 451 exception.

--- a/CHANGES/7689.bugfix
+++ b/CHANGES/7689.bugfix
@@ -1,1 +1,0 @@
-Make ``link`` argument optional and handle invalid values in HTTP 451 exception.

--- a/CHANGES/7689.feature
+++ b/CHANGES/7689.feature
@@ -1,0 +1,1 @@
+Allow ``link`` argument to be set to None/empty in HTTP 451 exception.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -144,6 +144,7 @@ Hrishikesh Paranjape
 Hu Bo
 Hugh Young
 Hugo Herter
+Hugo Hromic
 Hugo van Kemenade
 Hynek Schlawack
 Igor Alexandrov

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -420,20 +420,18 @@ class HTTPUnavailableForLegalReasons(HTTPClientError):
 
     def __init__(
         self,
-        link: Optional[StrOrURL] = None,
+        link: Optional[StrOrURL],
         *,
         headers: Optional[LooseHeaders] = None,
         reason: Optional[str] = None,
         text: Optional[str] = None,
         content_type: Optional[str] = None,
     ) -> None:
-        if link is not None and not link:
-            raise ValueError("link argument cannot be empty.")
         super().__init__(
             headers=headers, reason=reason, text=text, content_type=content_type
         )
         self._link = None
-        if self.link:
+        if link:
             self._link = URL(link)
             self.headers["Link"] = f'<{str(self._link)}>; rel="blocked-by"'
 

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -427,11 +427,16 @@ class HTTPUnavailableForLegalReasons(HTTPClientError):
         text: Optional[str] = None,
         content_type: Optional[str] = None,
     ) -> None:
+        if not link:
+            raise ValueError(
+                "HTTP unavailable for legal reasons needs a link to"
+                " a resource with information for the blocking reason."
+            )
         super().__init__(
             headers=headers, reason=reason, text=text, content_type=content_type
         )
-        self.headers["Link"] = f'<{str(link)}>; rel="blocked-by"'
         self._link = URL(link)
+        self.headers["Link"] = f'<{str(self.link)}>; rel="blocked-by"'
 
     @property
     def link(self) -> URL:

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -436,7 +436,7 @@ class HTTPUnavailableForLegalReasons(HTTPClientError):
             self.headers["Link"] = f'<{str(self._link)}>; rel="blocked-by"'
 
     @property
-    def link(self) -> URL:
+    def link(self) -> Optional[URL]:
         return self._link
 
 

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -427,11 +427,11 @@ class HTTPUnavailableForLegalReasons(HTTPClientError):
         text: Optional[str] = None,
         content_type: Optional[str] = None,
     ) -> None:
+        if link is not None and not link:
+            raise ValueError("link argument cannot be empty.")
         super().__init__(
             headers=headers, reason=reason, text=text, content_type=content_type
         )
-        if link is not None and not link:
-            raise ValueError("link argument cannot be empty.")
         self._link = URL(link) if link else None
         if self._link:
             self.headers["Link"] = f'<{str(self.link)}>; rel="blocked-by"'

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -420,23 +420,21 @@ class HTTPUnavailableForLegalReasons(HTTPClientError):
 
     def __init__(
         self,
-        link: StrOrURL,
+        link: Optional[StrOrURL] = None,
         *,
         headers: Optional[LooseHeaders] = None,
         reason: Optional[str] = None,
         text: Optional[str] = None,
         content_type: Optional[str] = None,
     ) -> None:
-        if not link:
-            raise ValueError(
-                "HTTP unavailable for legal reasons needs a link to"
-                " a resource with information for the blocking reason."
-            )
         super().__init__(
             headers=headers, reason=reason, text=text, content_type=content_type
         )
-        self._link = URL(link)
-        self.headers["Link"] = f'<{str(self.link)}>; rel="blocked-by"'
+        if link is not None and not link:
+            raise ValueError("link argument cannot be empty.")
+        self._link = URL(link) if link else None
+        if self._link:
+            self.headers["Link"] = f'<{str(self.link)}>; rel="blocked-by"'
 
     @property
     def link(self) -> URL:

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -432,9 +432,10 @@ class HTTPUnavailableForLegalReasons(HTTPClientError):
         super().__init__(
             headers=headers, reason=reason, text=text, content_type=content_type
         )
-        self._link = URL(link) if link else None
+        self._link = None
         if self.link:
-            self.headers["Link"] = f'<{str(self.link)}>; rel="blocked-by"'
+            self._link = URL(link)
+            self.headers["Link"] = f'<{str(self._link)}>; rel="blocked-by"'
 
     @property
     def link(self) -> URL:

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -433,7 +433,7 @@ class HTTPUnavailableForLegalReasons(HTTPClientError):
             headers=headers, reason=reason, text=text, content_type=content_type
         )
         self._link = URL(link) if link else None
-        if self._link:
+        if self.link:
             self.headers["Link"] = f'<{str(self.link)}>; rel="blocked-by"'
 
     @property

--- a/docs/web_exceptions.rst
+++ b/docs/web_exceptions.rst
@@ -486,8 +486,8 @@ HTTP exceptions for status code in range 400-499, e.g. ``raise web.HTTPNotFound(
    An exception for *451 Unavailable For Legal Reasons*, a subclass of
    :exc:`HTTPClientError`.
 
-   :param link: A link to the entity implementing the blockage,
-                :class:`str` or :class:`~yarl.URL`
+   :param link: A link to yourself (as the entity implementing the blockage),
+                :class:`str`, :class:`~yarl.URL` or ``None``.
 
    For other parameters see :exc:`HTTPException` constructor.
 

--- a/docs/web_exceptions.rst
+++ b/docs/web_exceptions.rst
@@ -106,10 +106,10 @@ unsupported method and list of allowed methods::
                          headers=None, reason=None,
                          text=None, content_type=None)
 
-:exc:`HTTPUnavailableForLegalReasons` is constructed by providing the link
-to a resource with information for the blocking reason::
+:exc:`HTTPUnavailableForLegalReasons` is constructed by optionally providing
+a link to the entity implementing the blockage (if any)::
 
-    HTTPUnavailableForLegalReasons(link, *,
+    HTTPUnavailableForLegalReasons(link=None, *
                                    headers=None, reason=None,
                                    text=None, content_type=None)
 
@@ -475,7 +475,7 @@ HTTP exceptions for status code in range 400-499, e.g. ``raise web.HTTPNotFound(
    An exception for *431 Requests Header Fields Too Large*, a subclass of
    :exc:`HTTPClientError`.
 
-.. exception:: HTTPUnavailableForLegalReasons(link, *, \
+.. exception:: HTTPUnavailableForLegalReasons(link=None, *, \
                                               headers=None, \
                                               reason=None, \
                                               text=None, \
@@ -485,14 +485,14 @@ HTTP exceptions for status code in range 400-499, e.g. ``raise web.HTTPNotFound(
    An exception for *451 Unavailable For Legal Reasons*, a subclass of
    :exc:`HTTPClientError`.
 
-   :param link: A link to a resource with information for the blocking reason,
+   :param link: A link to the entity implementing the blockage,
                 :class:`str` or :class:`~yarl.URL`
 
    For other parameters see :exc:`HTTPException` constructor.
 
    .. attribute:: link
 
-      A :class:`~yarl.URL` link to a resource with information for the blocking reason,
+      A :class:`~yarl.URL` link to the entity implementing the blockage or ``None``,
       read-only property.
 
 

--- a/docs/web_exceptions.rst
+++ b/docs/web_exceptions.rst
@@ -110,7 +110,7 @@ unsupported method and list of allowed methods::
 to yourself (as the entity implementing the blockage), and an explanation for
 the block included in ``text``.::
 
-    HTTPUnavailableForLegalReasons(link=None, *
+    HTTPUnavailableForLegalReasons(link, *,
                                    headers=None, reason=None,
                                    text=None, content_type=None)
 
@@ -476,7 +476,7 @@ HTTP exceptions for status code in range 400-499, e.g. ``raise web.HTTPNotFound(
    An exception for *431 Requests Header Fields Too Large*, a subclass of
    :exc:`HTTPClientError`.
 
-.. exception:: HTTPUnavailableForLegalReasons(link=None, *, \
+.. exception:: HTTPUnavailableForLegalReasons(link, *, \
                                               headers=None, \
                                               reason=None, \
                                               text=None, \

--- a/docs/web_exceptions.rst
+++ b/docs/web_exceptions.rst
@@ -490,6 +490,7 @@ HTTP exceptions for status code in range 400-499, e.g. ``raise web.HTTPNotFound(
                 :class:`str`, :class:`~yarl.URL` or ``None``.
 
    For other parameters see :exc:`HTTPException` constructor.
+   A reason for the block should be included in ``text``.
 
    .. attribute:: link
 

--- a/docs/web_exceptions.rst
+++ b/docs/web_exceptions.rst
@@ -106,8 +106,9 @@ unsupported method and list of allowed methods::
                          headers=None, reason=None,
                          text=None, content_type=None)
 
-:exc:`HTTPUnavailableForLegalReasons` is constructed by optionally providing
-a link to the entity implementing the blockage (if any)::
+:exc:`HTTPUnavailableForLegalReasons` should be constructed with a ``link``
+to yourself (as the entity implementing the blockage), and an explanation for
+the block included in ``text``.::
 
     HTTPUnavailableForLegalReasons(link=None, *
                                    headers=None, reason=None,

--- a/docs/web_exceptions.rst
+++ b/docs/web_exceptions.rst
@@ -85,7 +85,7 @@ HTTP Exception hierarchy chart::
 All HTTP exceptions have the same constructor signature::
 
     HTTPNotFound(*, headers=None, reason=None,
-                 body=None, text=None, content_type=None)
+                 text=None, content_type=None)
 
 If not directly specified, *headers* will be added to the *default
 response headers*.
@@ -94,8 +94,8 @@ Classes :exc:`HTTPMultipleChoices`, :exc:`HTTPMovedPermanently`,
 :exc:`HTTPFound`, :exc:`HTTPSeeOther`, :exc:`HTTPUseProxy`,
 :exc:`HTTPTemporaryRedirect` have the following constructor signature::
 
-    HTTPFound(location, *, headers=None, reason=None,
-              body=None, text=None, content_type=None)
+    HTTPFound(location, *,headers=None, reason=None,
+              text=None, content_type=None)
 
 where *location* is value for *Location HTTP header*.
 
@@ -104,7 +104,14 @@ unsupported method and list of allowed methods::
 
     HTTPMethodNotAllowed(method, allowed_methods, *,
                          headers=None, reason=None,
-                         body=None, text=None, content_type=None)
+                         text=None, content_type=None)
+
+:exc:`HTTPUnavailableForLegalReasons` is constructed by providing the link
+to a resource with information for the blocking reason::
+
+    HTTPUnavailableForLegalReasons(link, *,
+                                   headers=None, reason=None,
+                                   text=None, content_type=None)
 
 Base HTTP Exception
 -------------------
@@ -478,14 +485,14 @@ HTTP exceptions for status code in range 400-499, e.g. ``raise web.HTTPNotFound(
    An exception for *451 Unavailable For Legal Reasons*, a subclass of
    :exc:`HTTPClientError`.
 
-   :param link: A link to a resource with information for blocking reason,
+   :param link: A link to a resource with information for the blocking reason,
                 :class:`str` or :class:`~yarl.URL`
 
    For other parameters see :exc:`HTTPException` constructor.
 
    .. attribute:: link
 
-      A :class:`~yarl.URL` link to a resource with information for blocking reason,
+      A :class:`~yarl.URL` link to a resource with information for the blocking reason,
       read-only property.
 
 

--- a/tests/test_web_exceptions.py
+++ b/tests/test_web_exceptions.py
@@ -330,25 +330,17 @@ class TestHTTPUnavailableForLegalReasons:
         assert exc.reason == "Zaprescheno"
         assert exc.status == 451
 
-    def test_ctor_no_link(self) -> None:
-        exc = web.HTTPUnavailableForLegalReasons(
-            headers={"X-Custom": "value"},
-            reason="Zaprescheno",
-            text="text",
-            content_type="custom",
-        )
-        assert exc.link is None
-        assert exc.text == "text"
-        compare: Mapping[str, str] = {
-            "X-Custom": "value",
-            "Content-Type": "custom",
-        }
-        assert exc.headers == compare
-        assert exc.reason == "Zaprescheno"
-        assert exc.status == 451
-
     def test_no_link(self) -> None:
-        exc = web.HTTPUnavailableForLegalReasons()
+        with pytest.raises(TypeError):
+            web.HTTPUnavailableForLegalReasons()
+
+    def test_none_link(self) -> None:
+        exc = web.HTTPUnavailableForLegalReasons(link=None)
+        assert exc.link is None
+        assert "Link" not in exc.headers
+
+    def test_empty_link(self) -> None:
+        exc = web.HTTPUnavailableForLegalReasons(link="")
         assert exc.link is None
         assert "Link" not in exc.headers
 
@@ -361,10 +353,6 @@ class TestHTTPUnavailableForLegalReasons:
         exc = web.HTTPUnavailableForLegalReasons(link=URL("http://warning.or.kr/"))
         assert exc.link == URL("http://warning.or.kr/")
         assert exc.headers["Link"] == '<http://warning.or.kr/>; rel="blocked-by"'
-
-    def test_empty_link(self) -> None:
-        with pytest.raises(ValueError):
-            web.HTTPUnavailableForLegalReasons(link="")
 
     def test_link_CRLF(self) -> None:
         exc = web.HTTPUnavailableForLegalReasons(link="http://warning.or.kr/\r\n")

--- a/tests/test_web_exceptions.py
+++ b/tests/test_web_exceptions.py
@@ -330,6 +330,28 @@ class TestHTTPUnavailableForLegalReasons:
         assert exc.reason == "Zaprescheno"
         assert exc.status == 451
 
+    def test_ctor_no_link(self) -> None:
+        exc = web.HTTPUnavailableForLegalReasons(
+            headers={"X-Custom": "value"},
+            reason="Zaprescheno",
+            text="text",
+            content_type="custom",
+        )
+        assert exc.link is None
+        assert exc.text == "text"
+        compare: Mapping[str, str] = {
+            "X-Custom": "value",
+            "Content-Type": "custom",
+        }
+        assert exc.headers == compare
+        assert exc.reason == "Zaprescheno"
+        assert exc.status == 451
+
+    def test_no_link(self) -> None:
+        exc = web.HTTPUnavailableForLegalReasons()
+        assert exc.link is None
+        assert "Link" not in exc.headers
+
     def test_link_str(self) -> None:
         exc = web.HTTPUnavailableForLegalReasons(link="http://warning.or.kr/")
         assert exc.link == URL("http://warning.or.kr/")
@@ -343,8 +365,6 @@ class TestHTTPUnavailableForLegalReasons:
     def test_empty_link(self) -> None:
         with pytest.raises(ValueError):
             web.HTTPUnavailableForLegalReasons(link="")
-        with pytest.raises(ValueError):
-            web.HTTPUnavailableForLegalReasons(link=None)  # type: ignore[arg-type]
 
     def test_link_CRLF(self) -> None:
         exc = web.HTTPUnavailableForLegalReasons(link="http://warning.or.kr/\r\n")

--- a/tests/test_web_exceptions.py
+++ b/tests/test_web_exceptions.py
@@ -332,7 +332,7 @@ class TestHTTPUnavailableForLegalReasons:
 
     def test_no_link(self) -> None:
         with pytest.raises(TypeError):
-            web.HTTPUnavailableForLegalReasons()
+            web.HTTPUnavailableForLegalReasons()  # type: ignore[call-arg]
 
     def test_none_link(self) -> None:
         exc = web.HTTPUnavailableForLegalReasons(link=None)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR allows for the link argument to be set to None/empty (so it can be optional) as per RFC in the HTTP 451 exception (`HTTPUnavailableForLegalReasons`). It also adds suitable unit tests for the `link` argument and aligns variable naming in the test class of this exception.

I also updated the documentation for this exception and adjusted the documented signatures of the other exceptions in the same section (the `body` argument does not exist anymore).

## Are there changes in behavior for the user?

The exception constructor no longer requires the `link` argument nor accepts empty or invalid values.

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
