### PR TITLE
Tightening the runtime type check for ssl (#7698)

### DIFF
--- a/CHANGES/7698.feature
+++ b/CHANGES/7698.feature
@@ -1,0 +1,1 @@
+Added support for passing `True` to `ssl` while deprecating `None`. -- by :user:`xiangyan99`

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -431,11 +431,6 @@ class ClientSession:
         if self.closed:
             raise RuntimeError("Session is closed")
 
-        if not isinstance(ssl, SSL_ALLOWED_TYPES):
-            raise TypeError(
-                "ssl should be SSLContext, Fingerprint, or bool, "
-                "got {!r} instead.".format(ssl)
-            )
         ssl = _merge_ssl_params(ssl, verify_ssl, ssl_context, fingerprint)
 
         if data is not None and json is not None:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -570,7 +570,7 @@ class ClientSession:
                         proxy_auth=proxy_auth,
                         timer=timer,
                         session=self,
-                        ssl=ssl if ssl is not None else True,  # type: ignore[redundant-expr]
+                        ssl=ssl if ssl is not None else True,
                         server_hostname=server_hostname,
                         proxy_headers=proxy_headers,
                         traces=traces,

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -182,12 +182,12 @@ class ClientConnectorError(ClientOSError):
         return self._conn_key.port
 
     @property
-    def ssl(self) -> Union[SSLContext, None, bool, "Fingerprint"]:
+    def ssl(self) -> Union[SSLContext, bool, "Fingerprint"]:
         return self._conn_key.ssl
 
     def __str__(self) -> str:
         return "Cannot connect to host {0.host}:{0.port} ssl:{1} [{2}]".format(
-            self, self.ssl if self.ssl is not None else "default", self.strerror
+            self, "default" if self.ssl is True else self.ssl, self.strerror
         )
 
     # OSError.__reduce__ does too much black magick
@@ -221,7 +221,7 @@ class UnixClientConnectorError(ClientConnectorError):
 
     def __str__(self) -> str:
         return "Cannot connect to unix socket {0.path} ssl:{1} [{2}]".format(
-            self, self.ssl if self.ssl is not None else "default", self.strerror
+            self, "default" if self.ssl is True else self.ssl, self.strerror
         )
 
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -17,7 +17,6 @@ from typing import (
     Dict,
     Iterable,
     List,
-    Literal,
     Mapping,
     Optional,
     Tuple,
@@ -151,11 +150,11 @@ class Fingerprint:
 if ssl is not None:
     SSL_ALLOWED_TYPES = (ssl.SSLContext, bool, Fingerprint, type(None))
 else:  # pragma: no cover
-    SSL_ALLOWED_TYPES = type(None)
+    SSL_ALLOWED_TYPES = (bool, type(None))
 
 
 def _merge_ssl_params(
-    ssl: Union["SSLContext", Literal[False], Fingerprint, None],
+    ssl: Union["SSLContext", bool, Fingerprint, None],
     verify_ssl: Optional[bool],
     ssl_context: Optional["SSLContext"],
     fingerprint: Optional[bytes],
@@ -166,7 +165,7 @@ def _merge_ssl_params(
             DeprecationWarning,
             stacklevel=3,
         )
-        if ssl is not None:
+        if ssl is not True:
             raise ValueError(
                 "verify_ssl, ssl_context, fingerprint and ssl "
                 "parameters are mutually exclusive"
@@ -179,7 +178,7 @@ def _merge_ssl_params(
             DeprecationWarning,
             stacklevel=3,
         )
-        if ssl is not None:
+        if ssl is not True:
             raise ValueError(
                 "verify_ssl, ssl_context, fingerprint and ssl "
                 "parameters are mutually exclusive"
@@ -192,7 +191,7 @@ def _merge_ssl_params(
             DeprecationWarning,
             stacklevel=3,
         )
-        if ssl is not None:
+        if ssl is not True:
             raise ValueError(
                 "verify_ssl, ssl_context, fingerprint and ssl "
                 "parameters are mutually exclusive"
@@ -214,7 +213,7 @@ class ConnectionKey:
     host: str
     port: Optional[int]
     is_ssl: bool
-    ssl: Union[SSLContext, None, Literal[False], Fingerprint]
+    ssl: Union[SSLContext, bool, Fingerprint]
     proxy: Optional[URL]
     proxy_auth: Optional[BasicAuth]
     proxy_headers_hash: Optional[int]  # hash(CIMultiDict)
@@ -276,7 +275,7 @@ class ClientRequest:
         proxy_auth: Optional[BasicAuth] = None,
         timer: Optional[BaseTimerContext] = None,
         session: Optional["ClientSession"] = None,
-        ssl: Union[SSLContext, Literal[False], Fingerprint, None] = None,
+        ssl: Union[SSLContext, bool, Fingerprint] = True,
         proxy_headers: Optional[LooseHeaders] = None,
         traces: Optional[List["Trace"]] = None,
         trust_env: bool = False,
@@ -315,7 +314,7 @@ class ClientRequest:
             real_response_class = response_class
         self.response_class: Type[ClientResponse] = real_response_class
         self._timer = timer if timer is not None else TimerNoop()
-        self._ssl = ssl
+        self._ssl = ssl if ssl is not None else True  # type: ignore[redundant-expr]
         self.server_hostname = server_hostname
 
         if loop.get_debug():
@@ -357,7 +356,7 @@ class ClientRequest:
         return self.url.scheme in ("https", "wss")
 
     @property
-    def ssl(self) -> Union["SSLContext", None, Literal[False], Fingerprint]:
+    def ssl(self) -> Union["SSLContext", bool, Fingerprint]:
         return self._ssl
 
     @property

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -154,7 +154,7 @@ else:  # pragma: no cover
 
 
 def _merge_ssl_params(
-    ssl: Union["SSLContext", bool, Fingerprint, None],
+    ssl: Union["SSLContext", bool, Fingerprint],
     verify_ssl: Optional[bool],
     ssl_context: Optional["SSLContext"],
     fingerprint: Optional[bytes],

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -158,7 +158,7 @@ def _merge_ssl_params(
     verify_ssl: Optional[bool],
     ssl_context: Optional["SSLContext"],
     fingerprint: Optional[bytes],
-) -> Union["SSLContext", Literal[False], Fingerprint, None]:
+) -> Union["SSLContext", bool, Fingerprint]:
     if verify_ssl is not None and not verify_ssl:
         warnings.warn(
             "verify_ssl is deprecated, use ssl=False instead",

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -314,7 +314,7 @@ class ClientRequest:
             real_response_class = response_class
         self.response_class: Type[ClientResponse] = real_response_class
         self._timer = timer if timer is not None else TimerNoop()
-        self._ssl = ssl if ssl is not None else True  # type: ignore[redundant-expr]
+        self._ssl = ssl if ssl is not None else True
         self.server_hostname = server_hostname
 
         if loop.get_debug():

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -768,7 +768,7 @@ class TCPConnector(BaseConnector):
         ttl_dns_cache: Optional[int] = 10,
         family: int = 0,
         ssl_context: Optional[SSLContext] = None,
-        ssl: Union[None, Literal[False], Fingerprint, SSLContext] = None,
+        ssl: Union[bool, Fingerprint, SSLContext] = True,
         local_addr: Optional[Tuple[str, int]] = None,
         resolver: Optional[AbstractResolver] = None,
         keepalive_timeout: Union[None, float, object] = sentinel,
@@ -791,6 +791,11 @@ class TCPConnector(BaseConnector):
             timeout_ceil_threshold=timeout_ceil_threshold,
         )
 
+        if not isinstance(ssl, SSL_ALLOWED_TYPES):
+            raise TypeError(
+                "ssl should be SSLContext, Fingerprint, or bool, "
+                "got {!r} instead.".format(ssl)
+            )
         self._ssl = _merge_ssl_params(ssl, verify_ssl, ssl_context, fingerprint)
         if resolver is None:
             resolver = DefaultResolver(loop=self._loop)
@@ -965,13 +970,13 @@ class TCPConnector(BaseConnector):
             sslcontext = req.ssl
             if isinstance(sslcontext, ssl.SSLContext):
                 return sslcontext
-            if sslcontext is not None:
+            if sslcontext is not True:
                 # not verified or fingerprinted
                 return self._make_ssl_context(False)
             sslcontext = self._ssl
             if isinstance(sslcontext, ssl.SSLContext):
                 return sslcontext
-            if sslcontext is not None:
+            if sslcontext is not True:
                 # not verified or fingerprinted
                 return self._make_ssl_context(False)
             return self._make_ssl_context(True)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -791,11 +791,6 @@ class TCPConnector(BaseConnector):
             timeout_ceil_threshold=timeout_ceil_threshold,
         )
 
-        if not isinstance(ssl, SSL_ALLOWED_TYPES):
-            raise TypeError(
-                "ssl should be SSLContext, Fingerprint, or bool, "
-                "got {!r} instead.".format(ssl)
-            )
         self._ssl = _merge_ssl_params(ssl, verify_ssl, ssl_context, fingerprint)
         if resolver is None:
             resolver = DefaultResolver(loop=self._loop)

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -119,7 +119,7 @@ class TestClientConnectorError:
         host="example.com",
         port=8080,
         is_ssl=False,
-        ssl=None,
+        ssl=True,
         proxy=None,
         proxy_auth=None,
         proxy_headers_hash=None,
@@ -136,7 +136,7 @@ class TestClientConnectorError:
         assert err.os_error.strerror == "No such file"
         assert err.host == "example.com"
         assert err.port == 8080
-        assert err.ssl is None
+        assert err.ssl is True
 
     def test_pickle(self) -> None:
         err = client.ClientConnectorError(
@@ -153,7 +153,7 @@ class TestClientConnectorError:
             assert err2.os_error.strerror == "No such file"
             assert err2.host == "example.com"
             assert err2.port == 8080
-            assert err2.ssl is None
+            assert err2.ssl is True
             assert err2.foo == "bar"
 
     def test_repr(self) -> None:
@@ -171,7 +171,7 @@ class TestClientConnectorError:
             os_error=OSError(errno.ENOENT, "No such file"),
         )
         assert str(err) == (
-            "Cannot connect to host example.com:8080 ssl:" "default [No such file]"
+            "Cannot connect to host example.com:8080 ssl:default [No such file]"
         )
 
 
@@ -180,7 +180,7 @@ class TestClientConnectorCertificateError:
         host="example.com",
         port=8080,
         is_ssl=False,
-        ssl=None,
+        ssl=True,
         proxy=None,
         proxy_auth=None,
         proxy_headers_hash=None,

--- a/tests/test_client_fingerprint.py
+++ b/tests/test_client_fingerprint.py
@@ -37,7 +37,7 @@ def test_fingerprint_check_no_ssl() -> None:
 
 def test__merge_ssl_params_verify_ssl() -> None:
     with pytest.warns(DeprecationWarning):
-        assert _merge_ssl_params(None, False, None, None) is False
+        assert _merge_ssl_params(True, False, None, None) is False
 
 
 def test__merge_ssl_params_verify_ssl_conflict() -> None:
@@ -50,7 +50,7 @@ def test__merge_ssl_params_verify_ssl_conflict() -> None:
 def test__merge_ssl_params_ssl_context() -> None:
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     with pytest.warns(DeprecationWarning):
-        assert _merge_ssl_params(None, None, ctx, None) is ctx
+        assert _merge_ssl_params(True, None, ctx, None) is ctx
 
 
 def test__merge_ssl_params_ssl_context_conflict() -> None:
@@ -64,7 +64,7 @@ def test__merge_ssl_params_ssl_context_conflict() -> None:
 def test__merge_ssl_params_fingerprint() -> None:
     digest = hashlib.sha256(b"123").digest()
     with pytest.warns(DeprecationWarning):
-        ret = _merge_ssl_params(None, None, None, digest)
+        ret = _merge_ssl_params(True, None, None, digest)
         assert ret.fingerprint == digest
 
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -166,7 +166,7 @@ def test_host_port_default_http(make_request) -> None:
     req = make_request("get", "http://python.org/")
     assert req.host == "python.org"
     assert req.port == 80
-    assert not req.ssl
+    assert not req.is_ssl()
 
 
 def test_host_port_default_https(make_request) -> None:
@@ -400,7 +400,7 @@ def test_ipv6_default_http_port(make_request) -> None:
     req = make_request("get", "http://[2001:db8::1]/")
     assert req.host == "2001:db8::1"
     assert req.port == 80
-    assert not req.ssl
+    assert not req.is_ssl()
 
 
 def test_ipv6_default_https_port(make_request) -> None:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -30,19 +30,19 @@ from aiohttp.tracing import Trace
 @pytest.fixture()
 def key():
     # Connection key
-    return ConnectionKey("localhost", 80, False, None, None, None, None)
+    return ConnectionKey("localhost", 80, False, True, None, None, None)
 
 
 @pytest.fixture
 def key2():
     # Connection key
-    return ConnectionKey("localhost", 80, False, None, None, None, None)
+    return ConnectionKey("localhost", 80, False, True, None, None, None)
 
 
 @pytest.fixture
 def ssl_key():
     # Connection key
-    return ConnectionKey("localhost", 80, True, None, None, None, None)
+    return ConnectionKey("localhost", 80, True, True, None, None, None)
 
 
 @pytest.fixture
@@ -1467,9 +1467,9 @@ async def test_cleanup_closed_disabled(loop, mocker) -> None:
     assert not conn._cleanup_closed_transports
 
 
-async def test_tcp_connector_ctor(loop) -> None:
-    conn = aiohttp.TCPConnector(loop=loop)
-    assert conn._ssl is None
+async def test_tcp_connector_ctor() -> None:
+    conn = aiohttp.TCPConnector()
+    assert conn._ssl is True
 
     assert conn.use_dns_cache
     assert conn.family == 0
@@ -1555,7 +1555,7 @@ async def test___get_ssl_context3(loop) -> None:
     conn = aiohttp.TCPConnector(loop=loop, ssl=ctx)
     req = mock.Mock()
     req.is_ssl.return_value = True
-    req.ssl = None
+    req.ssl = True
     assert conn._get_ssl_context(req) is ctx
 
 
@@ -1581,7 +1581,7 @@ async def test___get_ssl_context6(loop) -> None:
     conn = aiohttp.TCPConnector(loop=loop)
     req = mock.Mock()
     req.is_ssl.return_value = True
-    req.ssl = None
+    req.ssl = True
     assert conn._get_ssl_context(req) is conn._make_ssl_context(True)
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -92,7 +92,7 @@ class TestProxy(unittest.TestCase):
             auth=None,
             headers={"Host": "www.python.org"},
             loop=self.loop,
-            ssl=None,
+            ssl=True,
         )
 
         conn.close()
@@ -150,7 +150,7 @@ class TestProxy(unittest.TestCase):
             auth=None,
             headers={"Host": "www.python.org", "Foo": "Bar"},
             loop=self.loop,
-            ssl=None,
+            ssl=True,
         )
 
         conn.close()


### PR DESCRIPTION
Currently, the valid types of ssl parameter are SSLContext, Literal[False], Fingerprint or None.

If user sets ssl = False, we disable ssl certificate validation which makes total sense. But if user set ssl = True by mistake, instead of enabling ssl certificate validation or raising errors, we silently disable the validation too which is a little subtle but weird.

In this PR, we added a check that if user sets ssl=True, we enable certificate validation by treating it as using Default SSL Context.

---------

Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
Co-authored-by: Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>
Co-authored-by: Sam Bull <aa6bs0@sambull.org>
Co-authored-by: J. Nick Koston <nick@koston.org>
Co-authored-by: Sam Bull <git@sambull.org>
(cherry picked from commit 9e14ea19b5a48bb26797babc32202605066cb5f5)

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
