### PR TITLE
feat a new choice, use loop.sendfile, while uploading files on client

### DIFF
--- a/CHANGES/8213.feature
+++ b/CHANGES/8213.feature
@@ -1,5 +1,5 @@
 Provided users with a new option to use loop.sendfile when uploading files.
-like 
+like
 
 async with aiohttp.ClientSession() as sess:
         data = aiohttp.FormData(quote_fields=False)

--- a/CHANGES/8213.feature
+++ b/CHANGES/8213.feature
@@ -1,0 +1,13 @@
+Provided users with a new option to use loop.sendfile when uploading files.
+like 
+
+async with aiohttp.ClientSession() as sess:
+        data = aiohttp.FormData(quote_fields=False)
+        assert pathlib.Path(__file__).exists()
+        data.add_field('file', payload.SendFile(__file__), filename=pathlib.Path(__file__).name)
+        async with sess.post('http://localhost:8080/upload', data=data) as resp:
+            with open(pathlib.Path(__file__), "rb") as fp:
+                assert fp.read() == await resp.read()
+                print("Success")
+
+ -- by :user:`junbaibai0719`

--- a/CHANGES/8213.feature
+++ b/CHANGES/8213.feature
@@ -1,13 +1,2 @@
 Provided users with a new option to use loop.sendfile when uploading files.
-like
-
-async with aiohttp.ClientSession() as sess:
-        data = aiohttp.FormData(quote_fields=False)
-        assert pathlib.Path(__file__).exists()
-        data.add_field('file', payload.SendFile(__file__), filename=pathlib.Path(__file__).name)
-        async with sess.post('http://localhost:8080/upload', data=data) as resp:
-            with open(pathlib.Path(__file__), "rb") as fp:
-                assert fp.read() == await resp.read()
-                print("Success")
-
  -- by :user:`junbaibai0719`

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -51,6 +51,7 @@ Arseny Timoniq
 Artem Yushkovskiy
 Arthur Darcet
 Austin Scola
+BaiJun Lin
 Ben Bader
 Ben Greiner
 Ben Kallus

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -469,13 +469,9 @@ class SendFilePayload(Payload):
 
     async def write(self, writer: AbstractStreamWriter) -> None:
         if not isinstance(writer, StreamWriter):
-            raise TypeError(
-                "required a StreamWriter got {!r}".format(type(writer))
-            )
+            raise TypeError(f"required a StreamWriter got {type(writer)!r}")
         if writer.transport is None:
-            raise TypeError(
-                "required a Transport got None type"
-            )
+            raise TypeError("required a Transport got None type")
         if self._value:
             sendfile: SendFile = self._value
             with open(sendfile.file_path, "rb") as fp:

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -469,7 +469,13 @@ class SendFilePayload(Payload):
 
     async def write(self, writer: AbstractStreamWriter) -> None:
         if not isinstance(writer, StreamWriter):
-            raise TypeError(f"required a StreamWriter got {type(writer)!r}")
+            raise TypeError(
+                "required a StreamWriter got {!r}".format(type(writer))
+            )
+        if writer.transport is None:
+            raise TypeError(
+                "required a Transport got None type"
+            )
         if self._value:
             sendfile: SendFile = self._value
             with open(sendfile.file_path, "rb") as fp:

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -33,9 +33,9 @@ from .helpers import (
     parse_mimetype,
     sentinel,
 )
+from .http_writer import StreamWriter
 from .streams import StreamReader
 from .typedefs import JSONEncoder, _CIMultiDict
-from .http_writer import StreamWriter
 
 __all__ = (
     "PAYLOAD_REGISTRY",
@@ -469,9 +469,7 @@ class SendFilePayload(Payload):
 
     async def write(self, writer: AbstractStreamWriter) -> None:
         if not isinstance(writer, StreamWriter):
-            raise TypeError(
-                "required a StreamWriter got {!r}".format(type(writer))
-            )
+            raise TypeError(f"required a StreamWriter got {type(writer)!r}")
         if self._value:
             sendfile: SendFile = self._value
             with open(sendfile.file_path, "rb") as fp:

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -447,30 +447,30 @@ class StreamReaderPayload(AsyncIterablePayload):
 class SendFile:
     file_path: str
     chunk_size: int
-    def __init__(self, file_path: str, chunk_size: int = 0x7fff_ffff):
+
+    def __init__(self, file_path: str, chunk_size: int = 0x7FFF_FFFF):
         self.file_path = file_path
         if chunk_size <= 0:
-            self.chunk_size = 0x7fff_ffff
+            self.chunk_size = 0x7FFF_FFFF
         else:
-            self.chunk_size = min(chunk_size, 0x7fff_ffff)
+            self.chunk_size = min(chunk_size, 0x7FFF_FFFF)
+
 
 class SendFilePayload(Payload):
-    def __init__(self, value:SendFile, *args, **kwargs):
+    def __init__(self, value: SendFile, *args, **kwargs):
         if not isinstance(value, SendFile):
             raise TypeError(
-                "value argument must be SendFile "
-                "got {!r}".format(type(value))
+                "value argument must be SendFile " "got {!r}".format(type(value))
             )
 
         if "content_type" not in kwargs:
             kwargs["content_type"] = "application/octet-stream"
         super().__init__(value, *args, **kwargs)
 
-    
     async def write(self, writer: AbstractStreamWriter) -> None:
         if self._value:
-            sendfile:SendFile = self._value
-            with open(sendfile.file_path, 'rb') as fp:
+            sendfile: SendFile = self._value
+            with open(sendfile.file_path, "rb") as fp:
                 file_size = os.fstat(fp.fileno()).st_size
                 chunk_len_pre = ("%x\r\n" % file_size).encode("ascii")
                 writer._write(chunk_len_pre)
@@ -482,6 +482,7 @@ class SendFilePayload(Payload):
                     writer.output_size += size
                 writer._write(b"\r\n")
             self._value = None
+
 
 PAYLOAD_REGISTRY = PayloadRegistry()
 PAYLOAD_REGISTRY.register(BytesPayload, (bytes, bytearray, memoryview))

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -134,13 +134,17 @@ async def test_send_file_payload_writer() -> None:
         p = payload.SendFilePayload(payload.SendFile("/sendfile"))
         await p.write(object())
 
+
 async def test_send_file_payload_writer_transport() -> None:
     with pytest.raises(TypeError):
         p = payload.SendFilePayload(payload.SendFile("/sendfile"))
-        from aiohttp.http_writer import StreamWriter
-        from aiohttp.base_protocol import BaseProtocol
         import asyncio
+
+        from aiohttp.base_protocol import BaseProtocol
+        from aiohttp.http_writer import StreamWriter
+
         await p.write(StreamWriter(BaseProtocol(), asyncio.get_event_loop()))
+
 
 def test_send_file_default_chunk_size() -> None:
     sf = payload.SendFile("/sendfile")

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -134,6 +134,13 @@ async def test_send_file_payload_writer() -> None:
         p = payload.SendFilePayload(payload.SendFile("/sendfile"))
         await p.write(object())
 
+async def test_send_file_payload_writer_transport() -> None:
+    with pytest.raises(TypeError):
+        p = payload.SendFilePayload(payload.SendFile("/sendfile"))
+        from aiohttp.http_writer import StreamWriter
+        from aiohttp.base_protocol import BaseProtocol
+        import asyncio
+        await p.write(StreamWriter(BaseProtocol(), asyncio.get_event_loop()))
 
 def test_send_file_default_chunk_size() -> None:
     sf = payload.SendFile("/sendfile")

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -143,7 +143,11 @@ async def test_send_file_payload_writer_transport() -> None:
         from aiohttp.base_protocol import BaseProtocol
         from aiohttp.http_writer import StreamWriter
 
-        await p.write(StreamWriter(BaseProtocol(asyncio.get_event_loop()), asyncio.get_event_loop()))
+        await p.write(
+            StreamWriter(
+                BaseProtocol(asyncio.get_event_loop()), asyncio.get_event_loop()
+            )
+        )
 
 
 def test_send_file_default_chunk_size() -> None:

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -194,10 +194,10 @@ async def test_send_file_payload_write_correctly() -> None:
 
     import pathlib
 
-    import aiohttp
+    from aiohttp import ClientSession, FormData
 
-    async with aiohttp.ClientSession() as sess:
-        data = aiohttp.FormData(quote_fields=False)
+    async with ClientSession() as sess:
+        data = FormData(quote_fields=False)
         assert pathlib.Path(__file__).exists()
         data.add_field(
             "file", payload.SendFile(__file__), filename=pathlib.Path(__file__).name

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -126,13 +126,13 @@ def test_send_file_payload_content_type() -> None:
 
 def test_send_file_payload_not_send_file() -> None:
     with pytest.raises(TypeError):
-        payload.SendFilePayload(object())
+        payload.SendFilePayload(object())  # type: ignore[arg-type]
 
 
 async def test_send_file_payload_writer() -> None:
     with pytest.raises(TypeError):
         p = payload.SendFilePayload(payload.SendFile("/sendfile"))
-        await p.write(object())
+        await p.write(object())  # type: ignore[arg-type]
 
 
 async def test_send_file_payload_writer_transport() -> None:
@@ -176,19 +176,17 @@ async def test_send_file_payload_write_correctly() -> None:
 
     async def upload(request: Request) -> Response:
         parts = await request.multipart()
-        file: BodyPartReader = None
+        file = None
         while field := await parts.next():
+            assert isinstance(field, BodyPartReader)
             if field.name == "file":
                 file = field
                 break
         else:
             return Response(body=b"", status=400)
-        if file:
-            return Response(body=await file.read())
-        else:
-            return Response(body=b"", status=400)
+        return Response(body=await file.read())
 
-    server = web.Server(upload)
+    server = web.Server(upload)  # type: ignore[arg-type]
     runner = web.ServerRunner(server)
     await runner.setup()
     site = web.TCPSite(runner, "localhost", 9001)

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -143,7 +143,7 @@ async def test_send_file_payload_writer_transport() -> None:
         from aiohttp.base_protocol import BaseProtocol
         from aiohttp.http_writer import StreamWriter
 
-        await p.write(StreamWriter(BaseProtocol(), asyncio.get_event_loop()))
+        await p.write(StreamWriter(BaseProtocol(asyncio.get_event_loop()), asyncio.get_event_loop()))
 
 
 def test_send_file_default_chunk_size() -> None:


### PR DESCRIPTION
## What do these changes do?

These changes provide a new choice, use loop.sendfile, while uploading files on client.

## Are there changes in behavior for the user?

Users have a new choice to upload files, which cost less time, less memory and less cpu overhead . There is no impact on using AsyncIterable to upload files.

## Is it a substantial burden for the maintainers to support this?
I think not, if the interface in asyncio event loop has no changes throughout the next 5 years. 

## Related issue number
n/a

## Checklist

- [x] I think the code is well written 
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
