### PR TITLE
Message is not upgraded if Upgrade header is missing

### DIFF
--- a/CHANGES/7895.bugfix
+++ b/CHANGES/7895.bugfix
@@ -1,0 +1,1 @@
+Fixed messages being reported as upgraded without an Upgrade header in Python parser. -- by :user:`Dreamsorcerer`

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -503,7 +503,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                 close_conn = True
             elif v == "keep-alive":
                 close_conn = False
-            elif v == "upgrade":
+            elif v == "upgrade" and headers.get(hdrs.UPGRADE):
                 upgrade = True
 
         # encoding

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -503,6 +503,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                 close_conn = True
             elif v == "keep-alive":
                 close_conn = False
+            # https://www.rfc-editor.org/rfc/rfc9110.html#name-101-switching-protocols
             elif v == "upgrade" and headers.get(hdrs.UPGRADE):
                 upgrade = True
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -476,10 +476,7 @@ def test_conn_upgrade(parser: Any) -> None:
 def test_bad_upgrade(parser: Any) -> None:
     """Test not upgraded if missing Upgrade header."""
 
-    text = (
-        b"GET /test HTTP/1.1\r\n"
-        b"connection: upgrade\r\n\r\n"
-    )
+    text = b"GET /test HTTP/1.1\r\n" b"connection: upgrade\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert not msg.upgrade

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -473,6 +473,19 @@ def test_conn_upgrade(parser: Any) -> None:
     assert upgrade
 
 
+def test_bad_upgrade(parser: Any) -> None:
+    """Test not upgraded if missing Upgrade header."""
+
+    text = (
+        b"GET /test HTTP/1.1\r\n"
+        b"connection: upgrade\r\n\r\n"
+    )
+    messages, upgrade, tail = parser.feed_data(text)
+    msg = messages[0][0]
+    assert not msg.upgrade
+    assert not upgrade
+
+
 def test_compression_empty(parser: Any) -> None:
     text = b"GET /test HTTP/1.1\r\n" b"content-encoding: \r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -475,7 +475,6 @@ def test_conn_upgrade(parser: Any) -> None:
 
 def test_bad_upgrade(parser: Any) -> None:
     """Test not upgraded if missing Upgrade header."""
-
     text = b"GET /test HTTP/1.1\r\nconnection: upgrade\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -476,7 +476,7 @@ def test_conn_upgrade(parser: Any) -> None:
 def test_bad_upgrade(parser: Any) -> None:
     """Test not upgraded if missing Upgrade header."""
 
-    text = b"GET /test HTTP/1.1\r\n" b"connection: upgrade\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nconnection: upgrade\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert not msg.upgrade


### PR DESCRIPTION
It is a required header for a 101 response. Behaviour is already correct in llhttp.