### PR TITLE
Make regex range more explicit

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1033,7 +1033,7 @@ def populate_with_cookies(
 
 
 # https://tools.ietf.org/html/rfc7232#section-2.3
-_ETAGC = r"[!#-}\x80-\xff]+"
+_ETAGC = r"[!\x23-\x7E\x80-\xff]+"
 _ETAGC_RE = re.compile(_ETAGC)
 _QUOTED_ETAG = rf'(W/)?"({_ETAGC})"'
 QUOTED_ETAG_RE = re.compile(_QUOTED_ETAG)


### PR DESCRIPTION
It appears that 1 character was also missing from the range before (~, which is 0x7E), when comparing to the spec.
This is easier to compare to the spec and resolves a codeql issue.