### PR TITLE
Fix xfail reason for unsupported upgrade test

### DIFF
--- a/CHANGES/8085.bugfix.rst
+++ b/CHANGES/8085.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed xfail reason for unsupported upgrade server test -- by :user:`steverep`

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -307,6 +307,7 @@ Stepan Pletnev
 Stephan Jaensch
 Stephen Cirelli
 Stephen Granade
+Steve Repsher
 Steven Seguin
 Sunghyun Hwang
 Sunit Deshpande

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -24,12 +24,14 @@ async def test_simple_server(aiohttp_raw_server: Any, aiohttp_client: Any) -> No
 @pytest.mark.xfail(
     not helpers.NO_EXTENSIONS,
     raises=client.ServerDisconnectedError,
-    reason="The behavior of C-extensions differs from pure-Python: "
-    "https://github.com/aio-libs/aiohttp/issues/6446",
+    reason="The behavior of C-extensions differs from pure-Python (see #6446)",
 )
 async def test_unsupported_upgrade(aiohttp_raw_server, aiohttp_client) -> None:
-    # don't fail if a client probes for an unsupported protocol upgrade
-    # https://github.com/aio-libs/aiohttp/issues/6446#issuecomment-999032039
+    """don't fail if a client probes for an unsupported protocol upgrade
+
+    https://github.com/aio-libs/aiohttp/issues/6446#issuecomment-999032039
+    """
+
     async def handler(request: web.Request):
         return web.Response(body=await request.read())
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
I noticed this test is pretty finicky on Mac and Windows in #8063.  Again, my Python is quite rusty and still getting up to date, but the `reason` string given to `xfail` seems incorrectly spread over 2 lines.  The fact that it isn't caught by linting makes me think I'm wrong, but if I'm not it makes sense that Mac and Windows would be less forgiving and `pytest` might timeout.

In any case, I just shortened the string to one line since the URL is already within the test, and converted the comment to a doc string.  Hopefully that fixes the timeouts.


## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Nope

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->
n/a

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
