### PR TITLE
[PR #7808/213d1b2 backport][3.10] Restore requirements-txt-fixer in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,8 +45,7 @@ repos:
     exclude: >-
       ^docs/[^/]*\.svg$
   - id: requirements-txt-fixer
-    exclude: >-
-      ^requirements/.*\.txt$
+    files: requirements/.*\.in$
   - id: trailing-whitespace
   - id: file-contents-sorter
     args: ['--ignore-case']

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,4 @@ install-dev: .develop
 .PHONY: sync-direct-runtime-deps
 sync-direct-runtime-deps:
 	@echo Updating 'requirements/runtime-deps.in' from 'setup.cfg'... >&2
-	@echo '# Extracted from `setup.cfg` via `make sync-direct-runtime-deps`' > requirements/runtime-deps.in
-	@echo >> requirements/runtime-deps.in
-	@python -c 'from configparser import ConfigParser; from itertools import chain; from pathlib import Path; cfg = ConfigParser(); cfg.read_string(Path("setup.cfg").read_text()); print("\n".join(line.strip() for line in chain(cfg["options"].get("install_requires").splitlines(), "\n".join(cfg["options.extras_require"].values()).splitlines()) if line.strip()))' \
-		>> requirements/runtime-deps.in
+	@python requirements/sync-direct-runtime-deps.py

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -1,11 +1,11 @@
 # Extracted from `setup.cfg` via `make sync-direct-runtime-deps`
 
-attrs >= 17.3.0
-multidict >=4.5, < 7.0
-async-timeout >= 4.0, < 5.0 ; python_version < "3.11"
-yarl >= 1.0, < 2.0
-frozenlist >= 1.1.1
-aiosignal >= 1.1.2
 aiodns; sys_platform=="linux" or sys_platform=="darwin"
+aiosignal >= 1.1.2
+async-timeout >= 4.0, < 5.0 ; python_version < "3.11"
+attrs >= 17.3.0
 Brotli; platform_python_implementation == 'CPython'
 brotlicffi; platform_python_implementation != 'CPython'
+frozenlist >= 1.1.1
+multidict >=4.5, < 7.0
+yarl >= 1.0, < 2.0

--- a/requirements/sync-direct-runtime-deps.py
+++ b/requirements/sync-direct-runtime-deps.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+"""Sync direct runtime dependencies from setup.cfg to runtime-deps.in."""
+
+from configparser import ConfigParser
+from pathlib import Path
+
+cfg = ConfigParser()
+cfg.read(Path("setup.cfg"))
+reqs = cfg["options"]["install_requires"] + cfg.items("options.extras_require")[0][1]
+reqs = sorted(reqs.split("\n"), key=str.casefold)
+reqs.remove("")
+
+with open(Path("requirements", "runtime-deps.in"), "w") as outfile:
+    header = "# Extracted from `setup.cfg` via `make sync-direct-runtime-deps`\n\n"
+    outfile.write(header)
+    outfile.write("\n".join(reqs) + "\n")

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,5 +1,5 @@
--r base.in
 -c broken-projects.in
+-r base.in
 
 coverage
 mypy; implementation_name == "cpython"

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,12 +47,12 @@ zip_safe = False
 include_package_data = True
 
 install_requires =
-  attrs >= 17.3.0
-  multidict >=4.5, < 7.0
-  async-timeout >= 4.0, < 5.0 ; python_version < "3.11"
-  yarl >= 1.0, < 2.0
-  frozenlist >= 1.1.1
   aiosignal >= 1.1.2
+  async-timeout >= 4.0, < 5.0 ; python_version < "3.11"
+  attrs >= 17.3.0
+  frozenlist >= 1.1.1
+  multidict >=4.5, < 7.0
+  yarl >= 1.0, < 2.0
 
 [options.exclude_package_data]
 * =


### PR DESCRIPTION
Backport of https://github.com/aio-libs/aiohttp/pull/7808 cherry picked from commit 213d1b22d42ce8efc54d7858b490e920fcdb4f0a

<!-- Thank you for your contribution! -->

## What do these changes do?

Repair a useless pre-commit hook, since `requirements.txt` was removed in https://github.com/aio-libs/aiohttp/pull/6165

This can be verified with `pre-commit run --all-files`.

## Are there changes in behavior for the user?

No