### PR TITLE
Check for backports in CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,6 +26,15 @@ env:
 
 permissions: {}
 jobs:
+  backport:
+    runs-on: ubuntu-latest
+    name: Backport label added?
+    if: ${{ github.ref == 'refs/heads/master' }}
+    steps:
+    - name: Check labels
+      env:
+        LABELS: ${{ github.event.pull_request.labels }}
+      run: echo "$LABELS" | grep -q 'backport'
 
   lint:
     permissions:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,9 +32,7 @@ jobs:
     if: ${{ github.base_ref == 'master' }}
     steps:
     - name: Check labels
-      env:
-        LABELS: ${{ github.event.pull_request.labels }}
-      run: echo "$LABELS" | grep -q 'backport'
+      run: echo "${{ github.event.pull_request.labels }}" | grep -q 'backport'
 
   lint:
     permissions:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,7 +29,7 @@ jobs:
   backport:
     runs-on: ubuntu-latest
     name: Backport label added?
-    if: ${{ "$GITHUB_BASE_REF" == 'master' }}
+    if: ${{ github.ref == 'refs/heads/master' }}
     steps:
     - name: Check labels
       env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,7 +29,7 @@ jobs:
   backport:
     runs-on: ubuntu-latest
     name: Backport label added?
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ "$GITHUB_BASE_REF" == 'master' }}
     steps:
     - name: Check labels
       env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -29,7 +29,7 @@ jobs:
   backport:
     runs-on: ubuntu-latest
     name: Backport label added?
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.base_ref == 'master' }}
     steps:
     - name: Check labels
       env:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,19 +26,6 @@ env:
 
 permissions: {}
 jobs:
-  backport:
-    runs-on: ubuntu-latest
-    name: Backport label added?
-    if: ${{ github.base_ref == 'master' }}
-    steps:
-    - name: Check labels
-      run: |
-        for label in "${{ github.event.pull_request.labels }}"; do
-            case $label in backport*)
-                exit 0
-            esac
-        done
-        exit 1
 
   lint:
     permissions:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,7 +32,13 @@ jobs:
     if: ${{ github.base_ref == 'master' }}
     steps:
     - name: Check labels
-      run: echo "${{ github.event.pull_request.labels }}" | grep -q 'backport'
+      run: |
+        for label in "${{ github.event.pull_request.labels }}"; do
+            case $label in backport*)
+                exit 0
+            esac
+        done
+        exit 1
 
   lint:
     permissions:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -19,5 +19,6 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number
             });
-            if (!pr.labels.find(l => l.name.startsWith("backport")))
+            console.log(pr);
+            if (!pr.data.labels.find(l => l.name.startsWith("backport")))
               process.exit(1);

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pr = await github.pulls.get({
+            const pr = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - name: Check labels
       run: |
-        for label in "${{ github.event.pull_request.labels }}"; do
+        for label in ${{ github.event.pull_request.labels }}; do
             case $label in backport*)
                 exit 0
             esac

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,11 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     name: Backport label added
     steps:
-    - name: Check labels
-      run: |
-        for label in ${{ github.event.pull_request.labels }}; do
-            case $label in backport*)
-                exit 0
-            esac
-        done
-        exit 1
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const labels = await github.pulls.listLabelsOnPullRequest({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.pull_request.number
+            });
+            if (!labels.data.find(l => l.name.startsWith("backport")))
+              process.exit(1);

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,20 @@
+name: Labels
+on:
+  pull_request:
+    branches:
+      - 'master'
+    types: [labeled, opened]
+
+jobs:
+  backport:
+    runs-on: ubuntu-latest
+    name: Backport label added
+    steps:
+    - name: Check labels
+      run: |
+        for label in "${{ github.event.pull_request.labels }}"; do
+            case $label in backport*)
+                exit 0
+            esac
+        done
+        exit 1

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - 'master'
-    types: [labeled, opened, unlabeled]
+    types: [labeled, opened, synchronize, reopened, unlabeled]
 
 jobs:
   backport:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - 'master'
-    types: [labeled, opened]
+    types: [labeled, opened, unlabeled]
 
 jobs:
   backport:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -19,5 +19,5 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number
             });
-            if (!pr.labels.data.find(l => l.name.startsWith("backport")))
+            if (!pr.labels.find(l => l.name.startsWith("backport")))
               process.exit(1);

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const labels = await github.pulls.listLabelsOnPullRequest({
+            const pr = await github.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number
             });
-            if (!labels.data.find(l => l.name.startsWith("backport")))
+            if (!pr.labels.data.find(l => l.name.startsWith("backport")))
               process.exit(1);

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -19,6 +19,5 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number
             });
-            console.log(pr);
             if (!pr.data.labels.find(l => l.name.startsWith("backport")))
               process.exit(1);


### PR DESCRIPTION
Add a check for backport labels due to several PRs having missed backports by mistake.
We have a backport:skip label if we explicitly don't want to backport a PR.