### PR TITLE
Fix unhandled exception for invalid Unicode in Python HTTP parser

### DIFF
--- a/CHANGES/7712.bugfix
+++ b/CHANGES/7712.bugfix
@@ -1,0 +1,1 @@
+Add check to validate that absolute URIs have schemes.

--- a/CHANGES/7715.bugfix
+++ b/CHANGES/7715.bugfix
@@ -1,0 +1,1 @@
+Fix unhandled exception when Python HTTP parser encouners unpaired Unicode surrogates.

--- a/CHANGES/7715.bugfix
+++ b/CHANGES/7715.bugfix
@@ -1,1 +1,1 @@
-Fix unhandled exception when Python HTTP parser encouners unpaired Unicode surrogates.
+Fix unhandled exception when Python HTTP parser encounters unpaired Unicode surrogates.

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -85,11 +85,10 @@ class LineTooLong(BadHttpMessage):
 
 class InvalidHeader(BadHttpMessage):
     def __init__(self, hdr: Union[bytes, str]) -> None:
-        if isinstance(hdr, bytes):
-            hdr = repr(hdr)
-        super().__init__(f"Invalid HTTP header: {hdr}")
-        self.hdr = hdr
-        self.args = (hdr,)
+        hdr_s = hdr.decode(errors="backslashreplace") if isinstance(hdr, bytes) else hdr
+        super().__init__(f"Invalid HTTP header: {hdr_s}")
+        self.hdr = hdr_s
+        self.args = (hdr_s,)
 
 
 class BadStatusLine(BadHttpMessage):

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -86,8 +86,8 @@ class LineTooLong(BadHttpMessage):
 class InvalidHeader(BadHttpMessage):
     def __init__(self, hdr: Union[bytes, str]) -> None:
         if isinstance(hdr, bytes):
-            hdr = hdr.decode("utf-8", "surrogateescape")
-        super().__init__(f"Invalid HTTP Header: {hdr}")
+            hdr = repr(hdr)
+        super().__init__(f"Invalid HTTP header: {hdr}")
         self.hdr = hdr
         self.args = (hdr,)
 

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -86,9 +86,9 @@ class LineTooLong(BadHttpMessage):
 class InvalidHeader(BadHttpMessage):
     def __init__(self, hdr: Union[bytes, str]) -> None:
         hdr_s = hdr.decode(errors="backslashreplace") if isinstance(hdr, bytes) else hdr
-        super().__init__(f"Invalid HTTP header: {hdr_s}")
+        super().__init__(f"Invalid HTTP header: {hdr!r}")
         self.hdr = hdr_s
-        self.args = (hdr_s,)
+        self.args = (hdr,)
 
 
 class BadStatusLine(BadHttpMessage):

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -588,7 +588,9 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
             url = URL(path, encoded=True)
             if url.scheme == "":
                 # not absolute-form
-                raise InvalidURLError(path.encode(errors="surrogateescape").decode('latin1'))
+                raise InvalidURLError(
+                    path.encode(errors="surrogateescape").decode("latin1")
+                )
 
         # read headers
         (

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -578,10 +578,16 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
                 fragment=url_fragment,
                 encoded=True,
             )
+        elif path == "*" and method == "OPTIONS":
+            # asterisk-form,
+            url = URL(path, encoded=True)
         else:
             # absolute-form for proxy maybe,
             # https://datatracker.ietf.org/doc/html/rfc7230#section-5.3.2
             url = URL(path, encoded=True)
+            if url.scheme == "":
+                # not absolute-form
+                raise BadStatusLine(line)
 
         # read headers
         (

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -588,7 +588,7 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
             url = URL(path, encoded=True)
             if url.scheme == "":
                 # not absolute-form
-                raise InvalidURLError(repr(line))
+                raise InvalidURLError(path.encode(errors="surrogateescape").decode('latin1'))
 
         # read headers
         (

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -588,7 +588,7 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
             url = URL(path, encoded=True)
             if url.scheme == "":
                 # not absolute-form
-                raise InvalidURLError(line)
+                raise InvalidURLError(repr(line))
 
         # read headers
         (

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -34,6 +34,7 @@ from .http_exceptions import (
     ContentEncodingError,
     ContentLengthError,
     InvalidHeader,
+    InvalidURLError,
     LineTooLong,
     TransferEncodingError,
 )
@@ -587,7 +588,7 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
             url = URL(path, encoded=True)
             if url.scheme == "":
                 # not absolute-form
-                raise BadStatusLine(line)
+                raise InvalidURLError(line)
 
         # read headers
         (

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -103,7 +103,7 @@ class TestInvalidHeader:
     def test_ctor(self) -> None:
         err = http_exceptions.InvalidHeader("X-Spam")
         assert err.code == 400
-        assert err.message == "Invalid HTTP header: X-Spam"
+        assert err.message == "Invalid HTTP header: 'X-Spam'"
         assert err.headers is None
 
     def test_pickle(self) -> None:
@@ -113,17 +113,17 @@ class TestInvalidHeader:
             pickled = pickle.dumps(err, proto)
             err2 = pickle.loads(pickled)
             assert err2.code == 400
-            assert err2.message == "Invalid HTTP header: X-Spam"
+            assert err2.message == "Invalid HTTP header: 'X-Spam'"
             assert err2.headers is None
             assert err2.foo == "bar"
 
     def test_str(self) -> None:
         err = http_exceptions.InvalidHeader(hdr="X-Spam")
-        assert str(err) == "400, message:\n  Invalid HTTP header: X-Spam"
+        assert str(err) == "400, message:\n  Invalid HTTP header: 'X-Spam'"
 
     def test_repr(self) -> None:
         err = http_exceptions.InvalidHeader(hdr="X-Spam")
-        expected = "<InvalidHeader: 400, message='Invalid HTTP header: X-Spam'>"
+        expected = "<InvalidHeader: 400, message=\"Invalid HTTP header: 'X-Spam'\">"
         assert repr(err) == expected
 
 

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -103,7 +103,7 @@ class TestInvalidHeader:
     def test_ctor(self) -> None:
         err = http_exceptions.InvalidHeader("X-Spam")
         assert err.code == 400
-        assert err.message == "Invalid HTTP Header: X-Spam"
+        assert err.message == "Invalid HTTP header: X-Spam"
         assert err.headers is None
 
     def test_pickle(self) -> None:
@@ -113,17 +113,17 @@ class TestInvalidHeader:
             pickled = pickle.dumps(err, proto)
             err2 = pickle.loads(pickled)
             assert err2.code == 400
-            assert err2.message == "Invalid HTTP Header: X-Spam"
+            assert err2.message == "Invalid HTTP header: X-Spam"
             assert err2.headers is None
             assert err2.foo == "bar"
 
     def test_str(self) -> None:
         err = http_exceptions.InvalidHeader(hdr="X-Spam")
-        assert str(err) == "400, message:\n  Invalid HTTP Header: X-Spam"
+        assert str(err) == "400, message:\n  Invalid HTTP header: X-Spam"
 
     def test_repr(self) -> None:
         err = http_exceptions.InvalidHeader(hdr="X-Spam")
-        expected = "<InvalidHeader: 400, message='Invalid HTTP Header: X-Spam'>"
+        expected = "<InvalidHeader: 400, message='Invalid HTTP header: X-Spam'>"
         assert repr(err) == expected
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -186,9 +186,6 @@ def test_bad_headers(parser: Any, hdr: str) -> None:
 
 
 def test_unpaired_surrogate_in_header(parser: Any) -> None:
-    """Test that the text of the exception raised for an unpaired surrogate
-       in a header does not itself contain unpaired surrogates.
-    """
     text = b"POST / HTTP/1.1\r\n\xff\r\n\r\n"
     message = None
     try:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -741,7 +741,7 @@ def test_http_request_parser_bad_version_number(parser: Any) -> None:
 
 
 def test_http_request_parser_bad_uri(parser: Any) -> None:
-    with pytest.raises(http_exceptions.BadStatusLine):
+    with pytest.raises(http_exceptions.InvalidURLError):
         parser.feed_data(b"GET ! HTTP/1.1\r\n\r\n")
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -740,9 +740,14 @@ def test_http_request_parser_bad_version_number(parser: Any) -> None:
         parser.feed_data(b"GET /test HTTP/1.32\r\n\r\n")
 
 
-def test_http_request_parser_bad_uri(parser: Any) -> None:
+def test_http_request_parser_bad_ascii_uri(parser: Any) -> None:
     with pytest.raises(http_exceptions.InvalidURLError):
         parser.feed_data(b"GET ! HTTP/1.1\r\n\r\n")
+
+
+def test_http_request_parser_bad_nonascii_uri(parser: Any) -> None:
+    with pytest.raises(http_exceptions.InvalidURLError):
+        parser.feed_data(b"GET \xff HTTP/1.1\r\n\r\n")
 
 
 @pytest.mark.parametrize("size", [40965, 8191])

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -740,6 +740,11 @@ def test_http_request_parser_bad_version_number(parser: Any) -> None:
         parser.feed_data(b"GET /test HTTP/1.32\r\n\r\n")
 
 
+def test_http_request_parser_bad_uri(parser: Any) -> None:
+    with pytest.raises(http_exceptions.BadStatusLine):
+        parser.feed_data(b"GET ! HTTP/1.1\r\n\r\n")
+
+
 @pytest.mark.parametrize("size", [40965, 8191])
 def test_http_request_max_status_line(parser: Any, size: Any) -> None:
     path = b"t" * (size - 5)

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -185,7 +185,14 @@ def test_bad_headers(parser: Any, hdr: str) -> None:
         parser.feed_data(text)
 
 
-def test_unpaired_surrogate_in_header(parser: Any) -> None:
+def test_unpaired_surrogate_in_header_py(loop: Any, protocol: Any) -> None:
+    parser = HttpRequestParserPy(
+        protocol,
+        loop,
+        2**16,
+        max_line_size=8190,
+        max_field_size=8190,
+    )
     text = b"POST / HTTP/1.1\r\n\xff\r\n\r\n"
     message = None
     try:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -185,6 +185,19 @@ def test_bad_headers(parser: Any, hdr: str) -> None:
         parser.feed_data(text)
 
 
+def test_unpaired_surrogate_in_header(parser: Any) -> None:
+    """Test that the text of the exception raised for an unpaired surrogate
+       in a header does not itself contain unpaired surrogates.
+    """
+    text = b"POST / HTTP/1.1\r\n\xff\r\n\r\n"
+    message = None
+    try:
+        parser.feed_data(text)
+    except http_exceptions.InvalidHeader as e:
+        message = e.message.encode("utf-8")
+    assert message is not None
+
+
 def test_content_length_transfer_encoding(parser: Any) -> None:
     text = (
         b"GET / HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\nTransfer-Encoding: a\r\n\r\n"

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -187,7 +187,7 @@ def test_bad_headers(parser: Any, hdr: str) -> None:
 
 def test_unpaired_surrogate_in_header(parser: Any) -> None:
     """Test that the text of the exception raised for an unpaired surrogate
-       in a header does not itself contain unpaired surrogates.
+    in a header does not itself contain unpaired surrogates.
     """
     text = b"POST / HTTP/1.1\r\n\xff\r\n\r\n"
     message = None


### PR DESCRIPTION
## What do these changes do?

Fixes an unhandled exception in the Python HTTP parser that causes servers to 500 when they should 400 upon receiving a header with an invalid Unicode sequence.

## Are there changes in behavior for the user?

Nope.

## Related issue number

Fixes #7715