### PR TITLE
[PR #3955/8960063e backport][3.10] Replace all tmpdir fixtures with tmp_path (#3551)

### DIFF
--- a/CHANGES/3551.misc
+++ b/CHANGES/3551.misc
@@ -1,0 +1,1 @@
+Replace all tmpdir fixtures with tmp_path in test suite.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -225,6 +225,7 @@ Martin Richard
 Martin Sucha
 Mathias Fröjdman
 Mathieu Dugré
+Matt VanEseltine
 Matthias Marquardt
 Matthieu Hauglustaine
 Matthieu Rigal

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -762,8 +762,8 @@ async def test_pass_falsy_data(loop) -> None:
     await req.close()
 
 
-async def test_pass_falsy_data_file(loop, tmpdir) -> None:
-    testfile = tmpdir.join("tmpfile").open("w+b")
+async def test_pass_falsy_data_file(loop, tmp_path) -> None:
+    testfile = (tmp_path / "tmpfile").open("w+b")
     testfile.write(b"data")
     testfile.seek(0)
     skip = frozenset([hdrs.CONTENT_TYPE])

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -721,12 +721,12 @@ async def test_proxy_from_env_http_with_auth(proxy_test_server, get_request, moc
 
 
 async def test_proxy_from_env_http_with_auth_from_netrc(
-    proxy_test_server, get_request, tmpdir, mocker
+    proxy_test_server, get_request, tmp_path, mocker
 ):
     url = "http://aiohttp.io/path"
     proxy = await proxy_test_server()
     auth = aiohttp.BasicAuth("user", "pass")
-    netrc_file = tmpdir.join("test_netrc")
+    netrc_file = tmp_path / "test_netrc"
     netrc_file_data = "machine 127.0.0.1 login {} password {}".format(
         auth.login,
         auth.password,
@@ -747,12 +747,12 @@ async def test_proxy_from_env_http_with_auth_from_netrc(
 
 
 async def test_proxy_from_env_http_without_auth_from_netrc(
-    proxy_test_server, get_request, tmpdir, mocker
+    proxy_test_server, get_request, tmp_path, mocker
 ):
     url = "http://aiohttp.io/path"
     proxy = await proxy_test_server()
     auth = aiohttp.BasicAuth("user", "pass")
-    netrc_file = tmpdir.join("test_netrc")
+    netrc_file = tmp_path / "test_netrc"
     netrc_file_data = "machine 127.0.0.2 login {} password {}".format(
         auth.login,
         auth.password,
@@ -773,12 +773,12 @@ async def test_proxy_from_env_http_without_auth_from_netrc(
 
 
 async def test_proxy_from_env_http_without_auth_from_wrong_netrc(
-    proxy_test_server, get_request, tmpdir, mocker
+    proxy_test_server, get_request, tmp_path, mocker
 ):
     url = "http://aiohttp.io/path"
     proxy = await proxy_test_server()
     auth = aiohttp.BasicAuth("user", "pass")
-    netrc_file = tmpdir.join("test_netrc")
+    netrc_file = tmp_path / "test_netrc"
     invalid_data = f"machine 127.0.0.1 {auth.login} pass {auth.password}"
     with open(str(netrc_file), "w") as f:
         f.write(invalid_data)

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1786,7 +1786,7 @@ async def test_response_with_bodypart(aiohttp_client) -> None:
         await resp.release()
 
 
-async def test_response_with_bodypart_named(aiohttp_client, tmpdir) -> None:
+async def test_response_with_bodypart_named(aiohttp_client, tmp_path) -> None:
     async def handler(request):
         reader = await request.multipart()
         part = await reader.next()
@@ -1796,9 +1796,9 @@ async def test_response_with_bodypart_named(aiohttp_client, tmpdir) -> None:
     app.router.add_post("/", handler)
     client = await aiohttp_client(app)
 
-    f = tmpdir.join("foobar.txt")
+    f = tmp_path / "foobar.txt"
     f.write_text("test", encoding="utf8")
-    with open(str(f), "rb") as fd:
+    with f.open("rb") as fd:
         data = {"file": fd}
         resp = await client.post("/", data=data)
 

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -558,18 +558,18 @@ def test_static_route_path_existence_check() -> None:
         web.StaticResource("/", nodirectory)
 
 
-async def test_static_file_huge(aiohttp_client, tmpdir) -> None:
+async def test_static_file_huge(aiohttp_client, tmp_path) -> None:
     filename = "huge_data.unknown_mime_type"
 
     # fill 20MB file
-    with tmpdir.join(filename).open("wb") as f:
+    with (tmp_path / filename).open("wb") as f:
         for i in range(1024 * 20):
             f.write((chr(i % 64 + 0x20) * 1024).encode())
 
-    file_st = os.stat(str(tmpdir.join(filename)))
+    file_st = os.stat(str(tmp_path / filename))
 
     app = web.Application()
-    app.router.add_static("/static", str(tmpdir))
+    app.router.add_static("/static", str(tmp_path))
     client = await aiohttp_client(app)
 
     resp = await client.get("/static/" + filename)
@@ -579,7 +579,7 @@ async def test_static_file_huge(aiohttp_client, tmpdir) -> None:
     assert resp.headers.get("CONTENT-ENCODING") is None
     assert int(resp.headers.get("CONTENT-LENGTH")) == file_st.st_size
 
-    f = tmpdir.join(filename).open("rb")
+    f = (tmp_path / filename).open("rb")
     off = 0
     cnt = 0
     while off < file_st.st_size:
@@ -988,11 +988,11 @@ async def test_static_file_compression(aiohttp_client, sender) -> None:
     await client.close()
 
 
-async def test_static_file_huge_cancel(aiohttp_client, tmpdir) -> None:
+async def test_static_file_huge_cancel(aiohttp_client, tmp_path) -> None:
     filename = "huge_data.unknown_mime_type"
 
     # fill 100MB file
-    with tmpdir.join(filename).open("wb") as f:
+    with (tmp_path / filename).open("wb") as f:
         for i in range(1024 * 20):
             f.write((chr(i % 64 + 0x20) * 1024).encode())
 
@@ -1005,7 +1005,7 @@ async def test_static_file_huge_cancel(aiohttp_client, tmpdir) -> None:
         tr = request.transport
         sock = tr.get_extra_info("socket")
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1024)
-        ret = web.FileResponse(pathlib.Path(str(tmpdir.join(filename))))
+        ret = web.FileResponse(pathlib.Path(str(tmp_path / filename)))
         return ret
 
     app = web.Application()
@@ -1029,11 +1029,11 @@ async def test_static_file_huge_cancel(aiohttp_client, tmpdir) -> None:
     await client.close()
 
 
-async def test_static_file_huge_error(aiohttp_client, tmpdir) -> None:
+async def test_static_file_huge_error(aiohttp_client, tmp_path) -> None:
     filename = "huge_data.unknown_mime_type"
 
     # fill 20MB file
-    with tmpdir.join(filename).open("wb") as f:
+    with (tmp_path / filename).open("wb") as f:
         f.seek(20 * 1024 * 1024)
         f.write(b"1")
 
@@ -1042,7 +1042,7 @@ async def test_static_file_huge_error(aiohttp_client, tmpdir) -> None:
         tr = request.transport
         sock = tr.get_extra_info("socket")
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1024)
-        ret = web.FileResponse(pathlib.Path(str(tmpdir.join(filename))))
+        ret = web.FileResponse(pathlib.Path(str(tmp_path / filename)))
         return ret
 
     app = web.Application()

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -525,13 +525,13 @@ async def test_web_view(aiohttp_client: AiohttpClient) -> None:
 
 
 async def test_static_absolute_url(
-    aiohttp_client: AiohttpClient, tmpdir: pathlib.Path
+    aiohttp_client: AiohttpClient, tmp_path: pathlib.Path
 ) -> None:
     # requested url is an absolute name like
     # /static/\\machine_name\c$ or /static/D:\path
     # where the static dir is totally different
     app = web.Application()
-    fname = tmpdir / "file.txt"
+    fname = tmp_path / "file.txt"
     fname.write_text("sample text", "ascii")
     here = pathlib.Path(__file__).parent
     app.router.add_static("/static", here)


### PR DESCRIPTION
**This is a backport of PR #3955 as merged into master (8960063ef4137d6c547a687a45ed55b943e9b8d1).**

tmp_path is the replacement fixture in pytest for tmpdir; tmp_path
uses the builtin pathlib.Path class. As it says on the tin, this
commit replaces every instance of tmpdir in the test suite with
tmp_path. Aside from s/tmpdir/tmp_path/ this also required changing
instances of `tmpdir.join(foo)` to `tmp_path / foo`.

This is intended to comprehensively address and close #3551, and
should have no side effects. This does not affect end users.