### PR TITLE
fix base_url param documentation

### DIFF
--- a/CHANGES/8197.doc
+++ b/CHANGES/8197.doc
@@ -1,0 +1,1 @@
+Fixed false behavior of base_url param for ClientSession in client documentation -- by :user:`alexis974`.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -59,8 +59,8 @@ The client session supports the context manager protocol for self closing.
 
    :param base_url: Base part of the URL (optional)
       If set, it allows to skip the base part (https://docs.aiohttp.org) in
-      request calls. If base_url includes a path (as in
-      https://docs.aiohttp.org/en/stable) the path is ignored/discarded.
+      request calls. It must not include a path (as in
+      https://docs.aiohttp.org/en/stable).
 
       .. versionadded:: 3.8
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR update the documentation made in 38ffe6f09 to notify about a behavior introduce in 527b1b9b6

`base_url` must not include path, otherwise an AssertionError is raised

```
File "/XXXXXXXXXXXXXXXXXX/aiohttp/client.py", line 248, in __init__
    self._base_url.origin() == self._base_url
AssertionError: Only absolute URLs without path part are supported
```

## Are there changes in behavior for the user?

No changes in behavior for the user since this is a documentation update

## Is it a substantial burden for the maintainers to support this?

No

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [X] Add a new news fragment into the `CHANGES/` folder
