### PR TITLE
Ensure websocket transport is closed when client does not close it

### DIFF
--- a/CHANGES/8200.bugfix.rst
+++ b/CHANGES/8200.bugfix.rst
@@ -1,0 +1,6 @@
+Ensure websocket transport is closed when client does not close it
+-- by :user:`bdraco`.
+
+The transport could remain open if the client did not close it. This
+change ensures the transport is closed when the client does not close
+it.

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -555,5 +555,8 @@ class WebSocketResponse(StreamResponse):
         return msg
 
     def _cancel(self, exc: BaseException) -> None:
+        # web_protocol calls this from connection_lost
+        # or when the server is shutting down.
+        self._closed = True
         if self._reader is not None:
             set_exception(self._reader, exc)

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -557,6 +557,6 @@ class WebSocketResponse(StreamResponse):
     def _cancel(self, exc: BaseException) -> None:
         # web_protocol calls this from connection_lost
         # or when the server is shutting down.
-        self._closed = True
+        self._closing = True
         if self._reader is not None:
             set_exception(self._reader, exc)

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -406,8 +406,7 @@ async def test_receive_closing(make_request: Any, loop: Any) -> None:
     ws._cancel(ConnectionResetError("Connection lost"))
 
     msg = await ws.receive()
-    assert msg.type == WSMsgType.CLOSED
-    assert ws.closed
+    assert msg.type == WSMsgType.CLOSING
 
 
 async def test_close_after_closing(make_request: Any, loop: Any) -> None:

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -2,7 +2,7 @@
 # HTTP websocket server functional tests
 
 import asyncio
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 
@@ -258,7 +258,7 @@ async def test_close_timeout(loop: Any, aiohttp_client: Any) -> None:
     assert "reply" == (await ws.receive_str())
 
     # The server closes here.  Then the client sends bogus messages with an
-    # internval shorter than server-side close timeout, to make the server
+    # interval shorter than server-side close timeout, to make the server
     # hanging indefinitely.
     await asyncio.sleep(0.08)
     msg = await ws._reader.read()
@@ -300,6 +300,35 @@ async def test_concurrent_close(loop: Any, aiohttp_client: Any) -> None:
     ws = await client.ws_connect("/", autoclose=False, protocols=("eggs", "bar"))
 
     await srv_ws.close(code=WSCloseCode.INVALID_TEXT)
+
+    msg = await ws.receive()
+    assert msg.type == WSMsgType.CLOSE
+
+    await asyncio.sleep(0)
+    msg = await ws.receive()
+    assert msg.type == WSMsgType.CLOSED
+
+
+async def test_close_op_code_from_client(loop: Any, aiohttp_client: Any) -> None:
+    srv_ws: Optional[web.WebSocketResponse] = None
+
+    async def handler(request):
+        nonlocal srv_ws
+        ws = srv_ws = web.WebSocketResponse(protocols=("foo", "bar"))
+        await ws.prepare(request)
+
+        msg = await ws.receive()
+        assert msg.type == WSMsgType.CLOSE
+        await asyncio.sleep(0)
+        return ws
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    client = await aiohttp_client(app)
+
+    ws: web.WebSocketResponse = await client.ws_connect("/", protocols=("eggs", "bar"))
+
+    await ws._writer._send_frame(b"", WSMsgType.CLOSE)
 
     msg = await ws.receive()
     assert msg.type == WSMsgType.CLOSE


### PR DESCRIPTION

<!-- Thank you for your contribution! -->



## Are there changes in behavior for the user?

Ensures the websocket transport is closed if the client never closes the connection after sending the CLOSE message

## Is it a substantial burden for the maintainers to support this?

no

## Related issue number

fixes #8184


## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
