### PR TITLE
Fix double compress when compression enabled and compressed file exists

### DIFF
--- a/CHANGES/8014.bugfix
+++ b/CHANGES/8014.bugfix
@@ -1,0 +1,1 @@
+Fix double compress when compression enabled and compressed file exists

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -251,6 +251,10 @@ class FileResponse(StreamResponse):
             self.headers[hdrs.CONTENT_ENCODING] = encoding
         if gzip:
             self.headers[hdrs.VARY] = hdrs.ACCEPT_ENCODING
+            # Disable compression if we are already sending
+            # a compressed file since we don't want to double
+            # compress.
+            self._compression = False
 
         self.etag = etag_value  # type: ignore[assignment]
         self.last_modified = st.st_mtime  # type: ignore[assignment]


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

If the handler has `.enable_compression` set and we use the pre-compressed .gz we would compress twice. The caller may not know if the `.gz` file exists or not or have a mixed use case where some files are pre-compressed and some are compressed on the fly based if they have limited storage

fixes #8011

## Are there changes in behavior for the user?

Files are no longer double compressed which is likely never the desired outcome

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
