### PR TITLE
Ensure empty body response for 1xx/204/304 per RFC 9112 sec 6.3

### DIFF
--- a/CHANGES/7756.bugfix
+++ b/CHANGES/7756.bugfix
@@ -1,0 +1,1 @@
+Ensure empty body response for 1xx/204/304 per RFC 9112 sec 6.3

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1063,3 +1063,22 @@ def parse_http_date(date_str: Optional[str]) -> Optional[datetime.datetime]:
             with suppress(ValueError):
                 return datetime.datetime(*timetuple[:6], tzinfo=datetime.timezone.utc)
     return None
+
+
+def must_be_empty_body(method: str, code: int) -> bool:
+    """Check if a request must return an empty body."""
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
+    return status_code_must_be_empty_body(code) or method_must_be_empty_body(method)
+
+
+def method_must_be_empty_body(method: str) -> bool:
+    """Check if a method must return an empty body."""
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
+    return method in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
+
+
+def status_code_must_be_empty_body(code: int) -> bool:
+    """Check if a status code must return an empty body."""
+    # 204, 304, 1xx should not have a body per
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
+    return code in (204, 304) or 100 <= code < 200

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1067,7 +1067,6 @@ def parse_http_date(date_str: Optional[str]) -> Optional[datetime.datetime]:
 
 def must_be_empty_body(method: str, code: int) -> bool:
     """Check if a request must return an empty body."""
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
     return status_code_must_be_empty_body(code) or method_must_be_empty_body(method)
 
 
@@ -1089,10 +1088,6 @@ def should_remove_content_length(method: str, code: int) -> bool:
 
     This should always be a subset of must_be_empty_body
     """
-    # forbidden on 1xx/204/CONNECT per:
-    # https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
-    # discouraged on 304 per
-    # https://datatracker.ietf.org/doc/html/rfc7232#section-4.1
-    # HEAD requests should still include the content-length header
-    # per https://datatracker.ietf.org/doc/html/rfc2616#section-14.13
+    # https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6-7
+    # https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6-8
     return code in (204, 304) or 100 <= code < 200 or method == hdrs.METH_CONNECT

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1084,8 +1084,11 @@ def status_code_must_be_empty_body(code: int) -> bool:
     return code in (204, 304) or 100 <= code < 200
 
 
-def should_remove_content_length(code: int, method: str) -> bool:
-    """Check if a Content-Length header should be removed."""
+def should_remove_content_length(method: str, code: int) -> bool:
+    """Check if a Content-Length header should be removed.
+
+    This should always be a subset of must_be_empty_body
+    """
     # forbidden on 1xx/204/CONNECT per:
     # https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
     # discouraged on 304 per

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1082,3 +1082,14 @@ def status_code_must_be_empty_body(code: int) -> bool:
     # 204, 304, 1xx should not have a body per
     # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
     return code in (204, 304) or 100 <= code < 200
+
+
+def should_remove_content_length(code: int, method: str) -> bool:
+    """Check if a Content-Length header should be removed."""
+    # forbidden on 1xx/204/CONNECT per:
+    # https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
+    # discouraged on 304 per
+    # https://datatracker.ietf.org/doc/html/rfc7232#section-4.1
+    # HEAD requests should still include the content-length header
+    # per https://datatracker.ietf.org/doc/html/rfc2616#section-14.13
+    return code in (204, 304) or 100 <= code < 200 or method == hdrs.METH_CONNECT

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1070,7 +1070,7 @@ def must_be_empty_body(method: str, code: int) -> bool:
     return (
         status_code_must_be_empty_body(code)
         or method_must_be_empty_body(method)
-        or (code == 200 and method.upper() == hdrs.METH_CONNECT)
+        or (200 <= code < 300 and method.upper() == hdrs.METH_CONNECT)
     )
 
 
@@ -1097,5 +1097,5 @@ def should_remove_content_length(method: str, code: int) -> bool:
     return (
         code in {204, 304}
         or 100 <= code < 200
-        or (code == 200 and method.upper() == hdrs.METH_CONNECT)
+        or (200 <= code < 300 and method.upper() == hdrs.METH_CONNECT)
     )

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1092,8 +1092,8 @@ def should_remove_content_length(method: str, code: int) -> bool:
 
     This should always be a subset of must_be_empty_body
     """
-    # https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6-7
     # https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6-8
+    # https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5-4
     return (
         code in {204, 304}
         or 100 <= code < 200

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1067,14 +1067,18 @@ def parse_http_date(date_str: Optional[str]) -> Optional[datetime.datetime]:
 
 def must_be_empty_body(method: str, code: int) -> bool:
     """Check if a request must return an empty body."""
-    return status_code_must_be_empty_body(code) or method_must_be_empty_body(method)
+    return (
+        status_code_must_be_empty_body(code)
+        or method_must_be_empty_body(method)
+        or (code == 200 and method.upper() == hdrs.METH_CONNECT)
+    )
 
 
 def method_must_be_empty_body(method: str) -> bool:
     """Check if a method must return an empty body."""
     # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
     # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.2
-    return method.upper() in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
+    return method.upper() == hdrs.METH_HEAD
 
 
 def status_code_must_be_empty_body(code: int) -> bool:
@@ -1090,4 +1094,8 @@ def should_remove_content_length(method: str, code: int) -> bool:
     """
     # https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6-7
     # https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6-8
-    return code in (204, 304) or 100 <= code < 200 or method == hdrs.METH_CONNECT
+    return (
+        code in {204, 304}
+        or 100 <= code < 200
+        or (code == 200 and method.upper() == hdrs.METH_CONNECT)
+    )

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1073,15 +1073,16 @@ def must_be_empty_body(method: str, code: int) -> bool:
 
 def method_must_be_empty_body(method: str) -> bool:
     """Check if a method must return an empty body."""
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
-    return method in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.2
+    return method.upper() in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
 
 
 def status_code_must_be_empty_body(code: int) -> bool:
     """Check if a status code must return an empty body."""
     # 204, 304, 1xx should not have a body per
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
-    return code in (204, 304) or 100 <= code < 200
+    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
+    return code in {204, 304} or 100 <= code < 200
 
 
 def should_remove_content_length(method: str, code: int) -> bool:

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -16,7 +16,7 @@ from typing import (
 
 from . import hdrs
 from .abc import AbstractStreamWriter
-from .helpers import ETAG_ANY, ETag
+from .helpers import ETAG_ANY, ETag, must_be_empty_body
 from .typedefs import LooseHeaders, PathLike
 from .web_exceptions import (
     HTTPNotModified,
@@ -266,12 +266,7 @@ class FileResponse(StreamResponse):
             )
 
         # If we are sending 0 bytes calling sendfile() will throw a ValueError
-        if (
-            count == 0
-            or request.method in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
-            or self.status in (204, 304)
-            or 100 <= self.status < 200
-        ):
+        if count == 0 or must_be_empty_body(request.method, self.status):
             return await super().prepare(request)
 
         fobj = await loop.run_in_executor(None, filepath.open, "rb")

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -268,7 +268,7 @@ class FileResponse(StreamResponse):
         # If we are sending 0 bytes calling sendfile() will throw a ValueError
         if (
             count == 0
-            or request.method in (hdrs.METH_CONNECT or hdrs.METH_HEAD)
+            or request.method in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
             or self.status in (204, 304)
             or 100 <= self.status < 200
         ):

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -266,7 +266,12 @@ class FileResponse(StreamResponse):
             )
 
         # If we are sending 0 bytes calling sendfile() will throw a ValueError
-        if count == 0 or request.method == hdrs.METH_HEAD or self.status in [204, 304]:
+        if (
+            count == 0
+            or request.method in (hdrs.METH_CONNECT or hdrs.METH_HEAD)
+            or self.status in (204, 304)
+            or 100 <= self.status < 200
+        ):
             return await super().prepare(request)
 
         fobj = await loop.run_in_executor(None, filepath.open, "rb")

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -390,12 +390,12 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
 
         # HTTP 1.1: https://tools.ietf.org/html/rfc7230#section-3.3.2
         # HTTP 1.0: https://tools.ietf.org/html/rfc1945#section-10.4
-        # HEAD requests should still include the content-length header
-        # per https://datatracker.ietf.org/doc/html/rfc2616#section-14.13
-        if self._must_be_empty_body and request.method != hdrs.METH_HEAD:
+        if self._must_be_empty_body:
             # We need to remove the content-length for empty body
             # https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
-            if hdrs.CONTENT_LENGTH in headers:
+            # HEAD requests should still include the content-length header
+            # per https://datatracker.ietf.org/doc/html/rfc2616#section-14.13
+            if hdrs.CONTENT_LENGTH in headers and request.method != hdrs.METH_HEAD:
                 del headers[hdrs.CONTENT_LENGTH]
             # remove transfer codings when they are not needed
             # per https://datatracker.ietf.org/doc/html/rfc9112#section-6.1

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -30,6 +30,7 @@ from .helpers import (
     CookieMixin,
     ETag,
     HeadersMixin,
+    must_be_empty_body,
     parse_http_date,
     populate_with_cookies,
     rfc822_formatted_time,
@@ -335,15 +336,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             return None
         if self._payload_writer is not None:
             return self._payload_writer
-        # The following should not have a body per
-        # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
-        # status code: 204, 304, 1xx
-        # method: CONNECT, HEAD
-        self._must_be_empty_body = (
-            request.method in (hdrs.METH_HEAD, hdrs.METH_CONNECT)
-            or self.status in (204, 304)
-            or 100 <= self.status < 200
-        )
+        self._must_be_empty_body = must_be_empty_body(request.method, self.status)
         return await self._start(request)
 
     async def _start(self, request: "BaseRequest") -> AbstractStreamWriter:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -402,7 +402,6 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
                 del headers[hdrs.TRANSFER_ENCODING]
         else:
             headers.setdefault(hdrs.CONTENT_TYPE, "application/octet-stream")
-
         headers.setdefault(hdrs.DATE, rfc822_formatted_time())
         headers.setdefault(hdrs.SERVER, SERVER_SOFTWARE)
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -389,6 +389,8 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             if not request_indicates_empty_body:
                 writer.enable_chunking()
                 headers[hdrs.TRANSFER_ENCODING] = "chunked"
+            elif hdrs.TRANSFER_ENCODING in headers:
+                del headers[hdrs.TRANSFER_ENCODING]
             if hdrs.CONTENT_LENGTH in headers:
                 del headers[hdrs.CONTENT_LENGTH]
         elif self._length_check:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -384,6 +384,8 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
                 writer.enable_chunking()
                 headers[hdrs.TRANSFER_ENCODING] = "chunked"
             elif hdrs.TRANSFER_ENCODING in headers:
+                # remove transfer codings when they are not needed
+                # per https://datatracker.ietf.org/doc/html/rfc9112#section-6.1
                 del headers[hdrs.TRANSFER_ENCODING]
             if hdrs.CONTENT_LENGTH in headers:
                 del headers[hdrs.CONTENT_LENGTH]
@@ -402,6 +404,8 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             # HTTP 1.0: https://tools.ietf.org/html/rfc1945#section-10.4
             elif version >= HttpVersion11 and request_indicates_empty_body:
                 del headers[hdrs.CONTENT_LENGTH]
+                # remove transfer codings when they are not needed
+                # per https://datatracker.ietf.org/doc/html/rfc9112#section-6.1
                 if hdrs.TRANSFER_ENCODING in headers:
                     del headers[hdrs.TRANSFER_ENCODING]
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -364,7 +364,25 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         if self._compression:
             await self._start_compression(request)
 
-        if self._chunked:
+        if self.status in (204, 304) or 100 <= self.status < 200:
+            #
+            # Remove transfer-encoding/content-length since there is no
+            # body and this can confuse some clients (e.g. older aiohttp)
+            #
+            # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
+            #
+            # Any response to a HEAD request and any response with
+            # a 1xx (Informational), 204 (No Content), or 304
+            # (Not Modified) status code is always terminated by
+            # the first empty line after the header fields,
+            # regardless of the header fields present in the message,
+            # and thus cannot contain a message body or trailer section.
+            #
+            if hdrs.TRANSFER_ENCODING in headers:
+                del headers[hdrs.TRANSFER_ENCODING]
+            if hdrs.CONTENT_LENGTH in headers:
+                del headers[hdrs.CONTENT_LENGTH]
+        elif self._chunked:
             if version != HttpVersion11:
                 raise RuntimeError(
                     "Using chunked encoding is forbidden "

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -351,9 +351,9 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         # The following should not have a body per
         # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
         # status code: 204, 304, 1xx
-        # method: HEAD
+        # method: CONNECT, HEAD
         return (
-            request.method == hdrs.METH_HEAD
+            request.method in (hdrs.METH_HEAD, hdrs.METH_CONNECT)
             or self.status in (204, 304)
             or 100 <= self.status < 200
         )

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -396,9 +396,9 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
                 request.method, self.status
             ):
                 del headers[hdrs.CONTENT_LENGTH]
-            # remove transfer codings when they are not needed
-            # per https://datatracker.ietf.org/doc/html/rfc9112#section-6.1
-            if version >= HttpVersion11 and hdrs.TRANSFER_ENCODING in headers:
+            # https://datatracker.ietf.org/doc/html/rfc9112#section-6.1-10
+            # https://datatracker.ietf.org/doc/html/rfc9112#section-6.1-13
+            if hdrs.TRANSFER_ENCODING in headers:
                 del headers[hdrs.TRANSFER_ENCODING]
         else:
             headers.setdefault(hdrs.CONTENT_TYPE, "application/octet-stream")

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -395,7 +395,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             # We need to remove the content-length for empty body
             # https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
             if hdrs.CONTENT_LENGTH in headers and should_remove_content_length(
-                self.status, request.method
+                request.method, self.status
             ):
                 del headers[hdrs.CONTENT_LENGTH]
             # remove transfer codings when they are not needed
@@ -677,7 +677,7 @@ class Response(StreamResponse):
 
     async def _start(self, request: "BaseRequest") -> AbstractStreamWriter:
         if self._must_be_empty_body and should_remove_content_length(
-            self.status, request.method
+            request.method, self.status
         ):
             # We need to remove the content-length for empty body
             # https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -673,9 +673,7 @@ class Response(StreamResponse):
             await super().write_eof()
 
     async def _start(self, request: "BaseRequest") -> AbstractStreamWriter:
-        if self._must_be_empty_body and should_remove_content_length(
-            request.method, self.status
-        ):
+        if should_remove_content_length(request.method, self.status):
             if hdrs.CONTENT_LENGTH in self._headers:
                 del self._headers[hdrs.CONTENT_LENGTH]
         elif not self._chunked and hdrs.CONTENT_LENGTH not in self._headers:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -405,8 +405,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             # HTTP 1.1: https://tools.ietf.org/html/rfc7230#section-3.3.2
             # HTTP 1.0: https://tools.ietf.org/html/rfc1945#section-10.4
             elif version >= HttpVersion11 and request_indicates_empty_body:
-                if hdrs.CONTENT_LENGTH in headers:
-                    del headers[hdrs.CONTENT_LENGTH]
+                del headers[hdrs.CONTENT_LENGTH]
                 if hdrs.TRANSFER_ENCODING in headers:
                     del headers[hdrs.TRANSFER_ENCODING]
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -683,7 +683,9 @@ class Response(StreamResponse):
                     self._headers[hdrs.CONTENT_LENGTH] = str(size)
             else:
                 body_len = len(self._body) if self._body else "0"
-                self._headers[hdrs.CONTENT_LENGTH] = str(body_len)
+                # https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6-7
+                if body_len != "0" or request.method.upper() != hdrs.METH_HEAD:
+                    self._headers[hdrs.CONTENT_LENGTH] = str(body_len)
 
         return await super()._start(request)
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -390,7 +390,9 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
 
         # HTTP 1.1: https://tools.ietf.org/html/rfc7230#section-3.3.2
         # HTTP 1.0: https://tools.ietf.org/html/rfc1945#section-10.4
-        if self._must_be_empty_body:
+        # HEAD requests should still include the content-length header
+        # per https://datatracker.ietf.org/doc/html/rfc2616#section-14.13
+        if self._must_be_empty_body and request.method != hdrs.METH_HEAD:
             # We need to remove the content-length for empty body
             # https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
             if hdrs.CONTENT_LENGTH in headers:
@@ -673,7 +675,9 @@ class Response(StreamResponse):
             await super().write_eof()
 
     async def _start(self, request: "BaseRequest") -> AbstractStreamWriter:
-        if self._must_be_empty_body:
+        # HEAD requests should still include the content-length header
+        # per https://datatracker.ietf.org/doc/html/rfc2616#section-14.13
+        if self._must_be_empty_body and request.method != hdrs.METH_HEAD:
             # We need to remove the content-length for empty body
             # https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
             if hdrs.CONTENT_LENGTH in self._headers:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -672,7 +672,7 @@ class Response(StreamResponse):
         assert self._req is not None
         assert self._payload_writer is not None
         if body is not None:
-            if self._req._method == hdrs.METH_HEAD or self._status in [204, 304]:
+            if self._must_be_empty_body(self._req):
                 await super().write_eof()
             elif self._body_payload:
                 payload = cast(Payload, body)

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -684,7 +684,9 @@ class Response(StreamResponse):
             else:
                 body_len = len(self._body) if self._body else "0"
                 # https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6-7
-                if body_len != "0" or request.method.upper() != hdrs.METH_HEAD:
+                if body_len != "0" or (
+                    self.status != 304 and request.method.upper() != hdrs.METH_HEAD
+                ):
                     self._headers[hdrs.CONTENT_LENGTH] = str(body_len)
 
         return await super()._start(request)

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -364,16 +364,10 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         if self._compression:
             await self._start_compression(request)
 
-        # 204, 304, 1xx should not have a body per
+        # The following should not have a body per
         # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3
-        #
-        # Any response to a HEAD request and any response with
-        # a 1xx (Informational), 204 (No Content), or 304
-        # (Not Modified) status code is always terminated by
-        # the first empty line after the header fields,
-        # regardless of the header fields present in the message,
-        # and thus cannot contain a message body or trailer section.
-        #
+        # status code: 204, 304, 1xx
+        # method: HEAD
         request_indicates_empty_body = (
             request.method == "HEAD"
             or self.status in (204, 304)

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -392,7 +392,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
                     if not self._must_be_empty_body:
                         writer.enable_chunking()
                         headers[hdrs.TRANSFER_ENCODING] = "chunked"
-                else:
+                elif not self._must_be_empty_body:
                     keep_alive = False
 
         # HTTP 1.1: https://tools.ietf.org/html/rfc7230#section-3.3.2

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -409,10 +409,6 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
                     del headers[hdrs.CONTENT_LENGTH]
                 if hdrs.TRANSFER_ENCODING in headers:
                     del headers[hdrs.TRANSFER_ENCODING]
-        elif hdrs.TRANSFER_ENCODING in headers:
-            # Not chunked, but has transfer encoding
-            # remove the header since it is invalid
-            del headers[hdrs.TRANSFER_ENCODING]
 
         if not request_indicates_empty_body:
             headers.setdefault(hdrs.CONTENT_TYPE, "application/octet-stream")

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -392,8 +392,6 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         # HTTP 1.1: https://tools.ietf.org/html/rfc7230#section-3.3.2
         # HTTP 1.0: https://tools.ietf.org/html/rfc1945#section-10.4
         if self._must_be_empty_body:
-            # We need to remove the content-length for empty body
-            # https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
             if hdrs.CONTENT_LENGTH in headers and should_remove_content_length(
                 request.method, self.status
             ):
@@ -679,8 +677,6 @@ class Response(StreamResponse):
         if self._must_be_empty_body and should_remove_content_length(
             request.method, self.status
         ):
-            # We need to remove the content-length for empty body
-            # https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
             if hdrs.CONTENT_LENGTH in self._headers:
                 del self._headers[hdrs.CONTENT_LENGTH]
         elif not self._chunked and hdrs.CONTENT_LENGTH not in self._headers:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -400,7 +400,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
 
         # HTTP 1.1: https://tools.ietf.org/html/rfc7230#section-3.3.2
         # HTTP 1.0: https://tools.ietf.org/html/rfc1945#section-10.4
-        if must_be_empty_body and version >= HttpVersion11:
+        if must_be_empty_body:
             # If the content-length is not set to "0" we will
             # prematurely close a keep-alive connection that could
             # have been reused. This matches the behavior of Response
@@ -408,7 +408,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             headers[hdrs.CONTENT_LENGTH] = "0"
             # remove transfer codings when they are not needed
             # per https://datatracker.ietf.org/doc/html/rfc9112#section-6.1
-            if hdrs.TRANSFER_ENCODING in headers:
+            if version >= HttpVersion11 and hdrs.TRANSFER_ENCODING in headers:
                 del headers[hdrs.TRANSFER_ENCODING]
 
         if not must_be_empty_body:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -147,12 +147,8 @@ async def test_keepalive_after_empty_body_status_stream_response(
         app, connector=connector, trace_configs=[trace_config]
     )
 
-    import pprint
-
-    pprint.pprint("first")
     resp1 = await client.get("/")
     await resp1.read()
-    pprint.pprint("second")
     resp2 = await client.get("/")
     await resp2.read()
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -1902,7 +1902,7 @@ async def test_no_payload_304_with_chunked_encoding(aiohttp_client: Any) -> None
 
     resp = await client.get("/")
     assert resp.status == 304
-    assert hdrs.CONTENT_LENGTH not in resp.headers
+    assert resp.headers[hdrs.CONTENT_LENGTH] == "0"
     assert hdrs.TRANSFER_ENCODING not in resp.headers
     await resp.read()
 
@@ -1927,7 +1927,7 @@ async def test_head_request_with_chunked_encoding(aiohttp_client: Any) -> None:
 
     resp = await client.head("/")
     assert resp.status == 200
-    assert hdrs.CONTENT_LENGTH not in resp.headers
+    assert resp.headers[hdrs.CONTENT_LENGTH] == "0"
     assert hdrs.TRANSFER_ENCODING not in resp.headers
     await resp.read()
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -1898,7 +1898,7 @@ async def test_no_payload_304_with_chunked_encoding(aiohttp_client: Any) -> None
 
     resp = await client.get("/")
     assert resp.status == 304
-    assert resp.headers[hdrs.CONTENT_LENGTH] == "0"
+    assert hdrs.CONTENT_LENGTH not in resp.headers
     assert hdrs.TRANSFER_ENCODING not in resp.headers
     await resp.read()
 
@@ -1923,7 +1923,7 @@ async def test_head_request_with_chunked_encoding(aiohttp_client: Any) -> None:
 
     resp = await client.head("/")
     assert resp.status == 200
-    assert resp.headers[hdrs.CONTENT_LENGTH] == "0"
+    assert hdrs.CONTENT_LENGTH not in resp.headers
     assert hdrs.TRANSFER_ENCODING not in resp.headers
     await resp.read()
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -117,7 +117,7 @@ async def test_keepalive_after_empty_body_status(
     resp2 = await client.get("/")
     await resp2.read()
 
-    assert 1 == cnt_conn_reuse
+    assert cnt_conn_reuse == 1
     await client.close()
 
 
@@ -152,7 +152,7 @@ async def test_keepalive_after_empty_body_status_stream_response(
     resp2 = await client.get("/")
     await resp2.read()
 
-    assert 1 == cnt_conn_reuse
+    assert cnt_conn_reuse == 1
     await client.close()
 
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -83,7 +83,6 @@ async def test_keepalive_after_head_requests_success(aiohttp_client: Any) -> Non
     await resp2.read()
 
     assert 1 == cnt_conn_reuse
-    await client.close()
 
 
 @pytest.mark.parametrize("status", (101, 204, 304))
@@ -118,7 +117,6 @@ async def test_keepalive_after_empty_body_status(
     await resp2.read()
 
     assert cnt_conn_reuse == 1
-    await client.close()
 
 
 @pytest.mark.parametrize("status", (101, 204, 304))
@@ -153,7 +151,6 @@ async def test_keepalive_after_empty_body_status_stream_response(
     await resp2.read()
 
     assert cnt_conn_reuse == 1
-    await client.close()
 
 
 async def test_keepalive_response_released(aiohttp_client: Any) -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1110,5 +1110,8 @@ def test_should_remove_content_length_is_subset_of_must_be_empty_body():
     assert should_remove_content_length("CONNECT", 200) is True
     assert must_be_empty_body("CONNECT", 200) is True
 
+    assert should_remove_content_length("CONNECT", 201) is True
+    assert must_be_empty_body("CONNECT", 201) is True
+
     assert should_remove_content_length("CONNECT", 300) is False
     assert must_be_empty_body("CONNECT", 300) is False

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -19,6 +19,7 @@ from yarl import URL
 from aiohttp import helpers
 from aiohttp.helpers import (
     is_expected_content_type,
+    method_must_be_empty_body,
     must_be_empty_body,
     parse_http_date,
     should_remove_content_length,
@@ -1078,6 +1079,13 @@ def test_read_basicauth_from_empty_netrc():
         helpers.basicauth_from_netrc(netrc_obj, "example.com")
 
 
+def test_method_must_be_empty_body():
+    """Test that HEAD is the only method that unequivocally must have an empty body."""
+    assert method_must_be_empty_body("HEAD") is True
+    # CONNECT is only empty on a successful response
+    assert method_must_be_empty_body("CONNECT") is False
+
+
 def test_should_remove_content_length_is_subset_of_must_be_empty_body():
     """Test should_remove_content_length is always a subset of must_be_empty_body."""
     assert should_remove_content_length("GET", 101) is True
@@ -1098,5 +1106,9 @@ def test_should_remove_content_length_is_subset_of_must_be_empty_body():
     assert should_remove_content_length("HEAD", 200) is False
     assert must_be_empty_body("HEAD", 200) is True
 
+    # CONNECT is only empty on a successful response
     assert should_remove_content_length("CONNECT", 200) is True
     assert must_be_empty_body("CONNECT", 200) is True
+
+    assert should_remove_content_length("CONNECT", 300) is False
+    assert must_be_empty_body("CONNECT", 300) is False

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -23,7 +23,6 @@ from aiohttp.helpers import (
     must_be_empty_body,
     parse_http_date,
     should_remove_content_length,
-    parse_http_date,
 )
 
 IS_PYPY = platform.python_implementation() == "PyPy"

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -2111,7 +2111,7 @@ async def test_auto_decompress(
     "status",
     [101, 204],
 )
-async def test_response_101_204_no_content_length_http11(
+async def test_response_101_204_zero_content_length_http11(
     status: Any, aiohttp_client: Any
 ) -> None:
     async def handler(_):
@@ -2121,7 +2121,7 @@ async def test_response_101_204_no_content_length_http11(
     app.router.add_get("/", handler)
     client = await aiohttp_client(app, version="1.1")
     resp = await client.get("/")
-    assert CONTENT_LENGTH not in resp.headers
+    assert resp.headers[CONTENT_LENGTH] == "0"
     assert TRANSFER_ENCODING not in resp.headers
     await resp.release()
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -144,6 +144,10 @@ async def test_head_returns_empty_body(aiohttp_client: Any) -> None:
     assert 200 == resp.status
     txt = await resp.text()
     assert "" == txt
+    # The Content-Length header should be set to 4 which is
+    # the length of the response body if it would have been
+    # returned by a GET request.
+    assert resp.headers["Content-Length"] == "4"
 
 
 async def test_response_before_complete(aiohttp_client: Any) -> None:

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -2111,7 +2111,7 @@ async def test_auto_decompress(
     "status",
     [101, 204],
 )
-async def test_response_101_204_zero_content_length_http11(
+async def test_response_101_204_no_content_length_http11(
     status: Any, aiohttp_client: Any
 ) -> None:
     async def handler(_):
@@ -2121,7 +2121,7 @@ async def test_response_101_204_zero_content_length_http11(
     app.router.add_get("/", handler)
     client = await aiohttp_client(app, version="1.1")
     resp = await client.get("/")
-    assert resp.headers[CONTENT_LENGTH] == "0"
+    assert CONTENT_LENGTH not in resp.headers
     assert TRANSFER_ENCODING not in resp.headers
     await resp.release()
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -683,7 +683,7 @@ async def test_head_response_omits_content_length_when_body_unset() -> None:
 async def test_304_response_omits_content_length_when_body_unset() -> None:
     """Verify 304 response omits content-length body when its unset."""
     writer = mock.create_autospec(StreamWriter, spec_set=True, instance=True)
-    req = make_request("HEAD", "/", version=HttpVersion11, writer=writer)
+    req = make_request("GET", "/", version=HttpVersion11, writer=writer)
     resp = Response(status=304)
     await resp.prepare(req)
     assert resp.content_length == 0

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -668,6 +668,30 @@ async def test_head_response_keeps_content_length_of_original_body() -> None:
     assert hdrs.TRANSFER_ENCODING not in resp.headers
 
 
+async def test_head_response_omits_content_length_when_body_unset() -> None:
+    """Verify HEAD response omits content-length body when its unset."""
+    writer = mock.create_autospec(StreamWriter, spec_set=True, instance=True)
+    req = make_request("HEAD", "/", version=HttpVersion11, writer=writer)
+    resp = Response(status=200)
+    await resp.prepare(req)
+    assert resp.content_length == 0
+    assert not resp.chunked
+    assert hdrs.CONTENT_LENGTH not in resp.headers
+    assert hdrs.TRANSFER_ENCODING not in resp.headers
+
+
+async def test_304_response_omits_content_length_when_body_unset() -> None:
+    """Verify 304 response omits content-length body when its unset."""
+    writer = mock.create_autospec(StreamWriter, spec_set=True, instance=True)
+    req = make_request("HEAD", "/", version=HttpVersion11, writer=writer)
+    resp = Response(status=304)
+    await resp.prepare(req)
+    assert resp.content_length == 0
+    assert not resp.chunked
+    assert hdrs.CONTENT_LENGTH not in resp.headers
+    assert hdrs.TRANSFER_ENCODING not in resp.headers
+
+
 async def test_content_length_on_chunked() -> None:
     req = make_request("GET", "/")
     resp = Response(body=b"answer")

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -643,6 +643,11 @@ async def test_rm_content_length_204_304_responses(status: int) -> None:
 
     https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.1
     https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
+
+    Content-Length is forbidden for 204
+
+    https://datatracker.ietf.org/doc/html/rfc7232#section-4.1
+    and discouraged for 304.
     """
     writer = mock.create_autospec(StreamWriter, spec_set=True, instance=True)
     req = make_request("GET", "/", version=HttpVersion11, writer=writer)

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -638,7 +638,7 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
 
 
 async def test_head_response_keeps_content_length_of_original_body() -> None:
-    """Remove HEAD response keeps the content length of the original body HTTP/1.1."""
+    """Verify HEAD response keeps the content length of the original body HTTP/1.1."""
     writer = mock.create_autospec(StreamWriter, spec_set=True, instance=True)
     req = make_request("HEAD", "/", version=HttpVersion11, writer=writer)
     resp = Response(status=200, body=b"answer")

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -638,7 +638,7 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     await resp.prepare(req)
     assert resp.content_length == 0
     assert not resp.chunked
-    assert hdrs.CONTENT_LENGTH not in resp.headers
+    assert resp.headers[hdrs.CONTENT_LENGTH] == "0"
     assert hdrs.TRANSFER_ENCODING not in resp.headers
 
 
@@ -655,7 +655,7 @@ async def test_rm_transfer_encoding_head_response() -> None:
     await resp.prepare(req)
     assert resp.content_length == 0
     assert not resp.chunked
-    assert hdrs.CONTENT_LENGTH not in resp.headers
+    assert resp.headers[hdrs.CONTENT_LENGTH] == "0"
     assert hdrs.TRANSFER_ENCODING not in resp.headers
 
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -637,9 +637,9 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     assert hdrs.TRANSFER_ENCODING not in resp.headers
 
 
-@pytest.mark.parametrize("status", (101, 204, 304))
-async def test_rm_content_length_101_204_304_responses(status: int) -> None:
-    """Remove content length for 101, 204, and 304 responses.
+@pytest.mark.parametrize("status", (100, 101, 102, 204, 304))
+async def test_rm_content_length_1xx_204_304_responses(status: int) -> None:
+    """Remove content length for 1xx, 204, and 304 responses.
 
     Content-Length is forbidden for 1xx and 204
     https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -641,6 +641,22 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     assert not resp.chunked
 
 
+async def test_rm_transfer_encoding_head_response() -> None:
+    """Remove transfer encoding from a HEAD response HTTP/1.1."""
+    writer = mock.Mock()
+
+    async def write_headers(status_line, headers):
+        assert hdrs.CONTENT_LENGTH not in headers
+        assert hdrs.TRANSFER_ENCODING not in headers
+
+    writer.write_headers.side_effect = write_headers
+    req = make_request("HEAD", "/", version=HttpVersion11, writer=writer)
+    resp = Response(status=200, headers={hdrs.TRANSFER_ENCODING: "chunked"})
+    await resp.prepare(req)
+    assert resp.content_length == 0
+    assert not resp.chunked
+
+
 async def test_content_length_on_chunked() -> None:
     req = make_request("GET", "/")
     resp = Response(body=b"answer")

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -637,6 +637,21 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     assert hdrs.TRANSFER_ENCODING not in resp.headers
 
 
+@pytest.mark.parametrize("status", (204, 304))
+async def test_rm_content_length_204_304_responses(status: int) -> None:
+    """Remove content length for 204 and 304 responses.
+
+    See RFC7230 3.3.1, RFC7230 3.3.2
+    """
+    writer = mock.create_autospec(StreamWriter, spec_set=True, instance=True)
+    req = make_request("GET", "/", version=HttpVersion11, writer=writer)
+    resp = Response(status=status, body="answer")
+    await resp.prepare(req)
+    assert not resp.chunked
+    assert hdrs.CONTENT_LENGTH not in resp.headers
+    assert hdrs.TRANSFER_ENCODING not in resp.headers
+
+
 async def test_head_response_keeps_content_length_of_original_body() -> None:
     """Verify HEAD response keeps the content length of the original body HTTP/1.1."""
     writer = mock.create_autospec(StreamWriter, spec_set=True, instance=True)

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -637,11 +637,11 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     assert hdrs.TRANSFER_ENCODING not in resp.headers
 
 
-@pytest.mark.parametrize("status", (204, 304))
-async def test_rm_content_length_204_304_responses(status: int) -> None:
-    """Remove content length for 204 and 304 responses.
+@pytest.mark.parametrize("status", (101, 204, 304))
+async def test_rm_content_length_101_204_304_responses(status: int) -> None:
+    """Remove content length for 101, 204, and 304 responses.
 
-    Content-Length is forbidden for 204
+    Content-Length is forbidden for 1xx and 204
     https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
 
     Content-Length is discouraged for 304.

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -16,7 +16,7 @@ from re_assert import Matches
 
 from aiohttp import HttpVersion, HttpVersion10, HttpVersion11, hdrs
 from aiohttp.helpers import ETag
-from aiohttp.http_writer import _serialize_headers
+from aiohttp.http_writer import StreamWriter, _serialize_headers
 from aiohttp.payload import BytesPayload
 from aiohttp.test_utils import make_mocked_coro, make_mocked_request
 from aiohttp.web import ContentCoding, Response, StreamResponse, json_response
@@ -627,12 +627,7 @@ async def test_rm_content_length_if_compression_http10() -> None:
 @pytest.mark.parametrize("status", (100, 101, 204, 304))
 async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     """Remove transfer encoding for RFC 9112 sec 6.3 with HTTP/1.1."""
-    writer = mock.Mock()
-
-    async def write_headers(status_line, headers):
-        pass
-
-    writer.write_headers.side_effect = write_headers
+    writer = mock.create_autospec(StreamWriter, spec_set=True, instance=True)
     req = make_request("GET", "/", version=HttpVersion11, writer=writer)
     resp = Response(status=status, headers={hdrs.TRANSFER_ENCODING: "chunked"})
     await resp.prepare(req)
@@ -644,12 +639,7 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
 
 async def test_rm_transfer_encoding_head_response() -> None:
     """Remove transfer encoding from a HEAD response HTTP/1.1."""
-    writer = mock.Mock()
-
-    async def write_headers(status_line, headers):
-        pass
-
-    writer.write_headers.side_effect = write_headers
+    writer = mock.create_autospec(StreamWriter, spec_set=True, instance=True)
     req = make_request("HEAD", "/", version=HttpVersion11, writer=writer)
     resp = Response(status=200, headers={hdrs.TRANSFER_ENCODING: "chunked"})
     await resp.prepare(req)

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -633,7 +633,7 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     await resp.prepare(req)
     assert resp.content_length == 0
     assert not resp.chunked
-    assert resp.headers[hdrs.CONTENT_LENGTH] == "0"
+    assert hdrs.CONTENT_LENGTH not in resp.headers
     assert hdrs.TRANSFER_ENCODING not in resp.headers
 
 
@@ -645,7 +645,7 @@ async def test_rm_transfer_encoding_head_response() -> None:
     await resp.prepare(req)
     assert resp.content_length == 0
     assert not resp.chunked
-    assert resp.headers[hdrs.CONTENT_LENGTH] == "0"
+    assert hdrs.CONTENT_LENGTH not in resp.headers
     assert hdrs.TRANSFER_ENCODING not in resp.headers
 
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -637,15 +637,15 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     assert hdrs.TRANSFER_ENCODING not in resp.headers
 
 
-async def test_rm_transfer_encoding_head_response() -> None:
-    """Remove transfer encoding from a HEAD response HTTP/1.1."""
+async def test_head_response_keeps_content_length_of_original_body() -> None:
+    """Remove HEAD response keeps the content length of the original body HTTP/1.1."""
     writer = mock.create_autospec(StreamWriter, spec_set=True, instance=True)
     req = make_request("HEAD", "/", version=HttpVersion11, writer=writer)
-    resp = Response(status=200, headers={hdrs.TRANSFER_ENCODING: "chunked"})
+    resp = Response(status=200, body=b"answer")
     await resp.prepare(req)
-    assert resp.content_length == 0
+    assert resp.content_length == 6
     assert not resp.chunked
-    assert hdrs.CONTENT_LENGTH not in resp.headers
+    assert resp.headers[hdrs.CONTENT_LENGTH] == "6"
     assert hdrs.TRANSFER_ENCODING not in resp.headers
 
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -630,8 +630,7 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     writer = mock.Mock()
 
     async def write_headers(status_line, headers):
-        assert hdrs.CONTENT_LENGTH not in headers
-        assert hdrs.TRANSFER_ENCODING not in headers
+        pass
 
     writer.write_headers.side_effect = write_headers
     req = make_request("GET", "/", version=HttpVersion11, writer=writer)
@@ -639,6 +638,8 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
     await resp.prepare(req)
     assert resp.content_length == 0
     assert not resp.chunked
+    assert hdrs.CONTENT_LENGTH not in resp.headers
+    assert hdrs.TRANSFER_ENCODING not in resp.headers
 
 
 async def test_rm_transfer_encoding_head_response() -> None:
@@ -646,8 +647,7 @@ async def test_rm_transfer_encoding_head_response() -> None:
     writer = mock.Mock()
 
     async def write_headers(status_line, headers):
-        assert hdrs.CONTENT_LENGTH not in headers
-        assert hdrs.TRANSFER_ENCODING not in headers
+        pass
 
     writer.write_headers.side_effect = write_headers
     req = make_request("HEAD", "/", version=HttpVersion11, writer=writer)
@@ -655,6 +655,8 @@ async def test_rm_transfer_encoding_head_response() -> None:
     await resp.prepare(req)
     assert resp.content_length == 0
     assert not resp.chunked
+    assert hdrs.CONTENT_LENGTH not in resp.headers
+    assert hdrs.TRANSFER_ENCODING not in resp.headers
 
 
 async def test_content_length_on_chunked() -> None:

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -641,13 +641,11 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
 async def test_rm_content_length_204_304_responses(status: int) -> None:
     """Remove content length for 204 and 304 responses.
 
-    https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.1
+    Content-Length is forbidden for 204
     https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
 
-    Content-Length is forbidden for 204
-
+    Content-Length is discouraged for 304.
     https://datatracker.ietf.org/doc/html/rfc7232#section-4.1
-    and discouraged for 304.
     """
     writer = mock.create_autospec(StreamWriter, spec_set=True, instance=True)
     req = make_request("GET", "/", version=HttpVersion11, writer=writer)

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -641,7 +641,8 @@ async def test_rm_transfer_encoding_rfc_9112_6_3_http_11(status: int) -> None:
 async def test_rm_content_length_204_304_responses(status: int) -> None:
     """Remove content length for 204 and 304 responses.
 
-    See RFC7230 3.3.1, RFC7230 3.3.2
+    https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.1
+    https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2
     """
     writer = mock.create_autospec(StreamWriter, spec_set=True, instance=True)
     req = make_request("GET", "/", version=HttpVersion11, writer=writer)

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -123,7 +123,7 @@ async def test_zero_bytes_file_mocked_native_sendfile(
         assert "" == txt.rstrip()
         assert "application/octet-stream" == resp.headers["Content-Type"]
         assert resp.headers.get("Content-Encoding") is None
-        assert resp.headers["Content-Length"] == "0"
+        assert resp.headers.get("Content-Length") == "0"
         await resp.release()
 
     await client.close()
@@ -290,7 +290,7 @@ async def test_static_file_if_modified_since(
     resp = await client.get("/", headers={"If-Modified-Since": lastmod})
     body = await resp.read()
     assert 304 == resp.status
-    assert resp.headers["Content-Length"] == "0"
+    assert resp.headers.get("Content-Length") is None
     assert resp.headers.get("Last-Modified") == lastmod
     assert b"" == body
     resp.close()
@@ -338,7 +338,7 @@ async def test_static_file_if_modified_since_future_date(
     resp = await client.get("/", headers={"If-Modified-Since": lastmod})
     body = await resp.read()
     assert 304 == resp.status
-    assert resp.headers["Content-Length"] == "0"
+    assert resp.headers.get("Content-Length") is None
     assert resp.headers.get("Last-Modified")
     assert b"" == body
     resp.close()
@@ -437,7 +437,7 @@ async def test_static_file_if_none_match(
     )
     body = await resp.read()
     assert 304 == resp.status
-    assert resp.headers["Content-Length"] == "0"
+    assert resp.headers.get("Content-Length") is None
     assert resp.headers.get("ETag") == original_etag
     assert b"" == body
     resp.close()
@@ -455,7 +455,7 @@ async def test_static_file_if_none_match_star(
     resp = await client.head("/", headers={"If-None-Match": "*"})
     body = await resp.read()
     assert 304 == resp.status
-    assert resp.headers["Content-Length"] == "0"
+    assert resp.headers.get("Content-Length") is None
     assert resp.headers.get("ETag")
     assert resp.headers.get("Last-Modified")
     assert b"" == body

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -123,7 +123,7 @@ async def test_zero_bytes_file_mocked_native_sendfile(
         assert "" == txt.rstrip()
         assert "application/octet-stream" == resp.headers["Content-Type"]
         assert resp.headers.get("Content-Encoding") is None
-        assert resp.headers.get("Content-Length") == "0"
+        assert resp.headers["Content-Length"] == "0"
         await resp.release()
 
     await client.close()
@@ -290,7 +290,7 @@ async def test_static_file_if_modified_since(
     resp = await client.get("/", headers={"If-Modified-Since": lastmod})
     body = await resp.read()
     assert 304 == resp.status
-    assert resp.headers.get("Content-Length") is None
+    assert resp.headers["Content-Length"] == "0"
     assert resp.headers.get("Last-Modified") == lastmod
     assert b"" == body
     resp.close()
@@ -338,7 +338,7 @@ async def test_static_file_if_modified_since_future_date(
     resp = await client.get("/", headers={"If-Modified-Since": lastmod})
     body = await resp.read()
     assert 304 == resp.status
-    assert resp.headers.get("Content-Length") is None
+    assert resp.headers["Content-Length"] == "0"
     assert resp.headers.get("Last-Modified")
     assert b"" == body
     resp.close()
@@ -437,7 +437,7 @@ async def test_static_file_if_none_match(
     )
     body = await resp.read()
     assert 304 == resp.status
-    assert resp.headers.get("Content-Length") is None
+    assert resp.headers["Content-Length"] == "0"
     assert resp.headers.get("ETag") == original_etag
     assert b"" == body
     resp.close()
@@ -455,7 +455,7 @@ async def test_static_file_if_none_match_star(
     resp = await client.head("/", headers={"If-None-Match": "*"})
     body = await resp.read()
     assert 304 == resp.status
-    assert resp.headers.get("Content-Length") is None
+    assert resp.headers["Content-Length"] == "0"
     assert resp.headers.get("ETag")
     assert resp.headers.get("Last-Modified")
     assert b"" == body


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

`Transfer-Encoding` and `Content-Length` will be removed from the server response when sending a 1xx (Informational), 204 (No Content), or 304 (Not Modified) status since no body is expected for these status codes

- `Content-Length` forbidden on 1xx/204 per https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2 and discouraged on 304 per https://datatracker.ietf.org/doc/html/rfc7232#section-4.1

We need to ensure `Content-Length` is kept for `HEAD` to ensure keep-alive works as expected and is allowed per https://datatracker.ietf.org/doc/html/rfc2616#section-14.13

- `Transfer-Encoding` removed per  https://datatracker.ietf.org/doc/html/rfc9112#section-6.1 
> any recipient on the response chain (including the origin server) can remove transfer codings when they are not needed.

`aiohttp` would incorrectly send an body of `0\r\n\r\n` when `chunked` was set for `Transfer-Encoding` with the above status code. 

This change ensures `aiohttp` does not send these invalid bodies.

## Are there changes in behavior for the user?

The `Transfer-Encoding` and `Content-Length` headers will be removed when sending a 1xx (Informational), 204 (No Content), or 304 (Not Modified) except for `HEAD` responses since these status since no body is expected for these status codes.

An invalid body of `0\r\n\r\n` will no longer be sent with these status codes.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."


TODO: 

- [x] figure out why client closes connection on HEAD requests with content length
- [x] figure out why client functional tests fail with AIOHTTP_NO_EXTENSIONS=1 `test_keepalive_after_empty_body_status` and `test_keepalive_after_empty_body_status_stream_response` -- They do not fail anymore after the fixed in https://github.com/aio-libs/aiohttp/pull/7755
- [x] timeline
- [x] more functional testing
