### PR TITLE
Restore async concurrency safety to websocket compressor (#7865)

### DIFF
--- a/CHANGES/7865.bugfix
+++ b/CHANGES/7865.bugfix
@@ -1,0 +1,1 @@
+Restore async concurrency safety to websocket compressor

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -62,19 +62,25 @@ class ZLibCompressor(ZlibBaseHandler):
             self._compressor = zlib.compressobj(
                 wbits=self._mode, strategy=strategy, level=level
             )
+        self._compress_lock = asyncio.Lock()
 
     def compress_sync(self, data: bytes) -> bytes:
         return self._compressor.compress(data)
 
     async def compress(self, data: bytes) -> bytes:
-        if (
-            self._max_sync_chunk_size is not None
-            and len(data) > self._max_sync_chunk_size
-        ):
-            return await asyncio.get_event_loop().run_in_executor(
-                self._executor, self.compress_sync, data
-            )
-        return self.compress_sync(data)
+        async with self._compress_lock:
+            # To ensure the stream is consistent in the event
+            # there are multiple writers, we need to lock
+            # the compressor so that only one writer can
+            # compress at a time.
+            if (
+                self._max_sync_chunk_size is not None
+                and len(data) > self._max_sync_chunk_size
+            ):
+                return await asyncio.get_event_loop().run_in_executor(
+                    self._executor, self.compress_sync, data
+                )
+            return self.compress_sync(data)
 
     def flush(self, mode: int = zlib.Z_FINISH) -> bytes:
         return self._compressor.flush(mode)

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -1,4 +1,3 @@
-# type: ignore
 import asyncio
 import random
 from typing import Any, Callable


### PR DESCRIPTION
Fixes #7859

(cherry picked from commit 86a23961531103ccc34853f67321c7d0f63797f5)
