### PR TITLE
Add runtime type check for `ClientSession` `timeout` param

### DIFF
--- a/CHANGES/8021.bugfix
+++ b/CHANGES/8021.bugfix
@@ -1,1 +1,1 @@
-Handle ``ClientSession`` ``timeout`` param types properly.
+Add runtime type check for ``ClientSession`` ``timeout`` parameter.

--- a/CHANGES/8021.bugfix
+++ b/CHANGES/8021.bugfix
@@ -1,0 +1,1 @@
+Handle ``ClientSession`` ``timeout`` param types properly.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -149,6 +149,7 @@ Hugo Hromic
 Hugo van Kemenade
 Hynek Schlawack
 Igor Alexandrov
+Igor Bolshakov
 Igor Davydenko
 Igor Mozharovsky
 Igor Pavlov

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -269,15 +269,13 @@ class ClientSession:
         self._version = version
         self._json_serialize = json_serialize
         if timeout is sentinel or timeout is None:
-            self._timeout = DEFAULT_TIMEOUT
-        else:
-            if not isinstance(timeout, ClientTimeout):
-                raise ValueError(
-                    f"timeout parameter cannot be of {type(timeout)} type, "
-                    "please use 'timeout=ClientTimeout(...)'",
-                )
-            else:
-                self._timeout = timeout
+            timeout = DEFAULT_TIMEOUT
+        if not isinstance(timeout, ClientTimeout):
+            raise ValueError(
+                f"timeout parameter cannot be of {type(timeout)} type, "
+                "please use 'timeout=ClientTimeout(...)'",
+            )
+        self._timeout = timeout
         self._raise_for_status = raise_for_status
         self._auto_decompress = auto_decompress
         self._trust_env = trust_env

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -271,19 +271,10 @@ class ClientSession:
         if timeout is sentinel or timeout is None:
             self._timeout = DEFAULT_TIMEOUT
         else:
-            if not isinstance(timeout, (ClientTimeout, int, float)):
+            if not isinstance(timeout, ClientTimeout):
                 raise ValueError(
                     f"timeout parameter cannot be of {type(timeout)} type, "
                     "please use 'timeout=ClientTimeout(...)'",
-                )
-            if not isinstance(timeout, ClientTimeout):
-                self._timeout = ClientTimeout(total=timeout)
-                warnings.warn(
-                    "parameter 'timeout' of type 'float' or 'int' "
-                    "is deprecated, please use "
-                    "'timeout=ClientTimeout(total=...)'",
-                    DeprecationWarning,
-                    stacklevel=2,
                 )
             else:
                 self._timeout = timeout

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -271,7 +271,22 @@ class ClientSession:
         if timeout is sentinel or timeout is None:
             self._timeout = DEFAULT_TIMEOUT
         else:
-            self._timeout = timeout
+            if not isinstance(timeout, (ClientTimeout, int, float)):
+                raise ValueError(
+                    f"timeout parameter cannot be of {type(timeout)} type, "
+                    "please use 'timeout=ClientTimeout(...)'",
+                )
+            if not isinstance(timeout, ClientTimeout):
+                self._timeout = ClientTimeout(total=timeout)
+                warnings.warn(
+                    "parameter 'timeout' of type 'float' or 'int' "
+                    "is deprecated, please use "
+                    "'timeout=ClientTimeout(total=...)'",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            else:
+                self._timeout = timeout
         self._raise_for_status = raise_for_status
         self._auto_decompress = auto_decompress
         self._trust_env = trust_env

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -798,11 +798,8 @@ async def test_client_session_timeout_zero() -> None:
 async def test_client_session_timeout_bad_argument() -> None:
     with pytest.raises(ValueError):
         ClientSession(timeout="test_bad_argumnet")
-
-
-async def test_client_session_timeout_arg_deprecation_warning() -> None:
-    with pytest.warns(DeprecationWarning):
-        ClientSession(timeout=0.1)
+    with pytest.raises(ValueError):
+        ClientSession(timeout=100)
 
 
 async def test_requote_redirect_url_default() -> None:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -779,13 +779,6 @@ async def test_client_session_timeout_default_args(loop: Any) -> None:
     await session1.close()
 
 
-async def test_client_session_timeout_argument() -> None:
-    timeout = client.ClientTimeout(total=500)
-    session = ClientSession(timeout=timeout)
-    assert session.timeout == timeout
-    await session.close()
-
-
 async def test_client_session_timeout_zero() -> None:
     timeout = client.ClientTimeout(total=10, connect=0, sock_connect=0, sock_read=0)
     try:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -780,8 +780,9 @@ async def test_client_session_timeout_default_args(loop: Any) -> None:
 
 
 async def test_client_session_timeout_argument() -> None:
-    session = ClientSession(timeout=500)
-    assert session.timeout == 500
+    timeout = client.ClientTimeout(total=500)
+    session = ClientSession(timeout=timeout)
+    assert session.timeout == timeout
     await session.close()
 
 
@@ -792,6 +793,16 @@ async def test_client_session_timeout_zero() -> None:
             await session.get("http://example.com")
     except asyncio.TimeoutError:
         pytest.fail("0 should disable timeout.")
+
+
+async def test_client_session_timeout_bad_argument() -> None:
+    with pytest.raises(ValueError):
+        ClientSession(timeout="test_bad_argumnet")
+
+
+async def test_client_session_timeout_arg_deprecation_warning() -> None:
+    with pytest.warns(DeprecationWarning):
+        ClientSession(timeout=0.1)
 
 
 async def test_requote_redirect_url_default() -> None:


### PR DESCRIPTION
## What do these changes do?

Handle `ClientSession` `timeout` param type properly when creating a client.

## Are there changes in behavior for the user?

A `ValueError` is raised when using something other than `ClientTimeout` in `timeout` param.

## Related issue number

Fixes #8021

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder