### PR TITLE
Fix CONNECT always being treated as having an empty body

### DIFF
--- a/CHANGES/7772.bugfix
+++ b/CHANGES/7772.bugfix
@@ -1,0 +1,1 @@
+Fix CONNECT always being treated as having an empty body

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1069,7 +1069,7 @@ def method_must_be_empty_body(method: str) -> bool:
     """Check if a method must return an empty body."""
     # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
     # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.2
-    return method.upper() in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
+    return method.upper() == hdrs.METH_HEAD
 
 
 def status_code_must_be_empty_body(code: int) -> bool:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,7 +17,11 @@ from re_assert import Matches
 from yarl import URL
 
 from aiohttp import helpers
-from aiohttp.helpers import is_expected_content_type, parse_http_date
+from aiohttp.helpers import (
+    is_expected_content_type,
+    method_must_be_empty_body,
+    parse_http_date,
+)
 
 IS_PYPY = platform.python_implementation() == "PyPy"
 
@@ -1071,3 +1075,10 @@ def test_read_basicauth_from_empty_netrc():
         LookupError, match="No entry for example.com found in the `.netrc` file."
     ):
         helpers.basicauth_from_netrc(netrc_obj, "example.com")
+
+
+def test_method_must_be_empty_body():
+    """Test that HEAD is the only method that unequivocally must have an empty body."""
+    assert method_must_be_empty_body("HEAD") is True
+    # CONNECT is only empty on a successful response
+    assert method_must_be_empty_body("CONNECT") is False


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

CONNECT will only have an empty body on 2xx

fixes a mistake in #7755

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
