### PR TITLE
Fix flaky websocket test

### DIFF
--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -8,6 +8,7 @@ import pytest
 import aiohttp
 from aiohttp import hdrs, web
 from aiohttp.client_ws import ClientWSTimeout
+from aiohttp.http import WSCloseCode
 
 if sys.version_info >= (3, 11):
     import asyncio as async_timeout
@@ -645,10 +646,9 @@ async def test_heartbeat_no_pong(aiohttp_client: Any) -> None:
     client = await aiohttp_client(app)
     resp = await client.ws_connect("/", heartbeat=0.05)
 
-    await resp.receive()
-    await resp.receive()
-
+    await asyncio.sleep(0.1)
     assert ping_received
+    assert resp.close_code is WSCloseCode.ABNORMAL_CLOSURE
 
 
 async def test_send_recv_compress(aiohttp_client: Any) -> None:

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -644,9 +644,10 @@ async def test_heartbeat_no_pong(aiohttp_client: Any) -> None:
     app.router.add_route("GET", "/", handler)
 
     client = await aiohttp_client(app)
-    resp = await client.ws_connect("/", heartbeat=0.05)
+    resp = await client.ws_connect("/", heartbeat=0.1)
 
-    await asyncio.sleep(0.1)
+    # Connection should be closed roughly after 1.5x heartbeat.
+    await asyncio.sleep(0.2)
     assert ping_received
     assert resp.close_code is WSCloseCode.ABNORMAL_CLOSURE
 


### PR DESCRIPTION
Hopefully fixes the flakiness, by allowing a little extra time. Also improved the test by actually testing the client behaviour, and removing some calls which did nothing.