### PR TITLE
Fix examples of `fallback_charset_resolver` function in client_advanced documentation

### DIFF
--- a/CHANGES/7995.doc
+++ b/CHANGES/7995.doc
@@ -1,0 +1,1 @@
+Fix examples of `fallback_charset_resolver` function in client_advanced documentation. -- by :user:`henry0312`

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -761,7 +761,7 @@ example, this can be used with the ``chardetng_py`` library.::
 
     def charset_resolver(resp: ClientResponse, body: bytes) -> str:
         tld = resp.url.host.rsplit(".", maxsplit=1)[-1]
-        return detect(body, allow_utf8=True, tld=tld)
+        return detect(body, allow_utf8=True, tld=tld.encode())
 
     ClientSession(fallback_charset_resolver=charset_resolver)
 
@@ -769,4 +769,4 @@ Or, if ``chardetng_py`` doesn't work for you, then ``charset-normalizer`` is ano
 
     from charset_normalizer import detect
 
-    ClientSession(fallback_charset_resolver=lamba r, b: detect(b)["encoding"] or "utf-8")
+    ClientSession(fallback_charset_resolver=lambda r, b: detect(b)["encoding"] or "utf-8")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This PR improves the `client_advanced.rst` documentation in the aiohttp project. It corrects the syntax in the `fallback_charset_resolver` function example. Specifically, it changes a miswritten 'lamba' to 'lambda' and adds `.encode()` to the `tld` parameter in the `detect` function call, ensuring proper byte format.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No changes in behavior for the end users are introduced. This PR solely improves the documentation for better clarity and correctness in the examples provided.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->
There's no specific related issue number for this PR. This is a direct improvement to the documentation based on observed inconsistencies.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
