### PR TITLE
Revert #3492

### DIFF
--- a/CHANGES/2302.feature
+++ b/CHANGES/2302.feature
@@ -1,1 +1,0 @@
-Support reading multipart data with `\n` (`LF`) lines

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -346,7 +346,9 @@ class BodyPartReader:
             self._at_eof = True
         if self._at_eof:
             clrf = await self._content.readline()
-            assert b'\r\n' == clrf,  "reader did not read all the data or it is malformed"
+            assert (
+                b"\r\n" == clrf
+            ), "reader did not read all the data or it is malformed"
         return chunk
 
     async def _read_chunk_from_length(self, size: int) -> bytes:
@@ -372,7 +374,7 @@ class BodyPartReader:
         assert self._content_eof < 3, "Reading after EOF"
         assert self._prev_chunk is not None
         window = self._prev_chunk + chunk
-        sub = b'\r\n' + self._boundary
+        sub = b"\r\n" + self._boundary
         if first_chunk:
             idx = window.find(sub)
         else:
@@ -684,7 +686,7 @@ class MultipartReader:
     async def _read_until_first_boundary(self) -> None:
         while True:
             chunk = await self._readline()
-            if chunk == b'':
+            if chunk == b"":
                 raise ValueError(f"Could not find starting boundary {self._boundary!r}")
             chunk = chunk.rstrip()
             if chunk == self._boundary:

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -691,7 +691,7 @@ class MultipartReader:
             chunk = chunk.rstrip()
             if chunk == self._boundary:
                 return
-            elif chunk == end_boundary:
+            elif chunk == self._boundary + b"--":
                 self._at_eof = True
                 return
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -370,7 +370,7 @@ class TestPartReader:
         assert "Hello, world!" == result
 
     async def test_read_text_default_encoding(self) -> None:
-        with Stream(b"Привет, Мир!\r\n--:--") as stream:
+        with Stream("Привет, Мир!\r\n--:--".encode("utf-8")) as stream:
             obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.text()
         assert "Привет, Мир!" == result

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -25,11 +25,6 @@ from aiohttp.test_utils import make_mocked_coro
 BOUNDARY: bytes = b"--:"
 
 
-def pytest_generate_tests(metafunc: Any) -> None:  # pragma: no cover
-    if "newline" in metafunc.fixturenames:
-        metafunc.parametrize("newline", [b"\r\n", b"\n"], ids=str)
-
-
 @pytest.fixture
 def buf():
     return bytearray()
@@ -127,28 +122,25 @@ class TestMultipartResponseWrapper:
 
 
 class TestPartReader:
-    async def test_next(self, newline: Any) -> None:
-        data = b"Hello, world!%s--:" % newline
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream, _newline=newline)
+    async def test_next(self) -> None:
+        with Stream(b"Hello, world!\r\n--:") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.next()
             assert b"Hello, world!" == result
             assert obj.at_eof()
 
-    async def test_next_next(self, newline: Any) -> None:
-        data = b"Hello, world!%s--:" % newline
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream, _newline=newline)
+    async def test_next_next(self) -> None:
+        with Stream(b"Hello, world!\r\n--:") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.next()
             assert b"Hello, world!" == result
             assert obj.at_eof()
             result = await obj.next()
             assert result is None
 
-    async def test_read(self, newline: Any) -> None:
-        data = b"Hello, world!%s--:" % newline
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream, _newline=newline)
+    async def test_read(self) -> None:
+        with Stream(b"Hello, world!\r\n--:") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.read()
             assert b"Hello, world!" == result
             assert obj.at_eof()
@@ -160,17 +152,16 @@ class TestPartReader:
             result = await obj.read_chunk()
         assert b"" == result
 
-    async def test_read_chunk_without_content_length(self, newline: Any) -> None:
-        data = b"Hello, world!%s--:" % newline
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream, _newline=newline)
+    async def test_read_chunk_without_content_length(self) -> None:
+        with Stream(b"Hello, world!\r\n--:") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             c1 = await obj.read_chunk(8)
             c2 = await obj.read_chunk(8)
             c3 = await obj.read_chunk(8)
         assert c1 + c2 == b"Hello, world!"
         assert c3 == b""
 
-    async def test_read_incomplete_chunk(self, newline: Any) -> None:
+    async def test_read_incomplete_chunk(self) -> None:
         with Stream(b"") as stream:
 
             def prepare(data):
@@ -182,11 +173,11 @@ class TestPartReader:
                 side_effect=[
                     prepare(b"Hello, "),
                     prepare(b"World"),
-                    prepare(b"!%s--:" % newline),
+                    prepare(b"!\r\n--:"),
                     prepare(b""),
                 ],
             ):
-                obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream, _newline=newline)
+                obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
                 c1 = await obj.read_chunk(8)
                 assert c1 == b"Hello, "
                 c2 = await obj.read_chunk(8)
@@ -194,27 +185,25 @@ class TestPartReader:
                 c3 = await obj.read_chunk(8)
                 assert c3 == b"!"
 
-    async def test_read_all_at_once(self, newline: Any) -> None:
-        data = b"Hello, World!%s--:--%s" % (newline, newline)
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream, _newline=newline)
+    async def test_read_all_at_once(self) -> None:
+        with Stream(b"Hello, World!\r\n--:--\r\n") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.read_chunk()
             assert b"Hello, World!" == result
             result = await obj.read_chunk()
             assert b"" == result
             assert obj.at_eof()
 
-    async def test_read_incomplete_body_chunked(self, newline: Any) -> None:
-        data = b"Hello, World!%s--" % newline
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream, _newline=newline)
+    async def test_read_incomplete_body_chunked(self) -> None:
+        with Stream(b"Hello, World!\r\n-") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = b""
             with pytest.raises(AssertionError):
                 for _ in range(4):
                     result += await obj.read_chunk(7)
-        assert data == result
+        assert b"Hello, World!\r\n-" == result
 
-    async def test_read_boundary_with_incomplete_chunk(self, newline: Any) -> None:
+    async def test_read_boundary_with_incomplete_chunk(self) -> None:
         with Stream(b"") as stream:
 
             def prepare(data):
@@ -225,12 +214,12 @@ class TestPartReader:
                 "read",
                 side_effect=[
                     prepare(b"Hello, World"),
-                    prepare(b"!%s" % newline),
+                    prepare(b"!\r\n"),
                     prepare(b"--:"),
                     prepare(b""),
                 ],
             ):
-                obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream, _newline=newline)
+                obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
                 c1 = await obj.read_chunk(12)
                 assert c1 == b"Hello, World"
                 c2 = await obj.read_chunk(8)
@@ -238,27 +227,20 @@ class TestPartReader:
                 c3 = await obj.read_chunk(8)
                 assert c3 == b""
 
-    async def test_multi_read_chunk(self, newline: Any) -> None:
-        data = b"Hello,%s--:%s%sworld!%s--:--" % ((newline,) * 4)
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream, _newline=newline)
+    async def test_multi_read_chunk(self) -> None:
+        with Stream(b"Hello,\r\n--:\r\n\r\nworld!\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.read_chunk(8)
             assert b"Hello," == result
             result = await obj.read_chunk(8)
             assert b"" == result
             assert obj.at_eof()
 
-    async def test_read_chunk_properly_counts_read_bytes(self, newline: Any) -> None:
+    async def test_read_chunk_properly_counts_read_bytes(self) -> None:
         expected = b"." * 10
-        tail = b"%s--:--" % newline
         size = len(expected)
-        with StreamWithShortenRead(expected + tail) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {"CONTENT-LENGTH": size},
-                stream,
-                _newline=newline,
-            )
+        with StreamWithShortenRead(expected + b"\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {"CONTENT-LENGTH": size}, stream)
             result = bytearray()
             while True:
                 chunk = await obj.read_chunk()
@@ -269,144 +251,92 @@ class TestPartReader:
         assert b"." * size == result
         assert obj.at_eof()
 
-    async def test_read_does_not_read_boundary(self, newline: Any) -> None:
-        data = b"Hello, world!%s--:" % newline
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream, _newline=newline)
+    async def test_read_does_not_read_boundary(self) -> None:
+        with Stream(b"Hello, world!\r\n--:") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.read()
             assert b"Hello, world!" == result
             assert b"--:" == (await stream.read())
 
-    async def test_multiread(self, newline: Any) -> None:
-        data = b"Hello,%s--:%s%sworld!%s--:--" % ((newline,) * 4)
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream, _newline=newline)
+    async def test_multiread(self) -> None:
+        with Stream(b"Hello,\r\n--:\r\n\r\nworld!\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.read()
             assert b"Hello," == result
             result = await obj.read()
             assert b"" == result
             assert obj.at_eof()
 
-    async def test_read_multiline(self, newline: Any) -> None:
-        data = b"Hello\n,\r\nworld!%s--:--" % newline
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream, _newline=newline)
+    async def test_read_multiline(self) -> None:
+        with Stream(b"Hello\n,\r\nworld!\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.read()
             assert b"Hello\n,\r\nworld!" == result
             result = await obj.read()
             assert b"" == result
             assert obj.at_eof()
 
-    async def test_read_respects_content_length(self, newline: Any) -> None:
-        data = b"." * 100500
-        tail = b"%s--:--" % newline
-        with Stream(data + tail) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {"CONTENT-LENGTH": 100500},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_respects_content_length(self) -> None:
+        with Stream(b"." * 100500 + b"\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {"CONTENT-LENGTH": 100500}, stream)
             result = await obj.read()
-            assert data == result
+            assert b"." * 100500 == result
             assert obj.at_eof()
 
-    async def test_read_with_content_encoding_gzip(self, newline: Any) -> None:
+    async def test_read_with_content_encoding_gzip(self) -> None:
         with Stream(
             b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\x0b\xc9\xccMU"
             b"(\xc9W\x08J\xcdI\xacP\x04\x00$\xfb\x9eV\x0e\x00\x00\x00"
-            b"%s--:--" % newline
+            b"\r\n--:--"
         ) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_ENCODING: "gzip"},
-                stream,
-                _newline=newline,
-            )
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_ENCODING: "gzip"}, stream)
             result = await obj.read(decode=True)
         assert b"Time to Relax!" == result
 
-    async def test_read_with_content_encoding_deflate(self, newline: Any) -> None:
-        data = b"\x0b\xc9\xccMU(\xc9W\x08J\xcdI\xacP\x04\x00"
-        tail = b"%s--:--" % newline
-        with Stream(data + tail) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_ENCODING: "deflate"},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_with_content_encoding_deflate(self) -> None:
+        with Stream(b"\x0b\xc9\xccMU(\xc9W\x08J\xcdI\xacP\x04\x00\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_ENCODING: "deflate"}, stream)
             result = await obj.read(decode=True)
         assert b"Time to Relax!" == result
 
-    async def test_read_with_content_encoding_identity(self, newline: Any) -> None:
+    async def test_read_with_content_encoding_identity(self) -> None:
         thing = (
             b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03\x0b\xc9\xccMU"
             b"(\xc9W\x08J\xcdI\xacP\x04\x00$\xfb\x9eV\x0e\x00\x00\x00"
+            b"\r\n"
         )
-        with Stream(thing + b"%s--:--" % newline) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_ENCODING: "identity"},
-                stream,
-                _newline=newline,
-            )
+        with Stream(thing + b"--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_ENCODING: "identity"}, stream)
             result = await obj.read(decode=True)
-        assert thing == result
+        assert thing[:-2] == result
 
-    async def test_read_with_content_encoding_unknown(self, newline: Any) -> None:
-        with Stream(b"\x0e4Time to Relax!%s--:--" % newline) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_ENCODING: "snappy"},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_with_content_encoding_unknown(self) -> None:
+        with Stream(b"\x0e4Time to Relax!\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_ENCODING: "snappy"}, stream)
             with pytest.raises(RuntimeError):
                 await obj.read(decode=True)
 
-    async def test_read_with_content_transfer_encoding_base64(
-        self, newline: Any
-    ) -> None:
-        with Stream(b"VGltZSB0byBSZWxheCE=%s--:--" % newline) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_TRANSFER_ENCODING: "base64"},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_with_content_transfer_encoding_base64(self) -> None:
+        with Stream(b"VGltZSB0byBSZWxheCE=\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TRANSFER_ENCODING: "base64"}, stream)
             result = await obj.read(decode=True)
         assert b"Time to Relax!" == result
 
-    async def test_decode_with_content_transfer_encoding_base64(
-        self, newline: Any
-    ) -> None:
-        with Stream(b"VG\r\r\nltZSB0byBSZ\r\nWxheCE=%s--:--" % newline) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_TRANSFER_ENCODING: "base64"},
-                stream,
-                _newline=newline,
-            )
+    async def test_decode_with_content_transfer_encoding_base64(self) -> None:
+        with Stream(b"VG\r\r\nltZSB0byBSZ\r\nWxheCE=\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TRANSFER_ENCODING: "base64"}, stream)
             result = b""
             while not obj.at_eof():
                 chunk = await obj.read_chunk(size=6)
                 result += obj.decode(chunk)
         assert b"Time to Relax!" == result
 
-    async def test_read_with_content_transfer_encoding_quoted_printable(
-        self, newline: Any
-    ) -> None:
+    async def test_read_with_content_transfer_encoding_quoted_printable(self) -> None:
         with Stream(
             b"=D0=9F=D1=80=D0=B8=D0=B2=D0=B5=D1=82,"
-            b" =D0=BC=D0=B8=D1=80!%s--:--" % newline
+            b" =D0=BC=D0=B8=D1=80!\r\n--:--"
         ) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_TRANSFER_ENCODING: "quoted-printable"},
-                stream,
-                _newline=newline,
-            )
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TRANSFER_ENCODING: "quoted-printable"}, stream)
             result = await obj.read(decode=True)
         expected = (
             b"\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82,"
@@ -416,93 +346,53 @@ class TestPartReader:
 
     @pytest.mark.parametrize("encoding", ("binary", "8bit", "7bit"))
     async def test_read_with_content_transfer_encoding_binary(
-        self, encoding: Any, newline: Any
+        self, encoding: Any
     ) -> None:
         data = (
             b"\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82,"
             b" \xd0\xbc\xd0\xb8\xd1\x80!"
         )
-        with Stream(data + b"%s--:--" % newline) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_TRANSFER_ENCODING: encoding},
-                stream,
-                _newline=newline,
-            )
+        with Stream(data + b"\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TRANSFER_ENCODING: encoding}, stream)
             result = await obj.read(decode=True)
         assert data == result
 
-    async def test_read_with_content_transfer_encoding_unknown(
-        self, newline: Any
-    ) -> None:
-        with Stream(b"\x0e4Time to Relax!%s--:--" % newline) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_TRANSFER_ENCODING: "unknown"},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_with_content_transfer_encoding_unknown(self) -> None:
+        with Stream(b"\x0e4Time to Relax!\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TRANSFER_ENCODING: "unknown"}, stream)
             with pytest.raises(RuntimeError):
                 await obj.read(decode=True)
 
-    async def test_read_text(self, newline: Any) -> None:
-        with Stream(b"Hello, world!%s--:--" % newline) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_text(self) -> None:
+        with Stream(b"Hello, world!\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.text()
         assert "Hello, world!" == result
 
-    async def test_read_text_default_encoding(self, newline: Any) -> None:
-        data = "Привет, Мир!"
-        tail = b"%s--:--" % newline
-        with Stream(data.encode("utf-8") + tail) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_text_default_encoding(self) -> None:
+        with Stream(b"Привет, Мир!\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.text()
-        assert data == result
+        assert "Привет, Мир!" == result
 
-    async def test_read_text_encoding(self, newline: Any) -> None:
-        data = "Привет, Мир!"
-        tail = b"%s--:--" % newline
-        with Stream(data.encode("cp1251") + tail) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_text_encoding(self) -> None:
+        with Stream("Привет, Мир!\r\n--:--".encode("cp1251")) as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.text(encoding="cp1251")
-        assert data == result
+        assert "Привет, Мир!" == result
 
-    async def test_read_text_guess_encoding(self, newline: Any) -> None:
-        data = "Привет, Мир!"
-        tail = b"%s--:--" % newline
-        with Stream(data.encode("cp1251") + tail) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_TYPE: "text/plain;charset=cp1251"},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_text_guess_encoding(self) -> None:
+        with Stream("Привет, Мир!\r\n--:--".encode("cp1251")) as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "text/plain;charset=cp1251"}, stream)
             result = await obj.text()
-        assert data == result
+        assert "Привет, Мир!" == result
 
-    async def test_read_text_compressed(self, newline: Any) -> None:
-        data = b"\x0b\xc9\xccMU(\xc9W\x08J\xcdI\xacP\x04\x00" b"%s--:--" % newline
-        with Stream(data) as stream:
+    async def test_read_text_compressed(self) -> None:
+        with Stream(b"\x0b\xc9\xccMU(\xc9W\x08J\xcdI\xacP\x04\x00\r\n--:--") as stream:
             obj = aiohttp.BodyPartReader(
                 BOUNDARY,
                 {CONTENT_ENCODING: "deflate", CONTENT_TYPE: "text/plain"},
-                stream,
-                _newline=newline,
+                stream
             )
             result = await obj.text()
         assert "Time to Relax!" == result
@@ -514,52 +404,30 @@ class TestPartReader:
             result = await obj.text()
         assert "" == result
 
-    async def test_read_json(self, newline: Any) -> None:
-        with Stream(b'{"test": "passed"}%s--:--' % newline) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_TYPE: "application/json"},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_json(self) -> None:
+        with Stream(b'{"test": "passed"}\r\n--:--') as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "application/json"}, stream)
             result = await obj.json()
         assert {"test": "passed"} == result
 
-    async def test_read_json_encoding(self, newline: Any) -> None:
-        data = '{"тест": "пассед"}'.encode("cp1251")
-        tail = b"%s--:--" % newline
-        with Stream(data + tail) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_TYPE: "application/json"},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_json_encoding(self) -> None:
+        with Stream('{"тест": "пассед"}\r\n--:--'.encode("cp1251")) as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "application/json"}, stream)
             result = await obj.json(encoding="cp1251")
         assert {"тест": "пассед"} == result
 
-    async def test_read_json_guess_encoding(self, newline: Any) -> None:
-        data = '{"тест": "пассед"}'.encode("cp1251")
-        tail = b"%s--:--" % newline
-        with Stream(data + tail) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_TYPE: "application/json; charset=cp1251"},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_json_guess_encoding(self) -> None:
+        with Stream('{"тест": "пассед"}\r\n--:--'.encode("cp1251")) as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "application/json; charset=cp1251"}, stream)
             result = await obj.json()
         assert {"тест": "пассед"} == result
 
-    async def test_read_json_compressed(self, newline: Any) -> None:
-        with Stream(
-            b"\xabV*I-.Q\xb2RP*H,.NMQ\xaa\x05\x00" b"%s--:--" % newline
-        ) as stream:
+    async def test_read_json_compressed(self) -> None:
+        with Stream(b"\xabV*I-.Q\xb2RP*H,.NMQ\xaa\x05\x00\r\n--:--") as stream:
             obj = aiohttp.BodyPartReader(
                 BOUNDARY,
                 {CONTENT_ENCODING: "deflate", CONTENT_TYPE: "application/json"},
                 stream,
-                _newline=newline,
             )
             result = await obj.json()
         assert {"test": "passed"} == result
@@ -573,53 +441,32 @@ class TestPartReader:
             result = await obj.json()
         assert result is None
 
-    async def test_read_form(self, newline: Any) -> None:
-        data = b"foo=bar&foo=baz&boo=%s--:--" % newline
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_TYPE: "application/x-www-form-urlencoded"},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_form(self) -> None:
+        with Stream(b"foo=bar&foo=baz&boo=\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "application/x-www-form-urlencoded"}, stream)
             result = await obj.form()
         assert [("foo", "bar"), ("foo", "baz"), ("boo", "")] == result
 
-    async def test_read_form_invalid_utf8(self, newline: Any) -> None:
-        invalid_unicode_byte = b"\xff"
-        data = invalid_unicode_byte + b"%s--:--" % newline
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_TYPE: "application/x-www-form-urlencoded"},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_form_invalid_utf8(self) -> None:
+        with Stream(b"\xff\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "application/x-www-form-urlencoded"}, stream)
             with pytest.raises(
                 ValueError, match="data cannot be decoded with utf-8 encoding"
             ):
                 await obj.form()
 
-    async def test_read_form_encoding(self, newline: Any) -> None:
-        data = b"foo=bar&foo=baz&boo=%s--:--" % newline
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_TYPE: "application/x-www-form-urlencoded"},
-                stream,
-                _newline=newline,
-            )
+    async def test_read_form_encoding(self) -> None:
+        with Stream("foo=bar&foo=baz&boo=\r\n--:--".encode("cp1251")) as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "application/x-www-form-urlencoded"}, stream)
             result = await obj.form(encoding="cp1251")
         assert [("foo", "bar"), ("foo", "baz"), ("boo", "")] == result
 
-    async def test_read_form_guess_encoding(self, newline: Any) -> None:
-        data = b"foo=bar&foo=baz&boo=%s--:--" % newline
-        with Stream(data) as stream:
+    async def test_read_form_guess_encoding(self) -> None:
+        with Stream(b"foo=bar&foo=baz&boo=\r\n--:--") as stream:
             obj = aiohttp.BodyPartReader(
                 BOUNDARY,
                 {CONTENT_TYPE: "application/x-www-form-urlencoded; charset=utf-8"},
                 stream,
-                _newline=newline,
             )
             result = await obj.form()
         assert [("foo", "bar"), ("foo", "baz"), ("boo", "")] == result
@@ -635,15 +482,9 @@ class TestPartReader:
             result = await obj.form()
         assert not result
 
-    async def test_readline(self, newline: Any) -> None:
-        data = b"Hello\n,\r\nworld!%s--:--" % newline
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {},
-                stream,
-                _newline=newline,
-            )
+    async def test_readline(self) -> None:
+        with Stream(b"Hello\n,\r\nworld!\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.readline()
             assert b"Hello\n" == result
             result = await obj.readline()
@@ -654,45 +495,26 @@ class TestPartReader:
             assert b"" == result
             assert obj.at_eof()
 
-    async def test_release(self, newline: Any) -> None:
-        data = b"Hello,%s--:\r\n\r\nworld!%s--:--" % (newline, newline)
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {},
-                stream,
-                _newline=newline,
-            )
-            remained = b"--:\r\n\r\nworld!%s--:--" % newline
+    async def test_release(self) -> None:
+        with Stream(b"Hello,\r\n--:\r\n\r\nworld!\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             await obj.release()
             assert obj.at_eof()
-            assert remained == stream.content.read()
+            assert b"--:\r\n\r\nworld!\r\n--:--" == stream.content.read()
 
-    async def test_release_respects_content_length(self, newline: Any) -> None:
-        with Stream(b"." * 100500 + b"%s--:--" % newline) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {"CONTENT-LENGTH": 100500},
-                stream,
-                _newline=newline,
-            )
+    async def test_release_respects_content_length(self) -> None:
+        with Stream(b"." * 100500 + b"\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {"CONTENT-LENGTH": 100500}, stream)
             result = await obj.release()
             assert result is None
             assert obj.at_eof()
 
-    async def test_release_release(self, newline: Any) -> None:
-        data = b"Hello,%s--:\r\n\r\nworld!%s--:--" % (newline, newline)
-        remained = b"--:\r\n\r\nworld!%s--:--" % newline
-        with Stream(data) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {},
-                stream,
-                _newline=newline,
-            )
+    async def test_release_release(self) -> None:
+        with Stream(b"Hello,\r\n--:\r\n\r\nworld!\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             await obj.release()
             await obj.release()
-            assert remained == stream.content.read()
+            assert b"--:\r\n\r\nworld!\r\n--:--" == stream.content.read()
 
     async def test_filename(self) -> None:
         part = aiohttp.BodyPartReader(
@@ -700,20 +522,20 @@ class TestPartReader:
         )
         assert "foo.html" == part.filename
 
-    async def test_reading_long_part(self, newline: Any) -> None:
+    async def test_reading_long_part(self) -> None:
         size = 2 * 2**16
         protocol = mock.Mock(_reading_paused=False)
         stream = StreamReader(protocol, 2**16, loop=asyncio.get_event_loop())
-        stream.feed_data(b"0" * size + b"%s--:--" % newline)
+        stream.feed_data(b"0" * size + b"\r\n--:--")
         stream.feed_eof()
-        obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream, _newline=newline)
+        obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
         data = await obj.read()
         assert len(data) == size
 
 
 class TestMultipartReader:
-    def test_from_response(self, newline: Any) -> None:
-        with Stream(b"--:%s\r\nhello%s--:--" % (newline, newline)) as stream:
+    def test_from_response(self) -> None:
+        with Stream(b"--:\r\n\r\nhello\r\n--:--") as stream:
             resp = Response(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
                 stream,
@@ -730,8 +552,8 @@ class TestMultipartReader:
             with pytest.raises(ValueError):
                 aiohttp.MultipartReader.from_response(resp)
 
-    def test_dispatch(self, newline: Any) -> None:
-        with Stream(b"--:%s\r\necho%s--:--" % (newline, newline)) as stream:
+    def test_dispatch(self) -> None:
+        with Stream(b"--:\r\n\r\necho\r\n--:--") as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
                 stream,
@@ -739,8 +561,8 @@ class TestMultipartReader:
             res = reader._get_part_reader({CONTENT_TYPE: "text/plain"})
         assert isinstance(res, reader.part_reader_cls)
 
-    def test_dispatch_bodypart(self, newline: Any) -> None:
-        with Stream(b"--:%s\r\necho%s--:--" % (newline, newline)) as stream:
+    def test_dispatch_bodypart(self) -> None:
+        with Stream(b"--:\r\n\r\necho\r\n--:--") as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
                 stream,
@@ -748,19 +570,16 @@ class TestMultipartReader:
             res = reader._get_part_reader({CONTENT_TYPE: "text/plain"})
         assert isinstance(res, reader.part_reader_cls)
 
-    def test_dispatch_multipart(self, newline: Any) -> None:
+    def test_dispatch_multipart(self) -> None:
         with Stream(
-            newline.join(
-                [
-                    b"----:--",
-                    b"",
-                    b"test",
-                    b"----:--",
-                    b"",
-                    b"passed",
-                    b"----:----" b"--:--",
-                ]
-            )
+            b"----:--\r\n"
+            b"\r\n"
+            b"test\r\n"
+            b"----:--\r\n"
+            b"\r\n"
+            b"passed\r\n"
+            b"----:----\r\n"
+            b"--:--"
         ) as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
@@ -771,23 +590,19 @@ class TestMultipartReader:
             )
         assert isinstance(res, reader.__class__)
 
-    def test_dispatch_custom_multipart_reader(self, newline: Any) -> None:
+    def test_dispatch_custom_multipart_reader(self) -> None:
         class CustomReader(aiohttp.MultipartReader):
             pass
 
         with Stream(
-            newline.join(
-                [
-                    b"----:--",
-                    b"",
-                    b"test",
-                    b"----:--",
-                    b"",
-                    b"passed",
-                    b"----:----",
-                    b"--:--",
-                ]
-            )
+            b"----:--\r\n"
+            b"\r\n"
+            b"test\r\n"
+            b"----:--\r\n"
+            b"\r\n"
+            b"passed\r\n"
+            b"----:----\r\n"
+            b"--:--"
         ) as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
@@ -799,8 +614,8 @@ class TestMultipartReader:
             )
         assert isinstance(res, CustomReader)
 
-    async def test_emit_next(self, newline: Any) -> None:
-        with Stream(b"--:%s\r\necho%s--:--" % (newline, newline)) as stream:
+    async def test_emit_next(self) -> None:
+        with Stream(b"--:\r\n\r\necho\r\n--:--") as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
                 stream,
@@ -808,8 +623,8 @@ class TestMultipartReader:
             res = await reader.next()
         assert isinstance(res, reader.part_reader_cls)
 
-    async def test_invalid_boundary(self, newline: Any) -> None:
-        with Stream(b"---:%s\r\necho%s---:--" % (newline, newline)) as stream:
+    async def test_invalid_boundary(self) -> None:
+        with Stream(b"---:\r\n\r\necho\r\n---:--") as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
                 stream,
@@ -817,24 +632,20 @@ class TestMultipartReader:
             with pytest.raises(ValueError):
                 await reader.next()
 
-    async def test_release(self, newline: Any) -> None:
+    async def test_release(self) -> None:
         with Stream(
-            newline.join(
-                [
-                    b"--:",
-                    b"Content-Type: multipart/related;boundary=--:--",
-                    b"",
-                    b"----:--",
-                    b"",
-                    b"test",
-                    b"----:--",
-                    b"",
-                    b"passed",
-                    b"----:----",
-                    b"",
-                    b"--:--",
-                ]
-            )
+            b"--:\r\n"
+            b"Content-Type: multipart/related;boundary=--:--\r\n"
+            b"\r\n"
+            b"----:--\r\n"
+            b"\r\n"
+            b"test\r\n"
+            b"----:--\r\n"
+            b"\r\n"
+            b"passed\r\n"
+            b"----:----\r\n"
+            b"\r\n"
+            b"--:--"
         ) as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/mixed;boundary=":"'},
@@ -843,8 +654,8 @@ class TestMultipartReader:
             await reader.release()
             assert reader.at_eof()
 
-    async def test_release_release(self, newline: Any) -> None:
-        with Stream(b"--:%s\r\necho%s--:--" % (newline, newline)) as stream:
+    async def test_release_release(self) -> None:
+        with Stream(b"--:\r\n\r\necho\r\n--:--") as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
                 stream,
@@ -854,8 +665,8 @@ class TestMultipartReader:
             await reader.release()
             assert reader.at_eof()
 
-    async def test_release_next(self, newline: Any) -> None:
-        with Stream(b"--:%s\r\necho%s--:--" % (newline, newline)) as stream:
+    async def test_release_next(self) -> None:
+        with Stream(b"--:\r\n\r\necho\r\n--:--") as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
                 stream,
@@ -865,19 +676,15 @@ class TestMultipartReader:
             res = await reader.next()
             assert res is None
 
-    async def test_second_next_releases_previous_object(self, newline: Any) -> None:
+    async def test_second_next_releases_previous_object(self) -> None:
         with Stream(
-            newline.join(
-                [
-                    b"--:",
-                    b"",
-                    b"test",
-                    b"--:",
-                    b"",
-                    b"passed",
-                    b"--:--",
-                ]
-            )
+            b"--:\r\n"
+            b"\r\n"
+            b"test\r\n"
+            b"--:\r\n"
+            b"\r\n"
+            b"passed\r\n"
+            b"--:--"
         ) as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
@@ -889,19 +696,15 @@ class TestMultipartReader:
             assert first.at_eof()
             assert not second.at_eof()
 
-    async def test_release_without_read_the_last_object(self, newline: Any) -> None:
+    async def test_release_without_read_the_last_object(self) -> None:
         with Stream(
-            newline.join(
-                [
-                    b"--:",
-                    b"",
-                    b"test",
-                    b"--:",
-                    b"",
-                    b"passed",
-                    b"--:--",
-                ]
-            )
+            b"--:\r\n"
+            b"\r\n"
+            b"test\r\n"
+            b"--:\r\n"
+            b"\r\n"
+            b"passed\r\n"
+            b"--:--"
         ) as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
@@ -916,23 +719,15 @@ class TestMultipartReader:
             assert second.at_eof()
             assert third is None
 
-    async def test_read_chunk_by_length_doesnt_breaks_reader(
-        self, newline: Any
-    ) -> None:
+    async def test_read_chunk_by_length_doesnt_break_reader(self) -> None:
         with Stream(
-            newline.join(
-                [
-                    b"--:",
-                    b"Content-Length: 4",
-                    b"",
-                    b"test",
-                    b"--:",
-                    b"Content-Length: 6",
-                    b"",
-                    b"passed",
-                    b"--:--",
-                ]
-            )
+            b"--:\r\n"
+            b"Content-Length: 4\r\n\r\n"
+            b"test"
+            b"\r\n--:\r\n"
+            b"Content-Length: 6\r\n\r\n"
+            b"passed"
+            b"\r\n--:--"
         ) as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
@@ -950,21 +745,15 @@ class TestMultipartReader:
 
         assert body_parts == [b"test", b"passed"]
 
-    async def test_read_chunk_from_stream_doesnt_breaks_reader(
-        self, newline: Any
-    ) -> None:
+    async def test_read_chunk_from_stream_doesnt_break_reader(self) -> None:
         with Stream(
-            newline.join(
-                [
-                    b"--:",
-                    b"",
-                    b"chunk",
-                    b"--:",
-                    b"",
-                    b"two_chunks",
-                    b"--:--",
-                ]
-            )
+            b"--:\r\n"
+            b"\r\n"
+            b"chunk"
+            b"\r\n--:\r\n"
+            b"\r\n"
+            b"two_chunks"
+            b"\r\n--:--"
         ) as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
@@ -984,21 +773,17 @@ class TestMultipartReader:
 
         assert body_parts == [b"chunk", b"two_chunks"]
 
-    async def test_reading_skips_prelude(self, newline: Any) -> None:
+    async def test_reading_skips_prelude(self) -> None:
         with Stream(
-            newline.join(
-                [
-                    b"Multi-part data is not supported.",
-                    b"",
-                    b"--:",
-                    b"",
-                    b"test",
-                    b"--:",
-                    b"",
-                    b"passed",
-                    b"--:--",
-                ]
-            )
+            b"Multi-part data is not supported.\r\n"
+            b"\r\n"
+            b"--:\r\n"
+            b"\r\n"
+            b"test\r\n"
+            b"--:\r\n"
+            b"\r\n"
+            b"passed\r\n"
+            b"--:--"
         ) as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
@@ -1010,39 +795,6 @@ class TestMultipartReader:
 
             assert first.at_eof()
             assert not second.at_eof()
-
-    async def test_read_mixed_newlines(self) -> None:
-        with Stream(
-            b"".join(
-                [
-                    b"--:\n",
-                    b"Content-Type: multipart/related;boundary=--:--\n",
-                    b"\n",
-                    b"----:--\r\n",
-                    b"\r\n",
-                    b"test\r\n",
-                    b"----:--\r\n",
-                    b"\r\n",
-                    b"passed\r\n",
-                    b"----:----\r\n",
-                    b"\n",
-                    b"--:--",
-                ]
-            )
-        ) as stream:
-            reader = aiohttp.MultipartReader(
-                {CONTENT_TYPE: 'multipart/mixed;boundary=":"'},
-                stream,
-            )
-            while True:
-                part = await reader.next()
-                if part is None:
-                    break
-                while True:
-                    subpart = await part.next()
-                    if subpart is None:
-                        break
-
 
 async def test_writer(writer: Any) -> None:
     assert writer.size == 7

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -295,7 +295,9 @@ class TestPartReader:
 
     async def test_read_with_content_encoding_deflate(self) -> None:
         with Stream(b"\x0b\xc9\xccMU(\xc9W\x08J\xcdI\xacP\x04\x00\r\n--:--") as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_ENCODING: "deflate"}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_ENCODING: "deflate"}, stream
+            )
             result = await obj.read(decode=True)
         assert b"Time to Relax!" == result
 
@@ -306,7 +308,9 @@ class TestPartReader:
             b"\r\n"
         )
         with Stream(thing + b"--:--") as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_ENCODING: "identity"}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_ENCODING: "identity"}, stream
+            )
             result = await obj.read(decode=True)
         assert thing[:-2] == result
 
@@ -318,13 +322,17 @@ class TestPartReader:
 
     async def test_read_with_content_transfer_encoding_base64(self) -> None:
         with Stream(b"VGltZSB0byBSZWxheCE=\r\n--:--") as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TRANSFER_ENCODING: "base64"}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_TRANSFER_ENCODING: "base64"}, stream
+            )
             result = await obj.read(decode=True)
         assert b"Time to Relax!" == result
 
     async def test_decode_with_content_transfer_encoding_base64(self) -> None:
         with Stream(b"VG\r\r\nltZSB0byBSZ\r\nWxheCE=\r\n--:--") as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TRANSFER_ENCODING: "base64"}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_TRANSFER_ENCODING: "base64"}, stream
+            )
             result = b""
             while not obj.at_eof():
                 chunk = await obj.read_chunk(size=6)
@@ -333,10 +341,11 @@ class TestPartReader:
 
     async def test_read_with_content_transfer_encoding_quoted_printable(self) -> None:
         with Stream(
-            b"=D0=9F=D1=80=D0=B8=D0=B2=D0=B5=D1=82,"
-            b" =D0=BC=D0=B8=D1=80!\r\n--:--"
+            b"=D0=9F=D1=80=D0=B8=D0=B2=D0=B5=D1=82," b" =D0=BC=D0=B8=D1=80!\r\n--:--"
         ) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TRANSFER_ENCODING: "quoted-printable"}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_TRANSFER_ENCODING: "quoted-printable"}, stream
+            )
             result = await obj.read(decode=True)
         expected = (
             b"\xd0\x9f\xd1\x80\xd0\xb8\xd0\xb2\xd0\xb5\xd1\x82,"
@@ -353,13 +362,17 @@ class TestPartReader:
             b" \xd0\xbc\xd0\xb8\xd1\x80!"
         )
         with Stream(data + b"\r\n--:--") as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TRANSFER_ENCODING: encoding}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_TRANSFER_ENCODING: encoding}, stream
+            )
             result = await obj.read(decode=True)
         assert data == result
 
     async def test_read_with_content_transfer_encoding_unknown(self) -> None:
         with Stream(b"\x0e4Time to Relax!\r\n--:--") as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TRANSFER_ENCODING: "unknown"}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_TRANSFER_ENCODING: "unknown"}, stream
+            )
             with pytest.raises(RuntimeError):
                 await obj.read(decode=True)
 
@@ -370,7 +383,7 @@ class TestPartReader:
         assert "Hello, world!" == result
 
     async def test_read_text_default_encoding(self) -> None:
-        with Stream("Привет, Мир!\r\n--:--".encode("utf-8")) as stream:
+        with Stream("Привет, Мир!\r\n--:--".encode()) as stream:
             obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
             result = await obj.text()
         assert "Привет, Мир!" == result
@@ -383,7 +396,9 @@ class TestPartReader:
 
     async def test_read_text_guess_encoding(self) -> None:
         with Stream("Привет, Мир!\r\n--:--".encode("cp1251")) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "text/plain;charset=cp1251"}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_TYPE: "text/plain;charset=cp1251"}, stream
+            )
             result = await obj.text()
         assert "Привет, Мир!" == result
 
@@ -392,7 +407,7 @@ class TestPartReader:
             obj = aiohttp.BodyPartReader(
                 BOUNDARY,
                 {CONTENT_ENCODING: "deflate", CONTENT_TYPE: "text/plain"},
-                stream
+                stream,
             )
             result = await obj.text()
         assert "Time to Relax!" == result
@@ -406,19 +421,25 @@ class TestPartReader:
 
     async def test_read_json(self) -> None:
         with Stream(b'{"test": "passed"}\r\n--:--') as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "application/json"}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_TYPE: "application/json"}, stream
+            )
             result = await obj.json()
         assert {"test": "passed"} == result
 
     async def test_read_json_encoding(self) -> None:
         with Stream('{"тест": "пассед"}\r\n--:--'.encode("cp1251")) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "application/json"}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_TYPE: "application/json"}, stream
+            )
             result = await obj.json(encoding="cp1251")
         assert {"тест": "пассед"} == result
 
     async def test_read_json_guess_encoding(self) -> None:
         with Stream('{"тест": "пассед"}\r\n--:--'.encode("cp1251")) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "application/json; charset=cp1251"}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_TYPE: "application/json; charset=cp1251"}, stream
+            )
             result = await obj.json()
         assert {"тест": "пассед"} == result
 
@@ -443,13 +464,17 @@ class TestPartReader:
 
     async def test_read_form(self) -> None:
         with Stream(b"foo=bar&foo=baz&boo=\r\n--:--") as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "application/x-www-form-urlencoded"}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_TYPE: "application/x-www-form-urlencoded"}, stream
+            )
             result = await obj.form()
         assert [("foo", "bar"), ("foo", "baz"), ("boo", "")] == result
 
     async def test_read_form_invalid_utf8(self) -> None:
         with Stream(b"\xff\r\n--:--") as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "application/x-www-form-urlencoded"}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_TYPE: "application/x-www-form-urlencoded"}, stream
+            )
             with pytest.raises(
                 ValueError, match="data cannot be decoded with utf-8 encoding"
             ):
@@ -457,7 +482,9 @@ class TestPartReader:
 
     async def test_read_form_encoding(self) -> None:
         with Stream("foo=bar&foo=baz&boo=\r\n--:--".encode("cp1251")) as stream:
-            obj = aiohttp.BodyPartReader(BOUNDARY, {CONTENT_TYPE: "application/x-www-form-urlencoded"}, stream)
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY, {CONTENT_TYPE: "application/x-www-form-urlencoded"}, stream
+            )
             result = await obj.form(encoding="cp1251")
         assert [("foo", "bar"), ("foo", "baz"), ("boo", "")] == result
 
@@ -678,13 +705,7 @@ class TestMultipartReader:
 
     async def test_second_next_releases_previous_object(self) -> None:
         with Stream(
-            b"--:\r\n"
-            b"\r\n"
-            b"test\r\n"
-            b"--:\r\n"
-            b"\r\n"
-            b"passed\r\n"
-            b"--:--"
+            b"--:\r\n" b"\r\n" b"test\r\n" b"--:\r\n" b"\r\n" b"passed\r\n" b"--:--"
         ) as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
@@ -698,13 +719,7 @@ class TestMultipartReader:
 
     async def test_release_without_read_the_last_object(self) -> None:
         with Stream(
-            b"--:\r\n"
-            b"\r\n"
-            b"test\r\n"
-            b"--:\r\n"
-            b"\r\n"
-            b"passed\r\n"
-            b"--:--"
+            b"--:\r\n" b"\r\n" b"test\r\n" b"--:\r\n" b"\r\n" b"passed\r\n" b"--:--"
         ) as stream:
             reader = aiohttp.MultipartReader(
                 {CONTENT_TYPE: 'multipart/related;boundary=":"'},
@@ -795,6 +810,7 @@ class TestMultipartReader:
 
             assert first.at_eof()
             assert not second.at_eof()
+
 
 async def test_writer(writer: Any) -> None:
     assert writer.size == 7


### PR DESCRIPTION
#3492 was never backported and nobody seems to have reported the missing feature after 5 years which suggests there is little demand for it.

Furthermore, there is a risk that this may introduce HTTP request smuggling vulnerabilities.

Therefore, we should revert this for now. If there is desire to re-add the feature, the specs will need to referenced and evaluated to ensure this doesn't present a security issue.