### PR TITLE
added server_hostname param to ws_connect method

### DIFF
--- a/CHANGES/7941.feature
+++ b/CHANGES/7941.feature
@@ -1,1 +1,1 @@
-added server_hostname param to ws_connect
+Added ``server_hostname`` parameter to ``ws_connect``.

--- a/CHANGES/7941.feature
+++ b/CHANGES/7941.feature
@@ -1,0 +1,1 @@
+added server_hostname param to ws_connect

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -689,6 +689,7 @@ class ClientSession:
         proxy: Optional[StrOrURL] = None,
         proxy_auth: Optional[BasicAuth] = None,
         ssl: Union[SSLContext, Literal[False], None, Fingerprint] = None,
+        server_hostname: Optional[str] = None,
         proxy_headers: Optional[LooseHeaders] = None,
         compress: int = 0,
         max_msg_size: int = 4 * 1024 * 1024,
@@ -711,6 +712,7 @@ class ClientSession:
                 proxy=proxy,
                 proxy_auth=proxy_auth,
                 ssl=ssl,
+                server_hostname=server_hostname,
                 proxy_headers=proxy_headers,
                 compress=compress,
                 max_msg_size=max_msg_size,
@@ -735,6 +737,7 @@ class ClientSession:
         proxy: Optional[StrOrURL] = None,
         proxy_auth: Optional[BasicAuth] = None,
         ssl: Union[SSLContext, Literal[False], None, Fingerprint] = None,
+        server_hostname: Optional[str] = None,
         proxy_headers: Optional[LooseHeaders] = None,
         compress: int = 0,
         max_msg_size: int = 4 * 1024 * 1024,
@@ -806,6 +809,7 @@ class ClientSession:
             proxy=proxy,
             proxy_auth=proxy_auth,
             ssl=ssl,
+            server_hostname=server_hostname,
             proxy_headers=proxy_headers,
         )
 


### PR DESCRIPTION
added the server_hostname param to ws_connect method, so it will simply be passed to the _request method which already supports the server_hostname param.

Fixes #7941