### PR TITLE
Restore async concurrency safety to websocket compressor

### DIFF
--- a/CHANGES/7865.bugfix
+++ b/CHANGES/7865.bugfix
@@ -1,0 +1,1 @@
+Restore async concurrency safety to websocket compressor

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -72,7 +72,7 @@ class ZLibCompressor(ZlibBaseHandler):
             # To ensure the stream is consistent in the event
             # there are multiple writers, we need to lock
             # the compressor so that only one writer can
-            # write at a time.
+            # compress at a time.
             if (
                 self._max_sync_chunk_size is not None
                 and len(data) > self._max_sync_chunk_size

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -37,6 +37,12 @@ class ZlibBaseHandler:
         self._executor = executor
         self._max_sync_chunk_size = max_sync_chunk_size
 
+    def should_run_in_executor(self, data: bytes) -> bool:
+        return (
+            self._max_sync_chunk_size is not None
+            and len(data) > self._max_sync_chunk_size
+        )
+
 
 class ZLibCompressor(ZlibBaseHandler):
     def __init__(
@@ -48,7 +54,7 @@ class ZLibCompressor(ZlibBaseHandler):
         strategy: int = zlib.Z_DEFAULT_STRATEGY,
         executor: Optional[Executor] = None,
         max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE,
-    ):
+    ) -> None:
         super().__init__(
             mode=encoding_to_mode(encoding, suppress_deflate_header)
             if wbits is None
@@ -66,14 +72,14 @@ class ZLibCompressor(ZlibBaseHandler):
     def compress_sync(self, data: bytes) -> bytes:
         return self._compressor.compress(data)
 
+    async def compress_executor(self, data: bytes) -> bytes:
+        return await asyncio.get_event_loop().run_in_executor(
+            self._executor, self.compress_sync, data
+        )
+
     async def compress(self, data: bytes) -> bytes:
-        if (
-            self._max_sync_chunk_size is not None
-            and len(data) > self._max_sync_chunk_size
-        ):
-            return await asyncio.get_event_loop().run_in_executor(
-                self._executor, self.compress_sync, data
-            )
+        if self.should_run_in_executor(data):
+            return await self.compress_executor(data)
         return self.compress_sync(data)
 
     def flush(self, mode: int = zlib.Z_FINISH) -> bytes:

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -48,7 +48,7 @@ class ZLibCompressor(ZlibBaseHandler):
         strategy: int = zlib.Z_DEFAULT_STRATEGY,
         executor: Optional[Executor] = None,
         max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE,
-    ) -> None:
+    ):
         super().__init__(
             mode=encoding_to_mode(encoding, suppress_deflate_header)
             if wbits is None

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -610,7 +610,6 @@ class WebSocketWriter:
         self._limit = limit
         self._output_size = 0
         self._compressobj: Any = None  # actually compressobj
-        self._compress_lock: Optional[asyncio.Lock] = None
 
     async def _send_frame(
         self, message: bytes, opcode: int, compress: Optional[int] = None
@@ -628,47 +627,19 @@ class WebSocketWriter:
             if compress:
                 # Do not set self._compress if compressing is for this frame
                 compressobj = self._make_compress_obj(compress)
-                message = await compressobj.compress(message)
-                self._write_compressed_message(message, opcode, compressobj, rsv)
             else:  # self.compress
-                # If we are reusing the compress object, we need to hold a lock
-                # around the compress/flush/write to ensure that messages get
-                # compressed in order and takeover is not violated.
                 if not self._compressobj:
                     self._compressobj = self._make_compress_obj(self.compress)
-                    self._compress_lock = asyncio.Lock()
                 compressobj = self._compressobj
-                async with self._compress_lock:
-                    message = await compressobj.compress(message)
-                    self._write_compressed_message(message, opcode, compressobj, rsv)
 
-        else:
-            self._write_message(message, opcode, rsv)
+            message = await compressobj.compress(message)
+            message += compressobj.flush(
+                zlib.Z_FULL_FLUSH if self.notakeover else zlib.Z_SYNC_FLUSH
+            )
+            if message.endswith(_WS_DEFLATE_TRAILING):
+                message = message[:-4]
+            rsv = rsv | 0x40
 
-        if self._output_size > self._limit:
-            self._output_size = 0
-            await self.protocol._drain_helper()
-
-    def _make_compress_obj(self, compress: int) -> ZLibCompressor:
-        return ZLibCompressor(
-            level=zlib.Z_BEST_SPEED,
-            wbits=-compress,
-            max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
-        )
-
-    def _write_compressed_message(
-        self, message: bytes, opcode: int, compressobj: ZLibCompressor, rsv: int
-    ) -> None:
-        message += compressobj.flush(
-            zlib.Z_FULL_FLUSH if self.notakeover else zlib.Z_SYNC_FLUSH
-        )
-        if message.endswith(_WS_DEFLATE_TRAILING):
-            message = message[:-4]
-        rsv = rsv | 0x40
-        self._write_message(message, opcode, rsv)
-
-    def _write_message(self, message: bytes, opcode: int, rsv: int) -> None:
-        """Write a complete websocket frame to the transport."""
         msg_length = len(message)
 
         use_mask = self.use_mask
@@ -683,7 +654,6 @@ class WebSocketWriter:
             header = PACK_LEN2(0x80 | rsv | opcode, 126 | mask_bit, msg_length)
         else:
             header = PACK_LEN3(0x80 | rsv | opcode, 127 | mask_bit, msg_length)
-
         if use_mask:
             mask = self.randrange(0, 0xFFFFFFFF)
             mask = mask.to_bytes(4, "big")
@@ -691,15 +661,25 @@ class WebSocketWriter:
             _websocket_mask(mask, message)
             self._write(header + mask + message)
             self._output_size += len(header) + len(mask) + len(message)
-            return
-
-        if len(message) > MSG_SIZE:
-            self._write(header)
-            self._write(message)
         else:
-            self._write(header + message)
+            if len(message) > MSG_SIZE:
+                self._write(header)
+                self._write(message)
+            else:
+                self._write(header + message)
 
-        self._output_size += len(header) + len(message)
+            self._output_size += len(header) + len(message)
+
+        if self._output_size > self._limit:
+            self._output_size = 0
+            await self.protocol._drain_helper()
+
+    def _make_compress_obj(self, compress: int) -> ZLibCompressor:
+        return ZLibCompressor(
+            level=zlib.Z_BEST_SPEED,
+            wbits=-compress,
+            max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
+        )
 
     def _write(self, data: bytes) -> None:
         if self.transport.is_closing():

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -636,9 +636,8 @@ class WebSocketWriter:
                 # compressed in order and takeover is not violated.
                 if not self._compressobj:
                     self._compressobj = self._make_compress_obj(self.compress)
-                compressobj = self._compressobj
-                if not self._compress_lock:
                     self._compress_lock = asyncio.Lock()
+                compressobj = self._compressobj
                 async with self._compress_lock:
                     message = await compressobj.compress(message)
                     self._write_compressed_message(message, opcode, compressobj, rsv)

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -675,7 +675,7 @@ class WebSocketWriter:
             self._output_size += len(header) + len(message)
 
         # It is safe to return control to the event loop when using compression
-        # after this point as we have already send or buffers all the data.
+        # after this point as we have already sent or buffered all the data.
 
         if self._output_size > self._limit:
             self._output_size = 0

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -610,6 +610,7 @@ class WebSocketWriter:
         self._limit = limit
         self._output_size = 0
         self._compressobj: Any = None  # actually compressobj
+        self._compress_lock: Optional[asyncio.Lock] = None
 
     async def _send_frame(
         self, message: bytes, opcode: int, compress: Optional[int] = None
@@ -626,28 +627,57 @@ class WebSocketWriter:
         if (compress or self.compress) and opcode < 8:
             if compress:
                 # Do not set self._compress if compressing is for this frame
-                compressobj = ZLibCompressor(
-                    level=zlib.Z_BEST_SPEED,
-                    wbits=-compress,
-                    max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
-                )
+                compressobj = self._make_compress_obj(compress)
             else:  # self.compress
                 if not self._compressobj:
-                    self._compressobj = ZLibCompressor(
-                        level=zlib.Z_BEST_SPEED,
-                        wbits=-self.compress,
-                        max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
-                    )
+                    self._compressobj = self._make_compress_obj(self.compress)
                 compressobj = self._compressobj
 
-            message = await compressobj.compress(message)
-            message += compressobj.flush(
-                zlib.Z_FULL_FLUSH if self.notakeover else zlib.Z_SYNC_FLUSH
-            )
-            if message.endswith(_WS_DEFLATE_TRAILING):
-                message = message[:-4]
-            rsv = rsv | 0x40
+            if not compressobj.should_run_in_executor(message):
+                # Compress message if it is smaller than max sync chunk size
+                # without awaiting to ensure that the message written before
+                # the next message can be compressed.
+                message = compressobj.compress_sync(message)
+                self._write_compressed_message(message, opcode, compressobj, rsv)
+            else:
+                # Since we are compressing in an executor, and the await returns
+                # control to the event loop we need to hold a lock to ensure that
+                # the compressed message is written before the next message is
+                # compressed to ensure that the messages are written in the correct
+                # order and context takeover is not violated.
+                if not self._compress_lock:
+                    self._compress_lock = asyncio.Lock()
+                async with self._compress_lock:
+                    message = await compressobj.compress_executor(message)
+                    self._write_compressed_message(message, opcode, compressobj, rsv)
 
+        else:
+            self._write_message(message, opcode, rsv)
+
+        if self._output_size > self._limit:
+            self._output_size = 0
+            await self.protocol._drain_helper()
+
+    def _make_compress_obj(self, compress: int) -> ZLibCompressor:
+        return ZLibCompressor(
+            level=zlib.Z_BEST_SPEED,
+            wbits=-compress,
+            max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
+        )
+
+    def _write_compressed_message(
+        self, message: bytes, opcode: int, compressobj: ZLibCompressor, rsv: int
+    ) -> None:
+        message += compressobj.flush(
+            zlib.Z_FULL_FLUSH if self.notakeover else zlib.Z_SYNC_FLUSH
+        )
+        if message.endswith(_WS_DEFLATE_TRAILING):
+            message = message[:-4]
+        rsv = rsv | 0x40
+        self._write_message(message, opcode, rsv)
+
+    def _write_message(self, message: bytes, opcode: int, rsv: int) -> None:
+        """Write a complete websocket frame to the transport."""
         msg_length = len(message)
 
         use_mask = self.use_mask
@@ -662,6 +692,7 @@ class WebSocketWriter:
             header = PACK_LEN2(0x80 | rsv | opcode, 126 | mask_bit, msg_length)
         else:
             header = PACK_LEN3(0x80 | rsv | opcode, 127 | mask_bit, msg_length)
+
         if use_mask:
             mask = self.randrange(0, 0xFFFFFFFF)
             mask = mask.to_bytes(4, "big")
@@ -669,18 +700,15 @@ class WebSocketWriter:
             _websocket_mask(mask, message)
             self._write(header + mask + message)
             self._output_size += len(header) + len(mask) + len(message)
+            return
+
+        if len(message) > MSG_SIZE:
+            self._write(header)
+            self._write(message)
         else:
-            if len(message) > MSG_SIZE:
-                self._write(header)
-                self._write(message)
-            else:
-                self._write(header + message)
+            self._write(header + message)
 
-            self._output_size += len(header) + len(message)
-
-        if self._output_size > self._limit:
-            self._output_size = 0
-            await self.protocol._drain_helper()
+        self._output_size += len(header) + len(message)
 
     def _write(self, data: bytes) -> None:
         if self.transport.is_closing():

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -110,32 +110,44 @@ async def test_send_compress_text_per_message(protocol: Any, transport: Any) -> 
     writer.transport.write.assert_called_with(b"\xc1\x06*I\xad(\x01\x00")
 
 
-@mock.patch("aiohttp.http_websocket.WEBSOCKET_MAX_SYNC_CHUNK_SIZE", 16)
-async def test_concurrent_messages_with_executor(protocol: Any, transport: Any) -> None:
+@pytest.mark.parametrize("max_sync_chunk_size", (16, 4096))
+async def test_concurrent_messages(
+    protocol: Any, transport: Any, max_sync_chunk_size: int
+) -> None:
     """Ensure messages are compressed correctly when there are multiple concurrent writers.
 
-    This test generates messages large enough that they will
-    be compressed in the executor.
+    This test generates is parametrized to
+
+    - Generate messages that are larger than patch
+      WEBSOCKET_MAX_SYNC_CHUNK_SIZE of 16
+      where compression will run in the executor
+
+    - Generate messages that are smaller than patch
+      WEBSOCKET_MAX_SYNC_CHUNK_SIZE of 4096
+      where compression will run in the event loop
     """
-    writer = WebSocketWriter(protocol, transport, compress=15)
-    queue: DataQueue[WSMessage] = DataQueue(asyncio.get_running_loop())
-    reader = WebSocketReader(queue, 50000)
-    writers = []
-    payloads = []
-    msg_length = 16 + 1
-    for count in range(1, 64 + 1):
-        payload = bytes((count,)) * msg_length
-        payloads.append(payload)
-        writers.append(writer.send(payload, binary=True))
-    await asyncio.gather(*writers)
-    for call in writer.transport.write.call_args_list:
-        call_bytes = call[0][0]
-        result, _ = reader.feed_data(call_bytes)
-        assert result is False
-        msg = await queue.read()
-        bytes_data: bytes = msg.data
-        assert len(bytes_data) == msg_length
-        assert bytes_data == bytes_data[0:1] * msg_length
+    with mock.patch(
+        "aiohttp.http_websocket.WEBSOCKET_MAX_SYNC_CHUNK_SIZE", max_sync_chunk_size
+    ):
+        writer = WebSocketWriter(protocol, transport, compress=15)
+        queue: DataQueue[WSMessage] = DataQueue(asyncio.get_running_loop())
+        reader = WebSocketReader(queue, 50000)
+        writers = []
+        payloads = []
+        msg_length = 16 + 1
+        for count in range(1, 64 + 1):
+            payload = bytes((count,)) * msg_length
+            payloads.append(payload)
+            writers.append(writer.send(payload, binary=True))
+        await asyncio.gather(*writers)
+        for call in writer.transport.write.call_args_list:
+            call_bytes = call[0][0]
+            result, _ = reader.feed_data(call_bytes)
+            assert result is False
+            msg = await queue.read()
+            bytes_data: bytes = msg.data
+            assert len(bytes_data) == msg_length
+            assert bytes_data == bytes_data[0:1] * msg_length
 
 
 async def test_concurrent_messages_without_executor(

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -180,4 +180,8 @@ async def test_concurrent_messages_with_and_with_out_executor(
         first_char = bytes_data[0:1]
         char_val = ord(first_char)
         assert len(bytes_data) == char_val
+        # If we have a concurrency problem, the data
+        # tends to get mixed up between messages so
+        # we want to validate that all the bytes are
+        # the same value
         assert bytes_data == bytes_data[0:1] * char_val

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -166,7 +166,7 @@ async def test_concurrent_messages_with_and_with_out_executor(
     writers = []
     payloads = []
     for count in range(1, 64 + 1):
-        payload = bytes((count,)) * (64 if count % 2 else 8)
+        payload = bytes((count,)) * (32 + count if count % 2 else count)
         payloads.append(payload)
         writers.append(writer.send(payload, binary=True))
     await asyncio.gather(*writers)

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -165,3 +165,35 @@ async def test_concurrent_messages_without_executor(
         bytes_data: bytes = msg.data
         assert len(bytes_data) == msg_length
         assert bytes_data == bytes_data[0:1] * msg_length
+
+
+@mock.patch("aiohttp.http_websocket.WEBSOCKET_MAX_SYNC_CHUNK_SIZE", 32)
+async def test_concurrent_messages_with_and_with_out_executor(
+    protocol: Any, transport: Any
+) -> None:
+    """Ensure messages are compressed correctly when there are multiple concurrent writers.
+
+    This test generates messages mixes messages that
+    are small enough to not be compressed in the executor
+    with messages that need to be compressed in the executor.
+    """
+    writer = WebSocketWriter(protocol, transport, compress=15)
+    queue: DataQueue[WSMessage] = DataQueue(asyncio.get_running_loop())
+    reader = WebSocketReader(queue, 50000)
+    writers = []
+    payloads = []
+    for count in range(1, 64 + 1):
+        payload = bytes((count,)) * count
+        payloads.append(payload)
+        writers.append(writer.send(payload, binary=True))
+    await asyncio.gather(*writers)
+    for call in writer.transport.write.call_args_list:
+        call_bytes = call[0][0]
+        result, _ = reader.feed_data(call_bytes)
+        assert result is False
+        msg = await queue.read()
+        bytes_data: bytes = msg.data
+        first_char = bytes_data[0:1]
+        char_val = ord(first_char)
+        assert len(bytes_data) == char_val
+        assert bytes_data == bytes_data[0:1] * char_val

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -155,17 +155,18 @@ async def test_concurrent_messages(
             payloads.append(payload)
             writers.append(writer.send(payload, binary=True))
         await asyncio.gather(*writers)
-        for call in writer.transport.write.call_args_list:
-            call_bytes = call[0][0]
-            result, _ = reader.feed_data(call_bytes)
-            assert result is False
-            msg = await queue.read()
-            bytes_data: bytes = msg.data
-            first_char = bytes_data[0:1]
-            char_val = ord(first_char)
-            assert len(bytes_data) == char_val
-            # If we have a concurrency problem, the data
-            # tends to get mixed up between messages so
-            # we want to validate that all the bytes are
-            # the same value
-            assert bytes_data == bytes_data[0:1] * char_val
+
+    for call in writer.transport.write.call_args_list:
+        call_bytes = call[0][0]
+        result, _ = reader.feed_data(call_bytes)
+        assert result is False
+        msg = await queue.read()
+        bytes_data: bytes = msg.data
+        first_char = bytes_data[0:1]
+        char_val = ord(first_char)
+        assert len(bytes_data) == char_val
+        # If we have a concurrency problem, the data
+        # tends to get mixed up between messages so
+        # we want to validate that all the bytes are
+        # the same value
+        assert bytes_data == bytes_data[0:1] * char_val

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -166,7 +166,8 @@ async def test_concurrent_messages_with_and_with_out_executor(
     writers = []
     payloads = []
     for count in range(1, 64 + 1):
-        payload = bytes((count,)) * (32 + count if count % 2 else count)
+        point = 64 + count if count % 2 else count
+        payload = bytes((point,)) * point
         payloads.append(payload)
         writers.append(writer.send(payload, binary=True))
     await asyncio.gather(*writers)

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -195,7 +195,7 @@ async def test_concurrent_messages_with_and_with_out_executor(
     writers = []
     payloads = []
     for count in range(1, 64 + 1):
-        payload = bytes((count,)) * count
+        payload = bytes((count,)) * (64 if count % 2 else 8)
         payloads.append(payload)
         writers.append(writer.send(payload, binary=True))
     await asyncio.gather(*writers)

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -1,11 +1,13 @@
 # type: ignore
+import asyncio
 import random
 from typing import Any
 from unittest import mock
 
 import pytest
 
-from aiohttp.http import WebSocketWriter
+from aiohttp import DataQueue, WSMessage
+from aiohttp.http import WebSocketReader, WebSocketWriter
 from aiohttp.test_utils import make_mocked_coro
 
 
@@ -106,3 +108,60 @@ async def test_send_compress_text_per_message(protocol: Any, transport: Any) -> 
     writer.transport.write.assert_called_with(b"\x81\x04text")
     await writer.send(b"text", compress=15)
     writer.transport.write.assert_called_with(b"\xc1\x06*I\xad(\x01\x00")
+
+
+@mock.patch("aiohttp.http_websocket.WEBSOCKET_MAX_SYNC_CHUNK_SIZE", 16)
+async def test_concurrent_messages_with_executor(protocol: Any, transport: Any) -> None:
+    """Ensure messages are compressed correctly when there are multiple concurrent writers.
+
+    This test generates messages large enough that they will
+    be compressed in the executor.
+    """
+    writer = WebSocketWriter(protocol, transport, compress=15)
+    queue: DataQueue[WSMessage] = DataQueue(asyncio.get_running_loop())
+    reader = WebSocketReader(queue, 50000)
+    writers = []
+    payloads = []
+    msg_length = 16 + 1
+    for count in range(1, 64 + 1):
+        payload = bytes((count,)) * msg_length
+        payloads.append(payload)
+        writers.append(writer.send(payload, binary=True))
+    await asyncio.gather(*writers)
+    for call in writer.transport.write.call_args_list:
+        call_bytes = call[0][0]
+        result, _ = reader.feed_data(call_bytes)
+        assert result is False
+        msg = await queue.read()
+        bytes_data: bytes = msg.data
+        assert len(bytes_data) == msg_length
+        assert bytes_data == bytes_data[0:1] * msg_length
+
+
+async def test_concurrent_messages_without_executor(
+    protocol: Any, transport: Any
+) -> None:
+    """Ensure messages are compressed correctly when there are multiple concurrent writers.
+
+    This test generates messages that are small enough that
+    they will not be compressed in the executor.
+    """
+    writer = WebSocketWriter(protocol, transport, compress=15)
+    queue: DataQueue[WSMessage] = DataQueue(asyncio.get_running_loop())
+    reader = WebSocketReader(queue, 50000)
+    writers = []
+    payloads = []
+    msg_length = 16 + 1
+    for count in range(1, 64 + 1):
+        payload = bytes((count,)) * msg_length
+        payloads.append(payload)
+        writers.append(writer.send(payload, binary=True))
+    await asyncio.gather(*writers)
+    for call in writer.transport.write.call_args_list:
+        call_bytes = call[0][0]
+        result, _ = reader.feed_data(call_bytes)
+        assert result is False
+        msg = await queue.read()
+        bytes_data: bytes = msg.data
+        assert len(bytes_data) == msg_length
+        assert bytes_data == bytes_data[0:1] * msg_length


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Restore async concurrency safety to websocket compressor


## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

fixes #7859
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
