### PR TITLE
Bugfix Edge Case Handling for ResponseParser for missing reason value

### DIFF
--- a/CHANGES/7776.bugfix
+++ b/CHANGES/7776.bugfix
@@ -1,0 +1,1 @@
+Edge Case Handling for ResponseParser for missing reason value

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -259,6 +259,7 @@ Oleg Höfling
 Pahaz Blinov
 Panagiotis Kolokotronis
 Pankaj Pandey
+Parag Jain
 Pau Freixes
 Paul Colomiets
 Paulius Šileikis

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -661,7 +661,7 @@ class HttpResponseParser(HttpParser[RawResponseMessage]):
         try:
             status, reason = status.split(maxsplit=1)
         except ValueError:
-            status = status.trim()
+            status = status.strip()
             reason = ""
 
         if len(reason) > self.max_line_size:

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -661,6 +661,7 @@ class HttpResponseParser(HttpParser[RawResponseMessage]):
         try:
             status, reason = status.split(maxsplit=1)
         except ValueError:
+            status = status.trim()
             reason = ""
 
         if len(reason) > self.max_line_size:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -818,6 +818,22 @@ def test_http_response_parser_utf8(response: Any) -> None:
     assert not tail
 
 
+def test_http_response_parser_utf8_without_reason(response: Any) -> None:
+    text = "HTTP/1.1 200 \r\nx-test:тест\r\n\r\n".encode()
+
+    messages, upgraded, tail = response.feed_data(text)
+    assert len(messages) == 1
+    msg = messages[0][0]
+
+    assert msg.version == (1, 1)
+    assert msg.code == 200
+    assert msg.reason == ""
+    assert msg.headers == CIMultiDict([("X-TEST", "тест")])
+    assert msg.raw_headers == ((b"x-test", "тест".encode()),)
+    assert not upgraded
+    assert not tail
+
+
 @pytest.mark.parametrize("size", [40962, 8191])
 def test_http_response_parser_bad_status_line_too_long(
     response: Any, size: Any


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

For cases where response stream does not contain a reason, the current HttpResponseParser throws "Bad Status Line" Error. HTTP/1.1 protocol does not mandate reason to be present, hence this PR adds logic fix to handle this edge case. 

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No, this is not changing user behavior. Standard "HTTP/1.1 200 OK" and edge case of "HTTP/1.1 200 "  should work after this PR gets merged. 

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
No. This edge case is handled in 3.7 and earlier, but breaks from 3.8 forward versions. 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
