### PR TITLE
Create marker for internal tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -213,7 +213,7 @@ jobs:
         PIP_USER: 1
       run: >-
         PATH="${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}"
-        pytest -m internal
+        pytest
       shell: bash
     - name: Re-run the failing tests with maximum verbosity
       if: failure()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -213,7 +213,7 @@ jobs:
         PIP_USER: 1
       run: >-
         PATH="${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}"
-        pytest
+        pytest -m internal
       shell: bash
     - name: Re-run the failing tests with maximum verbosity
       if: failure()

--- a/CHANGES/8299.packaging.rst
+++ b/CHANGES/8299.packaging.rst
@@ -1,2 +1,2 @@
-Added an 'internal' pytest marker for tests which should be skipped
+Added an ``internal`` pytest marker for tests which should be skipped
 by packagers and disabled them by default -- by :user:`Dreamsorcerer`.

--- a/CHANGES/8299.packaging.rst
+++ b/CHANGES/8299.packaging.rst
@@ -1,2 +1,2 @@
-Added an 'internal' pytest marker for tests which should skipped
+Added an 'internal' pytest marker for tests which should be skipped
 by packagers and disabled them by default -- by :user:`Dreamsorcerer`.

--- a/CHANGES/8299.packaging.rst
+++ b/CHANGES/8299.packaging.rst
@@ -1,0 +1,2 @@
+Added an 'internal' pytest marker for tests which should skipped
+by packagers and disabled them by default -- by :user:`Dreamsorcerer`.

--- a/CHANGES/8299.packaging.rst
+++ b/CHANGES/8299.packaging.rst
@@ -1,2 +1,2 @@
 Added an ``internal`` pytest marker for tests which should be skipped
-by packagers and disabled them by default -- by :user:`Dreamsorcerer`.
+by packagers (use ``-m 'not internal'`` to disable them) -- by :user:`Dreamsorcerer`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,6 +134,8 @@ addopts =
 
     # run tests that are not marked with dev_mode
     -m "not dev_mode"
+    # skip internal by default for other users (re-enabled explicitly in CI).
+    -m "not internal"
 filterwarnings =
     error
     ignore:module 'ssl' has no attribute 'OP_NO_COMPRESSION'. The Python interpreter is compiled against OpenSSL < 1.0.0. Ref. https.//docs.python.org/3/library/ssl.html#ssl.OP_NO_COMPRESSION:UserWarning
@@ -170,3 +172,4 @@ junit_family=xunit2
 xfail_strict = true
 markers =
     dev_mode: mark test to run in dev mode.
+    internal: tests which may cause issues for packagers, but should be run in aiohttp's CI.

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,8 +134,6 @@ addopts =
 
     # run tests that are not marked with dev_mode
     -m "not dev_mode"
-    # skip internal by default for other users (re-enabled explicitly in CI).
-    -m "not internal"
 filterwarnings =
     error
     ignore:module 'ssl' has no attribute 'OP_NO_COMPRESSION'. The Python interpreter is compiled against OpenSSL < 1.0.0. Ref. https.//docs.python.org/3/library/ssl.html#ssl.OP_NO_COMPRESSION:UserWarning

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -33,6 +33,7 @@ _TARGET_TIMINGS_BY_PYTHON_VERSION = {
 }
 
 
+@pytest.mark.internal
 @pytest.mark.skipif(
     not sys.platform.startswith("linux") or platform.python_implementation() == "PyPy",
     reason="Timing is more reliable on Linux",


### PR DESCRIPTION
To help avoid issues with downstream packagers etc. we should disable a few tests for them which are dependent on the CI environment.