### PR TITLE
Leave websocket transport open if receive times out or is cancelled

### DIFF
--- a/CHANGES/8251.bugfix.rst
+++ b/CHANGES/8251.bugfix.rst
@@ -1,0 +1,4 @@
+Leave websocket transport open if receive times out or is cancelled
+-- by :user:`bdraco`.
+
+This restores the behavior prior to the change in #7978.

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -474,8 +474,7 @@ class WebSocketResponse(StreamResponse):
                     waiter = self._waiting
                     set_result(waiter, True)
                     self._waiting = None
-            except (asyncio.CancelledError, asyncio.TimeoutError):
-                self._close_code = WSCloseCode.ABNORMAL_CLOSURE
+            except asyncio.TimeoutError:
                 raise
             except EofStream:
                 self._close_code = WSCloseCode.OK

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -475,7 +475,7 @@ class WebSocketResponse(StreamResponse):
                     set_result(waiter, True)
                     self._waiting = None
             except (asyncio.CancelledError, asyncio.TimeoutError):
-                self._set_code_close_transport(WSCloseCode.ABNORMAL_CLOSURE)
+                self._close_code = WSCloseCode.ABNORMAL_CLOSURE
                 raise
             except EofStream:
                 self._close_code = WSCloseCode.OK

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -358,7 +358,8 @@ async def test_receive_timeouterror(make_request: Any, loop: Any) -> None:
     with pytest.raises(asyncio.TimeoutError):
         await ws.receive()
 
-    assert len(ws._req.transport.close.mock_calls) == 1
+    # Should not close the connection on timeout
+    assert len(ws._req.transport.close.mock_calls) == 0
 
 
 async def test_multiple_receive_on_close_connection(make_request: Any) -> None:

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -879,8 +879,7 @@ async def test_receive_timeout_keeps_connection_open(
 
     ws = await client.ws_connect("/", autoping=False)
 
-    await asyncio.sleep(0)
-    await asyncio.sleep(sys.float_info.min)
+    await asyncio.sleep(0.1)
     await ws.ping("data")
 
     msg = await ws.receive()

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -2,6 +2,8 @@
 # HTTP websocket server functional tests
 
 import asyncio
+import contextlib
+import sys
 from typing import Any
 
 import pytest
@@ -799,3 +801,92 @@ async def test_bug3380(loop: Any, aiohttp_client: Any) -> None:
     resp = await client.get("/api/null", timeout=aiohttp.ClientTimeout(total=1))
     assert (await resp.json()) == {"err": None}
     resp.close()
+
+
+async def test_receive_being_cancelled_keeps_connection_open(
+    loop: Any, aiohttp_client: Any
+) -> None:
+    closed = loop.create_future()
+
+    async def handler(request):
+        ws = web.WebSocketResponse(autoping=False)
+        await ws.prepare(request)
+
+        task = asyncio.create_task(ws.receive())
+        await asyncio.sleep(0)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        msg = await ws.receive()
+        assert msg.type == WSMsgType.PING
+        await asyncio.sleep(0)
+        await ws.pong("data")
+
+        msg = await ws.receive()
+        assert msg.type == WSMsgType.CLOSE
+        assert msg.data == WSCloseCode.OK
+        assert msg.extra == "exit message"
+        closed.set_result(None)
+        return ws
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    client = await aiohttp_client(app)
+
+    ws = await client.ws_connect("/", autoping=False)
+
+    await asyncio.sleep(0)
+    await ws.ping("data")
+
+    msg = await ws.receive()
+    assert msg.type == WSMsgType.PONG
+    assert msg.data == b"data"
+
+    await ws.close(code=WSCloseCode.OK, message="exit message")
+
+    await closed
+
+
+async def test_receive_timeout_keeps_connection_open(
+    loop: Any, aiohttp_client: Any
+) -> None:
+    closed = loop.create_future()
+
+    async def handler(request):
+        ws = web.WebSocketResponse(autoping=False)
+        await ws.prepare(request)
+
+        task = asyncio.create_task(ws.receive(sys.float_info.min))
+        with contextlib.suppress(asyncio.TimeoutError):
+            await task
+
+        msg = await ws.receive()
+        assert msg.type == WSMsgType.PING
+        await asyncio.sleep(0)
+        await ws.pong("data")
+
+        msg = await ws.receive()
+        assert msg.type == WSMsgType.CLOSE
+        assert msg.data == WSCloseCode.OK
+        assert msg.extra == "exit message"
+        closed.set_result(None)
+        return ws
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    client = await aiohttp_client(app)
+
+    ws = await client.ws_connect("/", autoping=False)
+
+    await asyncio.sleep(0)
+    await asyncio.sleep(sys.float_info.min)
+    await ws.ping("data")
+
+    msg = await ws.receive()
+    assert msg.type == WSMsgType.PONG
+    assert msg.data == b"data"
+
+    await ws.close(code=WSCloseCode.OK, message="exit message")
+
+    await closed


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Leave websocket transport open if receive times out or is cancelled.

This change restores the behavior before #7978

See https://github.com/aio-libs/aiohttp/pull/7978#issuecomment-2015714011

## Are there changes in behavior for the user?

The connection is left open if the receive call times out or is cancelled

## Is it a substantial burden for the maintainers to support this?

no

## Related issue number

https://github.com/aio-libs/aiohttp/pull/7978#issuecomment-2015714011

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
