### PR TITLE
Require full version and method regex matches

### DIFF
--- a/CHANGES/7700.bugfix
+++ b/CHANGES/7700.bugfix
@@ -1,0 +1,1 @@
+Fix issue with insufficient HTTP method and version validation.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -53,6 +53,7 @@ Arthur Darcet
 Austin Scola
 Ben Bader
 Ben Greiner
+Ben Kallus
 Ben Timby
 Benedikt Reinartz
 Bob Haddleton

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -549,11 +549,11 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
             )
 
         # method
-        if not METHRE.match(method):
+        if not METHRE.fullmatch(method):
             raise BadStatusLine(method)
 
         # version
-        match = VERSRE.match(version)
+        match = VERSRE.fullmatch(version)
         if match is None:
             raise BadStatusLine(line)
         version_o = HttpVersion(int(match.group(1)), int(match.group(2)))
@@ -652,7 +652,7 @@ class HttpResponseParser(HttpParser[RawResponseMessage]):
             )
 
         # version
-        match = VERSRE.match(version)
+        match = VERSRE.fullmatch(version)
         if match is None:
             raise BadStatusLine(line)
         version_o = HttpVersion(int(match.group(1)), int(match.group(2)))

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -727,7 +727,7 @@ def test_http_request_parser_two_slashes(parser: Any) -> None:
 
 def test_http_request_parser_bad_method(parser: Any) -> None:
     with pytest.raises(http_exceptions.BadStatusLine):
-        parser.feed_data(b'=":<G>(e),[T];?" /get HTTP/1.1\r\n\r\n')
+        parser.feed_data(b'G=":<>(e),[T];?" /get HTTP/1.1\r\n\r\n')
 
 
 def test_http_request_parser_bad_version(parser: Any) -> None:
@@ -737,7 +737,7 @@ def test_http_request_parser_bad_version(parser: Any) -> None:
 
 def test_http_request_parser_bad_version_number(parser: Any) -> None:
     with pytest.raises(http_exceptions.BadHttpMessage):
-        parser.feed_data(b"GET /test HTTP/12.3\r\n\r\n")
+        parser.feed_data(b"GET /test HTTP/1.32\r\n\r\n")
 
 
 @pytest.mark.parametrize("size", [40965, 8191])


### PR DESCRIPTION
## What do these changes do?

These changes ensure that HTTP versions and methods fully match the regular expressions for those constructs. AIOHTTP currently only applies prefix-matching, which I assume was unintentional.

## Are there changes in behavior for the user?

There should be no observable changes to the user, unless they use HTTP servers/clients that generate very malformed request lines. Such clients/servers are unlikely to exist because most other web servers reject these malformed messages.

## Related issue number

Fixes #7700
