### PR TITLE
Fix for #8253 "Unclosed client session" when initialization fails

### DIFF
--- a/CHANGES/8253.bugfix
+++ b/CHANGES/8253.bugfix
@@ -1,0 +1,1 @@
+Fixed "Unclosed client session" when initialization of ClientSession fails -- by :user:`NewGlad`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -27,6 +27,7 @@ Alexander Shorin
 Alexander Travov
 Alexandru Mihai
 Alexey Firsov
+Alexey Nikitin
 Alexey Popravka
 Alexey Stepanov
 Almaz Salakhov

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -262,10 +262,10 @@ class ClientSession:
                 f"timeout parameter cannot be of {type(timeout)} type, "
                 "please use 'timeout=ClientTimeout(...)'",
             )
+        self._timeout = timeout
 
         if connector is None:
             connector = TCPConnector()
-        self._timeout = timeout
         # Initialize these three attrs before raising any exception,
         # they are used in __del__
         self._connector = connector

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -255,7 +255,15 @@ class ClientSession:
 
         if connector is None:
             connector = TCPConnector()
-
+        if timeout is sentinel or timeout is None:
+            timeout = DEFAULT_TIMEOUT
+        if not isinstance(timeout, ClientTimeout):
+            self._connector = None
+            raise ValueError(
+                f"timeout parameter cannot be of {type(timeout)} type, "
+                "please use 'timeout=ClientTimeout(...)'",
+            )
+        self._timeout = timeout
         # Initialize these three attrs before raising any exception,
         # they are used in __del__
         self._connector: Optional[BaseConnector] = connector
@@ -281,14 +289,6 @@ class ClientSession:
         self._default_auth = auth
         self._version = version
         self._json_serialize = json_serialize
-        if timeout is sentinel or timeout is None:
-            timeout = DEFAULT_TIMEOUT
-        if not isinstance(timeout, ClientTimeout):
-            raise ValueError(
-                f"timeout parameter cannot be of {type(timeout)} type, "
-                "please use 'timeout=ClientTimeout(...)'",
-            )
-        self._timeout = timeout
         self._raise_for_status = raise_for_status
         self._auto_decompress = auto_decompress
         self._trust_env = trust_env

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -214,8 +214,6 @@ class ClientSession:
         "_resolve_charset",
     )
 
-    _connector: Optional[BaseConnector] = None
-
     def __init__(
         self,
         base_url: Optional[StrOrURL] = None,
@@ -245,6 +243,9 @@ class ClientSession:
         max_field_size: int = 8190,
         fallback_charset_resolver: _CharsetResolver = lambda r, b: "utf-8",
     ) -> None:
+        # We initialise _connector to None immediately, as it's referenced in __del__()
+        # and could cause issues if an exception occurs during initialisation.
+        self._connector: Optional[BaseConnector] = None
         if base_url is None or isinstance(base_url, URL):
             self._base_url: Optional[URL] = base_url
         else:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -214,6 +214,8 @@ class ClientSession:
         "_resolve_charset",
     )
 
+    _connector: Optional[BaseConnector] = None
+
     def __init__(
         self,
         base_url: Optional[StrOrURL] = None,
@@ -253,20 +255,20 @@ class ClientSession:
 
         loop = asyncio.get_running_loop()
 
-        if connector is None:
-            connector = TCPConnector()
         if timeout is sentinel or timeout is None:
             timeout = DEFAULT_TIMEOUT
         if not isinstance(timeout, ClientTimeout):
-            self._connector = None
             raise ValueError(
                 f"timeout parameter cannot be of {type(timeout)} type, "
                 "please use 'timeout=ClientTimeout(...)'",
             )
+
+        if connector is None:
+            connector = TCPConnector()
         self._timeout = timeout
         # Initialize these three attrs before raising any exception,
         # they are used in __del__
-        self._connector: Optional[BaseConnector] = connector
+        self._connector = connector
         self._loop = loop
         if loop.get_debug():
             self._source_traceback: Optional[traceback.StackSummary] = (

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -841,3 +841,13 @@ async def test_build_url_returns_expected_url(
 ) -> None:
     session = await create_session(base_url)
     assert session._build_url(url) == expected_url
+
+
+async def test_instantiation_with_invalid_timeout_value(loop):
+    loop.set_debug(False)
+    logs = []
+    loop.set_exception_handler(lambda loop, ctx: logs.append(ctx))
+    with pytest.raises(ValueError, match="timeout parameter cannot be .*"):
+        ClientSession(timeout=1)
+    # should not have "Unclosed client session" warning
+    assert not logs

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -843,11 +843,6 @@ async def test_build_url_returns_expected_url(
     assert session._build_url(url) == expected_url
 
 
-async def test_instantiation_with_invalid_timeout_value(loop):
-    loop.set_debug(False)
-    logs = []
-    loop.set_exception_handler(lambda loop, ctx: logs.append(ctx))
+async def test_instantiation_with_invalid_timeout_value():
     with pytest.raises(ValueError, match="timeout parameter cannot be .*"):
         ClientSession(timeout=1)
-    # should not have "Unclosed client session" warning
-    assert not logs


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What do these changes do?

Fix for the issue https://github.com/aio-libs/aiohttp/issues/8253

## Are there changes in behavior for the user?

Should not change behavior

## Is it a substantial burden for the maintainers to support this?
Nope!

## Related issue number
Fixes #8253

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
