### PR TITLE
re-enable 4 tests, accidentally dropped

### DIFF
--- a/CHANGES/8088.contrib.rst
+++ b/CHANGES/8088.contrib.rst
@@ -1,0 +1,1 @@
+Enabled HTTP parser tests originally intended for 3.9.2 release -- by :user:`pajod`.

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -282,9 +282,20 @@ def test_parse_headers_longline(parser: Any) -> None:
         parser.feed_data(text)
 
 
+@pytest.fixture
+def xfail_c_parser_status(request) -> None:
+    if isinstance(request.getfixturevalue("parser"), HttpRequestParserPy):
+        return
+    request.node.add_marker(
+        pytest.mark.xfail(
+            reason="Regression test for Py parser. May match C behaviour later.",
+            raises=http_exceptions.BadStatusLine,
+        )
+    )
+
+
+@pytest.mark.usefixtures("xfail_c_parser_status")
 def test_parse_unusual_request_line(parser: Any) -> None:
-    if not isinstance(response, HttpResponseParserPy):
-        pytest.xfail("Regression test for Py parser. May match C behaviour later.")
     text = b"#smol //a HTTP/1.3\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     assert len(messages) == 1
@@ -611,9 +622,25 @@ _pad: Dict[bytes, str] = {
 }
 
 
+@pytest.fixture
+def xfail_c_parser_empty_header(request) -> None:
+    if not all(
+        (request.getfixturevalue(name) == b"") for name in ("pad1", "pad2", "hdr")
+    ):
+        return
+    if isinstance(request.getfixturevalue("parser"), HttpRequestParserPy):
+        return
+    request.node.add_marker(
+        pytest.mark.xfail(
+            reason="Regression test for Py parser. May match C behaviour later.",
+        )
+    )
+
+
 @pytest.mark.parametrize("hdr", [b"", b"foo"], ids=["name-empty", "with-name"])
 @pytest.mark.parametrize("pad2", _pad.keys(), ids=["post-" + n for n in _pad.values()])
 @pytest.mark.parametrize("pad1", _pad.keys(), ids=["pre-" + n for n in _pad.values()])
+@pytest.mark.usefixtures("xfail_c_parser_empty_header")
 def test_invalid_header_spacing(
     parser: Any, pad1: bytes, pad2: bytes, hdr: bytes
 ) -> None:
@@ -622,15 +649,12 @@ def test_invalid_header_spacing(
     if pad1 == pad2 == b"" and hdr != b"":
         # one entry in param matrix is correct: non-empty name, not padded
         expectation = nullcontext()
-    if pad1 == pad2 == hdr == b"":
-        if not isinstance(response, HttpResponseParserPy):
-            pytest.xfail("Regression test for Py parser. May match C behaviour later.")
     with expectation:
         parser.feed_data(text)
 
 
 def test_empty_header_name(parser: Any) -> None:
-    if not isinstance(response, HttpResponseParserPy):
+    if not isinstance(parser, HttpRequestParserPy):
         pytest.xfail("Regression test for Py parser. May match C behaviour later.")
     text = b"GET /test HTTP/1.1\r\n" b":test\r\n\r\n"
     with pytest.raises(http_exceptions.BadHttpMessage):
@@ -808,9 +832,20 @@ def test_http_request_upgrade(parser: Any) -> None:
     assert tail == b"some raw data"
 
 
+@pytest.fixture
+def xfail_c_parser_url(request) -> None:
+    if isinstance(request.getfixturevalue("parser"), HttpRequestParserPy):
+        return
+    request.node.add_marker(
+        pytest.mark.xfail(
+            reason="Regression test for Py parser. May match C behaviour later.",
+            raises=http_exceptions.InvalidURLError,
+        )
+    )
+
+
+@pytest.mark.usefixtures("xfail_c_parser_url")
 def test_http_request_parser_utf8_request_line(parser: Any) -> None:
-    if not isinstance(response, HttpResponseParserPy):
-        pytest.xfail("Regression test for Py parser. May match C behaviour later.")
     messages, upgrade, tail = parser.feed_data(
         # note the truncated unicode sequence
         b"GET /P\xc3\xbcnktchen\xa0\xef\xb7 HTTP/1.1\r\n" +

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -865,7 +865,9 @@ def test_http_request_parser_utf8_request_line(parser: Any) -> None:
     assert msg.compression is None
     assert not msg.upgrade
     assert not msg.chunked
-    assert msg.url.path == URL("/P%C3%BCnktchen\udca0\udcef\udcb7").path
+    # python HTTP parser depends on Cython and CPython URL to match
+    # .. but yarl.URL("/abs") is not equal to URL.build(path="/abs"), see #6409
+    assert msg.url == URL.build(path="/Pünktchen\udca0\udcef\udcb7", encoded=True)
 
 
 def test_http_request_parser_utf8(parser: Any) -> None:


### PR DESCRIPTION
## What do these changes do?

I copied the wrong line, earlier, so those new tests did not run.
It is the (request) parser param that should have informed the xfail() decision.

```diff
 def test_request_parser_foo(parser: Any) -> None:
-    if not isinstance(response, HttpResponseParserPy):
+    if not isinstance(parser, HttpRequestParserPy):
         pytest.xfail("duh")
```

## Are there changes in behavior for the user?

Testing only.

However, I do expect behaviour and/or [documentation](https://docs.aiohttp.org/en/stable/web_advanced.html#unicode-support) changes are desirable.. after I figured out a way to rewrite these tests to more clearly pinpoint the problem.

## Commentary

* test_empty_header_name, which is a subset of test_invalid_header_spacing: [testing against llhttp 9.2](https://github.com/aio-libs/aiohttp/pull/8146) makes those pass

* test_parse_unusual_request_line: I expected applying #7651 would give me a descriptive exception text for the remaining differences, but I still get "BadStatusLine" so I stopped short of figuring out if they fail in any of the [actually relevant](https://github.com/aio-libs/aiohttp/pull/6409) branches, or need to be fine-tuned before even attempting at making them pass.

* test_http_request_parser_utf8_request_line: After reading up on more clever ways to abuse parser differences, maybe leaving the llhttp side as-is and making the python parser less liberal (as in rfc761#section-2.10) would be the better choice.

## Related issue number

Follow-up to #8074

## Checklist

- [x] I think the code looks ugly
 * Unfortunately, `pytest.xfail()` [does not appear to share](https://github.com/pytest-dev/pytest/issues/4216) the strict_xfail behaviour of `pytest.mark.xfail()` - but how else could I see the XPASS when testing against llhttp main branch?
- [x] Unit tests for the changes exist
- [x] No API changes to be documented
- [x] Add a new news fragment into the `CHANGES/` folder
- [x] Incomplete, but safe to merge at this stage
 * While I expect no harm from merging the initial commit, going straight for a cleaner and more generic test refactoring would make more sense to me. The point of submitting is more about the verification CI run, and creating a place to leave additional comments on style and future for these tests without spamming the PR that introduced the problem