### PR TITLE
Close client connections when writer is unexpectedly cancelled

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -709,7 +709,7 @@ class ClientResponse(HeadersMixin):
     _closed = True  # to allow __del__ for non-initialized properly response
     _released = False
     __writer = None
-    __writer_cancelled = False
+    __writer_cancelled_internally = False
 
     def __init__(
         self,
@@ -768,7 +768,7 @@ class ClientResponse(HeadersMixin):
         if self.__writer is not None:
             self.__writer.remove_done_callback(self.__reset_writer)
         self.__writer = writer
-        self.__writer_cancelled = False
+        self.__writer_cancelled_internally = False
         if writer is not None:
             writer.add_done_callback(self.__reset_writer)
 
@@ -1022,7 +1022,7 @@ class ClientResponse(HeadersMixin):
             # since we won't be able to write the rest of the body
             # we need to close the connection since we can't reuse it
             self.close()
-            if not self.__writer_cancelled:
+            if not self.__writer_cancelled_internally:
                 raise
 
     async def _wait_released(self) -> None:
@@ -1032,7 +1032,7 @@ class ClientResponse(HeadersMixin):
 
     def _cleanup_writer(self) -> None:
         if self._writer is not None:
-            self.__writer_cancelled = True
+            self.__writer_cancelled_internally = True
             self._writer.cancel()
         self._session = None
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -14,6 +14,7 @@ from types import MappingProxyType, TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
+    Awaitable,
     Callable,
     Dict,
     Iterable,
@@ -1008,7 +1009,7 @@ class ClientResponse(HeadersMixin):
             else:
                 self._writer.add_done_callback(lambda f: self._release_connection())
 
-    async def _wait_for_writer(self, writer: asyncio.Task[None]) -> None:
+    async def _wait_for_writer(self, writer: Awaitable[None]) -> None:
         """Wait for the writer to finish.
 
         If we cancel the writer, we will suppress the CancelledError


### PR DESCRIPTION
TODO: figure out how to test this

<!-- Thank you for your contribution! -->

## What do these changes do?

If the writer is cancelled out while waiting for the connection to close or release, we now suppress the cancellation to prevent it from leaking upwards and force close the connection to ensure we do not reuse a connection which has an indeterminate state. 

https://github.com/aio-libs/aiohttp/discussions/8035#discussioncomment-8186816


## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
