### PR TITLE
rename a shadowed test and re-enable F811 to catch future cases (#8139)

### DIFF
--- a/CHANGES/8139.contrib.rst
+++ b/CHANGES/8139.contrib.rst
@@ -1,0 +1,1 @@
+Two definitions for "test_invalid_route_name" existed, only one was being run. Refactored them into a single parameterized test. Enabled lint rule to prevent regression. -- by :user:`alexmac`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,7 @@ zip_ok = false
 [flake8]
 extend-select = B950
 # TODO: don't disable D*, fix up issues instead
-ignore = N801,N802,N803,E203,E226,E305,W504,E252,E301,E302,E501,E704,W503,W504,F811,D1,D4
+ignore = N801,N802,N803,E203,E226,E305,W504,E252,E301,E302,E501,E704,W503,W504,D1,D4
 max-line-length = 88
 per-file-ignores =
     # I900: Shouldn't appear in requirements for examples.

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -154,11 +154,6 @@ async def test_threaded_negative_lookup() -> None:
         await resolver.resolve("doesnotexist.bla")
 
 
-async def test_close_for_threaded_resolver(loop) -> None:
-    resolver = ThreadedResolver(loop=loop)
-    await resolver.close()
-
-
 async def test_threaded_negative_lookup_with_unknown_result() -> None:
     loop = Mock()
 
@@ -182,6 +177,9 @@ async def test_threaded_negative_lookup_with_unknown_result() -> None:
         res = await resolver.resolve("www.python.org")
     assert len(res) == 0
 
+
+async def test_close_for_threaded_resolver(loop) -> None:
+    resolver = ThreadedResolver()
     await resolver.close()
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -154,30 +154,6 @@ async def test_threaded_negative_lookup() -> None:
         await resolver.resolve("doesnotexist.bla")
 
 
-async def test_threaded_negative_lookup_with_unknown_result() -> None:
-    loop = Mock()
-
-    # If compile CPython with `--disable-ipv6` option,
-    # we will get an (int, bytes) tuple, instead of a Exception.
-    async def unknown_addrinfo(*args: Any, **kwargs: Any) -> List[Any]:
-        return [
-            (
-                socket.AF_INET6,
-                socket.SOCK_STREAM,
-                6,
-                "",
-                (10, b"\x01\xbb\x00\x00\x00\x00*\x04NB\x00\x1a\x00\x00"),
-            )
-        ]
-
-    loop.getaddrinfo = unknown_addrinfo
-    resolver = ThreadedResolver()
-    resolver._loop = loop
-    with patch("socket.has_ipv6", False):
-        res = await resolver.resolve("www.python.org")
-    assert len(res) == 0
-
-
 async def test_close_for_threaded_resolver(loop) -> None:
     resolver = ThreadedResolver(loop=loop)
     await resolver.close()

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1130,14 +1130,16 @@ def test_subapp_iter(app) -> None:
     assert list(resource) == [r1, r2]
 
 
-def test_invalid_route_name(router) -> None:
+@pytest.mark.parametrize(
+    "route_name",
+    (
+        "invalid name",
+        "class",
+    ),
+)
+def test_invalid_route_name(router: Any, route_name: str) -> None:
     with pytest.raises(ValueError):
-        router.add_get("/", make_handler(), name="invalid name")
-
-
-def test_invalid_route_name(router) -> None:
-    with pytest.raises(ValueError):
-        router.add_get("/", make_handler(), name="class")  # identifier
+        router.add_get("/", make_handler(), name=route_name)
 
 
 def test_frozen_router(router) -> None:

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1137,7 +1137,7 @@ def test_subapp_iter(app) -> None:
         "class",
     ),
 )
-def test_invalid_route_name(router: Any, route_name: str) -> None:
+def test_invalid_route_name(router, route_name: str) -> None:
     with pytest.raises(ValueError):
         router.add_get("/", make_handler(), name=route_name)
 


### PR DESCRIPTION
(cherry picked from commit 3c0f1eb29d3512419ea65e7cdeb61ba3f3496f00)

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
