### PR TITLE
Index resources in the UrlDispatcher to avoid linear search for most cases

### DIFF
--- a/CHANGES/7829.misc
+++ b/CHANGES/7829.misc
@@ -1,1 +1,3 @@
-Index resources in the UrlDispatcher to avoid linear search for most cases
+Improved URL handler resolution time by indexing resources in the UrlDispatcher.
+For applications with a large number of handlers, this should increase performance significantly.
+-- by :user:`bdraco`

--- a/CHANGES/7829.misc
+++ b/CHANGES/7829.misc
@@ -1,1 +1,1 @@
-Index resources in the UrlDispatcher to avoid linear search on hit
+Index resources in the UrlDispatcher to avoid linear search for most cases

--- a/CHANGES/7829.misc
+++ b/CHANGES/7829.misc
@@ -1,0 +1,1 @@
+Index resources in the UrlDispatcher to avoid linear search on hit

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1067,7 +1067,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         self._resources.append(resource)
         canonical = resource.canonical
         if "{" in canonical:  # strip at the first { to allow for variables
-            canonical = canonical.partition("{")[0].rstrip("/")
+            canonical = canonical.partition("{")[0].rstrip("/") or "/"
         # There may be multiple resources for a canonical path
         # so we use a list to avoid falling back to a full linear search
         self._resource_index.setdefault(canonical, []).append(resource)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -979,8 +979,24 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         super().__init__()
         self._resources: List[AbstractResource] = []
         self._named_resources: Dict[str, AbstractResource] = {}
+        self._resource_index: dict[str, list[AbstractResource]] = {}
 
     async def resolve(self, request: Request) -> UrlMappingMatchInfo:
+        url_parts = request.rel_url.raw_parts
+        resource_index = self._resource_index
+
+        # Walk the url parts looking for candidates
+        for i in range(len(url_parts), 0, -1):
+            url_part = "/" + "/".join(url_parts[1:i])
+            if (resource_candidates := resource_index.get(url_part)) is not None:
+                for candidate in resource_candidates:
+                    if (
+                        match_dict := (await candidate.resolve(request))[0]
+                    ) is not None:
+                        return match_dict
+
+        # We didn't find any candidates, so will fallback to a linear search
+
         method = request.method
         allowed_methods: Set[str] = set()
 
@@ -1049,6 +1065,12 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
                 )
             self._named_resources[name] = resource
         self._resources.append(resource)
+        canonical = resource.canonical
+        if "{" in canonical:  # strip at the first { to allow for variables
+            canonical = canonical.split("{")[0].rstrip("/")
+        # There may be multiple resources for a canonical path
+        # so we use a list to avoid falling back to a full linear search
+        self._resource_index.setdefault(canonical, []).append(resource)
 
     def add_resource(self, path: str, *, name: Optional[str] = None) -> Resource:
         if path and not path.startswith("/"):

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1024,7 +1024,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
                 allowed_methods |= allowed
 
         if allowed_methods:
-            return MatchInfoError(HTTPMethodNotAllowed(method, allowed_methods))
+            return MatchInfoError(HTTPMethodNotAllowed(request.method, allowed_methods))
         else:
             return MatchInfoError(HTTPNotFound())
 

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1005,8 +1005,10 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
                     else:
                         allowed_methods |= allowed
 
-        # We didn't find any candidates, so we'll try the sub-app resources
-        # which we have to walk in a linear fashion because they have match rules
+        # We didn't find any candidates, so we'll try the matched sub-app resources
+        # which we have to walk in a linear fashion because they have match rules.
+        # For most cases we do not expect there to be many of these since currently
+        # they are only added by add_domain
         method = request.method
         for resource in self._matched_sub_app_resources:
             match_dict, allowed = await resource.resolve(request)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1091,9 +1091,8 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
 
     def _get_resource_index_key(self, resource: AbstractResource) -> str:
         """Return a key to index the resource in the resource index."""
-        canonical = resource.canonical
-        if "{" in canonical:  # strip at the first { to allow for variables
-            canonical = canonical.partition("{")[0].rstrip("/")
+        # strip at the first { to allow for variables
+        canonical = resource.canonical.partition("{")[0].rstrip("/")
         return canonical or "/"
 
     def index_resource(self, resource: AbstractResource) -> None:

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -738,11 +738,6 @@ class PrefixedSubAppResource(PrefixResource):
         return {"app": self._app, "prefix": self._prefix}
 
     async def resolve(self, request: Request) -> _Resolve:
-        if (
-            not request.url.raw_path.startswith(self._prefix2)
-            and request.url.raw_path != self._prefix
-        ):
-            return None, set()
         match_info = await self._app.router.resolve(request)
         match_info.add_app(self._app)
         if isinstance(match_info.http_exception, HTTPMethodNotAllowed):

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1093,8 +1093,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
     def _get_resource_index_key(self, resource: AbstractResource) -> str:
         """Return a key to index the resource in the resource index."""
         # strip at the first { to allow for variables
-        canonical = resource.canonical.partition("{")[0].rstrip("/")
-        return canonical or "/"
+        return resource.canonical.partition("{")[0].rstrip("/") or "/"
 
     def index_resource(self, resource: AbstractResource) -> None:
         """Add a resource to the resource index."""

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -294,13 +294,6 @@ class MatchInfoError(UrlMappingMatchInfo):
     def http_exception(self) -> HTTPException:
         return self._exception
 
-    def freeze(self) -> None:
-        """Freeze the match info.
-
-        MatchInfoErrors are SystemRoutes and
-        shared across all apps so freeze is a noop.
-        """
-
     def __repr__(self) -> str:
         return "<MatchInfoError {}: {}>".format(
             self._exception.status, self._exception.reason
@@ -1226,6 +1219,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         super().freeze()
         for resource in self._resources:
             resource.freeze()
+        self._http_not_found_match.freeze()
 
     def add_routes(self, routes: Iterable[AbstractRouteDef]) -> List[AbstractRoute]:
         """Append routes to route table.

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -294,6 +294,13 @@ class MatchInfoError(UrlMappingMatchInfo):
     def http_exception(self) -> HTTPException:
         return self._exception
 
+    def freeze(self) -> None:
+        """Freeze the match info.
+
+        MatchInfoErrors are SystemRoutes and
+        shared across all apps so freeze is a noop.
+        """
+
     def __repr__(self) -> str:
         return "<MatchInfoError {}: {}>".format(
             self._exception.status, self._exception.reason

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -974,9 +974,6 @@ class RoutesView(Sized, Iterable[AbstractRoute], Container[AbstractRoute]):
         return route in self._routes
 
 
-NOT_FOUND_MATCH_ERROR = MatchInfoError(HTTPNotFound())
-
-
 class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
     NAME_SPLIT_RE = re.compile(r"[.:-]")
 
@@ -986,6 +983,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         self._named_resources: Dict[str, AbstractResource] = {}
         self._resource_index: dict[str, list[AbstractResource]] = {}
         self._matched_sub_app_resources: List[MatchedSubAppResource] = []
+        self._http_not_found_match = MatchInfoError(HTTPNotFound())
 
     async def resolve(self, request: Request) -> UrlMappingMatchInfo:
         resource_index = self._resource_index
@@ -1026,7 +1024,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         if allowed_methods:
             return MatchInfoError(HTTPMethodNotAllowed(request.method, allowed_methods))
 
-        return NOT_FOUND_MATCH_ERROR
+        return self._http_not_found_match
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._named_resources)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -994,7 +994,11 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         resource_index = self._resource_index
         allowed_methods: Set[str] = set()
 
-        # Walk the url parts looking for candidates
+        # Walk the url parts looking for candidates. We walk the url backwards
+        # to ensure the most explicit match is found first. If there are multiple
+        # candidates for a given url part because there are multiple resources
+        # registered for the same canonical path, we resolve them in a linear
+        # fashion to ensure registration order is respected.
         for i in range(len(url_parts), 0, -1):
             url_part = "/" + "/".join(url_parts[1:i])
             if (resource_candidates := resource_index.get(url_part)) is not None:

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -995,7 +995,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
                     ) is not None:
                         return match_dict
 
-        # We didn't find any candidates, so will fallback to a linear search
+        # We didn't find any candidates, so we fallback to a linear search
 
         method = request.method
         allowed_methods: Set[str] = set()

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -294,6 +294,13 @@ class MatchInfoError(UrlMappingMatchInfo):
     def http_exception(self) -> HTTPException:
         return self._exception
 
+    def freeze(self) -> None:
+        """Freeze the match info.
+
+        MatchInfoErrors are SystemRoutes and
+        shared across all apps so freeze is a noop.
+        """
+
     def __repr__(self) -> str:
         return "<MatchInfoError {}: {}>".format(
             self._exception.status, self._exception.reason
@@ -1219,7 +1226,6 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         super().freeze()
         for resource in self._resources:
             resource.freeze()
-        self._http_not_found_match.freeze()
 
     def add_routes(self, routes: Iterable[AbstractRouteDef]) -> List[AbstractRoute]:
         """Append routes to route table.

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1094,7 +1094,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         """Return a key to index the resource in the resource index."""
         canonical = resource.canonical
         if "{" in canonical:  # strip at the first { to allow for variables
-            return canonical.partition("{")[0].rstrip("/")
+            canonical = canonical.partition("{")[0].rstrip("/")
         return canonical or "/"
 
     def index_resource(self, resource: AbstractResource) -> None:

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1016,7 +1016,6 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         # For most cases we do not expect there to be many of these since
         # currently they are only added by `add_domain`
         #
-        method = request.method
         for resource in self._matched_sub_app_resources:
             match_dict, allowed = await resource.resolve(request)
             if match_dict is not None:

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -294,13 +294,6 @@ class MatchInfoError(UrlMappingMatchInfo):
     def http_exception(self) -> HTTPException:
         return self._exception
 
-    def freeze(self) -> None:
-        """Freeze the match info.
-
-        MatchInfoErrors are SystemRoutes and
-        shared across all apps so freeze is a noop.
-        """
-
     def __repr__(self) -> str:
         return "<MatchInfoError {}: {}>".format(
             self._exception.status, self._exception.reason

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1094,8 +1094,8 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         """Return a key to index the resource in the resource index."""
         canonical = resource.canonical
         if "{" in canonical:  # strip at the first { to allow for variables
-            return canonical.partition("{")[0].rstrip("/") or "/"
-        return canonical
+            return canonical.partition("{")[0].rstrip("/")
+        return canonical or "/"
 
     def index_resource(self, resource: AbstractResource) -> None:
         """Add a resource to the resource index."""

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -974,6 +974,9 @@ class RoutesView(Sized, Iterable[AbstractRoute], Container[AbstractRoute]):
         return route in self._routes
 
 
+NOT_FOUND_MATCH_ERROR = MatchInfoError(HTTPNotFound())
+
+
 class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
     NAME_SPLIT_RE = re.compile(r"[.:-]")
 
@@ -1022,8 +1025,8 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
 
         if allowed_methods:
             return MatchInfoError(HTTPMethodNotAllowed(request.method, allowed_methods))
-        else:
-            return MatchInfoError(HTTPNotFound())
+
+        return NOT_FOUND_MATCH_ERROR
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._named_resources)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1001,13 +1001,12 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         # fashion to ensure registration order is respected.
         for i in range(len(url_parts), 0, -1):
             url_part = "/" + "/".join(url_parts[1:i])
-            if (resource_candidates := resource_index.get(url_part)) is not None:
-                for candidate in resource_candidates:
-                    match_dict, allowed = await candidate.resolve(request)
-                    if match_dict is not None:
-                        return match_dict
-                    else:
-                        allowed_methods |= allowed
+            for candidate in resource_index.get(url_part, ()):
+                match_dict, allowed = await candidate.resolve(request)
+                if match_dict is not None:
+                    return match_dict
+                else:
+                    allowed_methods |= allowed
 
         #
         # We didn't find any candidates, so we'll try the matched sub-app

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -998,7 +998,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         # candidates for a given url part because there are multiple resources
         # registered for the same canonical path, we resolve them in a linear
         # fashion to ensure registration order is respected.
-        url_part = request.rel_url.path
+        url_part = request.rel_url.raw_path
         while url_part:
             for candidate in resource_index.get(url_part, ()):
                 match_dict, allowed = await candidate.resolve(request)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1010,12 +1010,12 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
                         allowed_methods |= allowed
 
         #
-        # We didn't find any candidates, so we'll try the matched sub-app resources
-        # which we have to walk in a linear fashion because they have regex/wildcard
-        # match rules and we cannot index them.
+        # We didn't find any candidates, so we'll try the matched sub-app
+        # resources which we have to walk in a linear fashion because they
+        # have regex/wildcard match rules and we cannot index them.
         #
-        # For most cases we do not expect there to be many of these since currently
-        # they are only added by add_domain
+        # For most cases we do not expect there to be many of these since
+        # currently they are only added by `add_domain`
         #
         method = request.method
         for resource in self._matched_sub_app_resources:

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -974,9 +974,6 @@ class RoutesView(Sized, Iterable[AbstractRoute], Container[AbstractRoute]):
         return route in self._routes
 
 
-NOT_FOUND_MATCH_ERROR = MatchInfoError(HTTPNotFound())
-
-
 class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
     NAME_SPLIT_RE = re.compile(r"[.:-]")
 
@@ -1025,8 +1022,8 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
 
         if allowed_methods:
             return MatchInfoError(HTTPMethodNotAllowed(request.method, allowed_methods))
-
-        return NOT_FOUND_MATCH_ERROR
+        else:
+            return MatchInfoError(HTTPNotFound())
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._named_resources)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -716,16 +716,17 @@ class PrefixedSubAppResource(PrefixResource):
     def __init__(self, prefix: str, app: "Application") -> None:
         super().__init__(prefix)
         self._app = app
-        router = app.router
-        for resource in app.router.resources():
-            router.unindex_resource(resource)
-            resource.add_prefix(prefix)
-            router.index_resource(resource)
+        self._add_prefix_to_resources(prefix)
 
     def add_prefix(self, prefix: str) -> None:
         super().add_prefix(prefix)
+        self._add_prefix_to_resources(prefix)
+
+    def _add_prefix_to_resources(self, prefix: str) -> None:
         router = self._app.router
         for resource in router.resources():
+            # Since the canonical path of a resource is about
+            # to change, we need to unindex it and then reindex
             router.unindex_resource(resource)
             resource.add_prefix(prefix)
             router.index_resource(resource)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1067,7 +1067,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         self._resources.append(resource)
         canonical = resource.canonical
         if "{" in canonical:  # strip at the first { to allow for variables
-            canonical = canonical.split("{")[0].rstrip("/")
+            canonical = canonical.partition("{")[0].rstrip("/")
         # There may be multiple resources for a canonical path
         # so we use a list to avoid falling back to a full linear search
         self._resource_index.setdefault(canonical, []).append(resource)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1101,7 +1101,8 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         """Add a resource to the resource index."""
         resource_key = self._get_resource_index_key(resource)
         # There may be multiple resources for a canonical path
-        # so we use a list to avoid falling back to a full linear search
+        # so we keep them in a list to ensure that registration
+        # order is respected.
         self._resource_index.setdefault(resource_key, []).append(resource)
 
     def unindex_resource(self, resource: AbstractResource) -> None:

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1005,10 +1005,14 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
                     else:
                         allowed_methods |= allowed
 
+        #
         # We didn't find any candidates, so we'll try the matched sub-app resources
-        # which we have to walk in a linear fashion because they have match rules.
+        # which we have to walk in a linear fashion because they have regex/wildcard
+        # match rules and we cannot index them.
+        #
         # For most cases we do not expect there to be many of these since currently
         # they are only added by add_domain
+        #
         method = request.method
         for resource in self._matched_sub_app_resources:
             match_dict, allowed = await resource.resolve(request)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -976,6 +976,7 @@ class RoutesView(Sized, Iterable[AbstractRoute], Container[AbstractRoute]):
 
 class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
     NAME_SPLIT_RE = re.compile(r"[.:-]")
+    HTTP_NOT_FOUND = HTTPNotFound()
 
     def __init__(self) -> None:
         super().__init__()
@@ -1022,8 +1023,8 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
 
         if allowed_methods:
             return MatchInfoError(HTTPMethodNotAllowed(request.method, allowed_methods))
-        else:
-            return MatchInfoError(HTTPNotFound())
+
+        return MatchInfoError(self.HTTP_NOT_FOUND)
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._named_resources)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -974,6 +974,9 @@ class RoutesView(Sized, Iterable[AbstractRoute], Container[AbstractRoute]):
         return route in self._routes
 
 
+NOT_FOUND_MATCH_ERROR = MatchInfoError(HTTPNotFound())
+
+
 class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
     NAME_SPLIT_RE = re.compile(r"[.:-]")
 
@@ -983,7 +986,6 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         self._named_resources: Dict[str, AbstractResource] = {}
         self._resource_index: dict[str, list[AbstractResource]] = {}
         self._matched_sub_app_resources: List[MatchedSubAppResource] = []
-        self._http_not_found_match = MatchInfoError(HTTPNotFound())
 
     async def resolve(self, request: Request) -> UrlMappingMatchInfo:
         resource_index = self._resource_index
@@ -1024,7 +1026,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         if allowed_methods:
             return MatchInfoError(HTTPMethodNotAllowed(request.method, allowed_methods))
 
-        return self._http_not_found_match
+        return NOT_FOUND_MATCH_ERROR
 
     def __iter__(self) -> Iterator[str]:
         return iter(self._named_resources)

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -198,9 +198,17 @@ Variable Resources
 
 .. versionchanged:: 3.10
 
-    Fixed paths are always preferred over variable paths. For example,
+    Fixed paths are preferred over variable paths. For example,
     if you have two routes ``/a/b`` and ``/a/{name}``, then the first
     route will always be preferred over the second one.
+
+    If there are multiple dynamic paths with the same fixed prefix,
+    they will be resolved in order of registration.
+
+    For example, if you have two dynamic routes that are prefixed
+    with the fixed ``/users`` path such as ``/users/{x}/{y}/z`` and
+    ``/users/{x}/y/z``, the first one will be preferred over the
+    second one.
 
 Resource may have *variable path* also. For instance, a resource with
 the path ``'/a/{name}/c'`` would match all incoming requests with

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -196,6 +196,12 @@ First one is *optimized*. You have got the idea.
 Variable Resources
 ^^^^^^^^^^^^^^^^^^
 
+.. versionchanged:: 4.0
+
+    Fixed paths are always preferred over variable paths. For example,
+    if you have two routes ``/a/b`` and ``/a/{name}``, then the first
+    route will always be preferred over the second one.
+
 Resource may have *variable path* also. For instance, a resource with
 the path ``'/a/{name}/c'`` would match all incoming requests with
 paths such as ``'/a/b/c'``, ``'/a/1/c'``, and ``'/a/etc/c'``.

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -196,7 +196,7 @@ First one is *optimized*. You have got the idea.
 Variable Resources
 ^^^^^^^^^^^^^^^^^^
 
-.. versionchanged:: 4.0
+.. versionchanged:: 3.10
 
     Fixed paths are always preferred over variable paths. For example,
     if you have two routes ``/a/b`` and ``/a/{name}``, then the first

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -196,20 +196,6 @@ First one is *optimized*. You have got the idea.
 Variable Resources
 ^^^^^^^^^^^^^^^^^^
 
-.. versionchanged:: 3.10
-
-    Fixed paths are preferred over variable paths. For example,
-    if you have two routes ``/a/b`` and ``/a/{name}``, then the first
-    route will always be preferred over the second one.
-
-    If there are multiple dynamic paths with the same fixed prefix,
-    they will be resolved in order of registration.
-
-    For example, if you have two dynamic routes that are prefixed
-    with the fixed ``/users`` path such as ``/users/{x}/{y}/z`` and
-    ``/users/{x}/y/z``, the first one will be preferred over the
-    second one.
-
 Resource may have *variable path* also. For instance, a resource with
 the path ``'/a/{name}/c'`` would match all incoming requests with
 paths such as ``'/a/b/c'``, ``'/a/1/c'``, and ``'/a/etc/c'``.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1878,7 +1878,7 @@ unique *name* and at least one :term:`route`.
    and will iterate over the list of
    :class:`~aiohttp.web.MatchedSubAppResource` in a linear fashion
    until a match is found.
-4. If no *resource* / *route* pair was found the *router*
+4. If no *resource* / *route* pair was found, the *router*
    returns special :class:`~aiohttp.abc.AbstractMatchInfo`
    instance with :attr:`aiohttp.abc.AbstractMatchInfo.http_exception` is not ``None``
    but :exc:`HTTPException` with  either *HTTP 404 Not Found* or

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1865,21 +1865,20 @@ unique *name* and at least one :term:`route`.
 
 :term:`web-handler` lookup is performed in the following way:
 
-1. Router splits the url and checks the index from longest to shortest.
+1. Router splits the URL and checks the index from longest to shortest.
    For example, '/one/two/three' will first check the index for
    '/one/two/three', then '/one/two' and finally '/'.
-2. If *resource* matches to requested URL the resource iterates over
-   the *routes* for the canonical URL in the index.
-3. If route matches to requested HTTP method (or ``'*'`` wildcard) the
-   route's handler is used as found :term:`web-handler`. The lookup is
-   finished.
-4. If the route is not found in the index, the router tries to find
+2. If the URL part matches is found in the index, the list of routes for
+   that URL part is iterated over. If a route matches to requested HTTP
+   method (or ``'*'`` wildcard) the route's handler is used as found
+   :term:`web-handler`. The lookup is finished.
+3. If the route is not found in the index, the router tries to find
    the route in the list of :class:`~aiohttp.web.MatchedSubAppResource`,
    (current only created from and :meth:`~aiohttp.web_app.Application.add_domain`
    call), and will iterate over the list of
    :class:`~aiohttp.web.MatchedSubAppResource` in a linear fashion
    until a match is found.
-5. If the end of *routing table* is reached and no *resource* /
+4. If the end of *routing table* is reached and no *resource* /
    *route* pair found the *router* returns special :class:`~aiohttp.abc.AbstractMatchInfo`
    instance with :attr:`aiohttp.abc.AbstractMatchInfo.http_exception` is not ``None``
    but :exc:`HTTPException` with  either *HTTP 404 Not Found* or

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1874,8 +1874,8 @@ unique *name* and at least one :term:`route`.
    :term:`web-handler`. The lookup is finished.
 3. If the route is not found in the index, the router tries to find
    the route in the list of :class:`~aiohttp.web.MatchedSubAppResource`,
-   (current only created from and :meth:`~aiohttp.web_app.Application.add_domain`
-   call), and will iterate over the list of
+   (current only created from :meth:`~aiohttp.web_app.Application.add_domain`),
+   and will iterate over the list of
    :class:`~aiohttp.web.MatchedSubAppResource` in a linear fashion
    until a match is found.
 4. If no *resource* / *route* pair was found the *router*

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1874,7 +1874,7 @@ unique *name* and at least one :term:`route`.
    :term:`web-handler`. The lookup is finished.
 3. If the route is not found in the index, the router tries to find
    the route in the list of :class:`~aiohttp.web.MatchedSubAppResource`,
-   (current only created from :meth:`~aiohttp.web_app.Application.add_domain`),
+   (current only created from :meth:`~aiohttp.web.Application.add_domain`),
    and will iterate over the list of
    :class:`~aiohttp.web.MatchedSubAppResource` in a linear fashion
    until a match is found.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1865,7 +1865,7 @@ unique *name* and at least one :term:`route`.
 
 :term:`web-handler` lookup is performed in the following way:
 
-1. Router splits the URL and checks the index from longest to shortest.
+1. The router splits the URL and checks the index from longest to shortest.
    For example, '/one/two/three' will first check the index for
    '/one/two/three', then '/one/two' and finally '/'.
 2. If the URL part is found in the index, the list of routes for

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1879,7 +1879,7 @@ unique *name* and at least one :term:`route`.
    :class:`~aiohttp.web.MatchedSubAppResource` in a linear fashion
    until a match is found.
 4. If no *resource* / *route* pair was found, the *router*
-   returns special :class:`~aiohttp.abc.AbstractMatchInfo`
+   returns the special :class:`~aiohttp.abc.AbstractMatchInfo`
    instance with :attr:`aiohttp.abc.AbstractMatchInfo.http_exception` is not ``None``
    but :exc:`HTTPException` with  either *HTTP 404 Not Found* or
    *HTTP 405 Method Not Allowed* status code.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1865,13 +1865,20 @@ unique *name* and at least one :term:`route`.
 
 :term:`web-handler` lookup is performed in the following way:
 
-1. Router iterates over *resources* one-by-one.
+1. Router splits the url and checks the index from longest to shortest.
+   For example, '/one/two/three' will first check the index for
+   '/one/two/three', then '/one/two' and finally '/'.
 2. If *resource* matches to requested URL the resource iterates over
-   own *routes*.
+   the *routes* for the canonical URL in the index.
 3. If route matches to requested HTTP method (or ``'*'`` wildcard) the
    route's handler is used as found :term:`web-handler`. The lookup is
    finished.
-4. Otherwise router tries next resource from the *routing table*.
+4. If the route is not found in the index, the router tries to find
+   the route in the list of :class:`~aiohttp.web.MatchedSubAppResource`,
+   (current only created from and :meth:`~aiohttp.web_app.Application.add_domain`
+   call), and will iterate over the list of
+   :class:`~aiohttp.web.MatchedSubAppResource` in a linear fashion
+   until a match is found.
 5. If the end of *routing table* is reached and no *resource* /
    *route* pair found the *router* returns special :class:`~aiohttp.abc.AbstractMatchInfo`
    instance with :attr:`aiohttp.abc.AbstractMatchInfo.http_exception` is not ``None``
@@ -1900,7 +1907,10 @@ Resource classes hierarchy::
      Resource
        PlainResource
        DynamicResource
+     PrefixResource
        StaticResource
+       PrefixedSubAppResource
+          MatchedSubAppResource
 
 
 .. class:: AbstractResource

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1885,6 +1885,18 @@ unique *name* and at least one :term:`route`.
    *HTTP 405 Method Not Allowed* status code.
    Registered :meth:`~aiohttp.abc.AbstractMatchInfo.handler` raises this exception on call.
 
+Fixed paths are preferred over variable paths. For example,
+if you have two routes ``/a/b`` and ``/a/{name}``, then the first
+route will always be preferred over the second one.
+
+If there are multiple dynamic paths with the same fixed prefix,
+they will be resolved in order of registration.
+
+For example, if you have two dynamic routes that are prefixed
+with the fixed ``/users`` path such as ``/users/{x}/{y}/z`` and
+``/users/{x}/y/z``, the first one will be preferred over the
+second one.
+
 User should never instantiate resource classes but give it by
 :meth:`UrlDispatcher.add_resource` call.
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1868,7 +1868,7 @@ unique *name* and at least one :term:`route`.
 1. Router splits the URL and checks the index from longest to shortest.
    For example, '/one/two/three' will first check the index for
    '/one/two/three', then '/one/two' and finally '/'.
-2. If the URL part matches is found in the index, the list of routes for
+2. If the URL part is found in the index, the list of routes for
    that URL part is iterated over. If a route matches to requested HTTP
    method (or ``'*'`` wildcard) the route's handler is used as found
    :term:`web-handler`. The lookup is finished.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1870,7 +1870,7 @@ unique *name* and at least one :term:`route`.
    '/one/two/three', then '/one/two' and finally '/'.
 2. If the URL part is found in the index, the list of routes for
    that URL part is iterated over. If a route matches to requested HTTP
-   method (or ``'*'`` wildcard) the route's handler is used as found
+   method (or ``'*'`` wildcard) the route's handler is used as the chosen
    :term:`web-handler`. The lookup is finished.
 3. If the route is not found in the index, the router tries to find
    the route in the list of :class:`~aiohttp.web.MatchedSubAppResource`,

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1878,8 +1878,8 @@ unique *name* and at least one :term:`route`.
    call), and will iterate over the list of
    :class:`~aiohttp.web.MatchedSubAppResource` in a linear fashion
    until a match is found.
-4. If the end of *routing table* is reached and no *resource* /
-   *route* pair found the *router* returns special :class:`~aiohttp.abc.AbstractMatchInfo`
+4. If no *resource* / *route* pair was found the *router*
+   returns special :class:`~aiohttp.abc.AbstractMatchInfo`
    instance with :attr:`aiohttp.abc.AbstractMatchInfo.http_exception` is not ``None``
    but :exc:`HTTPException` with  either *HTTP 404 Not Found* or
    *HTTP 405 Method Not Allowed* status code.

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1264,10 +1264,17 @@ async def test_prefixed_subapp_overlap(app: Any) -> None:
     subapp2.router.add_get("/b", handler2)
     app.add_subapp("/ss", subapp2)
 
+    subapp3 = web.Application()
+    handler3 = make_handler()
+    subapp3.router.add_get("/c", handler3)
+    app.add_subapp("/s/s", subapp3)
+
     match_info = await app.router.resolve(make_mocked_request("GET", "/s/a"))
     assert match_info.route.handler is handler1
     match_info = await app.router.resolve(make_mocked_request("GET", "/ss/b"))
     assert match_info.route.handler is handler2
+    match_info = await app.router.resolve(make_mocked_request("GET", "/s/s/c"))
+    assert match_info.route.handler is handler3
 
 
 async def test_prefixed_subapp_empty_route(app: Any) -> None:

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -547,7 +547,10 @@ async def test_decoded_url_match(
 
 
 async def test_order_is_preserved(aiohttp_client: AiohttpClient) -> None:
-    """Test route order is preserved."""
+    """Test route order is preserved.
+
+    Note that fixed/static paths are always preferred over a regex path.
+    """
     app = web.Application()
 
     async def handler(request: web.Request) -> web.Response:
@@ -581,9 +584,10 @@ async def test_order_is_preserved(aiohttp_client: AiohttpClient) -> None:
     assert await r.text() == "/second/{user}/info"
     await r.release()
 
+    # Fixed/static paths are always preferred over regex paths
     r = await client.get("/second/bob/info")
     assert r.status == 200
-    assert await r.text() == "/second/{user}/info"
+    assert await r.text() == "/second/bob/info"
     await r.release()
 
     r = await client.get("/third/bob/info")
@@ -601,9 +605,10 @@ async def test_order_is_preserved(aiohttp_client: AiohttpClient) -> None:
     assert await r.text() == "/forth/{name}"
     await r.release()
 
+    # Fixed/static paths are always preferred over regex paths
     r = await client.get("/forth/42")
     assert r.status == 200
-    assert await r.text() == "/forth/{name}"
+    assert await r.text() == "/forth/42"
     await r.release()
 
     r = await client.get("/fifth/21")

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -555,9 +555,9 @@ async def test_order_is_preserved(aiohttp_client: AiohttpClient) -> None:
         return web.Response(text=request.match_info._route.resource.canonical)
 
     app.router.add_get("/first/x/{b}/", handler)
-    app.router.add_get("/first/{x:.*/b}", handler)
+    app.router.add_get(r"/first/{x:.*/b}", handler)
 
-    app.router.add_get("/second/{x:.*/b}", handler)
+    app.router.add_get(r"/second/{x:.*/b}", handler)
     app.router.add_get("/second/x/{b}/", handler)
 
     client = await aiohttp_client(app)

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -10,7 +10,7 @@ import yarl
 
 from aiohttp import web
 from aiohttp.pytest_plugin import AiohttpClient
-from aiohttp.web_urldispatcher import SystemRoute
+from aiohttp.web_urldispatcher import Resource, SystemRoute
 
 
 @pytest.mark.parametrize(
@@ -551,6 +551,7 @@ async def test_order_is_preserved(aiohttp_client: AiohttpClient) -> None:
     app = web.Application()
 
     async def handler(request: web.Request) -> web.Response:
+        assert isinstance(request.match_info._route, Resource)
         return web.Response(text=request.match_info._route.resource.canonical)
 
     app.router.add_get("/first/x/{b}/", handler)

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -557,8 +557,11 @@ async def test_order_is_preserved(aiohttp_client: AiohttpClient) -> None:
     app.router.add_get("/first/x/{b}/", handler)
     app.router.add_get(r"/first/{x:.*/b}", handler)
 
-    app.router.add_get(r"/second/{x:.*/b}", handler)
-    app.router.add_get("/second/x/{b}/", handler)
+    app.router.add_get(r"/second/{user}/info", handler)
+    app.router.add_get("/second/bob/info", handler)
+
+    app.router.add_get("/third/bob/info", handler)
+    app.router.add_get(r"/third/{user}/info", handler)
 
     client = await aiohttp_client(app)
 
@@ -567,7 +570,22 @@ async def test_order_is_preserved(aiohttp_client: AiohttpClient) -> None:
     assert await r.text() == "/first/x/{b}/"
     await r.release()
 
-    r = await client.get("/second/x/b/")
+    r = await client.get("/second/frank/info")
     assert r.status == 200
-    assert await r.text() == "/second/{x:.*/b}"
+    assert await r.text() == "/second/{user}/info"
+    await r.release()
+
+    r = await client.get("/second/bob/info")
+    assert r.status == 200
+    assert await r.text() == "/second/{user}/info"
+    await r.release()
+
+    r = await client.get("/third/bob/info")
+    assert r.status == 200
+    assert await r.text() == "/third/bob/info"
+    await r.release()
+
+    r = await client.get("/third/frank/info")
+    assert r.status == 200
+    assert await r.text() == "/third/{user}/info"
     await r.release()

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -610,3 +610,26 @@ async def test_order_is_preserved(aiohttp_client: AiohttpClient) -> None:
     r = await client.get("/fifth/42")
     assert r.status == 200
     assert await r.text() == "/fifth/42"
+
+
+async def test_url_with_many_slashes(aiohttp_client: AiohttpClient) -> None:
+    app = web.Application()
+
+    class MyView(web.View):
+        async def get(self) -> web.Response:
+            return web.Response()
+
+        async def post(self) -> web.Response:
+            return web.Response()
+
+    app.router.add_routes([web.view("/a", MyView), web.view("/a/b/c/d", MyView)])
+
+    client = await aiohttp_client(app)
+
+    r = await client.get("///a////b//////c//d")
+    assert r.status == 200
+    await r.release()
+
+    r = await client.get("///a")
+    assert r.status == 200
+    await r.release()

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -142,7 +142,6 @@ async def test_access_to_the_file_with_spaces(
     r = await client.get(url)
     assert r.status == 200
     assert (await r.text()) == data
-    await r.release()
 
 
 async def test_access_non_existing_resource(
@@ -577,46 +576,37 @@ async def test_order_is_preserved(aiohttp_client: AiohttpClient) -> None:
     r = await client.get("/first/x/b/")
     assert r.status == 200
     assert await r.text() == "/first/x/{b}/"
-    await r.release()
 
     r = await client.get("/second/frank/info")
     assert r.status == 200
     assert await r.text() == "/second/{user}/info"
-    await r.release()
 
     # Fixed/static paths are always preferred over regex paths
     r = await client.get("/second/bob/info")
     assert r.status == 200
     assert await r.text() == "/second/bob/info"
-    await r.release()
 
     r = await client.get("/third/bob/info")
     assert r.status == 200
     assert await r.text() == "/third/bob/info"
-    await r.release()
 
     r = await client.get("/third/frank/info")
     assert r.status == 200
     assert await r.text() == "/third/{user}/info"
-    await r.release()
 
     r = await client.get("/forth/21")
     assert r.status == 200
     assert await r.text() == "/forth/{name}"
-    await r.release()
 
     # Fixed/static paths are always preferred over regex paths
     r = await client.get("/forth/42")
     assert r.status == 200
     assert await r.text() == "/forth/42"
-    await r.release()
 
     r = await client.get("/fifth/21")
     assert r.status == 200
     assert await r.text() == "/fifth/{name}"
-    await r.release()
 
     r = await client.get("/fifth/42")
     assert r.status == 200
     assert await r.text() == "/fifth/42"
-    await r.release()

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -551,7 +551,7 @@ async def test_order_is_preserved(aiohttp_client: AiohttpClient) -> None:
     app = web.Application()
 
     async def handler(request: web.Request) -> web.Response:
-        assert isinstance(request.match_info._route, Resource)
+        assert isinstance(request.match_info._route.resource, Resource)
         return web.Response(text=request.match_info._route.resource.canonical)
 
     app.router.add_get("/first/x/{b}/", handler)

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -619,16 +619,9 @@ async def test_url_with_many_slashes(aiohttp_client: AiohttpClient) -> None:
         async def get(self) -> web.Response:
             return web.Response()
 
-        async def post(self) -> web.Response:
-            return web.Response()
-
-    app.router.add_routes([web.view("/a", MyView), web.view("/a/b/c/d", MyView)])
+    app.router.add_routes([web.view("/a", MyView)])
 
     client = await aiohttp_client(app)
-
-    r = await client.get("///a////b//////c//d")
-    assert r.status == 200
-    await r.release()
 
     r = await client.get("///a")
     assert r.status == 200

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -563,6 +563,12 @@ async def test_order_is_preserved(aiohttp_client: AiohttpClient) -> None:
     app.router.add_get("/third/bob/info", handler)
     app.router.add_get(r"/third/{user}/info", handler)
 
+    app.router.add_get(r"/forth/{name:\d+}", handler)
+    app.router.add_get("/forth/42", handler)
+
+    app.router.add_get("/fifth/42", handler)
+    app.router.add_get(r"/fifth/{name:\d+}", handler)
+
     client = await aiohttp_client(app)
 
     r = await client.get("/first/x/b/")
@@ -588,4 +594,24 @@ async def test_order_is_preserved(aiohttp_client: AiohttpClient) -> None:
     r = await client.get("/third/frank/info")
     assert r.status == 200
     assert await r.text() == "/third/{user}/info"
+    await r.release()
+
+    r = await client.get("/forth/21")
+    assert r.status == 200
+    assert await r.text() == "/forth/{name}"
+    await r.release()
+
+    r = await client.get("/forth/42")
+    assert r.status == 200
+    assert await r.text() == "/forth/{name}"
+    await r.release()
+
+    r = await client.get("/fifth/21")
+    assert r.status == 200
+    assert await r.text() == "/fifth/{name}"
+    await r.release()
+
+    r = await client.get("/fifth/42")
+    assert r.status == 200
+    assert await r.text() == "/fifth/42"
     await r.release()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The time complexity of the UrlDispatcher on a hit averaged `O(n)`

The UrlDispatcher now keeps an index of all resources and will attempt to avoid doing a linear search to resolve.  On a hit the performance should be nearly `O(url_parts)` on a miss the time complexity will be `O(domains) + O(url_parts)`

This works for prefixed subapps as well.

sub apps added by `add_domain` (aka `MatchedSubAppResource`) will fallback to linear searching as they are not indexable since they support wildcard/regexs

## Are there changes in behavior for the user?

A fixed/static path will always be preferred over a dynamic path.

## Related issue number

fixes #7828

benchmark
```python
import asyncio
import timeit
from unittest.mock import MagicMock, AsyncMock

from yarl import URL

from aiohttp import web
from aiohttp.web_urldispatcher import (
    UrlDispatcher,
)

URL_COUNT = 5000


def make_mock_request(url: str) -> web.Request:
    return web.Request(
        MagicMock(url=URL(url), method="GET"),
        MagicMock(),
        protocol=MagicMock(),
        host="example.com",
        task=MagicMock(),
        loop=asyncio.get_running_loop(),
        payload_writer=MagicMock(),
    )


async def url_dispatcher_performance():
    """Filter out large cookies from the cookie jar."""
    dispatcher = UrlDispatcher()
    for i in range(URL_COUNT):
        dispatcher.add_get(f"/static/sub/path{i}", AsyncMock())

    first_url = "/static/sub/path0"
    last_url = f"/static/sub/path{URL_COUNT-1}"
    long_url = "/static/lots/of/sub/path/segments/0/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15"
    mid_size_url = "/static/midsize/of/sub/path/segments"
    miss_url = "/is/a/miss"
    long_miss_url = "/is/a/miss/with/lots/of/sub/path/segments/0/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15"

    dispatcher.add_get(long_url, AsyncMock())
    dispatcher.add_get(mid_size_url, AsyncMock())

    request_first_url = make_mock_request(first_url)
    match_info = await dispatcher.resolve(request_first_url)
    assert match_info.route.resource.canonical == first_url

    request_last_url = make_mock_request(last_url)
    match_info = await dispatcher.resolve(request_last_url)
    assert match_info.route.resource.canonical == last_url

    request_long_url = make_mock_request(long_url)
    match_info = await dispatcher.resolve(request_long_url)
    assert match_info.route.resource.canonical == long_url

    request_mid_size_url = make_mock_request(mid_size_url)
    match_info = await dispatcher.resolve(request_mid_size_url)
    assert match_info.route.resource.canonical == mid_size_url

    request_miss_url = make_mock_request(miss_url)
    match_info = await dispatcher.resolve(request_miss_url)
    assert match_info.route.status == 404

    request_long_miss_url = make_mock_request(long_miss_url)
    match_info = await dispatcher.resolve(request_long_miss_url)
    assert match_info.route.status == 404

    async def resolve_times(request: web.Request, times: int) -> float:
        start = timeit.default_timer()
        for _ in range(times):
            await dispatcher.resolve(request)
        end = timeit.default_timer()
        return end - start

    run_count = 2000
    resolve_time_first_url = await resolve_times(request_first_url, run_count)
    resolve_time_last_url = await resolve_times(request_last_url, run_count)
    resolve_time_mid_size_url = await resolve_times(request_mid_size_url, run_count)
    resolve_time_long_url = await resolve_times(request_long_url, run_count)
    resolve_time_miss = await resolve_times(request_miss_url, run_count)
    resolve_time_long_miss = await resolve_times(request_long_miss_url, run_count)
    print(f"resolve_time_first_url: {resolve_time_first_url}")
    print(f"resolve_time_last_url: {resolve_time_last_url}")
    print(f"resolve_time_mid_size_url: {resolve_time_mid_size_url}")
    print(f"resolve_time_long_url: {resolve_time_long_url}")
    print(f"resolve_time_miss: {resolve_time_miss}")
    print(f"resolve_time_long_miss: {resolve_time_long_miss}")


asyncio.run(url_dispatcher_performance())
```

before (5002 urls)
```
resolve_time_first_url: 0.0016546659753657877
resolve_time_last_url: 2.253484041953925
resolve_time_mid_size_url: 2.1529546250239946
resolve_time_long_url: 2.136738500033971
resolve_time_miss: 2.152159374963958
resolve_time_long_miss: 2.173428333015181
```
before (7 urls)
```
resolve_time_first_url: 0.0019221249967813492
resolve_time_last_url: 0.0038797500310465693
resolve_time_mid_size_url: 0.004664750013034791
resolve_time_long_url: 0.004066875029820949
resolve_time_miss: 0.00846966594690457
resolve_time_long_miss: 0.008330333046615124
```

after (5002 urls)
```
resolve_time_first_url: 0.0019938750192523003
resolve_time_last_url: 0.0020484999986365438
resolve_time_mid_size_url: 0.002027958049438894
resolve_time_long_url: 0.0019290419877506793
resolve_time_miss: 0.0035507080028764904
resolve_time_long_miss: 0.007968166959472
```
after (7 urls)
```
resolve_time_first_url: 0.0019937920151278377
resolve_time_last_url: 0.002007792005315423
resolve_time_mid_size_url: 0.0019652920309454203
resolve_time_long_url: 0.0019985410035587847
resolve_time_miss: 0.003473666962236166
resolve_time_long_miss: 0.007722083013504744
```

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
