### PR TITLE
[PR #8089/dc38630b backport][3.10] 💅 Propagate error causes via asyncio protocols

### DIFF
--- a/CHANGES/8089.bugfix.rst
+++ b/CHANGES/8089.bugfix.rst
@@ -1,0 +1,3 @@
+The asynchronous internals now set the underlying causes
+when assigning exceptions to the future objects
+-- by :user:`webknjaz`.

--- a/aiohttp/base_protocol.py
+++ b/aiohttp/base_protocol.py
@@ -1,6 +1,7 @@
 import asyncio
 from typing import Optional, cast
 
+from .helpers import set_exception
 from .tcp_helpers import tcp_nodelay
 
 
@@ -76,7 +77,11 @@ class BaseProtocol(asyncio.Protocol):
         if exc is None:
             waiter.set_result(None)
         else:
-            waiter.set_exception(exc)
+            set_exception(
+                waiter,
+                ConnectionError("Connection lost"),
+                exc,
+            )
 
     async def _drain_helper(self) -> None:
         if not self.connected:

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -9,8 +9,14 @@ from .client_exceptions import (
     ServerDisconnectedError,
     SocketTimeoutError,
 )
-from .helpers import BaseTimerContext, status_code_must_be_empty_body
+from .helpers import (
+    _EXC_SENTINEL,
+    BaseTimerContext,
+    set_exception,
+    status_code_must_be_empty_body,
+)
 from .http import HttpResponseParser, RawResponseMessage
+from .http_exceptions import HttpProcessingError
 from .streams import EMPTY_PAYLOAD, DataQueue, StreamReader
 
 
@@ -73,28 +79,50 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
     def connection_lost(self, exc: Optional[BaseException]) -> None:
         self._drop_timeout()
 
+        original_connection_error = exc
+        reraised_exc = original_connection_error
+
+        connection_closed_cleanly = original_connection_error is None
+
         if self._payload_parser is not None:
-            with suppress(Exception):
+            with suppress(Exception):  # FIXME: log this somehow?
                 self._payload_parser.feed_eof()
 
         uncompleted = None
         if self._parser is not None:
             try:
                 uncompleted = self._parser.feed_eof()
-            except Exception as e:
+            except Exception as underlying_exc:
                 if self._payload is not None:
-                    exc = ClientPayloadError("Response payload is not completed")
-                    exc.__cause__ = e
-                    self._payload.set_exception(exc)
+                    client_payload_exc_msg = (
+                        f"Response payload is not completed: {underlying_exc !r}"
+                    )
+                    if not connection_closed_cleanly:
+                        client_payload_exc_msg = (
+                            f"{client_payload_exc_msg !s}. "
+                            f"{original_connection_error !r}"
+                        )
+                    set_exception(
+                        self._payload,
+                        ClientPayloadError(client_payload_exc_msg),
+                        underlying_exc,
+                    )
 
         if not self.is_eof():
-            if isinstance(exc, OSError):
-                exc = ClientOSError(*exc.args)
-            if exc is None:
-                exc = ServerDisconnectedError(uncompleted)
+            if isinstance(original_connection_error, OSError):
+                reraised_exc = ClientOSError(*original_connection_error.args)
+            if connection_closed_cleanly:
+                reraised_exc = ServerDisconnectedError(uncompleted)
             # assigns self._should_close to True as side effect,
             # we do it anyway below
-            self.set_exception(exc)
+            underlying_non_eof_exc = (
+                _EXC_SENTINEL
+                if connection_closed_cleanly
+                else original_connection_error
+            )
+            assert underlying_non_eof_exc is not None
+            assert reraised_exc is not None
+            self.set_exception(reraised_exc, underlying_non_eof_exc)
 
         self._should_close = True
         self._parser = None
@@ -102,7 +130,7 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
         self._payload_parser = None
         self._reading_paused = False
 
-        super().connection_lost(exc)
+        super().connection_lost(reraised_exc)
 
     def eof_received(self) -> None:
         # should call parser.feed_eof() most likely
@@ -116,10 +144,14 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
         super().resume_reading()
         self._reschedule_timeout()
 
-    def set_exception(self, exc: BaseException) -> None:
+    def set_exception(
+        self,
+        exc: BaseException,
+        exc_cause: BaseException = _EXC_SENTINEL,
+    ) -> None:
         self._should_close = True
         self._drop_timeout()
-        super().set_exception(exc)
+        super().set_exception(exc, exc_cause)
 
     def set_parser(self, parser: Any, payload: Any) -> None:
         # TODO: actual types are:
@@ -196,7 +228,7 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
         exc = SocketTimeoutError("Timeout on reading data from socket")
         self.set_exception(exc)
         if self._payload is not None:
-            self._payload.set_exception(exc)
+            set_exception(self._payload, exc)
 
     def data_received(self, data: bytes) -> None:
         self._reschedule_timeout()
@@ -222,14 +254,14 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
                 # parse http messages
                 try:
                     messages, upgraded, tail = self._parser.feed_data(data)
-                except BaseException as exc:
+                except BaseException as underlying_exc:
                     if self.transport is not None:
                         # connection.release() could be called BEFORE
                         # data_received(), the transport is already
                         # closed in this case
                         self.transport.close()
                     # should_close is True after the call
-                    self.set_exception(exc)
+                    self.set_exception(HttpProcessingError(), underlying_exc)
                     return
 
                 self._upgraded = upgraded

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -28,10 +28,12 @@ from . import hdrs
 from .base_protocol import BaseProtocol
 from .compression_utils import HAS_BROTLI, BrotliDecompressor, ZLibDecompressor
 from .helpers import (
+    _EXC_SENTINEL,
     DEBUG,
     NO_EXTENSIONS,
     BaseTimerContext,
     method_must_be_empty_body,
+    set_exception,
     status_code_must_be_empty_body,
 )
 from .http_exceptions import (
@@ -446,13 +448,16 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                 assert self._payload_parser is not None
                 try:
                     eof, data = self._payload_parser.feed_data(data[start_pos:], SEP)
-                except BaseException as exc:
+                except BaseException as underlying_exc:
+                    reraised_exc = underlying_exc
                     if self.payload_exception is not None:
-                        self._payload_parser.payload.set_exception(
-                            self.payload_exception(str(exc))
-                        )
-                    else:
-                        self._payload_parser.payload.set_exception(exc)
+                        reraised_exc = self.payload_exception(str(underlying_exc))
+
+                    set_exception(
+                        self._payload_parser.payload,
+                        reraised_exc,
+                        underlying_exc,
+                    )
 
                     eof = True
                     data = b""
@@ -834,7 +839,7 @@ class HttpPayloadParser:
                             exc = TransferEncodingError(
                                 chunk[:pos].decode("ascii", "surrogateescape")
                             )
-                            self.payload.set_exception(exc)
+                            set_exception(self.payload, exc)
                             raise exc
                         size = int(bytes(size_b), 16)
 
@@ -939,8 +944,12 @@ class DeflateBuffer:
         else:
             self.decompressor = ZLibDecompressor(encoding=encoding)
 
-    def set_exception(self, exc: BaseException) -> None:
-        self.out.set_exception(exc)
+    def set_exception(
+        self,
+        exc: BaseException,
+        exc_cause: BaseException = _EXC_SENTINEL,
+    ) -> None:
+        set_exception(self.out, exc, exc_cause)
 
     def feed_data(self, chunk: bytes, size: int) -> None:
         if not size:

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -25,7 +25,7 @@ from typing import (
 
 from .base_protocol import BaseProtocol
 from .compression_utils import ZLibCompressor, ZLibDecompressor
-from .helpers import NO_EXTENSIONS
+from .helpers import NO_EXTENSIONS, set_exception
 from .streams import DataQueue
 
 __all__ = (
@@ -314,7 +314,7 @@ class WebSocketReader:
             return self._feed_data(data)
         except Exception as exc:
             self._exc = exc
-            self.queue.set_exception(exc)
+            set_exception(self.queue, exc)
             return True, b""
 
     def _feed_data(self, data: bytes) -> Tuple[bool, bytes]:

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -26,7 +26,7 @@ import yarl
 
 from .abc import AbstractAccessLogger, AbstractStreamWriter
 from .base_protocol import BaseProtocol
-from .helpers import ceil_timeout
+from .helpers import ceil_timeout, set_exception
 from .http import (
     HttpProcessingError,
     HttpRequestParser,
@@ -565,7 +565,7 @@ class RequestHandler(BaseProtocol):
                         self.log_debug("Uncompleted request.")
                         self.close()
 
-                payload.set_exception(PayloadAccessError())
+                set_exception(payload, PayloadAccessError())
 
             except asyncio.CancelledError:
                 self.log_debug("Ignored premature client disconnection ")

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -48,6 +48,7 @@ from .helpers import (
     parse_http_date,
     reify,
     sentinel,
+    set_exception,
 )
 from .http_parser import RawRequestMessage
 from .http_writer import HttpVersion
@@ -814,7 +815,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         return
 
     def _cancel(self, exc: BaseException) -> None:
-        self._payload.set_exception(exc)
+        set_exception(self._payload, exc)
 
 
 class Request(BaseRequest):

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -11,7 +11,7 @@ from multidict import CIMultiDict
 
 from . import hdrs
 from .abc import AbstractStreamWriter
-from .helpers import call_later, set_result
+from .helpers import call_later, set_exception, set_result
 from .http import (
     WS_CLOSED_MESSAGE,
     WS_CLOSING_MESSAGE,
@@ -526,4 +526,4 @@ class WebSocketResponse(StreamResponse):
 
     def _cancel(self, exc: BaseException) -> None:
         if self._reader is not None:
-            self._reader.set_exception(exc)
+            set_exception(self._reader, exc)

--- a/tests/test_base_protocol.py
+++ b/tests/test_base_protocol.py
@@ -186,9 +186,9 @@ async def test_lost_drain_waited_exception() -> None:
     assert pr._drain_waiter is not None
     exc = RuntimeError()
     pr.connection_lost(exc)
-    with pytest.raises(RuntimeError) as cm:
+    with pytest.raises(ConnectionError, match=r"^Connection lost$") as cm:
         await t
-    assert cm.value is exc
+    assert cm.value.__cause__ is exc
     assert pr._drain_waiter is None
 
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -14,6 +14,7 @@ from yarl import URL
 
 import aiohttp
 from aiohttp import BaseConnector, hdrs, helpers, payload
+from aiohttp.client_exceptions import ClientConnectionError
 from aiohttp.client_reqrep import (
     ClientRequest,
     ClientResponse,
@@ -1096,9 +1097,8 @@ async def test_data_stream_exc_chain(loop, conn) -> None:
     # assert connection.close.called
     assert conn.protocol.set_exception.called
     outer_exc = conn.protocol.set_exception.call_args[0][0]
-    assert isinstance(outer_exc, ValueError)
-    assert inner_exc is outer_exc
-    assert inner_exc is outer_exc
+    assert isinstance(outer_exc, ClientConnectionError)
+    assert outer_exc.__cause__ is inner_exc
     await req.close()
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -280,6 +280,7 @@ def test_parse_headers_longline(parser: Any) -> None:
     header_name = b"Test" + invalid_unicode_byte + b"Header" + b"A" * 8192
     text = b"GET /test HTTP/1.1\r\n" + header_name + b": test\r\n" + b"\r\n" + b"\r\n"
     with pytest.raises((http_exceptions.LineTooLong, http_exceptions.BadHttpMessage)):
+        # FIXME: `LineTooLong` doesn't seem to actually be happening
         parser.feed_data(text)
 
 


### PR DESCRIPTION
**This is a backport of PR #8089 as merged into master (dc38630b168a169139974617d75e176530c91696).**

This is supposed to unify setting exceptions on the future objects, allowing to also attach their causes whenever available. It'll make possible for the end-users to see more detailed tracebacks.

It's also supposed to help with tracking down what's happening with #4581.

PR #8089

Co-Authored-By: J. Nick Koston <nick@koston.org>
Co-Authored-By: Sam Bull <aa6bs0@sambull.org>
(cherry picked from commit dc38630b168a169139974617d75e176530c91696)