### PR TITLE
Backport to 3.10: Add runtime type check for `ClientSession` `timeout` param (#8022)

### DIFF
--- a/CHANGES/8021.bugfix
+++ b/CHANGES/8021.bugfix
@@ -1,0 +1,1 @@
+Add runtime type check for ``ClientSession`` ``timeout`` parameter.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -143,6 +143,7 @@ Hugo Hromic
 Hugo van Kemenade
 Hynek Schlawack
 Igor Alexandrov
+Igor Bolshakov
 Igor Davydenko
 Igor Mozharovsky
 Igor Pavlov

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -298,7 +298,7 @@ class ClientSession:
                     f"timeout parameter cannot be of {type(timeout)} type, "
                     "please use 'timeout=ClientTimeout(...)'",
                 )
-            self._timeout = timeout  # type: ignore[assignment]
+            self._timeout = timeout
             if read_timeout is not sentinel:
                 raise ValueError(
                     "read_timeout and timeout parameters "

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -276,7 +276,7 @@ class ClientSession:
         self._default_auth = auth
         self._version = version
         self._json_serialize = json_serialize
-        if timeout is sentinel:
+        if timeout is sentinel or timeout is None:
             self._timeout = DEFAULT_TIMEOUT
             if read_timeout is not sentinel:
                 warnings.warn(
@@ -293,6 +293,11 @@ class ClientSession:
                     stacklevel=2,
                 )
         else:
+            if not isinstance(timeout, ClientTimeout):
+                raise ValueError(
+                    f"timeout parameter cannot be of {type(timeout)} type, "
+                    "please use 'timeout=ClientTimeout(...)'",
+                )
             self._timeout = timeout  # type: ignore[assignment]
             if read_timeout is not sentinel:
                 raise ValueError(

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -814,12 +814,6 @@ async def test_client_session_timeout_default_args(loop) -> None:
     await session1.close()
 
 
-async def test_client_session_timeout_argument() -> None:
-    session = ClientSession(timeout=500)
-    assert session.timeout == 500
-    await session.close()
-
-
 async def test_client_session_timeout_zero() -> None:
     timeout = client.ClientTimeout(total=10, connect=0, sock_connect=0, sock_read=0)
     try:
@@ -827,6 +821,13 @@ async def test_client_session_timeout_zero() -> None:
             await session.get("http://example.com")
     except asyncio.TimeoutError:
         pytest.fail("0 should disable timeout.")
+
+
+async def test_client_session_timeout_bad_argument() -> None:
+    with pytest.raises(ValueError):
+        ClientSession(timeout="test_bad_argumnet")
+    with pytest.raises(ValueError):
+        ClientSession(timeout=100)
 
 
 async def test_requote_redirect_url_default() -> None:


### PR DESCRIPTION
# Backport to 3.10


## What do these changes do?

Add runtime type check for `ClientSession` `timeout` param when creating a client. 

## Are there changes in behavior for the user?

A `ValueError` is raised when using something other than `ClientTimeout` in `timeout` param.

## Related issue number

Fixes #8021

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder