### PR TITLE
Fix increase in latency with small messages from websocket compression changes

### DIFF
--- a/CHANGES/7797.bugfix
+++ b/CHANGES/7797.bugfix
@@ -1,1 +1,1 @@
-Fix increase in latancy with small messages from websocket compression changes
+Fix increase in latency with small messages from websocket compression changes

--- a/CHANGES/7797.bugfix
+++ b/CHANGES/7797.bugfix
@@ -1,0 +1,1 @@
+Fix increase in latancy with small messages from websocket compression changes

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -59,6 +59,15 @@ class WSCloseCode(IntEnum):
 
 ALLOWED_CLOSE_CODES: Final[Set[int]] = {int(i) for i in WSCloseCode}
 
+# For websockets, keeping latency low is extremely important as implementations
+# generally expect to be able to send and receive messages quickly.  We use a
+# larger chunk size than the default to reduce the number of executor calls
+# since the executor is a significant source of latency and overhead when
+# the chunks are small. A size of 5KiB was chosen because it is also the
+# same value python-zlib-ng choose to use as the threshold to release the GIL.
+
+WEBSOCKET_MAX_SYNC_CHUNK_SIZE = 5 * 1024
+
 
 class WSMsgType(IntEnum):
     # websocket spec types
@@ -617,11 +626,17 @@ class WebSocketWriter:
         if (compress or self.compress) and opcode < 8:
             if compress:
                 # Do not set self._compress if compressing is for this frame
-                compressobj = ZLibCompressor(level=zlib.Z_BEST_SPEED, wbits=-compress)
+                compressobj = ZLibCompressor(
+                    level=zlib.Z_BEST_SPEED,
+                    wbits=-compress,
+                    max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
+                )
             else:  # self.compress
                 if not self._compressobj:
                     self._compressobj = ZLibCompressor(
-                        level=zlib.Z_BEST_SPEED, wbits=-self.compress
+                        level=zlib.Z_BEST_SPEED,
+                        wbits=-self.compress,
+                        max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
                     )
                 compressobj = self._compressobj
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Changes the threshold that is required to compress in the executor for websocket messages to 5KiB

https://github.com/aio-libs/aiohttp/pull/7223 changed the websocket implementation to compress messages > 1KiB in the executor.  The threshold was a bit low which caused an increase in latency compressing messages as the overhead to use the executor can exceed the cost to compress tiny messages. When testing 3.9.0 with Home Assistant, we saw a 3 order of magnitude increase in executor usage which resulted in an overall increase in cpu time since all the tiny messages were being compressed in the executor.

I could not find the motivation for choosing 1KiB in the original PR

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
