### PR TITLE
Update pyupgrade to --py37-plus

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,7 @@ repos:
   rev: 'v3.15.0'
   hooks:
   - id: pyupgrade
-    args: ['--py36-plus']
+    args: ['--py37-plus']
 - repo: https://github.com/PyCQA/flake8
   rev: '6.1.0'
   hooks:

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -135,7 +135,7 @@ native_byteorder: Final[str] = sys.byteorder
 
 
 # Used by _websocket_mask_python
-@functools.lru_cache()
+@functools.lru_cache
 def _xor_table() -> List[bytes]:
     return [bytes(a ^ b for a in range(256)) for b in range(256)]
 


### PR DESCRIPTION
I noticed the pre-commit hook has lagged behind supported versions.

Note that `--py-38-plus` will remove the version check, which probably isn't wanted.


(Also, I recommend ripping out `pyupgrade` and replacing with `ruff --select UP`
