### PR TITLE
Treat Accept-Encoding header as case-insensitive for gzip file check

### DIFF
--- a/CHANGES/8104.bugfix.rst
+++ b/CHANGES/8104.bugfix.rst
@@ -1,0 +1,1 @@
+Treated values of ``Accept-Encoding`` header as case-insensitive when checking for gzip files -- by :user:`steverep`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -307,6 +307,7 @@ Stepan Pletnev
 Stephan Jaensch
 Stephen Cirelli
 Stephen Granade
+Steve Repsher
 Steven Seguin
 Sunghyun Hwang
 Sunit Deshpande

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -142,6 +142,8 @@ class FileResponse(StreamResponse):
 
     async def prepare(self, request: "BaseRequest") -> Optional[AbstractStreamWriter]:
         loop = asyncio.get_event_loop()
+        # Encoding comparisons should be case-insensitive
+        # https://www.rfc-editor.org/rfc/rfc9110#section-8.4.1
         check_for_gzipped_file = (
             "gzip" in request.headers.get(hdrs.ACCEPT_ENCODING, "").lower()
         )

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -142,7 +142,9 @@ class FileResponse(StreamResponse):
 
     async def prepare(self, request: "BaseRequest") -> Optional[AbstractStreamWriter]:
         loop = asyncio.get_event_loop()
-        check_for_gzipped_file = "gzip" in request.headers.get(hdrs.ACCEPT_ENCODING, "")
+        check_for_gzipped_file = (
+            "gzip" in request.headers.get(hdrs.ACCEPT_ENCODING, "").lower()
+        )
         filepath, st, gzip = await loop.run_in_executor(
             None, self._get_file_path_stat_and_gzip, check_for_gzipped_file
         )

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -326,6 +326,8 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         if self._compression_force:
             await self._do_start_compression(self._compression_force)
         else:
+            # Encoding comparisons should be case-insensitive
+            # https://www.rfc-editor.org/rfc/rfc9110#section-8.4.1
             accept_encoding = request.headers.get(hdrs.ACCEPT_ENCODING, "").lower()
             for coding in ContentCoding:
                 if coding.value in accept_encoding:

--- a/tests/test_web_sendfile.py
+++ b/tests/test_web_sendfile.py
@@ -9,7 +9,10 @@ from aiohttp.web_fileresponse import FileResponse
 
 def test_using_gzip_if_header_present_and_file_available(loop: Any) -> None:
     request = make_mocked_request(
-        "GET", "http://python.org/logo.png", headers={hdrs.ACCEPT_ENCODING: "gzip"}
+        "GET",
+        "http://python.org/logo.png",
+        # Header uses some uppercase to ensure case-insensitive treatment
+        headers={hdrs.ACCEPT_ENCODING: "GZip"},
     )
 
     gz_filepath = mock.create_autospec(Path, spec_set=True)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Fixes issue in in server file response which does not convert `Accept-Encoding` header to lowercase before comparison.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->
No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->
Fixes 1st task of #8104 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
