### PR TITLE
Update Python version classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,8 @@ classifiers =
   Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
+  Programming Language :: Python :: 3.11
+  Programming Language :: Python :: 3.12
 
   Topic :: Internet :: WWW/HTTP
 


### PR DESCRIPTION
## What do these changes do?

Adds Python 3.11 and Python 3.12 classifiers to `setup.cfg`.

I just checked https://pyreadiness.org/3.12/ and was surprised that `aiohttp` does not support Python 3.12. Apparently they just look for the `Programming Language :: Python :: 3.12` classifier in a package's metadata (which is totally fine). However, the classifiers for 3.11 and 3.12 were missing here.

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

None.

## Checklist

Not really relevant I guess, because change is quite simple and has no actual code changes? Or should I add something to `CHANGES.md` to make the timeline protection build pass?