### PR TITLE
Add check to validate absolute URIs

### DIFF
--- a/CHANGES/7712.bugfix
+++ b/CHANGES/7712.bugfix
@@ -1,0 +1,1 @@
+Add check to validate that absolute URIs have schemes.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -578,10 +578,16 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
                 fragment=url_fragment,
                 encoded=True,
             )
+        elif path == "*" and method == "OPTIONS":
+            # asterisk-form,
+            url = URL(path, encoded=True)
         else:
             # absolute-form for proxy maybe,
             # https://datatracker.ietf.org/doc/html/rfc7230#section-5.3.2
             url = URL(path, encoded=True)
+            if url.scheme == "":
+                # not absolute-form
+                raise BadStatusLine(line)
 
         # read headers
         (

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -34,6 +34,7 @@ from .http_exceptions import (
     ContentEncodingError,
     ContentLengthError,
     InvalidHeader,
+    InvalidURLError,
     LineTooLong,
     TransferEncodingError,
 )
@@ -587,7 +588,7 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
             url = URL(path, encoded=True)
             if url.scheme == "":
                 # not absolute-form
-                raise BadStatusLine(line)
+                raise InvalidURLError(line)
 
         # read headers
         (

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -741,7 +741,7 @@ def test_http_request_parser_bad_version_number(parser: Any) -> None:
 
 
 def test_http_request_parser_bad_uri(parser: Any) -> None:
-    with pytest.raises(http_exceptions.BadStatusLine):
+    with pytest.raises(http_exceptions.InvalidURLError):
         parser.feed_data(b"GET ! HTTP/1.1\r\n\r\n")
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -740,6 +740,11 @@ def test_http_request_parser_bad_version_number(parser: Any) -> None:
         parser.feed_data(b"GET /test HTTP/1.32\r\n\r\n")
 
 
+def test_http_request_parser_bad_uri(parser: Any) -> None:
+    with pytest.raises(http_exceptions.BadStatusLine):
+        parser.feed_data(b"GET ! HTTP/1.1\r\n\r\n")
+
+
 @pytest.mark.parametrize("size", [40965, 8191])
 def test_http_request_max_status_line(parser: Any, size: Any) -> None:
     path = b"t" * (size - 5)


### PR DESCRIPTION
## What do these changes do?

This PR adds URI validation to the Python HTTP parser so that it matches llhttp.

## Are there changes in behavior for the user?

No changes should be observable, unless the user's HTTP client is sending malformed requests.

## Related issue number

Fixes #7712