### PR TITLE
Stop accepting `\x80-\xff` in header names; stop accepting `\n` as separating whitespace in status-lines

### DIFF
--- a/CHANGES/7719.bugfix
+++ b/CHANGES/7719.bugfix
@@ -1,0 +1,1 @@
+Update parser to disallow invalid characters in header field names and stop accepting LF as a request line separator.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -66,7 +66,9 @@ ASCIISET: Final[Set[str]] = set(string.printable)
 METHRE: Final[Pattern[str]] = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
 VERSRE: Final[Pattern[str]] = re.compile(r"HTTP/(\d).(\d)")
 STATUSLINESEP: Final[Pattern[str]] = re.compile(r"[ \t\v\f\r]+")
-HDRRE: Final[Pattern[bytes]] = re.compile(rb"[\x00-\x1F\x7F-\xFF()<>@,;:\[\]={} \t\"\\]")
+HDRRE: Final[Pattern[bytes]] = re.compile(
+    rb"[\x00-\x1F\x7F-\xFF()<>@,;:\[\]={} \t\"\\]"
+)
 HEXDIGIT = re.compile(rb"[0-9a-fA-F]+")
 
 

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -65,7 +65,8 @@ ASCIISET: Final[Set[str]] = set(string.printable)
 #     token = 1*tchar
 METHRE: Final[Pattern[str]] = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
 VERSRE: Final[Pattern[str]] = re.compile(r"HTTP/(\d).(\d)")
-HDRRE: Final[Pattern[bytes]] = re.compile(rb"[\x00-\x1F\x7F()<>@,;:\[\]={} \t\"\\]")
+STATUSLINESEP: Final[Pattern[str]] = re.compile(r"[ \t\v\f\r]+")
+HDRRE: Final[Pattern[bytes]] = re.compile(rb"[\x00-\x1F\x7F-\xFF()<>@,;:\[\]={} \t\"\\]")
 HEXDIGIT = re.compile(rb"[0-9a-fA-F]+")
 
 
@@ -540,7 +541,7 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
         # request line
         line = lines[0].decode("utf-8", "surrogateescape")
         try:
-            method, path, version = line.split(maxsplit=2)
+            method, path, version = re.split(STATUSLINESEP, line, maxsplit=2)
         except ValueError:
             raise BadStatusLine(line) from None
 

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -65,7 +65,6 @@ ASCIISET: Final[Set[str]] = set(string.printable)
 #     token = 1*tchar
 METHRE: Final[Pattern[str]] = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
 VERSRE: Final[Pattern[str]] = re.compile(r"HTTP/(\d).(\d)")
-STATUSLINESEP: Final[Pattern[str]] = re.compile(r"[ \t\v\f\r]+")
 HDRRE: Final[Pattern[bytes]] = re.compile(
     rb"[\x00-\x1F\x7F-\xFF()<>@,;:\[\]={} \t\"\\]"
 )
@@ -543,7 +542,7 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
         # request line
         line = lines[0].decode("utf-8", "surrogateescape")
         try:
-            method, path, version = re.split(STATUSLINESEP, line, maxsplit=2)
+            method, path, version = line.split(" ", maxsplit=2)
         except ValueError:
             raise BadStatusLine(line) from None
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -664,7 +664,7 @@ def test_http_request_bad_status_line(parser: Any) -> None:
 
 def test_http_request_bad_status_line_whitespace(parser: Any) -> None:
     text = b"GET\npathn\nHTTP/1.1\r\n\r\n"
-    with pytest.raises(http_exceptions.BadStatusLine) as exc_info:
+    with pytest.raises(http_exceptions.BadStatusLine):
         parser.feed_data(text)
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -663,7 +663,7 @@ def test_http_request_bad_status_line(parser: Any) -> None:
 
 
 def test_http_request_bad_status_line_whitespace(parser: Any) -> None:
-    text = b"GET\npathn\nHTTP/1.1\r\n\r\n"
+    text = b"GET\n/path\fHTTP/1.1\r\n\r\n"
     with pytest.raises(http_exceptions.BadStatusLine):
         parser.feed_data(text)
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -177,6 +177,7 @@ def test_cve_2023_37276(parser: Any) -> None:
         "Baz: abc\x00def",
         "Foo : bar",  # https://www.rfc-editor.org/rfc/rfc9112.html#section-5.1-2
         "Foo\t: bar",
+        "\xffoo: bar",
     ),
 )
 def test_bad_headers(parser: Any, hdr: str) -> None:
@@ -659,6 +660,12 @@ def test_http_request_bad_status_line(parser: Any) -> None:
         parser.feed_data(text)
     # Check for accidentally escaped message.
     assert r"\n" not in exc_info.value.message
+
+
+def test_http_request_bad_status_line_whitespace(parser: Any) -> None:
+    text = b"GET\npathn\nHTTP/1.1\r\n\r\n"
+    with pytest.raises(http_exceptions.BadStatusLine) as exc_info:
+        parser.feed_data(text)
 
 
 def test_http_request_upgrade(parser: Any) -> None:


### PR DESCRIPTION
## What do these changes do?

This PR updates the python HTTP parser to stop accepting `\x80-\xff` in header names and stop accepting `\n` as separating whitespace in status-lines. Both of these are not allowed in the RFCs.

## Are there changes in behavior for the user?

Only users of seriously misbehaving clients would notice a change in behavior for this patch. If a client sends non-ascii UTF-8 within header names, their messages will now 400. Note that (nearly) arbitrary values are still allowed within header values. Most HTTP servers (Apache, Nginx, IIS, Node) do not accept UTF-8 within header names because of the risk of control character injection.