### PR TITLE
[backport] feature: allow link argument to be set to None/empty in HTTP 451 exception

### DIFF
--- a/CHANGES/7689.feature
+++ b/CHANGES/7689.feature
@@ -1,0 +1,1 @@
+Allow ``link`` argument to be set to None/empty in HTTP 451 exception.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -139,6 +139,7 @@ Hrishikesh Paranjape
 Hu Bo
 Hugh Young
 Hugo Herter
+Hugo Hromic
 Hugo van Kemenade
 Hynek Schlawack
 Igor Alexandrov

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -367,7 +367,7 @@ class HTTPUnavailableForLegalReasons(HTTPClientError):
 
     def __init__(
         self,
-        link: str,
+        link: Optional[StrOrURL],
         *,
         headers: Optional[LooseHeaders] = None,
         reason: Optional[str] = None,
@@ -382,8 +382,14 @@ class HTTPUnavailableForLegalReasons(HTTPClientError):
             text=text,
             content_type=content_type,
         )
-        self.headers["Link"] = '<%s>; rel="blocked-by"' % link
-        self.link = link
+        self._link = None
+        if link:
+            self._link = URL(link)
+            self.headers["Link"] = f'<{str(self._link)}>; rel="blocked-by"'
+
+    @property
+    def link(self) -> Optional[URL]:
+        return self._link
 
 
 ############################################################

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -432,6 +432,7 @@ nitpick_ignore = [
     ("py:exc", "HTTPNotFound"),  # undocumented
     ("py:exc", "HTTPMethodNotAllowed"),  # undocumented
     ("py:class", "HTTPMethodNotAllowed"),  # undocumented
+    ("py:class", "HTTPUnavailableForLegalReasons"),  # undocumented
 ]
 
 # -- Options for towncrier_draft extension -----------------------------------

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -763,3 +763,11 @@ unsupported method and list of allowed methods::
     HTTPMethodNotAllowed(method, allowed_methods, *,
                          headers=None, reason=None,
                          body=None, text=None, content_type=None)
+
+:class:`HTTPUnavailableForLegalReasons` should be constructed with a ``link``
+to yourself (as the entity implementing the blockage), and an explanation for
+the block included in ``text``.::
+
+    HTTPUnavailableForLegalReasons(link, *,
+                                   headers=None, reason=None,
+                                   body=None, text=None, content_type=None)

--- a/tests/test_web_exceptions.py
+++ b/tests/test_web_exceptions.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import aiosignal
 import pytest
+from yarl import URL
 
 from aiohttp import helpers, web
 from aiohttp.pytest_plugin import AiohttpClient

--- a/tests/test_web_exceptions.py
+++ b/tests/test_web_exceptions.py
@@ -189,11 +189,38 @@ def test_empty_body_304() -> None:
     resp.body is None
 
 
-def test_link_header_451(buf) -> None:
-    resp = web.HTTPUnavailableForLegalReasons(link="http://warning.or.kr/")
+def test_no_link_451() -> None:
+    with pytest.raises(TypeError):
+        web.HTTPUnavailableForLegalReasons()  # type: ignore[call-arg]
 
-    assert "http://warning.or.kr/" == resp.link
-    assert '<http://warning.or.kr/>; rel="blocked-by"' == resp.headers["Link"]
+
+def test_link_none_451() -> None:
+    resp = web.HTTPUnavailableForLegalReasons(link=None)
+    assert resp.link is None
+    assert "Link" not in resp.headers
+
+
+def test_link_empty_451() -> None:
+    resp = web.HTTPUnavailableForLegalReasons(link="")
+    assert resp.link is None
+    assert "Link" not in resp.headers
+
+
+def test_link_str_451() -> None:
+    resp = web.HTTPUnavailableForLegalReasons(link="http://warning.or.kr/")
+    assert resp.link == URL("http://warning.or.kr/")
+    assert resp.headers["Link"] == '<http://warning.or.kr/>; rel="blocked-by"'
+
+
+def test_link_url_451() -> None:
+    resp = web.HTTPUnavailableForLegalReasons(link=URL("http://warning.or.kr/"))
+    assert resp.link == URL("http://warning.or.kr/")
+    assert resp.headers["Link"] == '<http://warning.or.kr/>; rel="blocked-by"'
+
+
+def test_link_CRLF_451() -> None:
+    resp = web.HTTPUnavailableForLegalReasons(link="http://warning.or.kr/\r\n")
+    assert "\r\n" not in resp.headers["Link"]
 
 
 def test_HTTPException_retains_cause() -> None:


### PR DESCRIPTION
This PR is the backport of #7689 for 3.9.
I tried to backport it as close as possible to the state of the 3.9 branch.