### PR TITLE
Use timestamp instead of datetime to achieve faster cookie expiration in CookieJar

### DIFF
--- a/CHANGES/7824.feature
+++ b/CHANGES/7824.feature
@@ -1,0 +1,1 @@
+Use timestamp instead of ``datetime`` to achieve faster cookie expiration in ``CookieJar``.

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -99,7 +99,7 @@ class CookieJar(AbstractCookieJar):
                 for url in treat_as_secure_origin
             ]
         self._treat_as_secure_origin = treat_as_secure_origin
-        self._next_expiration: Union[int, float] = ceil(time.time())
+        self._next_expiration: float = ceil(time.time())
         self._expirations: Dict[Tuple[str, str, str], Union[int, float]] = {}
 
     def save(self, file_path: PathLike) -> None:

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -56,9 +56,9 @@ class CookieJar(AbstractCookieJar):
 
     # calendar.timegm() fails for timestamps after datetime.datetime.max
     # Minus one as a loss of precision occurs when timestamp() is called.
-    MAX_TIME = int(
-        datetime.datetime.max.replace(tzinfo=datetime.timezone.utc).timestamp()
-    ) - 1
+    MAX_TIME = (
+        int(datetime.datetime.max.replace(tzinfo=datetime.timezone.utc).timestamp()) - 1
+    )
     # #4515: datetime.max may not be representable on 32-bit platforms
     try:
         calendar.timegm(time.gmtime(MAX_TIME))
@@ -384,9 +384,7 @@ class CookieJar(AbstractCookieJar):
         if year < 1601 or hour > 23 or minute > 59 or second > 59:
             return None
 
-        return calendar.timegm(
-                (year, month, day, hour, minute, second, -1, -1, -1)
-        )
+        return calendar.timegm((year, month, day, hour, minute, second, -1, -1, -1))
 
 
 class DummyCookieJar(AbstractCookieJar):

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -90,7 +90,7 @@ class CookieJar(AbstractCookieJar):
                 for url in treat_as_secure_origin
             ]
         self._treat_as_secure_origin = treat_as_secure_origin
-        self._next_expiration = next_whole_second()
+        self._next_expiration: Union[int, float] = next_whole_second()
         self._expirations: Dict[Tuple[str, str, str], Union[int, float]] = {}
 
     def save(self, file_path: PathLike) -> None:

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -66,8 +66,6 @@ class CookieJar(AbstractCookieJar):
         # Hit the maximum representable time on Windows
         # https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/localtime-localtime32-localtime64
         MAX_TIME = calendar.timegm((3000, 12, 31, 23, 59, 59, -1, -1, -1))
-        # The below line should never raise an exception
-        time.gmtime(MAX_TIME)
     except OverflowError:
         # #4515: datetime.max may not be representable on 32-bit platforms
         MAX_TIME = 2**31 - 1

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -8,9 +8,8 @@ import re
 import time
 import warnings
 from collections import defaultdict
-from math import ceil
-
 from http.cookies import BaseCookie, Morsel, SimpleCookie
+from math import ceil
 from typing import (  # noqa
     DefaultDict,
     Dict,

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -158,7 +158,7 @@ class CookieJar(AbstractCookieJar):
         self.clear(lambda x: False)
 
     def _expire_cookie(
-        self, when: Union[int, float], domain: str, path: str, name: str
+        self, when: float, domain: str, path: str, name: str
     ) -> None:
         self._next_expiration = min(self._next_expiration, when)
         self._expirations[(domain, path, name)] = when

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -100,7 +100,7 @@ class CookieJar(AbstractCookieJar):
             ]
         self._treat_as_secure_origin = treat_as_secure_origin
         self._next_expiration: float = ceil(time.time())
-        self._expirations: Dict[Tuple[str, str, str], Union[int, float]] = {}
+        self._expirations: Dict[Tuple[str, str, str], float] = {}
 
     def save(self, file_path: PathLike) -> None:
         file_path = pathlib.Path(file_path)

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -157,9 +157,7 @@ class CookieJar(AbstractCookieJar):
     def _do_expiration(self) -> None:
         self.clear(lambda x: False)
 
-    def _expire_cookie(
-        self, when: float, domain: str, path: str, name: str
-    ) -> None:
+    def _expire_cookie(self, when: float, domain: str, path: str, name: str) -> None:
         self._next_expiration = min(self._next_expiration, when)
         self._expirations[(domain, path, name)] = when
 

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -59,10 +59,16 @@ class CookieJar(AbstractCookieJar):
     MAX_TIME = (
         int(datetime.datetime.max.replace(tzinfo=datetime.timezone.utc).timestamp()) - 1
     )
-    # #4515: datetime.max may not be representable on 32-bit platforms
     try:
         calendar.timegm(time.gmtime(MAX_TIME))
+    except OSError:
+        # Hit the maximum representable time on Windows
+        # https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/localtime-localtime32-localtime64
+        MAX_TIME = calendar.timegm((3000, 12, 31, 23, 59, 59, -1, -1, -1))
+        # The below line should never raise an exception
+        time.gmtime(MAX_TIME)
     except OverflowError:
+        # #4515: datetime.max may not be representable on 32-bit platforms
         MAX_TIME = 2**31 - 1
 
     def __init__(

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -530,11 +530,6 @@ def is_ip_address(host: Optional[Union[str, bytes, bytearray, memoryview]]) -> b
     return is_ipv4_address(host) or is_ipv6_address(host)
 
 
-def next_whole_second() -> int:
-    """Return current time rounded up to the next whole second."""
-    return ceil(time.time())
-
-
 _cached_current_datetime: Optional[int] = None
 _cached_formatted_datetime = ""
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -530,11 +530,9 @@ def is_ip_address(host: Optional[Union[str, bytes, bytearray, memoryview]]) -> b
     return is_ipv4_address(host) or is_ipv6_address(host)
 
 
-def next_whole_second() -> datetime.datetime:
+def next_whole_second() -> int:
     """Return current time rounded up to the next whole second."""
-    return datetime.datetime.now(datetime.timezone.utc).replace(
-        microsecond=0
-    ) + datetime.timedelta(seconds=0)
+    return ceil(time.time())
 
 
 _cached_current_datetime: Optional[int] = None

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -102,24 +102,28 @@ def test_date_parsing() -> None:
     assert parse_func("") is None
 
     # 70 -> 1970
-    assert parse_func("Tue, 1 Jan 70 00:00:00 GMT") == datetime.datetime(
-        1970, 1, 1, tzinfo=utc
-    ).timestamp()
+    assert (
+        parse_func("Tue, 1 Jan 70 00:00:00 GMT")
+        == datetime.datetime(1970, 1, 1, tzinfo=utc).timestamp()
+    )
 
     # 10 -> 2010
-    assert parse_func("Tue, 1 Jan 10 00:00:00 GMT") == datetime.datetime(
-        2010, 1, 1, tzinfo=utc
-    ).timestamp()
+    assert (
+        parse_func("Tue, 1 Jan 10 00:00:00 GMT")
+        == datetime.datetime(2010, 1, 1, tzinfo=utc).timestamp()
+    )
 
     # No day of week string
-    assert parse_func("1 Jan 1970 00:00:00 GMT") == datetime.datetime(
-        1970, 1, 1, tzinfo=utc
-    ).timestamp()
+    assert (
+        parse_func("1 Jan 1970 00:00:00 GMT")
+        == datetime.datetime(1970, 1, 1, tzinfo=utc).timestamp()
+    )
 
     # No timezone string
-    assert parse_func("Tue, 1 Jan 1970 00:00:00") == datetime.datetime(
-        1970, 1, 1, tzinfo=utc
-    ).timestamp()
+    assert (
+        parse_func("Tue, 1 Jan 1970 00:00:00")
+        == datetime.datetime(1970, 1, 1, tzinfo=utc).timestamp()
+    )
 
     # No year
     assert parse_func("Tue, 1 Jan 00:00:00 GMT") is None

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -104,22 +104,22 @@ def test_date_parsing() -> None:
     # 70 -> 1970
     assert parse_func("Tue, 1 Jan 70 00:00:00 GMT") == datetime.datetime(
         1970, 1, 1, tzinfo=utc
-    )
+    ).timestamp()
 
     # 10 -> 2010
     assert parse_func("Tue, 1 Jan 10 00:00:00 GMT") == datetime.datetime(
         2010, 1, 1, tzinfo=utc
-    )
+    ).timestamp()
 
     # No day of week string
     assert parse_func("1 Jan 1970 00:00:00 GMT") == datetime.datetime(
         1970, 1, 1, tzinfo=utc
-    )
+    ).timestamp()
 
     # No timezone string
     assert parse_func("Tue, 1 Jan 1970 00:00:00") == datetime.datetime(
         1970, 1, 1, tzinfo=utc
-    )
+    ).timestamp()
 
     # No year
     assert parse_func("Tue, 1 Jan 00:00:00 GMT") is None


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Use timestamp instead of `datetime` to achieve faster cookie expiration in `CookieJar`

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

#7583
https://github.com/aio-libs/aiohttp/pull/7819#issuecomment-1806933086

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
