### PR TITLE
Fix websocket connection leak

### DIFF
--- a/CHANGES/7978.bugfix
+++ b/CHANGES/7978.bugfix
@@ -1,0 +1,1 @@
+Fix websocket connection leak

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -497,10 +497,10 @@ class WebSocketResponse(StreamResponse):
                 self._close_code = msg.data
                 # Could be closed while awaiting reader.
                 if not self._closed and self._autoclose:  # type: ignore[redundant-expr]
-                    # The client is going to close the connection
-                    # out from under us so we do not want to drain
-                    # any pending writes as it will likely result
-                    # writing to a broken pipe.
+                    # The client is likely going to close the
+                    # connection out from under us so we do not
+                    # want to drain any pending writes as it will
+                    # likely result writing to a broken pipe.
                     await self.close(drain=False)
             elif msg.type == WSMsgType.CLOSING:
                 self._closing = True

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -496,12 +496,15 @@ class WebSocketResponse(StreamResponse):
                 self._closing = True
                 self._close_code = msg.data
                 # Could be closed while awaiting reader.
-                if not self._closed and self._autoclose:  # type: ignore[redundant-expr]
+                if not self._closed:
                     # The client is going to close the connection
                     # out from under us so we do not want to drain
                     # any pending writes as it will likely result
                     # writing to a broken pipe.
-                    await self.close(drain=False)
+                    if self._autoclose:
+                        await self.close(drain=False)
+                    else:
+                        self._set_code_close_transport(msg.data)
             elif msg.type == WSMsgType.CLOSING:
                 self._closing = True
             elif msg.type == WSMsgType.PING and self._autoping:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -496,15 +496,12 @@ class WebSocketResponse(StreamResponse):
                 self._closing = True
                 self._close_code = msg.data
                 # Could be closed while awaiting reader.
-                if not self._closed:
+                if not self._closed and self._autoclose:  # type: ignore[redundant-expr]
                     # The client is going to close the connection
                     # out from under us so we do not want to drain
                     # any pending writes as it will likely result
                     # writing to a broken pipe.
-                    if self._autoclose:
-                        await self.close(drain=False)
-                    else:
-                        self._set_code_close_transport(msg.data)
+                    await self.close(drain=False)
             elif msg.type == WSMsgType.CLOSING:
                 self._closing = True
             elif msg.type == WSMsgType.PING and self._autoping:

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -988,6 +988,14 @@ and :ref:`aiohttp-web-signals` handlers::
 
       .. versionadded:: 3.3
 
+   :param bool autoclose: Close connection when the client sends
+                           a :const:`~aiohttp.WSMsgType.CLOSE` message,
+                           ``True`` by default. If set to ``False``,
+                           the connection is not closed and the
+                           caller is responsible for calling
+                           ``request.transport.close()`` to avoid
+                           leaking resources.
+
 
    The class supports ``async for`` statement for iterating over
    incoming messages::

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1172,7 +1172,7 @@ and :ref:`aiohttp-web-signals` handlers::
          The method is converted into :term:`coroutine`,
          *compress* parameter added.
 
-   .. method:: close(*, code=WSCloseCode.OK, message=b'')
+   .. method:: close(*, code=WSCloseCode.OK, message=b'', drain=True)
       :async:
 
       A :ref:`coroutine<coroutine>` that initiates closing
@@ -1185,6 +1185,8 @@ and :ref:`aiohttp-web-signals` handlers::
       :param message: optional payload of *close* message,
                       :class:`str` (converted to *UTF-8* encoded bytes)
                       or :class:`bytes`.
+
+      :param bool drain: drain outgoing buffer before closing connection.
 
       :raise RuntimeError: if connection is not started
 

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -140,7 +140,7 @@ async def test_write_non_prepared() -> None:
         await ws.write(b"data")
 
 
-async def test_ping_timeout(make_request: Any) -> None:
+async def test_heartbeat_timeout(make_request: Any) -> None:
     loop = asyncio.get_running_loop()
     future = loop.create_future()
     req = make_request("GET", "/")

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -141,6 +141,7 @@ async def test_write_non_prepared() -> None:
 
 
 async def test_heartbeat_timeout(make_request: Any) -> None:
+    """Verify the transport is closed when the heartbeat timeout is reached."""
     loop = asyncio.get_running_loop()
     future = loop.create_future()
     req = make_request("GET", "/")


### PR DESCRIPTION
fixes #6325

The existing implementation never closed the transport unless `heartbeat` was enabled (not default), the pong was not received, and `.close()` had not been called before the pong was not received since it cancelled the timer. 

We now always close the transport after we get the `WSMsgType.CLOSE` message or an abnormal closure occurs instead of hoping `asyncio` calls `connection_lost` which may not happen in a reasonable time frame (or ever?) for a variety of reasons deeper in the stack (network, bad client implementations, etc). 

Any time we are closing/setting `self._close_code` we must either call `self.close()` or close the transport otherwise its possible to leak the connection. 

To facilitate that, and reduce the chance of future refactoring re-introducing the problem, `_set_code_close_transport` is added which sets the code and closes the transport.  

All other places `self._close_code` is set have been audited to ensure they also call `self.close()` There is one exception if `self._autoclose` is set to `False` and the client closes the connection, than its the responsibility of the caller to close the connection as otherwise it can leak. This is now documented.