### PR TITLE
Backport 493f06797654c383242f0e8007f6e06b818a1fbc to 3.9

### DIFF
--- a/CHANGES/7719.bugfix
+++ b/CHANGES/7719.bugfix
@@ -1,0 +1,1 @@
+Update parser to disallow invalid characters in header field names and stop accepting LF as a request line separator.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -65,7 +65,9 @@ ASCIISET: Final[Set[str]] = set(string.printable)
 #     token = 1*tchar
 METHRE: Final[Pattern[str]] = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
 VERSRE: Final[Pattern[str]] = re.compile(r"HTTP/(\d).(\d)")
-HDRRE: Final[Pattern[bytes]] = re.compile(rb"[\x00-\x1F\x7F()<>@,;:\[\]={} \t\"\\]")
+HDRRE: Final[Pattern[bytes]] = re.compile(
+    rb"[\x00-\x1F\x7F-\xFF()<>@,;:\[\]={} \t\"\\]"
+)
 HEXDIGIT = re.compile(rb"[0-9a-fA-F]+")
 
 
@@ -547,7 +549,7 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
         # request line
         line = lines[0].decode("utf-8", "surrogateescape")
         try:
-            method, path, version = line.split(maxsplit=2)
+            method, path, version = line.split(" ", maxsplit=2)
         except ValueError:
             raise BadStatusLine(line) from None
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -178,6 +178,7 @@ def test_cve_2023_37276(parser: Any) -> None:
         "Baz: abc\x00def",
         "Foo : bar",  # https://www.rfc-editor.org/rfc/rfc9112.html#section-5.1-2
         "Foo\t: bar",
+        "\xffoo: bar",
     ),
 )
 def test_bad_headers(parser: Any, hdr: str) -> None:
@@ -679,7 +680,13 @@ def test_http_request_bad_status_line(parser) -> None:
     assert r"\n" not in exc_info.value.message
 
 
-def test_http_request_upgrade(parser) -> None:
+def test_http_request_bad_status_line_whitespace(parser: Any) -> None:
+    text = b"GET\n/path\fHTTP/1.1\r\n\r\n"
+    with pytest.raises(http_exceptions.BadStatusLine):
+        parser.feed_data(text)
+
+
+def test_http_request_upgrade(parser: Any) -> None:
     text = (
         b"GET /test HTTP/1.1\r\n"
         b"connection: upgrade\r\n"


### PR DESCRIPTION
Backports 493f06797654c383242f0e8007f6e06b818a1fbc to 3.9