### PR TITLE
Improve reliability of run_app test

### DIFF
--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -931,9 +931,9 @@ class TestShutdown:
 
     def run_app(self, port: int, timeout: int, task, extra_test=None) -> asyncio.Task:
         async def test() -> None:
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.5)
             async with ClientSession() as sess:
-                while True:
+                for _ in range(5):
                     try:
                         async with sess.get(f"http://localhost:{port}/"):
                             pass

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -933,8 +933,14 @@ class TestShutdown:
         async def test() -> None:
             await asyncio.sleep(1)
             async with ClientSession() as sess:
-                async with sess.get(f"http://localhost:{port}/"):
-                    pass
+                while True:
+                    try:
+                        async with sess.get(f"http://localhost:{port}/"):
+                            pass
+                    except aiohttp.ClientConnectorError:
+                        await asyncio.sleep(0.5)
+                    else:
+                        break
                 async with sess.get(f"http://localhost:{port}/stop"):
                     pass
 

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -937,7 +937,7 @@ class TestShutdown:
                     try:
                         async with sess.get(f"http://localhost:{port}/"):
                             pass
-                    except aiohttp.ClientConnectorError:
+                    except ClientConnectorError:
                         await asyncio.sleep(0.5)
                     else:
                         break

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -933,7 +933,7 @@ class TestShutdown:
         async def test() -> None:
             await asyncio.sleep(0.5)
             async with ClientSession() as sess:
-                for _ in range(5):
+                for _ in range(5):  # pragma: no cover
                     try:
                         async with sess.get(f"http://localhost:{port}/"):
                             pass


### PR DESCRIPTION
Have seen a flaky test failure where the server failed to accept the request in time, on mac.