### PR TITLE
Fix for cve-2023-49081/2

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -332,8 +332,17 @@ class ClientSession:
         self, method: str, url: StrOrURL, **kwargs: Any
     ) -> "_RequestContextManager":
         """Perform HTTP request."""
-        
-        valid_methods = ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "TRACE", "CONNECT"]
+
+        valid_methods = [
+            "GET",
+            "POST",
+            "PUT",
+            "DELETE",
+            "HEAD",
+            "OPTIONS",
+            "TRACE",
+            "CONNECT",
+        ]
         if method.upper() not in valid_methods:
             raise ValueError(f"Invalid HTTP method: {method}")
 

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -267,8 +267,11 @@ class ClientSession:
             self._cookie_jar.update_cookies(cookies)
 
         self._connector_owner = connector_owner
-        self._default_auth = auth
+
+        if not isinstance(version, HttpVersion):
+            raise ValueError("version parameter must be a valid HttpVersion value")
         self._version = version
+
         self._json_serialize = json_serialize
         if timeout is sentinel or timeout is None:
             timeout = DEFAULT_TIMEOUT
@@ -329,6 +332,11 @@ class ClientSession:
         self, method: str, url: StrOrURL, **kwargs: Any
     ) -> "_RequestContextManager":
         """Perform HTTP request."""
+        
+        valid_methods = ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "TRACE", "CONNECT"]
+        if method.upper() not in valid_methods:
+            raise ValueError(f"Invalid HTTP method: {method}")
+
         return _RequestContextManager(self._request(method, url, **kwargs))
 
     def _build_url(self, str_or_url: StrOrURL) -> URL:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -267,6 +267,7 @@ class ClientSession:
             self._cookie_jar.update_cookies(cookies)
 
         self._connector_owner = connector_owner
+        self._default_auth = auth
 
         if not isinstance(version, HttpVersion):
             raise ValueError("version parameter must be a valid HttpVersion value")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

The fixes for CVE-2023-49081/2 do not remediate the PoCs at https://gist.github.com/jnovikov/184afb593d9c2114d77f508e0ccd508e and https://gist.github.com/jnovikov/7f411ae9fe6a9a7804cf162a3bdbb44b. It looks like 3.9.0 introduced checks/sanitization in the http_parser.py. However, the PoC demonstrates an attack in the client.py. See the commit for something that catches the issue with the method and httpversion.

<!-- Please give a short brief about these changes. -->

For CVE-2023-49081, the changes add a http version check to ClientSession and throws an error if the version is not an http version. 

For CVE-2023-49082, the changes ad a validation check for the http methods passed to request and throws an error if it the str is not an RFC 2616 method.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

CVE-2023-49081 https://github.com/aio-libs/aiohttp/security/advisories/GHSA-q3qx-c6g2-7pw2
CVE-2023-49082 https://github.com/aio-libs/aiohttp/security/advisories/GHSA-qvrw-v9rv-5rjx

I found a few changes to http_parser.py that may be associated with the CVEs. See https://github.com/aio-libs/aiohttp/issues/7700. However, there's no associated commits or PRs with the two CVEs. I discovered the issue while looking into potential backports to older aiohttp versions (due to being stuck on Python 3.7). Can you please let us know what was fixed with the two CVEs?

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
