### PR TITLE
Partially revert "Add more information to contributing page (#7916)"

### DIFF
--- a/CHANGES/README.rst
+++ b/CHANGES/README.rst
@@ -1,15 +1,7 @@
-.. _Making a pull request:
-
-Making a pull request
-=====================
-
-When making a pull request, please include a short summary of the changes
-and a reference to any issue tickets that the PR is intended to solve.
-All PRs with code changes should include tests. All changes should
-include a changelog entry.
+.. _Adding change notes with your PRs:
 
 Adding change notes with your PRs
----------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 It is very important to maintain a log for news of how
 updating to the new version of the software will affect
@@ -27,7 +19,7 @@ to the end-users most of the time. And so such details should be
 recorded in the Git history rather than a changelog.
 
 Alright! So how to add a news fragment?
----------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ``aiohttp`` uses `towncrier <https://pypi.org/project/towncrier/>`_
 for changelog management.
@@ -47,9 +39,9 @@ linking parts of the docs or external sites.
 However, you do not need to reference the issue or PR numbers here
 as *towncrier* will automatically add a reference to all of the
 affected issues when rendering the news file.
-If you wish to sign your change, feel free to add
-``-- by :user:`github-username``` at the end (replace
-``github-username`` with your own!).
+If you wish to sign your change, feel free to add ``-- by
+:user:`github-username``` at the end (replace ``github-username``
+with your own!).
 
 Finally, name your file following the convention that Towncrier
 understands: it should start with the number of an issue or a
@@ -88,7 +80,7 @@ necessary to make a separate documentation fragment for documentation
 changes accompanying the relevant code changes.
 
 Examples for adding changelog entries to your Pull Requests
------------------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 File :file:`CHANGES/6045.doc.1.rst`:
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,12 +1,12 @@
 .. _aiohttp-contributing:
 
 Contributing
-************
+============
 
 (:doc:`contributing-admins`)
 
 Instructions for contributors
-=============================
+-----------------------------
 
 In order to make a clone of the GitHub_ repo: open the link and press the "Fork" button on the upper-right menu of the web page.
 
@@ -25,7 +25,7 @@ Workflow is pretty straightforward:
 
   4. Make sure all tests passed
 
-  5. Add a file into the ``CHANGES`` folder (see `Making a pull request`_ for how).
+  5. Add a file into the ``CHANGES`` folder (see `Changelog update`_ for how).
 
   6. Commit changes to your own aiohttp clone
 
@@ -53,7 +53,7 @@ Workflow is pretty straightforward:
 
 
 Preconditions for running aiohttp test suite
-============================================
+--------------------------------------------
 
 We expect you to use a python virtual environment to run our tests.
 
@@ -116,7 +116,7 @@ Congratulations, you are ready to run the test suite!
 
 
 Run autoformatter
-=================
+-----------------
 
 The project uses black_ + isort_ formatters to keep the source code style.
 Please run `make fmt` after every change before starting tests.
@@ -127,7 +127,7 @@ Please run `make fmt` after every change before starting tests.
 
 
 Run aiohttp test suite
-======================
+----------------------
 
 After all the preconditions are met you can run tests typing the next
 command:
@@ -159,7 +159,7 @@ Any extra texts (print statements and so on) should be removed.
      make test-3.10-no-extensions
 
 Code coverage
-=============
+-------------
 
 We use *codecov.io* as an indispensable tool for analyzing our coverage
 results. Visit https://codecov.io/gh/aio-libs/aiohttp to see coverage
@@ -226,7 +226,7 @@ $ python -m webbrowser -n file://"$(pwd)"/htmlcov/index.html
 ```
 
 Documentation
-=============
+-------------
 
 We encourage documentation improvements.
 
@@ -242,7 +242,7 @@ Once it finishes it will output the index html page
 Go to the link and make sure your doc changes looks good.
 
 Spell checking
-==============
+--------------
 
 We use ``pyenchant`` and ``sphinxcontrib-spelling`` for running spell
 checker for documentation:
@@ -261,18 +261,20 @@ To run spell checker on Linux box you should install it first:
    $ pip install sphinxcontrib-spelling
 
 
+Changelog update
+----------------
 
 .. include:: ../CHANGES/README.rst
 
 
 Making a Pull Request
-=====================
+---------------------
 
 After finishing all steps make a GitHub_ Pull Request with *master* base branch.
 
 
 Backporting
-===========
+-----------
 
 All Pull Requests are created against *master* git branch.
 
@@ -313,7 +315,7 @@ like *needs backport to 3.1*.
    merging the backport.
 
 How to become an aiohttp committer
-==================================
+----------------------------------
 
 Contribute!
 


### PR DESCRIPTION
This partially reverts commit 822fbc7431f3c5522d3e587ad0b658bef8b6a0ab.

In particular, this drops the top level title from README in the `CHANGES/` folder and restores the original label.

For the proper Sphinx ToC structuring, a title in the `docs/contributing.rst` document.