### PR TITLE
Fix py http parser not treating 204/304/1xx as an empty body

### DIFF
--- a/CHANGES/7755.bugfix
+++ b/CHANGES/7755.bugfix
@@ -1,0 +1,1 @@
+Fix py http parser not treating 204/304/1xx as an empty body

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -527,7 +527,7 @@ class ClientSession:
                     assert conn.protocol is not None
                     conn.protocol.set_response_params(
                         timer=timer,
-                        skip_payload=method_must_be_empty_body(method.upper()),
+                        skip_payload=method_must_be_empty_body(method),
                         read_until_eof=read_until_eof,
                         auto_decompress=auto_decompress,
                         read_timeout=real_timeout.sock_read,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -81,6 +81,7 @@ from .helpers import (
     TimeoutHandle,
     ceil_timeout,
     get_env_proxy_for_url,
+    method_must_be_empty_body,
     sentinel,
     strip_auth_from_url,
 )
@@ -526,8 +527,7 @@ class ClientSession:
                     assert conn.protocol is not None
                     conn.protocol.set_response_params(
                         timer=timer,
-                        skip_payload=method.upper()
-                        in (hdrs.METH_CONNECT, hdrs.METH_HEAD),
+                        skip_payload=method_must_be_empty_body(method.upper()),
                         read_until_eof=read_until_eof,
                         auto_decompress=auto_decompress,
                         read_timeout=real_timeout.sock_read,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -526,7 +526,8 @@ class ClientSession:
                     assert conn.protocol is not None
                     conn.protocol.set_response_params(
                         timer=timer,
-                        skip_payload=method.upper() == "HEAD",
+                        skip_payload=method.upper()
+                        in (hdrs.METH_CONNECT, hdrs.METH_HEAD),
                         read_until_eof=read_until_eof,
                         auto_decompress=auto_decompress,
                         read_timeout=real_timeout.sock_read,

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -9,7 +9,12 @@ from .client_exceptions import (
     ServerDisconnectedError,
     ServerTimeoutError,
 )
-from .helpers import BaseTimerContext, set_exception, set_result
+from .helpers import (
+    BaseTimerContext,
+    set_exception,
+    set_result,
+    status_code_must_be_empty_body,
+)
 from .http import HttpResponseParser, RawResponseMessage, WebSocketReader
 from .streams import EMPTY_PAYLOAD, DataQueue, StreamReader
 
@@ -248,10 +253,8 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
 
                     self._payload = payload
 
-                    if (
-                        self._skip_payload
-                        or message.code in (204, 304)
-                        or 100 <= message.code < 200
+                    if self._skip_payload or status_code_must_be_empty_body(
+                        message.code
                     ):
                         self.feed_data((message, EMPTY_PAYLOAD), 0)
                     else:

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -248,7 +248,11 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
 
                     self._payload = payload
 
-                    if self._skip_payload or message.code in (204, 304):
+                    if (
+                        self._skip_payload
+                        or message.code in (204, 304)
+                        or 100 <= message.code < 200
+                    ):
                         self.feed_data((message, EMPTY_PAYLOAD), 0)
                     else:
                         self.feed_data((message, payload), 0)

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1063,3 +1063,22 @@ def parse_http_date(date_str: Optional[str]) -> Optional[datetime.datetime]:
             with suppress(ValueError):
                 return datetime.datetime(*timetuple[:6], tzinfo=datetime.timezone.utc)
     return None
+
+
+def must_be_empty_body(method: str, code: int) -> bool:
+    """Check if a request must return an empty body."""
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
+    return status_code_must_be_empty_body(code) or method_must_be_empty_body(method)
+
+
+def method_must_be_empty_body(method: str) -> bool:
+    """Check if a method must return an empty body."""
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
+    return method in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
+
+
+def status_code_must_be_empty_body(code: int) -> bool:
+    """Check if a status code must return an empty body."""
+    # 204, 304, 1xx should not have a body per
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
+    return code in (204, 304) or 100 <= code < 200

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1067,18 +1067,17 @@ def parse_http_date(date_str: Optional[str]) -> Optional[datetime.datetime]:
 
 def must_be_empty_body(method: str, code: int) -> bool:
     """Check if a request must return an empty body."""
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
     return status_code_must_be_empty_body(code) or method_must_be_empty_body(method)
 
 
 def method_must_be_empty_body(method: str) -> bool:
     """Check if a method must return an empty body."""
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.2
     return method in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
 
 
 def status_code_must_be_empty_body(code: int) -> bool:
     """Check if a status code must return an empty body."""
-    # 204, 304, 1xx should not have a body per
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
-    return code in (204, 304) or 100 <= code < 200
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
+    return code in {204, 304} or 100 <= code < 200

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1074,6 +1074,5 @@ def method_must_be_empty_body(method: str) -> bool:
 
 def status_code_must_be_empty_body(code: int) -> bool:
     """Check if a status code must return an empty body."""
-    # 204, 304, 1xx should not have a body per
     # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
     return code in {204, 304} or 100 <= code < 200

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1074,7 +1074,7 @@ def method_must_be_empty_body(method: str) -> bool:
     """Check if a method must return an empty body."""
     # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
     # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.2
-    return method in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
+    return method.upper() in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
 
 
 def status_code_must_be_empty_body(code: int) -> bool:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1067,6 +1067,7 @@ def parse_http_date(date_str: Optional[str]) -> Optional[datetime.datetime]:
 
 def must_be_empty_body(method: str, code: int) -> bool:
     """Check if a request must return an empty body."""
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
     return status_code_must_be_empty_body(code) or method_must_be_empty_body(method)
 
 
@@ -1079,5 +1080,6 @@ def method_must_be_empty_body(method: str) -> bool:
 
 def status_code_must_be_empty_body(code: int) -> bool:
     """Check if a status code must return an empty body."""
+    # 204, 304, 1xx should not have a body per
     # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
     return code in {204, 304} or 100 <= code < 200

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1067,18 +1067,17 @@ def parse_http_date(date_str: Optional[str]) -> Optional[datetime.datetime]:
 
 def must_be_empty_body(method: str, code: int) -> bool:
     """Check if a request must return an empty body."""
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
     return status_code_must_be_empty_body(code) or method_must_be_empty_body(method)
 
 
 def method_must_be_empty_body(method: str) -> bool:
     """Check if a method must return an empty body."""
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
-    return method in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.2
+    return method.upper() in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
 
 
 def status_code_must_be_empty_body(code: int) -> bool:
     """Check if a status code must return an empty body."""
-    # 204, 304, 1xx should not have a body per
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
-    return code in (204, 304) or 100 <= code < 200
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
+    return code in {204, 304} or 100 <= code < 200

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1067,17 +1067,18 @@ def parse_http_date(date_str: Optional[str]) -> Optional[datetime.datetime]:
 
 def must_be_empty_body(method: str, code: int) -> bool:
     """Check if a request must return an empty body."""
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
     return status_code_must_be_empty_body(code) or method_must_be_empty_body(method)
 
 
 def method_must_be_empty_body(method: str) -> bool:
     """Check if a method must return an empty body."""
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.2
-    return method.upper() in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
+    return method in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
 
 
 def status_code_must_be_empty_body(code: int) -> bool:
     """Check if a status code must return an empty body."""
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
-    return code in {204, 304} or 100 <= code < 200
+    # 204, 304, 1xx should not have a body per
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
+    return code in (204, 304) or 100 <= code < 200

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1065,12 +1065,6 @@ def parse_http_date(date_str: Optional[str]) -> Optional[datetime.datetime]:
     return None
 
 
-def must_be_empty_body(method: str, code: int) -> bool:
-    """Check if a request must return an empty body."""
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
-    return status_code_must_be_empty_body(code) or method_must_be_empty_body(method)
-
-
 def method_must_be_empty_body(method: str) -> bool:
     """Check if a method must return an empty body."""
     # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -345,10 +345,8 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         # calculate payload
                         # 204, 304, 1xx should not have a body per
                         # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
-                        code_indicates_empty_body = (
-                            code in (204, 304) or 100 <= code < 200
-                        )
-                        if not code_indicates_empty_body and (
+                        must_be_empty_body = code in (204, 304) or 100 <= code < 200
+                        if not must_be_empty_body and (
                             (length is not None and length > 0)
                             or msg.chunked
                             and not msg.upgrade
@@ -391,7 +389,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                                 lax=self.lax,
                             )
                         elif (
-                            not code_indicates_empty_body
+                            not must_be_empty_body
                             and length is None
                             and self.read_until_eof
                         ):

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -348,10 +348,9 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         code_indicates_empty_body = (
                             code in (204, 304) or 100 <= code < 200
                         )
-                        if (
-                            not code_indicates_empty_body
-                            and ((length is not None and length > 0) or msg.chunked)
-                            and not msg.upgrade
+                        if not code_indicates_empty_body and (
+                            (length is not None and length > 0)
+                            or (msg.chunked and not msg.upgrade)
                         ):
                             payload = StreamReader(
                                 self.protocol,

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -5,6 +5,7 @@ import string
 from contextlib import suppress
 from enum import IntEnum
 from typing import (
+    TYPE_CHECKING,
     Any,
     ClassVar,
     Final,
@@ -337,9 +338,13 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
 
                         self._upgraded = msg.upgrade
 
-                        method: str = getattr(msg, "method", self.method)
+                        method = getattr(msg, "method", self.method)
+                        if TYPE_CHECKING:
+                            assert isinstance(method, str)
                         # code is only present on responses
-                        code: int = getattr(msg, "code", 0)
+                        code = getattr(msg, "code", 0)
+                        if TYPE_CHECKING:
+                            assert isinstance(code, int)
 
                         assert self.protocol is not None
                         # calculate payload

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -337,9 +337,9 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
 
                         self._upgraded = msg.upgrade
 
-                        method = getattr(msg, "method", self.method)
+                        method: str = getattr(msg, "method", self.method)
                         # code is only present on responses
-                        code = getattr(msg, "code", 0)
+                        code: int = getattr(msg, "code", 0)
 
                         assert self.protocol is not None
                         # calculate payload

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -350,7 +350,8 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         )
                         if not code_indicates_empty_body and (
                             (length is not None and length > 0)
-                            or (msg.chunked and not msg.upgrade)
+                            or msg.chunked
+                            and not msg.upgrade
                         ):
                             payload = StreamReader(
                                 self.protocol,

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -345,7 +345,11 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         # calculate payload
                         # 204, 304, 1xx should not have a body per
                         # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
-                        must_be_empty_body = code in (204, 304) or 100 <= code < 200
+                        must_be_empty_body = (
+                            method in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
+                            or code in (204, 304)
+                            or 100 <= code < 200
+                        )
                         if not must_be_empty_body and (
                             (length is not None and length > 0)
                             or msg.chunked

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -5,7 +5,6 @@ import string
 from contextlib import suppress
 from enum import IntEnum
 from typing import (
-    TYPE_CHECKING,
     Any,
     ClassVar,
     Final,
@@ -20,6 +19,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
 )
 
 from multidict import CIMultiDict, CIMultiDictProxy, istr
@@ -339,12 +339,10 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         self._upgraded = msg.upgrade
 
                         method = getattr(msg, "method", self.method)
-                        if TYPE_CHECKING:
-                            assert isinstance(method, str)
+                        # assert method is not None
+                        method = cast(str, method)
                         # code is only present on responses
                         code = getattr(msg, "code", 0)
-                        if TYPE_CHECKING:
-                            assert isinstance(code, int)
 
                         assert self.protocol is not None
                         # calculate payload

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -349,8 +349,9 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                             code in (204, 304) or 100 <= code < 200
                         )
                         if (
-                            (length is not None and length > 0)
-                            or (msg.chunked and not code_indicates_empty_body)
+                            not code_indicates_empty_body
+                            and (length is not None and length > 0)
+                            or msg.chunked
                             and not msg.upgrade
                         ):
                             payload = StreamReader(

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -350,7 +350,11 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         assert self.protocol is not None
                         # calculate payload
                         empty_body = status_code_must_be_empty_body(code)
-                        if method and method_must_be_empty_body(method):
+                        if (
+                            not empty_body
+                            and method
+                            and method_must_be_empty_body(method)
+                        ):
                             empty_body = True
                         if not empty_body and (
                             (length is not None and length > 0)

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -350,10 +350,8 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         )
                         if (
                             not code_indicates_empty_body
-                            and (length is not None and length > 0)
-                            or msg.chunked
-                            and not msg.upgrade
-                        ):
+                            and ((length is not None and length > 0) or msg.chunked)
+                        ) and not msg.upgrade:
                             payload = StreamReader(
                                 self.protocol,
                                 timer=self.timer,

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -349,13 +349,9 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
 
                         assert self.protocol is not None
                         # calculate payload
-                        empty_body = status_code_must_be_empty_body(code)
-                        if (
-                            not empty_body
-                            and method
-                            and method_must_be_empty_body(method)
-                        ):
-                            empty_body = True
+                        empty_body = status_code_must_be_empty_body(code) or bool(
+                            method and method_must_be_empty_body(method)
+                        )
                         if not empty_body and (
                             (length is not None and length > 0)
                             or msg.chunked

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -351,7 +351,8 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         if (
                             not code_indicates_empty_body
                             and ((length is not None and length > 0) or msg.chunked)
-                        ) and not msg.upgrade:
+                            and not msg.upgrade
+                        ):
                             payload = StreamReader(
                                 self.protocol,
                                 timer=self.timer,

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1141,7 +1141,7 @@ def test_parse_content_length_than_chunked_payload(response: Any) -> None:
     assert b"second" == b"".join(d for d in payload._buffer)
 
 
-@pytest.mark.parametrize("code", [204, 304, 101, 102])
+@pytest.mark.parametrize("code", (204, 304, 101, 102))
 def test_parse_chunked_payload_empty_body_than_another_chunked(
     response: Any, code: int
 ) -> None:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1062,7 +1062,7 @@ def test_parse_no_length_payload(parser: Any) -> None:
 
 
 def test_parse_content_length_payload_multiple(response: Any) -> None:
-    text = b"HTTP/1.1 200 OK\r\n" b"content-length: 5\r\n\r\n" b"first"
+    text = b"HTTP/1.1 200 OK\r\ncontent-length: 5\r\n\r\nfirst"
     msg, payload = response.feed_data(text)[0][0]
     assert msg.version == HttpVersion(major=1, minor=1)
     assert msg.code == 200
@@ -1080,7 +1080,7 @@ def test_parse_content_length_payload_multiple(response: Any) -> None:
     assert payload.is_eof()
     assert b"first" == b"".join(d for d in payload._buffer)
 
-    text = b"HTTP/1.1 200 OK\r\n" b"content-length: 6\r\n\r\n" b"second"
+    text = b"HTTP/1.1 200 OK\r\ncontent-length: 6\r\n\r\nsecond"
     msg, payload = response.feed_data(text)[0][0]
     assert msg.version == HttpVersion(major=1, minor=1)
     assert msg.code == 200
@@ -1100,7 +1100,7 @@ def test_parse_content_length_payload_multiple(response: Any) -> None:
 
 
 def test_parse_content_length_than_chunked_payload(response: Any) -> None:
-    text = b"HTTP/1.1 200 OK\r\n" b"content-length: 5\r\n\r\n" b"first"
+    text = b"HTTP/1.1 200 OK\r\ncontent-length: 5\r\n\r\nfirst"
     msg, payload = response.feed_data(text)[0][0]
     assert msg.version == HttpVersion(major=1, minor=1)
     assert msg.code == 200


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

There was a disagreement on how to handle 204/304/1xx responses between the c parser and py parser.

204/304/1xx are now always treated as an empty body in the py parser to match the c parser and comply with
https://datatracker.ietf.org/doc/html/rfc9112#section-6.3

## Are there changes in behavior for the user?

A empty chunked response body `0\r\n\r\n` will no longer be read for 204, 203, 1xx responses when using the py parser. This matches the behavior of the c parser.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."


TODO: 

- [x] timeline
- [x] mypy
- [x] more functional testing