### PR TITLE
Fix infinite loop releasing the connection when the writer is not finished

### DIFF
--- a/CHANGES/7798.bugfix
+++ b/CHANGES/7798.bugfix
@@ -1,0 +1,1 @@
+Fix infinite loop releasing the connection when the writer is not finished

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -916,10 +916,12 @@ class ClientResponse(HeadersMixin):
             ):
                 return
 
+            self._cleanup_writer()
             self._release_connection()
+        else:
+            self._cleanup_writer()
 
         self._closed = True
-        self._cleanup_writer()
 
     @property
     def closed(self) -> bool:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -968,7 +968,7 @@ class ClientResponse(HeadersMixin):
                 headers=self.headers,
             )
 
-    def _cleanup_writer_and_release_connection(self, _: asyncio.Future) -> None:
+    def _cleanup_writer_and_release_connection(self, _: asyncio.Future[None]) -> None:
         """Cleanup writer and release connection.
 
         This is called when the writer is not finished

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -974,10 +974,8 @@ class ClientResponse(HeadersMixin):
         This is called when the writer is not finished
         and _release_connection is called.
         """
-        if self._connection is not None:
-            self._cleanup_writer()
-            self._connection.release()
-            self._connection = None
+        self._writer = None
+        self._release_connection()
 
     def _release_connection(self) -> None:
         if self._connection is not None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -968,7 +968,7 @@ class ClientResponse(HeadersMixin):
                 headers=self.headers,
             )
 
-    def _cleanup_writer_and_release_connection(self, _: asyncio.Future[None]) -> None:
+    def _cleanup_writer_and_release_connection(self, _: "asyncio.Future[None]") -> None:
         """Cleanup writer and release connection.
 
         This is called when the writer is not finished

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -972,7 +972,7 @@ class ClientResponse(HeadersMixin):
         """Cleanup writer and release connection.
 
         This is called as a callback when the writer finishes
-        in the event _release_connection was called is called
+        in the event _release_connection was called
         before the writer is done.
         """
         self._writer = None


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?


#7764 ensured the connection was released if the writer was not done yet, but it never cleared the writer so it would schedule callbacks in a loop

<img width="1469" alt="Screenshot 2023-11-07 at 7 53 35 AM" src="https://github.com/aio-libs/aiohttp/assets/663432/c5ef6fd2-9eee-4ded-8095-261a92fb62aa">


## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
