### PR TITLE
[PR #3957/79fe2045 backport][3.10] Improve test suite handling of paths, temp files

### DIFF
--- a/CHANGES/3957.misc
+++ b/CHANGES/3957.misc
@@ -1,0 +1,1 @@
+Improve test suite handling of paths and temp files to consistently use pathlib and pytest fixtures.

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1,7 +1,7 @@
 import asyncio
 import hashlib
 import io
-import os.path
+import pathlib
 import urllib.parse
 import zlib
 from http.cookies import BaseCookie, Morsel, SimpleCookie
@@ -921,12 +921,11 @@ async def test_chunked_transfer_encoding(loop, conn) -> None:
 
 
 async def test_file_upload_not_chunked(loop) -> None:
-    here = os.path.dirname(__file__)
-    fname = os.path.join(here, "aiohttp.png")
-    with open(fname, "rb") as f:
+    file_path = pathlib.Path(__file__).parent / "aiohttp.png"
+    with file_path.open("rb") as f:
         req = ClientRequest("post", URL("http://python.org/"), data=f, loop=loop)
         assert not req.chunked
-        assert req.headers["CONTENT-LENGTH"] == str(os.path.getsize(fname))
+        assert req.headers["CONTENT-LENGTH"] == str(file_path.stat().st_size)
         await req.close()
 
 
@@ -947,19 +946,17 @@ async def test_precompressed_data_stays_intact(loop) -> None:
 
 
 async def test_file_upload_not_chunked_seek(loop) -> None:
-    here = os.path.dirname(__file__)
-    fname = os.path.join(here, "aiohttp.png")
-    with open(fname, "rb") as f:
+    file_path = pathlib.Path(__file__).parent / "aiohttp.png"
+    with file_path.open("rb") as f:
         f.seek(100)
         req = ClientRequest("post", URL("http://python.org/"), data=f, loop=loop)
-        assert req.headers["CONTENT-LENGTH"] == str(os.path.getsize(fname) - 100)
+        assert req.headers["CONTENT-LENGTH"] == str(file_path.stat().st_size - 100)
         await req.close()
 
 
 async def test_file_upload_force_chunked(loop) -> None:
-    here = os.path.dirname(__file__)
-    fname = os.path.join(here, "aiohttp.png")
-    with open(fname, "rb") as f:
+    file_path = pathlib.Path(__file__).parent / "aiohttp.png"
+    with file_path.open("rb") as f:
         req = ClientRequest(
             "post", URL("http://python.org/"), data=f, chunked=True, loop=loop
         )

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -1,9 +1,8 @@
 import asyncio
 import datetime
 import itertools
-import os
+import pathlib
 import pickle
-import tempfile
 import unittest
 from http.cookies import BaseCookie, Morsel, SimpleCookie
 from unittest import mock
@@ -178,8 +177,8 @@ async def test_constructor_with_expired(
     assert jar._loop is loop
 
 
-async def test_save_load(loop, cookies_to_send, cookies_to_receive) -> None:
-    file_path = tempfile.mkdtemp() + "/aiohttp.test.cookie"
+async def test_save_load(tmp_path, loop, cookies_to_send, cookies_to_receive) -> None:
+    file_path = pathlib.Path(str(tmp_path)) / "aiohttp.test.cookie"
 
     # export cookie jar
     jar_save = CookieJar(loop=loop)
@@ -193,7 +192,6 @@ async def test_save_load(loop, cookies_to_send, cookies_to_receive) -> None:
     for cookie in jar_load:
         jar_test[cookie.key] = cookie
 
-    os.unlink(file_path)
     assert jar_test == cookies_to_receive
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,7 +4,6 @@ import datetime
 import gc
 import platform
 import sys
-import tempfile
 import weakref
 from math import ceil, modf
 from pathlib import Path
@@ -73,9 +72,19 @@ def test_parse_mimetype(mimetype, expected) -> None:
 # ------------------- guess_filename ----------------------------------
 
 
-def test_guess_filename_with_tempfile() -> None:
-    with tempfile.TemporaryFile() as fp:
+def test_guess_filename_with_file_object(tmp_path) -> None:
+    file_path = tmp_path / "test_guess_filename"
+    with file_path.open("w+b") as fp:
         assert helpers.guess_filename(fp, "no-throw") is not None
+
+
+def test_guess_filename_with_path(tmp_path) -> None:
+    file_path = tmp_path / "test_guess_filename"
+    assert helpers.guess_filename(file_path, "no-throw") is not None
+
+
+def test_guess_filename_with_default() -> None:
+    assert helpers.guess_filename(None, "no-throw") == "no-throw"
 
 
 # ------------------- BasicAuth -----------------------------------

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import json
+import pathlib
 import zlib
 from unittest import mock
 
@@ -1270,7 +1271,7 @@ class TestMultipartWriter:
 
     async def test_preserve_content_disposition_header(self, buf, stream):
         # https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
-        with open(__file__, "rb") as fobj:
+        with pathlib.Path(__file__).open("rb") as fobj:
             with aiohttp.MultipartWriter("form-data", boundary=":") as writer:
                 part = writer.append(
                     fobj,
@@ -1297,7 +1298,7 @@ class TestMultipartWriter:
 
     async def test_set_content_disposition_override(self, buf, stream):
         # https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
-        with open(__file__, "rb") as fobj:
+        with pathlib.Path(__file__).open("rb") as fobj:
             with aiohttp.MultipartWriter("form-data", boundary=":") as writer:
                 part = writer.append(
                     fobj,
@@ -1324,7 +1325,7 @@ class TestMultipartWriter:
 
     async def test_reset_content_disposition_header(self, buf, stream):
         # https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
-        with open(__file__, "rb") as fobj:
+        with pathlib.Path(__file__).open("rb") as fobj:
             with aiohttp.MultipartWriter("form-data", boundary=":") as writer:
                 part = writer.append(
                     fobj,

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -731,7 +731,7 @@ async def test_proxy_from_env_http_with_auth_from_netrc(
         auth.login,
         auth.password,
     )
-    with open(str(netrc_file), "w") as f:
+    with netrc_file.open("w") as f:
         f.write(netrc_file_data)
     mocker.patch.dict(
         os.environ, {"http_proxy": str(proxy.url), "NETRC": str(netrc_file)}
@@ -757,7 +757,7 @@ async def test_proxy_from_env_http_without_auth_from_netrc(
         auth.login,
         auth.password,
     )
-    with open(str(netrc_file), "w") as f:
+    with netrc_file.open("w") as f:
         f.write(netrc_file_data)
     mocker.patch.dict(
         os.environ, {"http_proxy": str(proxy.url), "NETRC": str(netrc_file)}
@@ -780,7 +780,7 @@ async def test_proxy_from_env_http_without_auth_from_wrong_netrc(
     auth = aiohttp.BasicAuth("user", "pass")
     netrc_file = tmp_path / "test_netrc"
     invalid_data = f"machine 127.0.0.1 {auth.login} pass {auth.password}"
-    with open(str(netrc_file), "w") as f:
+    with netrc_file.open("w") as f:
         f.write(invalid_data)
 
     mocker.patch.dict(

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import pathlib
 import socket
 import zlib
@@ -503,7 +502,7 @@ async def test_static_file_ssl(
     aiohttp_client,
     client_ssl_ctx,
 ) -> None:
-    dirname = os.path.dirname(__file__)
+    dirname = pathlib.Path(__file__).parent
     filename = "data.unknown_mime_type"
     app = web.Application()
     app.router.add_static("/static", dirname)
@@ -524,9 +523,10 @@ async def test_static_file_ssl(
 
 
 async def test_static_file_directory_traversal_attack(aiohttp_client) -> None:
-    dirname = os.path.dirname(__file__)
+    dirname = pathlib.Path(__file__).parent
     relpath = "../README.rst"
-    assert os.path.isfile(os.path.join(dirname, relpath))
+    full_path = dirname / relpath
+    assert full_path.is_file()
 
     app = web.Application()
     app.router.add_static("/static", dirname)
@@ -541,7 +541,7 @@ async def test_static_file_directory_traversal_attack(aiohttp_client) -> None:
     assert 404 == resp.status
     await resp.release()
 
-    url_abspath = "/static/" + os.path.abspath(os.path.join(dirname, relpath))
+    url_abspath = "/static/" + str(full_path.resolve())
     resp = await client.get(url_abspath)
     assert 403 == resp.status
     await resp.release()
@@ -550,36 +550,36 @@ async def test_static_file_directory_traversal_attack(aiohttp_client) -> None:
 
 
 def test_static_route_path_existence_check() -> None:
-    directory = os.path.dirname(__file__)
+    directory = pathlib.Path(__file__).parent
     web.StaticResource("/", directory)
 
-    nodirectory = os.path.join(directory, "nonexistent-uPNiOEAg5d")
+    nodirectory = directory / "nonexistent-uPNiOEAg5d"
     with pytest.raises(ValueError):
         web.StaticResource("/", nodirectory)
 
 
 async def test_static_file_huge(aiohttp_client, tmp_path) -> None:
-    filename = "huge_data.unknown_mime_type"
+    file_path = tmp_path / "huge_data.unknown_mime_type"
 
     # fill 20MB file
-    with (tmp_path / filename).open("wb") as f:
+    with file_path.open("wb") as f:
         for i in range(1024 * 20):
             f.write((chr(i % 64 + 0x20) * 1024).encode())
 
-    file_st = os.stat(str(tmp_path / filename))
+    file_st = file_path.stat()
 
     app = web.Application()
     app.router.add_static("/static", str(tmp_path))
     client = await aiohttp_client(app)
 
-    resp = await client.get("/static/" + filename)
+    resp = await client.get("/static/" + file_path.name)
     assert 200 == resp.status
     ct = resp.headers["CONTENT-TYPE"]
     assert "application/octet-stream" == ct
     assert resp.headers.get("CONTENT-ENCODING") is None
     assert int(resp.headers.get("CONTENT-LENGTH")) == file_st.st_size
 
-    f = (tmp_path / filename).open("rb")
+    f = file_path.open("rb")
     off = 0
     cnt = 0
     while off < file_st.st_size:
@@ -989,10 +989,10 @@ async def test_static_file_compression(aiohttp_client, sender) -> None:
 
 
 async def test_static_file_huge_cancel(aiohttp_client, tmp_path) -> None:
-    filename = "huge_data.unknown_mime_type"
+    file_path = tmp_path / "huge_data.unknown_mime_type"
 
     # fill 100MB file
-    with (tmp_path / filename).open("wb") as f:
+    with file_path.open("wb") as f:
         for i in range(1024 * 20):
             f.write((chr(i % 64 + 0x20) * 1024).encode())
 
@@ -1005,7 +1005,7 @@ async def test_static_file_huge_cancel(aiohttp_client, tmp_path) -> None:
         tr = request.transport
         sock = tr.get_extra_info("socket")
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1024)
-        ret = web.FileResponse(pathlib.Path(str(tmp_path / filename)))
+        ret = web.FileResponse(file_path)
         return ret
 
     app = web.Application()
@@ -1030,10 +1030,10 @@ async def test_static_file_huge_cancel(aiohttp_client, tmp_path) -> None:
 
 
 async def test_static_file_huge_error(aiohttp_client, tmp_path) -> None:
-    filename = "huge_data.unknown_mime_type"
+    file_path = tmp_path / "huge_data.unknown_mime_type"
 
     # fill 20MB file
-    with (tmp_path / filename).open("wb") as f:
+    with file_path.open("wb") as f:
         f.seek(20 * 1024 * 1024)
         f.write(b"1")
 
@@ -1042,7 +1042,7 @@ async def test_static_file_huge_error(aiohttp_client, tmp_path) -> None:
         tr = request.transport
         sock = tr.get_extra_info("socket")
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 1024)
-        ret = web.FileResponse(pathlib.Path(str(tmp_path / filename)))
+        ret = web.FileResponse(file_path)
         return ret
 
     app = web.Application()

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -1,9 +1,6 @@
 import asyncio
 import functools
-import os
 import pathlib
-import shutil
-import tempfile
 from typing import Optional
 from unittest import mock
 from unittest.mock import MagicMock
@@ -14,24 +11,6 @@ import yarl
 from aiohttp import abc, web
 from aiohttp.pytest_plugin import AiohttpClient
 from aiohttp.web_urldispatcher import Resource, SystemRoute
-
-
-@pytest.fixture(scope="function")
-def tmp_dir_path(request):
-    """
-    Give a path for a temporary directory
-
-    The directory is destroyed at the end of the test.
-    """
-    # Temporary directory.
-    tmp_dir = tempfile.mkdtemp()
-
-    def teardown():
-        # Delete the whole directory:
-        shutil.rmtree(tmp_dir)
-
-    request.addfinalizer(teardown)
-    return tmp_dir
 
 
 @pytest.mark.parametrize(
@@ -63,7 +42,7 @@ def tmp_dir_path(request):
     ],
 )
 async def test_access_root_of_static_handler(
-    tmp_dir_path: pathlib.Path,
+    tmp_path: pathlib.Path,
     aiohttp_client: AiohttpClient,
     show_index: bool,
     status: int,
@@ -74,22 +53,22 @@ async def test_access_root_of_static_handler(
     # Try to access the root of static file server, and make
     # sure that correct HTTP statuses are returned depending if we directory
     # index should be shown or not.
-    # Put a file inside tmp_dir_path:
-    my_file_path = os.path.join(tmp_dir_path, "my_file")
-    with open(my_file_path, "w") as fw:
+    # Put a file inside tmp_path:
+    my_file = tmp_path / "my_file"
+    my_dir = tmp_path / "my_dir"
+    my_dir.mkdir()
+    my_file_in_dir = my_dir / "my_file_in_dir"
+
+    with my_file.open("w") as fw:
         fw.write("hello")
 
-    my_dir_path = os.path.join(tmp_dir_path, "my_dir")
-    os.mkdir(my_dir_path)
-
-    my_file_path = os.path.join(my_dir_path, "my_file_in_dir")
-    with open(my_file_path, "w") as fw:
+    with my_file_in_dir.open("w") as fw:
         fw.write("world")
 
     app = web.Application()
 
     # Register global static route:
-    app.router.add_static(prefix, tmp_dir_path, show_index=show_index)
+    app.router.add_static(prefix, str(tmp_path), show_index=show_index)
     client = await aiohttp_client(app)
 
     # Request the root of the static directory.
@@ -103,25 +82,25 @@ async def test_access_root_of_static_handler(
 
 
 async def test_follow_symlink(
-    tmp_dir_path: pathlib.Path, aiohttp_client: AiohttpClient
+    tmp_path: pathlib.Path, aiohttp_client: AiohttpClient
 ) -> None:
     # Tests the access to a symlink, in static folder
     data = "hello world"
 
-    my_dir_path = os.path.join(tmp_dir_path, "my_dir")
-    os.mkdir(my_dir_path)
+    my_dir_path = tmp_path / "my_dir"
+    my_dir_path.mkdir()
 
-    my_file_path = os.path.join(my_dir_path, "my_file_in_dir")
-    with open(my_file_path, "w") as fw:
+    my_file_path = my_dir_path / "my_file_in_dir"
+    with my_file_path.open("w") as fw:
         fw.write(data)
 
-    my_symlink_path = os.path.join(tmp_dir_path, "my_symlink")
-    os.symlink(my_dir_path, my_symlink_path)
+    my_symlink_path = tmp_path / "my_symlink"
+    pathlib.Path(str(my_symlink_path)).symlink_to(str(my_dir_path), True)
 
     app = web.Application()
 
     # Register global static route:
-    app.router.add_static("/", tmp_dir_path, follow_symlinks=True)
+    app.router.add_static("/", str(tmp_path), follow_symlinks=True)
     client = await aiohttp_client(app)
 
     # Request the root of the static directory.
@@ -229,7 +208,7 @@ async def test_follow_symlink_directory_traversal_after_normalization(
     ],
 )
 async def test_access_to_the_file_with_spaces(
-    tmp_dir_path: pathlib.Path,
+    tmp_path: pathlib.Path,
     aiohttp_client: AiohttpClient,
     dir_name: str,
     filename: str,
@@ -237,21 +216,19 @@ async def test_access_to_the_file_with_spaces(
 ) -> None:
     # Checks operation of static files with spaces
 
-    my_dir_path = os.path.join(tmp_dir_path, dir_name)
+    my_dir_path = tmp_path / dir_name
+    if my_dir_path != tmp_path:
+        my_dir_path.mkdir()
 
-    if dir_name:
-        os.mkdir(my_dir_path)
-
-    my_file_path = os.path.join(my_dir_path, filename)
-
-    with open(my_file_path, "w") as fw:
+    my_file_path = my_dir_path / filename
+    with my_file_path.open("w") as fw:
         fw.write(data)
 
     app = web.Application()
 
-    url = os.path.join("/", dir_name, filename)
+    url = "/" + str(pathlib.Path(dir_name, filename))
 
-    app.router.add_static("/", tmp_dir_path)
+    app.router.add_static("/", str(tmp_path))
     client = await aiohttp_client(app)
 
     r = await client.get(url)
@@ -260,7 +237,7 @@ async def test_access_to_the_file_with_spaces(
 
 
 async def test_access_non_existing_resource(
-    tmp_dir_path: pathlib.Path, aiohttp_client: AiohttpClient
+    tmp_path: pathlib.Path, aiohttp_client: AiohttpClient
 ) -> None:
     # Tests accessing non-existing resource
     # Try to access a non-exiting resource and make sure that 404 HTTP status
@@ -268,7 +245,7 @@ async def test_access_non_existing_resource(
     app = web.Application()
 
     # Register global static route:
-    app.router.add_static("/", tmp_dir_path, show_index=True)
+    app.router.add_static("/", str(tmp_path), show_index=True)
     client = await aiohttp_client(app)
 
     # Request the root of the static directory.
@@ -322,13 +299,13 @@ async def test_handler_metadata_persistence() -> None:
 
 
 async def test_unauthorized_folder_access(
-    tmp_dir_path: pathlib.Path, aiohttp_client: AiohttpClient
+    tmp_path: pathlib.Path, aiohttp_client: AiohttpClient
 ) -> None:
     # Tests the unauthorized access to a folder of static file server.
     # Try to list a folder content of static file server when server does not
     # have permissions to do so for the folder.
-    my_dir_path = os.path.join(tmp_dir_path, "my_dir")
-    os.mkdir(my_dir_path)
+    my_dir = tmp_path / "my_dir"
+    my_dir.mkdir()
 
     app = web.Application()
 
@@ -340,34 +317,34 @@ async def test_unauthorized_folder_access(
         path_constructor.return_value = path
 
         # Register global static route:
-        app.router.add_static("/", tmp_dir_path, show_index=True)
+        app.router.add_static("/", str(tmp_path), show_index=True)
         client = await aiohttp_client(app)
 
         # Request the root of the static directory.
-        r = await client.get("/my_dir")
+        r = await client.get("/" + my_dir.name)
         assert r.status == 403
 
 
 async def test_access_symlink_loop(
-    tmp_dir_path: pathlib.Path, aiohttp_client: AiohttpClient
+    tmp_path: pathlib.Path, aiohttp_client: AiohttpClient
 ) -> None:
     # Tests the access to a looped symlink, which could not be resolved.
-    my_dir_path = os.path.join(tmp_dir_path, "my_symlink")
-    os.symlink(my_dir_path, my_dir_path)
+    my_dir_path = tmp_path / "my_symlink"
+    pathlib.Path(str(my_dir_path)).symlink_to(str(my_dir_path), True)
 
     app = web.Application()
 
     # Register global static route:
-    app.router.add_static("/", tmp_dir_path, show_index=True)
+    app.router.add_static("/", str(tmp_path), show_index=True)
     client = await aiohttp_client(app)
 
     # Request the root of the static directory.
-    r = await client.get("/my_symlink")
+    r = await client.get("/" + my_dir_path.name)
     assert r.status == 404
 
 
 async def test_access_special_resource(
-    tmp_dir_path: pathlib.Path, aiohttp_client: AiohttpClient
+    tmp_path: pathlib.Path, aiohttp_client: AiohttpClient
 ) -> None:
     # Tests the access to a resource that is neither a file nor a directory.
     # Checks that if a special resource is accessed (f.e. named pipe or UNIX
@@ -387,7 +364,7 @@ async def test_access_special_resource(
         path_constructor.return_value = path
 
         # Register global static route:
-        app.router.add_static("/", tmp_dir_path, show_index=True)
+        app.router.add_static("/", str(tmp_path), show_index=True)
         client = await aiohttp_client(app)
 
         # Request the root of the static directory.
@@ -622,20 +599,20 @@ async def test_static_absolute_url(
     # /static/\\machine_name\c$ or /static/D:\path
     # where the static dir is totally different
     app = web.Application()
-    fname = tmp_path / "file.txt"
-    fname.write_text("sample text", "ascii")
+    file_path = tmp_path / "file.txt"
+    file_path.write_text("sample text", "ascii")
     here = pathlib.Path(__file__).parent
     app.router.add_static("/static", here)
     client = await aiohttp_client(app)
-    resp = await client.get("/static/" + str(fname))
+    resp = await client.get("/static/" + str(file_path.resolve()))
     assert resp.status == 403
 
 
 async def test_for_issue_5250(
-    aiohttp_client: AiohttpClient, tmp_dir_path: pathlib.Path
+    aiohttp_client: AiohttpClient, tmp_path: pathlib.Path
 ) -> None:
     app = web.Application()
-    app.router.add_static("/foo", tmp_dir_path)
+    app.router.add_static("/foo", tmp_path)
 
     async def get_foobar(request: web.Request) -> web.Response:
         return web.Response(body="success!")

--- a/tools/check_changes.py
+++ b/tools/check_changes.py
@@ -22,7 +22,7 @@ PATTERN = re.compile(
 
 
 def get_root(script_path):
-    folder = script_path.absolute().parent
+    folder = script_path.resolve().parent
     while not (folder / ".git").exists():
         folder = folder.parent
         if folder == folder.anchor:


### PR DESCRIPTION
**This is a backport of PR #3957 as merged into master (79fe204522ecf91e9c1cf1a3547c03f821106a74).**

* Improve test suite handling of paths, temp files

This updates most uses of `os.path` to instead use `pathlib.Path`. Relatedly, and following up from #3955 (which replaced pytest's `tmpdir` fixture with `tmp_path`), this removes most ad-hoc tempfile creation in favor of the `tmp_path` fixture. Following conversion, unnecessary `os` and `tempfile` imports were removed.

Most pathlib changes involve straightforward changes from `os` functions such as `os.mkdir` or `os.path.abspath` to their equivalent methods in `pathlib.Path`.

Changing ad-hoc temporary path to `tmp_path` involved removing the `tmp_dir_path` fixture and replacing its functionality with `tmp_path` in `test_save_load` and `test_guess_filename_with_tempfile`.

On `test_static_route_user_home` function:

* I think that the intention of this test is to ensure that aiohttp correctly expands the home path if passed in a string. I refactored it to `pathlib.Path` and cut out duplication of `relative_to()` calls. But if it's not doing anything but expanding `~`, then it's testing the functionality of `pathlib.Path`, not aiohttp.

On `unix_sockname` fixture:

This fixture uses `tempfile.TemporaryDirectory`. Because it's a somewhat complicated fixture used across multiple test modules, I left it as-is for now.

On `str(tmp_path)` and even `pathlib.Path(str(tmp_path))`:

pytest uses `pathlib2` to provide `tmp_path` for Python 3.5 (only). This is mostly fine but it fails on a couple of corner cases, such as `os.symlink()` which blocks all but `str` and `PurePath` via isinstance type checking. In several cases, this requires conversion to string or conversion to string and then into `pathlib.Path` to maintain code compatibility. See: pytest-dev/pytest/issues/5017

* Correct test_guess_filename to use file object

* Update symlink in tests; more guess_filename tests

(cherry picked from commit 79fe204522ecf91e9c1cf1a3547c03f821106a74)

<!-- Thank you for your contribution! -->

## What do these changes do?

This updates most uses of `os.path` to instead use `pathlib.Path`.
Relatedly, and following up from #3955 (which replaced pytest's `tmpdir`
fixture with `tmp_path`), this removes most ad-hoc tempfile creation in
favor of the `tmp_path` fixture. Following conversion, unnecessary `os`
and `tempfile` imports were removed.

Most pathlib changes involve straightforward changes from `os` functions
such as `os.mkdir` or `os.path.abspath` to their equivalent methods in
`pathlib.Path`.

Changing ad-hoc temporary path to `tmp_path` involved removing the
`tmp_dir_path` fixture and replacing its functionality with `tmp_path`
in `test_save_load` and `test_guess_filename_with_tempfile`.

On `test_static_route_user_home` function:

* I think that the intention of this test is to ensure that aiohttp
correctly expands the home path if passed in a string. I refactored it
to `pathlib.Path` and cut out duplication of `relative_to()` calls.
But if it's not doing anything but expanding `~`, then it's testing the
functionality of `pathlib.Path`, not aiohttp.

On `unix_sockname` fixture:

This fixture uses `tempfile.TemporaryDirectory`. Because it's a somewhat
complicated fixture used across multiple test modules, I left it as-is
for now.

On `str(tmp_path)` and even `pathlib.Path(str(tmp_path))`:

pytest uses `pathlib2` to provide `tmp_path` for Python 3.5 (only).
This is mostly fine but it fails on a couple of corner cases, such as
`os.symlink()` which blocks all but `str` and `PurePath` via isinstance
type checking. In several cases, this requires conversion to string or
conversion to string and then into `pathlib.Path` to maintain code
compatibility. See: pytest-dev/pytest/issues/5017

## Are there changes in behavior for the user?

These changes only affect the test suite and have no impact on the end user.

## Related issue number

This is intended to address discussion following the simplistic changes from tmpdir to tmp_path of #3955.

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."