### PR TITLE
Fix ClientResponse.close releasing the connection instead of closing

### DIFF
--- a/CHANGES/7869.bugfix
+++ b/CHANGES/7869.bugfix
@@ -1,0 +1,1 @@
+Fix ClientResponse.close releasing the connection instead of closing

--- a/CHANGES/7869.bugfix
+++ b/CHANGES/7869.bugfix
@@ -1,1 +1,0 @@
-Fix ClientResponse.close releasing the connection instead of closing

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -967,9 +967,7 @@ class ClientResponse(HeadersMixin):
             return
 
         self._cleanup_writer()
-        if self._connection is not None:
-            self._connection.close()
-            self._connection = None
+        self._release_connection()
 
     def release(self) -> Any:
         if not self._released:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -967,7 +967,9 @@ class ClientResponse(HeadersMixin):
             return
 
         self._cleanup_writer()
-        self._release_connection()
+        if self._connection is not None:
+            self._connection.close()
+            self._connection = None
 
     def release(self) -> Any:
         if not self._released:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3189,15 +3189,15 @@ async def test_read_timeout_closes_connection(aiohttp_client: AiohttpClient) -> 
     app = web.Application()
     app.add_routes([web.get("/", handler)])
 
-    timeout = aiohttp.ClientTimeout(sock_read=0.1)
+    timeout = aiohttp.ClientTimeout(total=0.1)
     client: TestClient = await aiohttp_client(app, timeout=timeout)
-    with pytest.raises(aiohttp.ServerTimeoutError):
+    with pytest.raises(asyncio.TimeoutError):
         await client.get("/")
 
     # Make sure its really closed
     assert not client.session.connector._conns
 
-    with pytest.raises(aiohttp.ServerTimeoutError):
+    with pytest.raises(asyncio.TimeoutError):
         await client.get("/")
 
     # Make sure its really closed

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3183,7 +3183,7 @@ async def test_read_timeout_closes_connection(aiohttp_client: AiohttpClient) -> 
         nonlocal request_count
         request_count += 1
         if request_count < 3:
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.5)
         return web.Response(body=f"request:{request_count}")
 
     app = web.Application()
@@ -3193,10 +3193,20 @@ async def test_read_timeout_closes_connection(aiohttp_client: AiohttpClient) -> 
     client: TestClient = await aiohttp_client(app, timeout=timeout)
     with pytest.raises(aiohttp.ServerTimeoutError):
         await client.get("/")
+
+    # Make sure its really closed
+    assert not client.session.connector._conns
+
     with pytest.raises(aiohttp.ServerTimeoutError):
         await client.get("/")
+
+    # Make sure its really closed
+    assert not client.session.connector._conns
     result = await client.get("/")
     assert await result.read() == b"request:3"
+
+    # Make sure its not closed
+    assert client.session.connector._conns
 
 
 async def test_read_timeout_on_prepared_response(aiohttp_client: Any) -> None:


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

Fix ClientResponse.close releasing the connection instead of closing

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

fixes #7864

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
