### PR TITLE
Bump pypy to 3.9

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -153,7 +153,7 @@ jobs:
           - os: windows
             no-extensions: 'Y'
         include:
-          - pyver: pypy-3.8
+          - pyver: pypy-3.9
             no-extensions: 'Y'
             os: ubuntu
             experimental: false


### PR DESCRIPTION
We're getting a lot of segfaults when initialising the tests with Pypy recently. Maybe bumping to a more recent release will help (3.8 is near EOL anyway).