### PR TITLE
Fix FileResponse doing blocking I/O in the event loop

### DIFF
--- a/CHANGES/8012.bugfix
+++ b/CHANGES/8012.bugfix
@@ -1,0 +1,1 @@
+Fix :py:class:`~aiohttp.web.FileResponse`. doing blocking I/O in the event loop

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -121,19 +121,31 @@ class FileResponse(StreamResponse):
         self.content_length = 0
         return await super().prepare(request)
 
-    async def prepare(self, request: "BaseRequest") -> Optional[AbstractStreamWriter]:
+    def _get_file_path_stat_and_gzip(
+        self, check_for_gzipped_file: bool
+    ) -> Tuple[pathlib.Path, os.stat_result, bool]:
+        """Return the file path, stat result, and gzip status.
+
+        This method should be called from a thread executor
+        since it calls os.stat which may block.
+        """
         filepath = self._path
-
-        gzip = False
-        if "gzip" in request.headers.get(hdrs.ACCEPT_ENCODING, ""):
+        if check_for_gzipped_file:
             gzip_path = filepath.with_name(filepath.name + ".gz")
+            try:
+                return gzip_path, gzip_path.stat(), True
+            except OSError:
+                # Fall through and try the non-gzipped file
+                pass
 
-            if gzip_path.is_file():
-                filepath = gzip_path
-                gzip = True
+        return filepath, filepath.stat(), False
 
+    async def prepare(self, request: "BaseRequest") -> Optional[AbstractStreamWriter]:
         loop = asyncio.get_event_loop()
-        st: os.stat_result = await loop.run_in_executor(None, filepath.stat)
+        check_for_gzipped_file = "gzip" in request.headers.get(hdrs.ACCEPT_ENCODING, "")
+        filepath, st, gzip = await loop.run_in_executor(
+            None, self._get_file_path_stat_and_gzip, check_for_gzipped_file
+        )
 
         etag_value = f"{st.st_mtime_ns:x}-{st.st_size:x}"
         last_modified = st.st_mtime

--- a/tests/test_web_sendfile.py
+++ b/tests/test_web_sendfile.py
@@ -13,7 +13,6 @@ def test_using_gzip_if_header_present_and_file_available(loop: Any) -> None:
     )
 
     gz_filepath = mock.create_autospec(Path, spec_set=True)
-    gz_filepath.is_file.return_value = True
     gz_filepath.stat.return_value.st_size = 1024
     gz_filepath.stat.return_value.st_mtime_ns = 1603733507222449291
 
@@ -35,7 +34,8 @@ def test_gzip_if_header_not_present_and_file_available(loop: Any) -> None:
     request = make_mocked_request("GET", "http://python.org/logo.png", headers={})
 
     gz_filepath = mock.create_autospec(Path, spec_set=True)
-    gz_filepath.is_file.return_value = True
+    gz_filepath.stat.return_value.st_size = 1024
+    gz_filepath.stat.return_value.st_mtime_ns = 1603733507222449291
 
     filepath = mock.create_autospec(Path, spec_set=True)
     filepath.name = "logo.png"
@@ -57,7 +57,7 @@ def test_gzip_if_header_not_present_and_file_not_available(loop: Any) -> None:
     request = make_mocked_request("GET", "http://python.org/logo.png", headers={})
 
     gz_filepath = mock.create_autospec(Path, spec_set=True)
-    gz_filepath.is_file.return_value = False
+    gz_filepath.stat.side_effect = OSError(2, "No such file or directory")
 
     filepath = mock.create_autospec(Path, spec_set=True)
     filepath.name = "logo.png"
@@ -81,7 +81,7 @@ def test_gzip_if_header_present_and_file_not_available(loop: Any) -> None:
     )
 
     gz_filepath = mock.create_autospec(Path, spec_set=True)
-    gz_filepath.is_file.return_value = False
+    gz_filepath.stat.side_effect = OSError(2, "No such file or directory")
 
     filepath = mock.create_autospec(Path, spec_set=True)
     filepath.name = "logo.png"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix `FileResponse` doing blocking I/O in the event loop

The call to `os.stat` was run in the executor but the call to `is_file()` was not. Additionally this resulted in two syscalls to `stat` since both `is_file` and `stat` will call `stat` under the hood. The code has been refactored to ensure there is only one `stat` syscall and it happens in the executor


## Are there changes in behavior for the user?

No

## Related issue number

discovered while investigating #8011 but not does fix the issue reported

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
