### PR TITLE
Ensure separate ZLibCompressor instances per coroutine when using max_sync_chunk_size

### DIFF
--- a/CHANGES/7859.bugfix
+++ b/CHANGES/7859.bugfix
@@ -1,0 +1,1 @@
+Ensure separate ZLibCompressor instances per coroutine when using max_sync_chunk_size

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -175,6 +175,7 @@ Jeongkyu Shin
 Jeroen van der Heijden
 Jesus Cea
 Jian Zeng
+Jing Yan
 Jinkyu Yi
 Joel Watts
 John Parton

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -67,6 +67,8 @@ class ZLibCompressor(ZlibBaseHandler):
         return self._compressor.compress(data)
 
     async def compress(self, data: bytes) -> bytes:
+        # In a multi-coroutine environment where max_sync_chunk_size is in use,
+        # ensure that each coroutine has its own compressor instance.
         if (
             self._max_sync_chunk_size is not None
             and len(data) > self._max_sync_chunk_size
@@ -99,6 +101,8 @@ class ZLibDecompressor(ZlibBaseHandler):
         return self._decompressor.decompress(data, max_length)
 
     async def decompress(self, data: bytes, max_length: int = 0) -> bytes:
+        # In a multi-coroutine environment where max_sync_chunk_size is in use,
+        # ensure that each coroutine has its own decompressor instance.
         if (
             self._max_sync_chunk_size is not None
             and len(data) > self._max_sync_chunk_size

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -609,7 +609,6 @@ class WebSocketWriter:
         self._closing = False
         self._limit = limit
         self._output_size = 0
-        self._compressobj: Any = None  # actually compressobj
 
     async def _send_frame(
         self, message: bytes, opcode: int, compress: Optional[int] = None
@@ -632,13 +631,11 @@ class WebSocketWriter:
                     max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
                 )
             else:  # self.compress
-                if not self._compressobj:
-                    self._compressobj = ZLibCompressor(
-                        level=zlib.Z_BEST_SPEED,
-                        wbits=-self.compress,
-                        max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
-                    )
-                compressobj = self._compressobj
+                compressobj = ZLibCompressor(
+                    level=zlib.Z_BEST_SPEED,
+                    wbits=-self.compress,
+                    max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
+                )
 
             message = await compressobj.compress(message)
             message += compressobj.flush(

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -87,7 +87,7 @@ async def test_send_compress_text(protocol: Any, transport: Any) -> None:
     await writer.send(b"text")
     writer.transport.write.assert_called_with(b"\xc1\x06*I\xad(\x01\x00")
     await writer.send(b"text")
-    writer.transport.write.assert_called_with(b"\xc1\x05*\x01b\x00\x00")
+    writer.transport.write.assert_called_with(b"\xc1\x06*I\xad(\x01\x00")
 
 
 async def test_send_compress_text_notakeover(protocol: Any, transport: Any) -> None:


### PR DESCRIPTION
## What do these changes do?

fix #7859 

Ensure separate ZLibCompressor instances per coroutine when using max_sync_chunk_size

## Are there changes in behavior for the user?

None

## Related issue number

Related issue :#7859 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
