### PR TITLE
Fix handling of unsupported upgrades with the pure python http parser

### DIFF
--- a/CHANGES/8252.bugfix.rst
+++ b/CHANGES/8252.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed content not being read when an upgrade request was not supported with the pure Python implementation.
+-- by :user:`bdraco`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -227,7 +227,7 @@ class HeadersParser:
 
 def _is_supported_upgrade(headers: CIMultiDictProxy[str]) -> bool:
     """Check if the upgrade header is supported."""
-    return headers.get(hdrs.UPGRADE, "").lower() in ("tcp", "websocket")
+    return headers.get(hdrs.UPGRADE, "").lower() in {"tcp", "websocket"}
 
 
 class HttpParser(abc.ABC, Generic[_MsgT]):

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -227,7 +227,7 @@ class HeadersParser:
 
 def _is_supported_upgrade(headers: CIMultiDictProxy[str]) -> bool:
     """Check if the upgrade header is supported."""
-    return headers.get(hdrs.UPGRADE, "").lower() == "websocket"
+    return headers.get(hdrs.UPGRADE, "").lower() in ("tcp", "websocket")
 
 
 class HttpParser(abc.ABC, Generic[_MsgT]):

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -225,7 +225,7 @@ class HeadersParser:
         return (CIMultiDictProxy(headers), tuple(raw_headers))
 
 
-def is_supported_upgrade(headers: CIMultiDict[str]) -> bool:
+def is_supported_upgrade(headers: CIMultiDictProxy[str]) -> bool:
     """Check if the upgrade header is supported."""
     return headers.get(hdrs.UPGRADE, "").lower() in ("tcp", "websocket")
 

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -225,7 +225,7 @@ class HeadersParser:
         return (CIMultiDictProxy(headers), tuple(raw_headers))
 
 
-def is_supported_upgrade(headers: CIMultiDictProxy[str]) -> bool:
+def _is_supported_upgrade(headers: CIMultiDictProxy[str]) -> bool:
     """Check if the upgrade header is supported."""
     return headers.get(hdrs.UPGRADE, "").lower() == "websocket"
 
@@ -365,7 +365,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         )
                         if not empty_body and (
                             ((length is not None and length > 0) or msg.chunked)
-                            and not (msg.upgrade and is_supported_upgrade(msg.headers))
+                            and not (msg.upgrade and _is_supported_upgrade(msg.headers))
                         ):
                             payload = StreamReader(
                                 self.protocol,

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -227,7 +227,7 @@ class HeadersParser:
 
 def is_supported_upgrade(headers: CIMultiDictProxy[str]) -> bool:
     """Check if the upgrade header is supported."""
-    return headers.get(hdrs.UPGRADE, "").lower() in ("tcp", "websocket")
+    return headers.get(hdrs.UPGRADE, "").lower() == "websocket"
 
 
 class HttpParser(abc.ABC, Generic[_MsgT]):

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -352,13 +352,13 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         if SEC_WEBSOCKET_KEY1 in msg.headers:
                             raise InvalidHeader(SEC_WEBSOCKET_KEY1)
 
-                        method = getattr(msg, "method", self.method)
-                        # code is only present on responses
-                        code = getattr(msg, "code", 0)
-
                         self._upgraded = msg.upgrade and _is_supported_upgrade(
                             msg.headers
                         )
+
+                        method = getattr(msg, "method", self.method)
+                        # code is only present on responses
+                        code = getattr(msg, "code", 0)
 
                         assert self.protocol is not None
                         # calculate payload


### PR DESCRIPTION
## What do these changes do?

Fix handling of unsupported upgrades with the pure python http parser

<!-- Please give a short brief about these changes. -->

The content is now read from an unsupported upgrade request

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

no

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
