### PR TITLE
Add test to confirm regression of parsing chunked with no length (3.8.6/3.9.0b)

### DIFF
--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -934,8 +934,8 @@ def test_http_request_chunked_payload(parser: Any) -> None:
     assert payload.is_eof()
 
 
-def test_http_chunked_zero_bytes(parser) -> None:
-    payload = (
+def test_http_chunked_zero_bytes(response: Any) -> None:
+    text = (
         b"HTTP/1.1 304 Not Modified\r\n"
         b"Server: nginx\r\n"
         b"Date: Fri, 13 Oct 2023 00:28:29 GMT\r\n"
@@ -947,14 +947,8 @@ def test_http_chunked_zero_bytes(parser) -> None:
         b"Content-Type: application/octet-stream\r\n"
         b"Transfer-Encoding: chunked\r\n\r\n0\r\n\r\n"
     )
-    messages, upgrade, tail = parser.feed_data(payload)
-    assert len(messages) == 1
+    msg, payload = parser.feed_data(text)[0][0]
 
-    msg, payload = messages[0]
-
-    assert msg.method == "GET"
-    assert msg.path == "/test/тест"
-    assert msg.version == (1, 1)
     assert payload.is_eof()
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -947,7 +947,7 @@ def test_http_chunked_zero_bytes(response: Any) -> None:
         b"Content-Type: application/octet-stream\r\n"
         b"Transfer-Encoding: chunked\r\n\r\n0\r\n\r\n"
     )
-    msg, payload = parser.feed_data(text)[0][0]
+    msg, payload = response.feed_data(text)[0][0]
 
     assert payload.is_eof()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This is to confirm the related issue https://github.com/home-assistant/core/issues/101893 (and https://github.com/home-assistant/core/pull/101913)

This regression affects 3.8.6 and 3.9.0b

~~I haven't figure out the source yet. It appears to be limited to the c parser.~~

This is a regression in llhttp.  I don't have a solution, but I do have a test case: https://github.com/nodejs/llhttp/pull/256

The failure is here: https://github.com/aio-libs/aiohttp/actions/runs/6502938416/job/17662729062?pr=7697

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
