### PR TITLE
Fix CONNECT always being treated as having an empty body (#7772)

### DIFF
--- a/CHANGES/7772.bugfix
+++ b/CHANGES/7772.bugfix
@@ -1,0 +1,1 @@
+Fix CONNECT always being treated as having an empty body

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -974,7 +974,7 @@ def method_must_be_empty_body(method: str) -> bool:
     """Check if a method must return an empty body."""
     # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
     # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.2
-    return method.upper() in (hdrs.METH_CONNECT, hdrs.METH_HEAD)
+    return method.upper() == hdrs.METH_HEAD
 
 
 def status_code_must_be_empty_body(code: int) -> bool:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,7 +16,7 @@ from multidict import MultiDict
 from yarl import URL
 
 from aiohttp import helpers
-from aiohttp.helpers import parse_http_date
+from aiohttp.helpers import method_must_be_empty_body, parse_http_date
 
 IS_PYPY = platform.python_implementation() == "PyPy"
 
@@ -909,3 +909,10 @@ def test_read_basicauth_from_empty_netrc():
         LookupError, match="No entry for example.com found in the `.netrc` file."
     ):
         helpers.basicauth_from_netrc(netrc_obj, "example.com")
+
+
+def test_method_must_be_empty_body():
+    """Test that HEAD is the only method that unequivocally must have an empty body."""
+    assert method_must_be_empty_body("HEAD") is True
+    # CONNECT is only empty on a successful response
+    assert method_must_be_empty_body("CONNECT") is False


### PR DESCRIPTION
(cherry picked from commit af2bb1e7ad2e07948b02af0a2db55d5f8555ef6b)
