### PR TITLE
Add classifiers for Python 3.11 and 3.12

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,8 @@ classifiers =
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
+  Programming Language :: Python :: 3.12
 
   Topic :: Internet :: WWW/HTTP
 


### PR DESCRIPTION
See suggestion at https://github.com/aio-libs/aiohttp/issues/7675#issuecomment-1811979555

## What do these changes do?
Adds PyPI classifiers that indicate Python 3.11 and 3.12 support.

## Are there changes in behavior for the user?
No.

## Related issue number
n/a

## Checklist
n/a
