### PR TITLE
rename a shadowed test and re-enable F811 to catch future cases

### DIFF
--- a/CHANGES/8139.bugfix.rst
+++ b/CHANGES/8139.bugfix.rst
@@ -1,0 +1,1 @@
+renamed a shadowed test and re-enabled F811 to catch future cases -- by :user:`alexmac`.

--- a/CHANGES/8139.bugfix.rst
+++ b/CHANGES/8139.bugfix.rst
@@ -1,1 +1,0 @@
-renamed a shadowed test and re-enabled F811 to catch future cases -- by :user:`alexmac`.

--- a/CHANGES/8139.contrib.rst
+++ b/CHANGES/8139.contrib.rst
@@ -1,0 +1,1 @@
+Two definitions for "test_invalid_route_name" existed, only one was being run. Refactored them into a single parameterized test. Enabled lint rule to prevent regression. -- by :user:`alexmac`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,7 +86,7 @@ zip_ok = false
 [flake8]
 extend-select = B950
 # TODO: don't disable D*, fix up issues instead
-ignore = N801,N802,N803,E203,E226,E305,W504,E252,E301,E302,E501,E704,W503,W504,F811,D1,D4
+ignore = N801,N802,N803,E203,E226,E305,W504,E252,E301,E302,E501,E704,W503,W504,D1,D4
 max-line-length = 88
 per-file-ignores =
     # I900: Shouldn't appear in requirements for examples.

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1146,14 +1146,16 @@ def test_subapp_iter(app: Any) -> None:
     assert list(resource) == [r1, r2]
 
 
-def test_invalid_route_name(router: Any) -> None:
+@pytest.mark.parametrize(
+    "route_name",
+    [
+        "invalid name",
+        "class",
+    ],
+)
+def test_invalid_route_name(router: Any, route_name: str) -> None:
     with pytest.raises(ValueError):
-        router.add_get("/", make_handler(), name="invalid name")
-
-
-def test_invalid_route_name_identifier(router) -> None:
-    with pytest.raises(ValueError):
-        router.add_get("/", make_handler(), name="class")  # identifier
+        router.add_get("/", make_handler(), name=route_name)
 
 
 def test_frozen_router(router: Any) -> None:

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1151,7 +1151,7 @@ def test_invalid_route_name(router: Any) -> None:
         router.add_get("/", make_handler(), name="invalid name")
 
 
-def test_invalid_route_name(router) -> None:
+def test_invalid_route_name_identifier(router) -> None:
     with pytest.raises(ValueError):
         router.add_get("/", make_handler(), name="class")  # identifier
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1148,10 +1148,10 @@ def test_subapp_iter(app: Any) -> None:
 
 @pytest.mark.parametrize(
     "route_name",
-    [
+    (
         "invalid name",
         "class",
-    ],
+    ),
 )
 def test_invalid_route_name(router: Any, route_name: str) -> None:
     with pytest.raises(ValueError):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Small fix to un-shadow a test that wasn't being run

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?

Depends, was there a reason F811 was set to ignore?

## Related issue number


## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
