### PR TITLE
Add Request type generics to Server

### DIFF
--- a/CHANGES/8064.feature
+++ b/CHANGES/8064.feature
@@ -1,0 +1,1 @@
+Add generics for request (factory) type in Server.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -55,6 +55,7 @@ Ben Bader
 Ben Greiner
 Ben Kallus
 Ben Timby
+Benedict Harcourt
 Benedikt Reinartz
 Bob Haddleton
 Boris Feld

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -162,7 +162,7 @@ class BaseTestServer(ABC):
         return self._closed
 
     @property
-    def handler(self) -> Server:
+    def handler(self) -> Server[Request]:
         # for backward compatibility
         # web.Server instance
         runner = self.runner
@@ -222,7 +222,7 @@ class TestServer(BaseTestServer):
 class RawTestServer(BaseTestServer):
     def __init__(
         self,
-        handler: _RequestHandler,
+        handler: _RequestHandler[Request],
         *,
         scheme: Union[str, _SENTINEL] = sentinel,
         host: str = "127.0.0.1",

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -148,7 +148,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         self,
         message: RawRequestMessage,
         payload: StreamReader,
-        protocol: "RequestHandler",
+        protocol: "RequestHandler[BaseRequest]",
         payload_writer: AbstractStreamWriter,
         task: "asyncio.Task[None]",
         loop: asyncio.AbstractEventLoop,
@@ -267,7 +267,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         return self._task
 
     @property
-    def protocol(self) -> "RequestHandler":
+    def protocol(self) -> "RequestHandler[BaseRequest]":
         return self._protocol
 
     @property


### PR DESCRIPTION
## What do these changes do?

The addition of this Generic allows type checkers and linters to link the type returned by the RequestFactory used by a Server, and the Request type that will be passed to the RequestHandler. The generic type maintains the BaseRequest bound.

## Are there changes in behavior for the user?

This does not change user behaviour, except for developers using custom Servers and type hinting, who may need to add 

Note: I'm honestly not sure if this change is worthwhile, and am happy for it to be closed as won't fix for the extra cognitive complexity it adds.

## Related issue number

N/A

## Checklist

(I'm considering unit tests / documentation as N/A)

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
