### PR TITLE
Skip filtering ``CookieJar`` when the jar is empty or all cookies have expired

### DIFF
--- a/CHANGES/7819.feature
+++ b/CHANGES/7819.feature
@@ -1,0 +1,1 @@
+Skip filtering ``CookieJar`` when the jar is empty or all cookies have expired.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -282,6 +282,7 @@ Robert Lu
 Robert Nikolich
 Roman Markeloff
 Roman Podoliaka
+Rong Zhang
 Samir Akarioh
 Samuel Colvin
 Sean Hunt

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -246,14 +246,11 @@ class CookieJar(AbstractCookieJar):
             SimpleCookie() if self._quote_cookie else BaseCookie()
         )
         if not self._cookies:
-            # Shortcut: empty jar
-            # We need the shortcut because the filtering itself and its
-            # preparation is expensive
+            # Skip do_expiration() if there are no cookies.
             return filtered
         self._do_expiration()
         if not self._cookies:
-            # Shortcut: all cookies expired
-            # Likewise.
+            # Skip rest of function if no non-expired cookies.
             return filtered
         hostname = request_url.raw_host or ""
         request_origin = URL()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The filtering itself and its preparation in `CookieJar.filter_cookies()` is expensive. Sometimes there are no cookies in the jar or all cookies have expired. Skip filtering and its preparation in this case.

Because the empty check is much cheaper than `_do_expiration()`, I think it deserves to be duplicated before and after calling `_do_expiration()`.

```console
$ python3.11 -m timeit -s 'from collections import defaultdict; d=defaultdict(foo="bar")' \
> 'if not d: pass'
50000000 loops, best of 5: 8.3 nsec per loop
$ python3.11 -m timeit -s 'from collections import defaultdict; d=defaultdict()' \
> 'if not d: pass'
50000000 loops, best of 5: 8.74 nsec per loop
$ python3.11 -m timeit -s 'from aiohttp import CookieJar; cj = CookieJar()' \
> 'cj._do_expiration()'
200000 loops, best of 5: 1.86 usec per loop
```

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

https://github.com/aio-libs/aiohttp/issues/7583#issuecomment-1806328904

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
