### PR TITLE
Backport to 3.9: Add runtime type check for `ClientSession` `timeout` param (#8022)

### DIFF
--- a/CHANGES/8021.bugfix
+++ b/CHANGES/8021.bugfix
@@ -1,0 +1,1 @@
+Add runtime type check for ``ClientSession`` ``timeout`` parameter.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -143,6 +143,7 @@ Hugo Hromic
 Hugo van Kemenade
 Hynek Schlawack
 Igor Alexandrov
+Igor Bolshakov
 Igor Davydenko
 Igor Mozharovsky
 Igor Pavlov

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -272,36 +272,40 @@ class ClientSession:
         self._default_auth = auth
         self._version = version
         self._json_serialize = json_serialize
-        if timeout is sentinel:
-            self._timeout = DEFAULT_TIMEOUT
+        if timeout is sentinel or timeout is None:
+            timeout = DEFAULT_TIMEOUT
             if read_timeout is not sentinel:
                 warnings.warn(
                     "read_timeout is deprecated, " "use timeout argument instead",
                     DeprecationWarning,
                     stacklevel=2,
                 )
-                self._timeout = attr.evolve(self._timeout, total=read_timeout)
+                timeout = attr.evolve(timeout, total=read_timeout)
             if conn_timeout is not None:
-                self._timeout = attr.evolve(self._timeout, connect=conn_timeout)
+                timeout = attr.evolve(timeout, connect=conn_timeout)
                 warnings.warn(
                     "conn_timeout is deprecated, " "use timeout argument instead",
                     DeprecationWarning,
                     stacklevel=2,
                 )
-        else:
-            self._timeout = timeout  # type: ignore[assignment]
-            if read_timeout is not sentinel:
-                raise ValueError(
-                    "read_timeout and timeout parameters "
-                    "conflict, please setup "
-                    "timeout.read"
-                )
-            if conn_timeout is not None:
-                raise ValueError(
-                    "conn_timeout and timeout parameters "
-                    "conflict, please setup "
-                    "timeout.connect"
-                )
+        if not isinstance(timeout, ClientTimeout):
+            raise ValueError(
+                f"timeout parameter cannot be of {type(timeout)} type, "
+                "please use 'timeout=ClientTimeout(...)'",
+            )
+        self._timeout = timeout
+        if read_timeout is not sentinel:
+            raise ValueError(
+                "read_timeout and timeout parameters "
+                "conflict, please setup "
+                "timeout.read"
+            )
+        if conn_timeout is not None:
+            raise ValueError(
+                "conn_timeout and timeout parameters "
+                "conflict, please setup "
+                "timeout.connect"
+            )
         self._raise_for_status = raise_for_status
         self._auto_decompress = auto_decompress
         self._trust_env = trust_env

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -294,7 +294,7 @@ class ClientSession:
                     f"timeout parameter cannot be of {type(timeout)} type, "
                     "please use 'timeout=ClientTimeout(...)'",
                 )
-            self._timeout = timeout  # type: ignore[assignment]
+            self._timeout = timeout
             if read_timeout is not sentinel:
                 raise ValueError(
                     "read_timeout and timeout parameters "

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -274,26 +274,11 @@ class ClientSession:
         self._json_serialize = json_serialize
         if timeout is sentinel or timeout is None:
             timeout = DEFAULT_TIMEOUT
-            if read_timeout is not sentinel:
-                warnings.warn(
-                    "read_timeout is deprecated, " "use timeout argument instead",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                timeout = attr.evolve(timeout, total=read_timeout)
-            if conn_timeout is not None:
-                timeout = attr.evolve(timeout, connect=conn_timeout)
-                warnings.warn(
-                    "conn_timeout is deprecated, " "use timeout argument instead",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
         if not isinstance(timeout, ClientTimeout):
             raise ValueError(
                 f"timeout parameter cannot be of {type(timeout)} type, "
                 "please use 'timeout=ClientTimeout(...)'",
             )
-        self._timeout = timeout
         if read_timeout is not sentinel:
             raise ValueError(
                 "read_timeout and timeout parameters "
@@ -306,6 +291,7 @@ class ClientSession:
                 "conflict, please setup "
                 "timeout.connect"
             )
+        self._timeout = timeout
         self._raise_for_status = raise_for_status
         self._auto_decompress = auto_decompress
         self._trust_env = trust_env

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -273,25 +273,40 @@ class ClientSession:
         self._version = version
         self._json_serialize = json_serialize
         if timeout is sentinel or timeout is None:
-            timeout = DEFAULT_TIMEOUT
-        if not isinstance(timeout, ClientTimeout):
-            raise ValueError(
-                f"timeout parameter cannot be of {type(timeout)} type, "
-                "please use 'timeout=ClientTimeout(...)'",
-            )
-        if read_timeout is not sentinel:
-            raise ValueError(
-                "read_timeout and timeout parameters "
-                "conflict, please setup "
-                "timeout.read"
-            )
-        if conn_timeout is not None:
-            raise ValueError(
-                "conn_timeout and timeout parameters "
-                "conflict, please setup "
-                "timeout.connect"
-            )
-        self._timeout = timeout
+            self._timeout = DEFAULT_TIMEOUT
+            if read_timeout is not sentinel:
+                warnings.warn(
+                    "read_timeout is deprecated, " "use timeout argument instead",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+                self._timeout = attr.evolve(self._timeout, total=read_timeout)
+            if conn_timeout is not None:
+                self._timeout = attr.evolve(self._timeout, connect=conn_timeout)
+                warnings.warn(
+                    "conn_timeout is deprecated, " "use timeout argument instead",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+        else:
+            if not isinstance(timeout, ClientTimeout):
+                raise ValueError(
+                    f"timeout parameter cannot be of {type(timeout)} type, "
+                    "please use 'timeout=ClientTimeout(...)'",
+                )
+            self._timeout = timeout  # type: ignore[assignment]
+            if read_timeout is not sentinel:
+                raise ValueError(
+                    "read_timeout and timeout parameters "
+                    "conflict, please setup "
+                    "timeout.read"
+                )
+            if conn_timeout is not None:
+                raise ValueError(
+                    "conn_timeout and timeout parameters "
+                    "conflict, please setup "
+                    "timeout.connect"
+                )
         self._raise_for_status = raise_for_status
         self._auto_decompress = auto_decompress
         self._trust_env = trust_env

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -790,8 +790,9 @@ async def test_client_session_timeout_args(loop) -> None:
     session1 = ClientSession(loop=loop)
     assert session1._timeout == client.DEFAULT_TIMEOUT
 
-    with pytest.raises(ValueError):
-        ClientSession(loop=loop, read_timeout=20 * 60, conn_timeout=30 * 60)
+    with pytest.warns(DeprecationWarning):
+        session2 = ClientSession(loop=loop, read_timeout=20 * 60, conn_timeout=30 * 60)
+    assert session2._timeout == client.ClientTimeout(total=20 * 60, connect=30 * 60)
 
     with pytest.raises(ValueError):
         ClientSession(
@@ -804,6 +805,7 @@ async def test_client_session_timeout_args(loop) -> None:
         )
 
     await session1.close()
+    await session2.close()
 
 
 async def test_client_session_timeout_default_args(loop) -> None:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -814,12 +814,6 @@ async def test_client_session_timeout_default_args(loop) -> None:
     await session1.close()
 
 
-async def test_client_session_timeout_argument() -> None:
-    session = ClientSession(timeout=500)
-    assert session.timeout == 500
-    await session.close()
-
-
 async def test_client_session_timeout_zero() -> None:
     timeout = client.ClientTimeout(total=10, connect=0, sock_connect=0, sock_read=0)
     try:
@@ -827,6 +821,13 @@ async def test_client_session_timeout_zero() -> None:
             await session.get("http://example.com")
     except asyncio.TimeoutError:
         pytest.fail("0 should disable timeout.")
+
+
+async def test_client_session_timeout_bad_argument() -> None:
+    with pytest.raises(ValueError):
+        ClientSession(timeout="test_bad_argumnet")
+    with pytest.raises(ValueError):
+        ClientSession(timeout=100)
 
 
 async def test_requote_redirect_url_default() -> None:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -790,9 +790,8 @@ async def test_client_session_timeout_args(loop) -> None:
     session1 = ClientSession(loop=loop)
     assert session1._timeout == client.DEFAULT_TIMEOUT
 
-    with pytest.warns(DeprecationWarning):
-        session2 = ClientSession(loop=loop, read_timeout=20 * 60, conn_timeout=30 * 60)
-    assert session2._timeout == client.ClientTimeout(total=20 * 60, connect=30 * 60)
+    with pytest.raises(ValueError):
+        ClientSession(loop=loop, read_timeout=20 * 60, conn_timeout=30 * 60)
 
     with pytest.raises(ValueError):
         ClientSession(
@@ -805,7 +804,6 @@ async def test_client_session_timeout_args(loop) -> None:
         )
 
     await session1.close()
-    await session2.close()
 
 
 async def test_client_session_timeout_default_args(loop) -> None:


### PR DESCRIPTION
# Backport to 3.9

## What do these changes do?

Handle `ClientSession` `timeout` param type properly when creating a client.

## Are there changes in behavior for the user?

A `ValueError` is raised when using something other than `ClientTimeout` in `timeout` param.

## Related issue number

Fixes #8021

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder