### PR TITLE
Redesign shutdown process

### DIFF
--- a/CHANGES/7718.feature
+++ b/CHANGES/7718.feature
@@ -1,0 +1,3 @@
+Fixed keep-alive connections stopping a graceful shutdown.
+Added ``shutdown_timeout`` parameter to ``BaseRunner``, while
+removing ``shutdown_timeout`` parameter from ``BaseSite``. -- by :user:`Dreamsorcerer`

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -304,6 +304,7 @@ async def _run_app(
         access_log_format=access_log_format,
         access_log=access_log,
         keepalive_timeout=keepalive_timeout,
+        shutdown_timeout=shutdown_timeout,
         handler_cancellation=handler_cancellation,
     )
 
@@ -319,7 +320,6 @@ async def _run_app(
                         runner,
                         host,
                         port,
-                        shutdown_timeout=shutdown_timeout,
                         ssl_context=ssl_context,
                         backlog=backlog,
                         reuse_address=reuse_address,
@@ -333,7 +333,6 @@ async def _run_app(
                             runner,
                             h,
                             port,
-                            shutdown_timeout=shutdown_timeout,
                             ssl_context=ssl_context,
                             backlog=backlog,
                             reuse_address=reuse_address,
@@ -345,7 +344,6 @@ async def _run_app(
                 TCPSite(
                     runner,
                     port=port,
-                    shutdown_timeout=shutdown_timeout,
                     ssl_context=ssl_context,
                     backlog=backlog,
                     reuse_address=reuse_address,
@@ -359,7 +357,6 @@ async def _run_app(
                     UnixSite(
                         runner,
                         path,
-                        shutdown_timeout=shutdown_timeout,
                         ssl_context=ssl_context,
                         backlog=backlog,
                     )
@@ -370,7 +367,6 @@ async def _run_app(
                         UnixSite(
                             runner,
                             p,
-                            shutdown_timeout=shutdown_timeout,
                             ssl_context=ssl_context,
                             backlog=backlog,
                         )
@@ -382,7 +378,6 @@ async def _run_app(
                     SockSite(
                         runner,
                         sock,
-                        shutdown_timeout=shutdown_timeout,
                         ssl_context=ssl_context,
                         backlog=backlog,
                     )
@@ -393,7 +388,6 @@ async def _run_app(
                         SockSite(
                             runner,
                             s,
-                            shutdown_timeout=shutdown_timeout,
                             ssl_context=ssl_context,
                             backlog=backlog,
                         )

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -330,7 +330,7 @@ async def _run_app(
     # the time we have completed the application startup (in runner.setup()),
     # so we just record all running tasks here and exclude them later.
     starting_tasks: "WeakSet[asyncio.Task[object]]" = WeakSet(asyncio.all_tasks())
-    runner.pre_shutdown_callback = partial(wait, starting_tasks, shutdown_timeout)
+    runner.shutdown_callback = partial(wait, starting_tasks, shutdown_timeout)
 
     sites: List[BaseSite] = []
 

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -298,12 +298,16 @@ async def _run_app(
         starting_tasks: "WeakSet[asyncio.Task[object]]", shutdown_timeout: float
     ) -> None:
         # Wait for pending tasks for a given time limit.
-        starting_tasks.add(asyncio.current_task())
+        t = asyncio.current_task()
+        assert t is not None
+        starting_tasks.add(t)
         with suppress(asyncio.TimeoutError):
             await asyncio.wait_for(_wait(starting_tasks), timeout=shutdown_timeout)
 
     async def _wait(exclude: "WeakSet[asyncio.Task[object]]") -> None:
-        exclude.add(asyncio.current_task())
+        t = asyncio.current_task()
+        assert t is not None
+        exclude.add(t)
         while tasks := asyncio.all_tasks().difference(exclude):
             await asyncio.wait(tasks)
 

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -84,7 +84,6 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
         "_subapps",
         "_on_response_prepare",
         "_on_startup",
-        "_on_pre_shutdown",
         "_on_shutdown",
         "_on_cleanup",
         "_client_max_size",
@@ -124,7 +123,6 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
 
         self._on_response_prepare: _RespPrepareSignal = Signal(self)
         self._on_startup: _AppSignal = Signal(self)
-        self._on_pre_shutdown: _AppSignal = Signal(self)
         self._on_shutdown: _AppSignal = Signal(self)
         self._on_cleanup: _AppSignal = Signal(self)
         self._cleanup_ctx = CleanupContext()
@@ -226,7 +224,6 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
         self._on_response_prepare.freeze()
         self._cleanup_ctx.freeze()
         self._on_startup.freeze()
-        self._on_pre_shutdown.freeze()
         self._on_shutdown.freeze()
         self._on_cleanup.freeze()
         self._middlewares_handlers = tuple(self._prepare_middleware())
@@ -275,7 +272,6 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
             appsig.append(handler)
 
         reg_handler("on_startup")
-        reg_handler("on_pre_shutdown")
         reg_handler("on_shutdown")
         reg_handler("on_cleanup")
 
@@ -324,10 +320,6 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
         return self._on_startup
 
     @property
-    def on_pre_shutdown(self) -> _AppSignal:
-        return self._on_pre_shutdown
-
-    @property
     def on_shutdown(self) -> _AppSignal:
         return self._on_shutdown
 
@@ -353,14 +345,6 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
         Should be called in the event loop along with the request handler.
         """
         await self.on_startup.send(self)
-
-    async def pre_shutdown(self) -> None:
-        """Causes on_pre_shutdown signal
-
-        Should be called before shutdown(), and before pausing to allow
-        running tasks to complete.
-        """
-        await self.on_pre_shutdown.send(self)
 
     async def shutdown(self) -> None:
         """Causes on_shutdown signal

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -226,6 +226,7 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
         self._on_response_prepare.freeze()
         self._cleanup_ctx.freeze()
         self._on_startup.freeze()
+        self._on_pre_shutdown.freeze()
         self._on_shutdown.freeze()
         self._on_cleanup.freeze()
         self._middlewares_handlers = tuple(self._prepare_middleware())
@@ -274,6 +275,7 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
             appsig.append(handler)
 
         reg_handler("on_startup")
+        reg_handler("on_pre_shutdown")
         reg_handler("on_shutdown")
         reg_handler("on_cleanup")
 

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -358,7 +358,7 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
         Should be called before shutdown(), and before pausing to allow
         running tasks to complete.
         """
-        await self.on_shutdown.send(self)
+        await self.on_pre_shutdown.send(self)
 
     async def shutdown(self) -> None:
         """Causes on_shutdown signal

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -73,9 +73,6 @@ class BaseSite(ABC):
         self._runner._check_site(self)
         if self._server is not None:  # Maybe not started yet
             self._server.close()
-            # named pipes do not have wait_closed property
-            if hasattr(self._server, "wait_closed"):
-                await self._server.wait_closed()
 
         self._runner._unreg_site(self)
 

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -313,7 +313,8 @@ class BaseRunner(ABC):
     async def cleanup(self) -> None:
         loop = asyncio.get_event_loop()
 
-        self._server.pre_shutdown()
+        if self._server is not None:
+            self._server.pre_shutdown()
         # The loop over sites is intentional, an exception on gather()
         # leaves self._sites in unpredictable state.
         # The loop guarantees that a site is either deleted on success or

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -234,9 +234,22 @@ class SockSite(BaseSite):
 
 
 class BaseRunner(ABC):
-    __slots__ = ("starting_tasks", "_handle_signals", "_kwargs", "_server", "_sites", "_shutdown_timeout")
+    __slots__ = (
+        "starting_tasks",
+        "_handle_signals",
+        "_kwargs",
+        "_server",
+        "_sites",
+        "_shutdown_timeout",
+    )
 
-    def __init__(self, *, handle_signals: bool = False, shutdown_timeout: float = 60.0, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *,
+        handle_signals: bool = False,
+        shutdown_timeout: float = 60.0,
+        **kwargs: Any,
+    ) -> None:
         self._handle_signals = handle_signals
         self._kwargs = kwargs
         self._server: Optional[Server] = None

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -74,13 +74,11 @@ class BaseSite(ABC):
 
     async def stop(self) -> None:
         self._runner._check_site(self)
-        if self._server is None:
-            self._runner._unreg_site(self)
-            return  # not started yet
-        self._server.close()
-        # named pipes do not have wait_closed property
-        if hasattr(self._server, "wait_closed"):
-            await self._server.wait_closed()
+        if self._server is not None:  # Maybe not started yet
+            self._server.close()
+            # named pipes do not have wait_closed property
+            if hasattr(self._server, "wait_closed"):
+                await self._server.wait_closed()
 
         self._runner._unreg_site(self)
 

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -313,6 +313,7 @@ class BaseRunner(ABC):
     async def cleanup(self) -> None:
         loop = asyncio.get_event_loop()
 
+        self._server.pre_shutdown()
         # The loop over sites is intentional, an exception on gather()
         # leaves self._sites in unpredictable state.
         # The loop guarantees that a site is either deleted on success or

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -2,7 +2,6 @@ import asyncio
 import signal
 import socket
 from abc import ABC, abstractmethod
-from contextlib import suppress
 from typing import Any, Awaitable, Callable, List, Optional, Set, Type
 
 from yarl import URL

--- a/aiohttp/web_server.py
+++ b/aiohttp/web_server.py
@@ -61,8 +61,12 @@ class Server:
     ) -> BaseRequest:
         return BaseRequest(message, payload, protocol, writer, task, self._loop)
 
+    def pre_shutdown(self) -> None:
+        for conn in self._connections:
+            conn.close()
+
     async def shutdown(self, timeout: Optional[float] = None) -> None:
-        coros = [conn.shutdown(timeout) for conn in self._connections]
+        coros = (conn.shutdown(timeout) for conn in self._connections)
         await asyncio.gather(*coros)
         self._connections.clear()
 

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -86,6 +86,7 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
                 access_log_format=self._get_valid_log_format(
                     self.cfg.access_log_format
                 ),
+                shutdown_timeout=self.cfg.graceful_timeout / 100 * 95,
             )
         await runner.setup()
 
@@ -99,7 +100,6 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
                 runner,
                 sock,
                 ssl_context=ctx,
-                shutdown_timeout=self.cfg.graceful_timeout / 100 * 95,
             )
             await site.start()
 

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -928,7 +928,7 @@ Stopping *aiohttp web server* by just closing all connections is not
 always satisfactory.
 
 When aiohttp is run with :func:`run_app`, it will attempt a graceful shutdown
-by following these steps (if using a :ref:`runner<aiohttp-web-app-runners>`,
+by following these steps (if using a :ref:`runner <aiohttp-web-app-runners>`,
 then calling :meth:`AppRunner.cleanup` will perform these steps, excluding
 steps 4 and 7).
 

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -927,25 +927,38 @@ Graceful shutdown
 Stopping *aiohttp web server* by just closing all connections is not
 always satisfactory.
 
-The first thing aiohttp will do is to stop listening on the sockets,
-so new connections will be rejected. It will then wait a few
-seconds to allow any pending tasks to complete before continuing
-with application shutdown. The timeout can be adjusted with
-``shutdown_timeout`` in :func:`run_app`.
+When aiohttp is run with :func:`run_app`, it will attempt a graceful shutdown
+by following these steps (if using a :ref:`runner<_aiohttp-web-app-runners>`,
+then calling :meth:`AppRunner.cleanup` will perform these steps, excluding
+steps 4 and 7).
 
-Another problem is if the application supports :term:`websockets <websocket>` or
-*data streaming* it most likely has open connections at server
-shutdown time.
+1. Stop each site listening on sockets, so new connections will be rejected.
+2. Close idle keep-alive connections (and set active ones to close upon completion).
+3. Call the :attr:`Application.on_shutdown` signal. This should be used to shutdown
+   long-lived connections, such as websockets (see below).
+4. Wait a short time for running tasks to complete. This allows any pending handlers
+   or background tasks to complete successfully. The timeout can be adjusted with
+   ``shutdown_timeout`` in :func:`run_app`.
+5. Close any remaining connections and cancel their handlers. It will wait on the
+   cancelling handlers for a short time, again adjustable with ``shutdown_timeout``.
+6. Call the :attr:`Application.on_cleanup` signal. This should be used to cleanup any
+   resources (such as DB connections). This includes completing the
+   :ref:`cleanup contexts<_aiohttp-web-cleanup-ctx>`.
+7. Cancel any remaining tasks and wait on them to complete.
 
-The *library* has no knowledge how to close them gracefully but
-developer can help by registering :attr:`Application.on_shutdown`
-signal handler and call the signal on *web server* closing.
+Websocket shutdown
+^^^^^^^^^^^^^^^^^^
 
-Developer should keep a list of opened connections
+One problem is if the application supports :term:`websockets <websocket>` or
+*data streaming* it most likely has open connections at server shutdown time.
+
+The *library* has no knowledge how to close them gracefully but a developer can
+help by registering an :attr:`Application.on_shutdown` signal handler.
+
+A developer should keep a list of opened connections
 (:class:`Application` is a good candidate).
 
-The following :term:`websocket` snippet shows an example for websocket
-handler::
+The following :term:`websocket` snippet shows an example of a websocket handler::
 
     from aiohttp import web
     import weakref
@@ -967,19 +980,15 @@ handler::
 
         return ws
 
-Signal handler may look like::
+Then the signal handler may look like::
 
     from aiohttp import WSCloseCode
 
     async def on_shutdown(app):
         for ws in set(app[websockets]):
-            await ws.close(code=WSCloseCode.GOING_AWAY,
-                           message='Server shutdown')
+            await ws.close(code=WSCloseCode.GOING_AWAY, message="Server shutdown")
 
     app.on_shutdown.append(on_shutdown)
-
-Both :func:`run_app` and :meth:`AppRunner.cleanup` call shutdown
-signal handlers.
 
 .. _aiohttp-web-ceil-absolute-timeout:
 

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -928,7 +928,7 @@ Stopping *aiohttp web server* by just closing all connections is not
 always satisfactory.
 
 When aiohttp is run with :func:`run_app`, it will attempt a graceful shutdown
-by following these steps (if using a :ref:`runner<_aiohttp-web-app-runners>`,
+by following these steps (if using a :ref:`runner<aiohttp-web-app-runners>`,
 then calling :meth:`AppRunner.cleanup` will perform these steps, excluding
 steps 4 and 7).
 
@@ -940,10 +940,10 @@ steps 4 and 7).
    or background tasks to complete successfully. The timeout can be adjusted with
    ``shutdown_timeout`` in :func:`run_app`.
 5. Close any remaining connections and cancel their handlers. It will wait on the
-   cancelling handlers for a short time, again adjustable with ``shutdown_timeout``.
+   canceling handlers for a short time, again adjustable with ``shutdown_timeout``.
 6. Call the :attr:`Application.on_cleanup` signal. This should be used to cleanup any
    resources (such as DB connections). This includes completing the
-   :ref:`cleanup contexts<_aiohttp-web-cleanup-ctx>`.
+   :ref:`cleanup contexts<aiohttp-web-cleanup-ctx>`.
 7. Cancel any remaining tasks and wait on them to complete.
 
 Websocket shutdown

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -20,11 +20,6 @@ from aiohttp import ClientConnectorError, ClientSession, web
 from aiohttp.test_utils import make_mocked_coro
 from aiohttp.web_runner import BaseRunner
 
-if sys.version_info >= (3, 11):
-    import asyncio as async_timeout
-else:
-    import async_timeout
-
 _has_unix_domain_socks = hasattr(socket, "AF_UNIX")
 if _has_unix_domain_socks:
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as _abstract_path_sock:

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1168,6 +1168,7 @@ class TestShutdown:
                 await ws.close(code=WSCloseCode.GOING_AWAY)
 
         async def test() -> None:
+            await asyncio.sleep(1)
             async with ClientSession() as sess:
                 async with sess.ws_connect(f"http://localhost:{port}/ws") as ws:
                     async with sess.get(f"http://localhost:{port}/stop"):

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -20,11 +20,6 @@ from aiohttp import ClientConnectorError, ClientSession, WSCloseCode, web
 from aiohttp.test_utils import make_mocked_coro
 from aiohttp.web_runner import BaseRunner
 
-if sys.version_info >= (3, 11):
-    import asyncio as async_timeout
-else:
-    import async_timeout
-
 _has_unix_domain_socks = hasattr(socket, "AF_UNIX")
 if _has_unix_domain_socks:
     with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as _abstract_path_sock:

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1189,7 +1189,7 @@ class TestShutdown:
         t = None
         app = web.Application()
         app[WS] = set()
-        app.on_pre_shutdown.append(close_websockets)
+        app.on_shutdown.append(close_websockets)
         app.cleanup_ctx.append(run_test)
         app.router.add_get("/ws", ws_handler)
         app.router.add_get("/stop", self.stop)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -79,6 +79,7 @@ def test_run(
     worker.cfg = mock.Mock()
     worker.cfg.access_log_format = ACCEPTABLE_LOG_FORMAT
     worker.cfg.is_ssl = False
+    worker.cfg.graceful_timeout = 100
     worker.sockets = []
 
     worker.loop = loop
@@ -95,6 +96,7 @@ def test_run_async_factory(
     worker.cfg = mock.Mock()
     worker.cfg.access_log_format = ACCEPTABLE_LOG_FORMAT
     worker.cfg.is_ssl = False
+    worker.cfg.graceful_timeout = 100
     worker.sockets = []
     app = worker.wsgi
 


### PR DESCRIPTION
This contains a few changes to rework the shutdown process to be a bit clearer and better match user expectations.

To summarise, I'm proposing the shutdown process should look like this now:

1. Stop each site listening for new connections.
2. Close idle keep-alive connections (and set active ones to close upon completion).
3. Call on_shutdown signal (should be used to close websocket connections).
4. Wait for running tasks to complete (with timeout).
5. Close any remaining connections (with timeout again).
6. Call on_cleanup signal.
7. Cancel any remaining tasks and wait on them.

Docs demo preview: https://aiohttp--7718.org.readthedocs.build/en/7718/web_advanced.html#graceful-shutdown