### PR TITLE
Inherit redirection protocol error from ClientError

### DIFF
--- a/CHANGES/8061.feature.rst
+++ b/CHANGES/8061.feature.rst
@@ -1,0 +1,1 @@
+Inherit redirection protocol client error from ClientError

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -49,6 +49,7 @@ from .client_exceptions import (
     ClientOSError,
     ClientPayloadError,
     ClientProxyConnectionError,
+    ClientRedirectionProtocolError,
     ClientResponseError,
     ClientSSLError,
     ConnectionTimeoutError,
@@ -621,7 +622,10 @@ class ClientSession:
                         scheme = parsed_url.scheme
                         if scheme not in ("http", "https", ""):
                             resp.close()
-                            raise ValueError("Can redirect only to http or https")
+                            raise ClientRedirectionProtocolError(
+                                "Can redirect only to http or https"
+                            )
+
                         elif not scheme:
                             parsed_url = url.join(parsed_url)
 

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -25,6 +25,7 @@ __all__ = (
     "ClientOSError",
     "ClientConnectorError",
     "ClientProxyConnectionError",
+    "ClientRedirectionProtocolError",
     "ClientSSLError",
     "ClientConnectorSSLError",
     "ClientConnectorCertificateError",
@@ -321,3 +322,7 @@ class ClientConnectorCertificateError(*cert_errors_bases):  # type: ignore[misc]
             "[{0.certificate_error.__class__.__name__}: "
             "{0.certificate_error.args}]".format(self)
         )
+
+
+class ClientRedirectionProtocolError(ClientError, ValueError):
+    """Redirection protocol error."""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Inherit redirection protocol error from ClientError

## Are there changes in behavior for the user?

User will be able to handle this kind of errors within `ClientError` (as well as by existing `ValueError`)

## Is it a substantial burden for the maintainers to support this?

dunno

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

Fixes #8061 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
