### PR TITLE
Fix type annotations on MultipartWriter.append

### DIFF
--- a/CHANGES/7741.bugfix.rst
+++ b/CHANGES/7741.bugfix.rst
@@ -1,7 +1,3 @@
-Fixed the type annotations on :meth:`MultipartWriter.append`,
+Changed the type annotations to allow dicts on :meth:`MultipartWriter.append`,
 :meth:`MultipartWriter.append_json` and
 :meth:`MultipartWriter.append_form` -- by :user:`cakemanny`
-
-Type checkers, such as mypy and Pyright, now no longer give type
-errors when calling :py:meth:`MultipartWriter.append` with a plain
-python dictionary as the headers argument.

--- a/CHANGES/7741.bugfix.rst
+++ b/CHANGES/7741.bugfix.rst
@@ -1,3 +1,3 @@
-Changed the type annotations to allow ``dict`` on :meth:`MultipartWriter.append`,
-:meth:`MultipartWriter.append_json` and
-:meth:`MultipartWriter.append_form` -- by :user:`cakemanny`
+Changed the type annotations to allow ``dict`` on :meth:`aiohttp.MultipartWriter.append`,
+:meth:`aiohttp.MultipartWriter.append_json` and
+:meth:`aiohttp.MultipartWriter.append_form` -- by :user:`cakemanny`

--- a/CHANGES/7741.bugfix.rst
+++ b/CHANGES/7741.bugfix.rst
@@ -1,3 +1,3 @@
-Changed the type annotations to allow dicts on :meth:`MultipartWriter.append`,
+Changed the type annotations to allow ``dict`` on :meth:`MultipartWriter.append`,
 :meth:`MultipartWriter.append_json` and
 :meth:`MultipartWriter.append_form` -- by :user:`cakemanny`

--- a/CHANGES/7741.bugfix.rst
+++ b/CHANGES/7741.bugfix.rst
@@ -1,7 +1,7 @@
-Fixed the type annotations on :py:meth:`MultipartWriter.append`,
-:py:meth:`MultipartWriter.append_json` and
-:py:meth:`MultipartWriter.append_form` -- by :user:`cakemanny`
+Fixed the type annotations on :meth:`MultipartWriter.append`,
+:meth:`MultipartWriter.append_json` and
+:meth:`MultipartWriter.append_form` -- by :user:`cakemanny`
 
-Typecheckers, such as mypy and pyright, now no longer give type
+Type checkers, such as mypy and Pyright, now no longer give type
 errors when calling :py:meth:`MultipartWriter.append` with a plain
 python dictionary as the headers argument.

--- a/CHANGES/7741.bugfix.rst
+++ b/CHANGES/7741.bugfix.rst
@@ -1,0 +1,7 @@
+Fixed the type annotations on :py:meth:`MultipartWriter.append`,
+:py:meth:`MultipartWriter.append_json` and
+:py:meth:`MultipartWriter.append_form` -- by :user:`cakemanny`
+
+Typecheckers, such as mypy and pyright, now no longer give type
+errors when calling :py:meth:`MultipartWriter.append` with a plain
+python dictionary as the headers argument.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -83,6 +83,7 @@ Damien Nadé
 Dan King
 Dan Xu
 Daniel García
+Daniel Golding
 Daniel Grossmann-Kavanagh
 Daniel Nelson
 Daniele Trifirò

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -25,7 +25,8 @@ from typing import (
 )
 from urllib.parse import parse_qsl, unquote, urlencode
 
-from multidict import CIMultiDict, CIMultiDictProxy, MultiMapping
+from multidict import CIMultiDict, CIMultiDictProxy
+
 
 from .compression_utils import ZLibCompressor, ZLibDecompressor
 from .hdrs import (
@@ -47,6 +48,7 @@ from .payload import (
     payload_type,
 )
 from .streams import StreamReader
+from .typedefs import LooseHeaders
 
 __all__ = (
     "MultipartReader",
@@ -853,7 +855,7 @@ class MultipartWriter(Payload):
     def boundary(self) -> str:
         return self._boundary.decode("ascii")
 
-    def append(self, obj: Any, headers: Optional[MultiMapping[str]] = None) -> Payload:
+    def append(self, obj: Any, headers: Optional[LooseHeaders] = None) -> Payload:
         if headers is None:
             headers = CIMultiDict()
 
@@ -901,7 +903,7 @@ class MultipartWriter(Payload):
         return payload
 
     def append_json(
-        self, obj: Any, headers: Optional[MultiMapping[str]] = None
+        self, obj: Any, headers: Optional[LooseHeaders] = None
     ) -> Payload:
         """Helper to append JSON part."""
         if headers is None:
@@ -912,7 +914,7 @@ class MultipartWriter(Payload):
     def append_form(
         self,
         obj: Union[Sequence[Tuple[str, str]], Mapping[str, str]],
-        headers: Optional[MultiMapping[str]] = None,
+        headers: Optional[LooseHeaders] = None,
     ) -> Payload:
         """Helper to append form urlencoded part."""
         assert isinstance(obj, (Sequence, Mapping))

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -47,7 +47,6 @@ from .payload import (
     payload_type,
 )
 from .streams import StreamReader
-from .typedefs import LooseHeaders
 
 __all__ = (
     "MultipartReader",
@@ -854,7 +853,7 @@ class MultipartWriter(Payload):
     def boundary(self) -> str:
         return self._boundary.decode("ascii")
 
-    def append(self, obj: Any, headers: Optional[LooseHeaders] = None) -> Payload:
+    def append(self, obj: Any, headers: Optional[Mapping[str, str]] = None) -> Payload:
         if headers is None:
             headers = CIMultiDict()
 
@@ -901,7 +900,7 @@ class MultipartWriter(Payload):
         self._parts.append((payload, encoding, te_encoding))  # type: ignore[arg-type]
         return payload
 
-    def append_json(self, obj: Any, headers: Optional[LooseHeaders] = None) -> Payload:
+    def append_json(self, obj: Any, headers: Optional[Mapping[str, str]] = None) -> Payload:
         """Helper to append JSON part."""
         if headers is None:
             headers = CIMultiDict()
@@ -911,7 +910,7 @@ class MultipartWriter(Payload):
     def append_form(
         self,
         obj: Union[Sequence[Tuple[str, str]], Mapping[str, str]],
-        headers: Optional[LooseHeaders] = None,
+        headers: Optional[Mapping[str, str]] = None,
     ) -> Payload:
         """Helper to append form urlencoded part."""
         assert isinstance(obj, (Sequence, Mapping))

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -27,7 +27,6 @@ from urllib.parse import parse_qsl, unquote, urlencode
 
 from multidict import CIMultiDict, CIMultiDictProxy
 
-
 from .compression_utils import ZLibCompressor, ZLibDecompressor
 from .hdrs import (
     CONTENT_DISPOSITION,
@@ -902,9 +901,7 @@ class MultipartWriter(Payload):
         self._parts.append((payload, encoding, te_encoding))  # type: ignore[arg-type]
         return payload
 
-    def append_json(
-        self, obj: Any, headers: Optional[LooseHeaders] = None
-    ) -> Payload:
+    def append_json(self, obj: Any, headers: Optional[LooseHeaders] = None) -> Payload:
         """Helper to append JSON part."""
         if headers is None:
             headers = CIMultiDict()

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -900,7 +900,9 @@ class MultipartWriter(Payload):
         self._parts.append((payload, encoding, te_encoding))  # type: ignore[arg-type]
         return payload
 
-    def append_json(self, obj: Any, headers: Optional[Mapping[str, str]] = None) -> Payload:
+    def append_json(
+        self, obj: Any, headers: Optional[Mapping[str, str]] = None
+    ) -> Payload:
         """Helper to append JSON part."""
         if headers is None:
             headers = CIMultiDict()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

They adjust the annotations on the `MultipartWriter.append` method (and two similar methods), so that type-checkers admit plain python dictionaries for the second argument; the headers parameter.

~I chose to use `LooseHeaders` as I knew it was already used as the `headers` parameter for the `web.Response` constructor, among others.~ _Changed to `Mapping[str, str]` , thank you Dreamsorcerer_

## Are there changes in behavior for the user?

No, this doesn't change any behaviour.

## Is it a substantial burden for the maintainers to support this?

Not that I can imagine.

## Related issue number

Fixes #7741 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
  * I think the existing tests should be sufficient for seeing that the `str` and `istr` keyed dictionaries work with `append`
    - https://github.com/aio-libs/aiohttp/blob/d8936aacf7d602a58228d95fd469bbf01a43216d/tests/test_multipart.py#L1310
    - https://github.com/aio-libs/aiohttp/blob/d8936aacf7d602a58228d95fd469bbf01a43216d/tests/test_multipart.py#L1323 
    but am also open to suggestions
- [x] Documentation reflects the changes
  * Documentation already gives examples 
    - https://github.com/aio-libs/aiohttp/blob/d8936aacf7d602a58228d95fd469bbf01a43216d/docs/multipart.rst?plain=1#L145-L146
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
