### PR TITLE
Make empty header names cause a 400 instead of an unhandled exception.

### DIFF
--- a/CHANGES/8055.bugfix
+++ b/CHANGES/8055.bugfix
@@ -1,0 +1,1 @@
+Make empty header names cause a 400 instead of an unhandled exception.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -147,7 +147,7 @@ class HeadersParser:
                 raise InvalidHeader(line) from None
 
             # https://www.rfc-editor.org/rfc/rfc9112.html#section-5.1-2
-            if {bname[0], bname[-1]} & {32, 9}:  # {" ", "\t"}
+            if bname == b"" or {bname[0], bname[-1]} & {32, 9}:  # {" ", "\t"}
                 raise InvalidHeader(line)
 
             bvalue = bvalue.lstrip(b" \t")

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -251,6 +251,20 @@ def test_bad_chunked_c(loop: Any, protocol: Any) -> None:
         parser.feed_data(text)
 
 
+def test_empty_header_name_py(loop: Any, protocol: Any) -> None:
+    """Test that empty header names can't be used."""
+    parser = HttpRequestParserPy(
+        protocol,
+        loop,
+        2**16,
+        max_line_size=8190,
+        max_field_size=8190,
+    )
+    text = b"GET / HTTP/1.1\r\n:\r\n\r\n"
+    with pytest.raises(http_exceptions.InvalidHeader):
+        parser.feed_data(text)
+
+
 def test_whitespace_before_header(parser: Any) -> None:
     text = b"GET / HTTP/1.1\r\n\tContent-Length: 1\r\n\r\nX"
     with pytest.raises(http_exceptions.BadHttpMessage):


### PR DESCRIPTION
## What do these changes do?

This patch ensures that requests containing empty header names are rejected by the Python HTTP parser, instead of causing an unhandled exception that results in the closing of the connection without a response.

## Are there changes in behavior for the user?

Shouldn't be!

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`names.
- [X] Add a new news fragment into the `CHANGES` folder