### PR TITLE
Add set_content_disposition test

### DIFF
--- a/CHANGES/8332.bugfix.rst
+++ b/CHANGES/8332.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed regression with adding Content-Disposition to form-data part after appending to writer -- by :user:`Dreamsorcerer`/:user:`Olegt0rr`.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -957,8 +957,8 @@ class MultipartWriter(Payload):
         for part, encoding, te_encoding in self._parts:
             if self._is_form_data:
                 # https://datatracker.ietf.org/doc/html/rfc7578#section-4.2
-                assert CONTENT_DISPOSITION in part.payload.headers
-                assert "name=" in part.payload.headers[CONTENT_DISPOSITION]
+                assert CONTENT_DISPOSITION in part.headers
+                assert "name=" in part.headers[CONTENT_DISPOSITION]
 
             await writer.write(b"--" + self._boundary + b"\r\n")
             await writer.write(part._binary_headers)

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -875,8 +875,6 @@ class MultipartWriter(Payload):
         if self._is_form_data:
             # https://datatracker.ietf.org/doc/html/rfc7578#section-4.7
             # https://datatracker.ietf.org/doc/html/rfc7578#section-4.8
-            assert CONTENT_DISPOSITION in payload.headers
-            assert "name=" in payload.headers[CONTENT_DISPOSITION]
             assert (
                 not {CONTENT_ENCODING, CONTENT_LENGTH, CONTENT_TRANSFER_ENCODING}
                 & payload.headers.keys()
@@ -957,6 +955,11 @@ class MultipartWriter(Payload):
     async def write(self, writer: Any, close_boundary: bool = True) -> None:
         """Write body."""
         for part, encoding, te_encoding in self._parts:
+            if self._is_form_data:
+                # https://datatracker.ietf.org/doc/html/rfc7578#section-4.2
+                assert CONTENT_DISPOSITION in part.payload.headers
+                assert "name=" in part.payload.headers[CONTENT_DISPOSITION]
+
             await writer.write(b"--" + self._boundary + b"\r\n")
             await writer.write(part._binary_headers)
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -3,11 +3,11 @@ import asyncio
 import io
 import json
 import pathlib
-import zlib
 from typing import Any, Optional
 from unittest import mock
 
 import pytest
+import zlib
 
 import aiohttp
 from aiohttp import payload
@@ -163,7 +163,6 @@ class TestPartReader:
 
     async def test_read_incomplete_chunk(self) -> None:
         with Stream(b"") as stream:
-
             def prepare(data):
                 return data
 
@@ -205,7 +204,6 @@ class TestPartReader:
 
     async def test_read_boundary_with_incomplete_chunk(self) -> None:
         with Stream(b"") as stream:
-
             def prepare(data):
                 return data
 
@@ -550,9 +548,9 @@ class TestPartReader:
         assert "foo.html" == part.filename
 
     async def test_reading_long_part(self) -> None:
-        size = 2 * 2**16
+        size = 2 * 2 ** 16
         protocol = mock.Mock(_reading_paused=False)
-        stream = StreamReader(protocol, 2**16, loop=asyncio.get_event_loop())
+        stream = StreamReader(protocol, 2 ** 16, loop=asyncio.get_event_loop())
         stream.feed_data(b"0" * size + b"\r\n--:--")
         stream.feed_eof()
         obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
@@ -875,7 +873,7 @@ async def test_writer_serialize_io_chunk(buf: Any, stream: Any, writer: Any) -> 
         await writer.write(stream)
     assert (
         buf == b"--:\r\nContent-Type: application/octet-stream"
-        b"\r\nContent-Length: 9\r\n\r\nfoobarbaz\r\n--:--\r\n"
+               b"\r\nContent-Length: 9\r\n\r\nfoobarbaz\r\n--:--\r\n"
     )
 
 
@@ -917,37 +915,37 @@ async def test_writer_write(buf: Any, stream: Any, writer: Any) -> None:
     await writer.write(stream)
 
     assert (
-        b"--:\r\n"
-        b"Content-Type: text/plain; charset=utf-8\r\n"
-        b"Content-Length: 11\r\n\r\n"
-        b"foo-bar-baz"
-        b"\r\n"
-        b"--:\r\n"
-        b"Content-Type: application/json\r\n"
-        b"Content-Length: 18\r\n\r\n"
-        b'{"test": "passed"}'
-        b"\r\n"
-        b"--:\r\n"
-        b"Content-Type: application/x-www-form-urlencoded\r\n"
-        b"Content-Length: 11\r\n\r\n"
-        b"test=passed"
-        b"\r\n"
-        b"--:\r\n"
-        b"Content-Type: application/x-www-form-urlencoded\r\n"
-        b"Content-Length: 11\r\n\r\n"
-        b"one=1&two=2"
-        b"\r\n"
-        b"--:\r\n"
-        b'Content-Type: multipart/mixed; boundary="::"\r\n'
-        b"X-CUSTOM: test\r\nContent-Length: 93\r\n\r\n"
-        b"--::\r\n"
-        b"Content-Type: text/plain; charset=utf-8\r\n"
-        b"Content-Length: 14\r\n\r\n"
-        b"nested content\r\n"
-        b"--::--\r\n"
-        b"\r\n"
-        b"--:--\r\n"
-    ) == bytes(buf)
+               b"--:\r\n"
+               b"Content-Type: text/plain; charset=utf-8\r\n"
+               b"Content-Length: 11\r\n\r\n"
+               b"foo-bar-baz"
+               b"\r\n"
+               b"--:\r\n"
+               b"Content-Type: application/json\r\n"
+               b"Content-Length: 18\r\n\r\n"
+               b'{"test": "passed"}'
+               b"\r\n"
+               b"--:\r\n"
+               b"Content-Type: application/x-www-form-urlencoded\r\n"
+               b"Content-Length: 11\r\n\r\n"
+               b"test=passed"
+               b"\r\n"
+               b"--:\r\n"
+               b"Content-Type: application/x-www-form-urlencoded\r\n"
+               b"Content-Length: 11\r\n\r\n"
+               b"one=1&two=2"
+               b"\r\n"
+               b"--:\r\n"
+               b'Content-Type: multipart/mixed; boundary="::"\r\n'
+               b"X-CUSTOM: test\r\nContent-Length: 93\r\n\r\n"
+               b"--::\r\n"
+               b"Content-Type: text/plain; charset=utf-8\r\n"
+               b"Content-Length: 14\r\n\r\n"
+               b"nested content\r\n"
+               b"--::--\r\n"
+               b"\r\n"
+               b"--:--\r\n"
+           ) == bytes(buf)
 
 
 async def test_writer_write_no_close_boundary(buf: Any, stream: Any) -> None:
@@ -959,27 +957,27 @@ async def test_writer_write_no_close_boundary(buf: Any, stream: Any) -> None:
     await writer.write(stream, close_boundary=False)
 
     assert (
-        b"--:\r\n"
-        b"Content-Type: text/plain; charset=utf-8\r\n"
-        b"Content-Length: 11\r\n\r\n"
-        b"foo-bar-baz"
-        b"\r\n"
-        b"--:\r\n"
-        b"Content-Type: application/json\r\n"
-        b"Content-Length: 18\r\n\r\n"
-        b'{"test": "passed"}'
-        b"\r\n"
-        b"--:\r\n"
-        b"Content-Type: application/x-www-form-urlencoded\r\n"
-        b"Content-Length: 11\r\n\r\n"
-        b"test=passed"
-        b"\r\n"
-        b"--:\r\n"
-        b"Content-Type: application/x-www-form-urlencoded\r\n"
-        b"Content-Length: 11\r\n\r\n"
-        b"one=1&two=2"
-        b"\r\n"
-    ) == bytes(buf)
+               b"--:\r\n"
+               b"Content-Type: text/plain; charset=utf-8\r\n"
+               b"Content-Length: 11\r\n\r\n"
+               b"foo-bar-baz"
+               b"\r\n"
+               b"--:\r\n"
+               b"Content-Type: application/json\r\n"
+               b"Content-Length: 18\r\n\r\n"
+               b'{"test": "passed"}'
+               b"\r\n"
+               b"--:\r\n"
+               b"Content-Type: application/x-www-form-urlencoded\r\n"
+               b"Content-Length: 11\r\n\r\n"
+               b"test=passed"
+               b"\r\n"
+               b"--:\r\n"
+               b"Content-Type: application/x-www-form-urlencoded\r\n"
+               b"Content-Length: 11\r\n\r\n"
+               b"one=1&two=2"
+               b"\r\n"
+           ) == bytes(buf)
 
 
 async def test_writer_write_no_parts(buf: Any, stream: Any, writer: Any) -> None:
@@ -1345,6 +1343,12 @@ async def test_async_for_reader() -> None:
                     await check(part)
 
         await check(reader)
+
+
+async def test_set_content_disposition():
+    writer = aiohttp.MultipartWriter("form-data")
+    payload = writer.append("some-data")
+    payload.set_content_disposition("form-data", name="method")
 
 
 async def test_async_for_bodypart() -> None:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1169,6 +1169,8 @@ class TestMultipartWriter:
         writer = aiohttp.MultipartWriter("form-data")
         payload = writer.append("some-data")
         payload.set_content_disposition("form-data", name="method")
+        assert CONTENT_DISPOSITION in payload.headers
+        assert "name=" in payload.headers[CONTENT_DISPOSITION]
 
     def test_with(self) -> None:
         with aiohttp.MultipartWriter(boundary=":") as writer:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1165,7 +1165,7 @@ class TestMultipartWriter:
         part = writer._parts[0][0]
         assert part.headers[CONTENT_TYPE] == "test/passed"
 
-    async def test_set_content_disposition(self):
+    async def test_set_content_disposition_after_append(self):
         writer = aiohttp.MultipartWriter("form-data")
         payload = writer.append("some-data")
         payload.set_content_disposition("form-data", name="method")

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1165,6 +1165,11 @@ class TestMultipartWriter:
         part = writer._parts[0][0]
         assert part.headers[CONTENT_TYPE] == "test/passed"
 
+    async def test_set_content_disposition(self):
+        writer = aiohttp.MultipartWriter("form-data")
+        payload = writer.append("some-data")
+        payload.set_content_disposition("form-data", name="method")
+
     def test_with(self) -> None:
         with aiohttp.MultipartWriter(boundary=":") as writer:
             writer.append("foo")
@@ -1345,12 +1350,6 @@ async def test_async_for_reader() -> None:
                     await check(part)
 
         await check(reader)
-
-
-async def test_set_content_disposition():
-    writer = aiohttp.MultipartWriter("form-data")
-    payload = writer.append("some-data")
-    payload.set_content_disposition("form-data", name="method")
 
 
 async def test_async_for_bodypart() -> None:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -3,11 +3,11 @@ import asyncio
 import io
 import json
 import pathlib
+import zlib
 from typing import Any, Optional
 from unittest import mock
 
 import pytest
-import zlib
 
 import aiohttp
 from aiohttp import payload
@@ -163,6 +163,7 @@ class TestPartReader:
 
     async def test_read_incomplete_chunk(self) -> None:
         with Stream(b"") as stream:
+
             def prepare(data):
                 return data
 
@@ -204,6 +205,7 @@ class TestPartReader:
 
     async def test_read_boundary_with_incomplete_chunk(self) -> None:
         with Stream(b"") as stream:
+
             def prepare(data):
                 return data
 
@@ -548,9 +550,9 @@ class TestPartReader:
         assert "foo.html" == part.filename
 
     async def test_reading_long_part(self) -> None:
-        size = 2 * 2 ** 16
+        size = 2 * 2**16
         protocol = mock.Mock(_reading_paused=False)
-        stream = StreamReader(protocol, 2 ** 16, loop=asyncio.get_event_loop())
+        stream = StreamReader(protocol, 2**16, loop=asyncio.get_event_loop())
         stream.feed_data(b"0" * size + b"\r\n--:--")
         stream.feed_eof()
         obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
@@ -873,7 +875,7 @@ async def test_writer_serialize_io_chunk(buf: Any, stream: Any, writer: Any) -> 
         await writer.write(stream)
     assert (
         buf == b"--:\r\nContent-Type: application/octet-stream"
-               b"\r\nContent-Length: 9\r\n\r\nfoobarbaz\r\n--:--\r\n"
+        b"\r\nContent-Length: 9\r\n\r\nfoobarbaz\r\n--:--\r\n"
     )
 
 
@@ -915,37 +917,37 @@ async def test_writer_write(buf: Any, stream: Any, writer: Any) -> None:
     await writer.write(stream)
 
     assert (
-               b"--:\r\n"
-               b"Content-Type: text/plain; charset=utf-8\r\n"
-               b"Content-Length: 11\r\n\r\n"
-               b"foo-bar-baz"
-               b"\r\n"
-               b"--:\r\n"
-               b"Content-Type: application/json\r\n"
-               b"Content-Length: 18\r\n\r\n"
-               b'{"test": "passed"}'
-               b"\r\n"
-               b"--:\r\n"
-               b"Content-Type: application/x-www-form-urlencoded\r\n"
-               b"Content-Length: 11\r\n\r\n"
-               b"test=passed"
-               b"\r\n"
-               b"--:\r\n"
-               b"Content-Type: application/x-www-form-urlencoded\r\n"
-               b"Content-Length: 11\r\n\r\n"
-               b"one=1&two=2"
-               b"\r\n"
-               b"--:\r\n"
-               b'Content-Type: multipart/mixed; boundary="::"\r\n'
-               b"X-CUSTOM: test\r\nContent-Length: 93\r\n\r\n"
-               b"--::\r\n"
-               b"Content-Type: text/plain; charset=utf-8\r\n"
-               b"Content-Length: 14\r\n\r\n"
-               b"nested content\r\n"
-               b"--::--\r\n"
-               b"\r\n"
-               b"--:--\r\n"
-           ) == bytes(buf)
+        b"--:\r\n"
+        b"Content-Type: text/plain; charset=utf-8\r\n"
+        b"Content-Length: 11\r\n\r\n"
+        b"foo-bar-baz"
+        b"\r\n"
+        b"--:\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: 18\r\n\r\n"
+        b'{"test": "passed"}'
+        b"\r\n"
+        b"--:\r\n"
+        b"Content-Type: application/x-www-form-urlencoded\r\n"
+        b"Content-Length: 11\r\n\r\n"
+        b"test=passed"
+        b"\r\n"
+        b"--:\r\n"
+        b"Content-Type: application/x-www-form-urlencoded\r\n"
+        b"Content-Length: 11\r\n\r\n"
+        b"one=1&two=2"
+        b"\r\n"
+        b"--:\r\n"
+        b'Content-Type: multipart/mixed; boundary="::"\r\n'
+        b"X-CUSTOM: test\r\nContent-Length: 93\r\n\r\n"
+        b"--::\r\n"
+        b"Content-Type: text/plain; charset=utf-8\r\n"
+        b"Content-Length: 14\r\n\r\n"
+        b"nested content\r\n"
+        b"--::--\r\n"
+        b"\r\n"
+        b"--:--\r\n"
+    ) == bytes(buf)
 
 
 async def test_writer_write_no_close_boundary(buf: Any, stream: Any) -> None:
@@ -957,27 +959,27 @@ async def test_writer_write_no_close_boundary(buf: Any, stream: Any) -> None:
     await writer.write(stream, close_boundary=False)
 
     assert (
-               b"--:\r\n"
-               b"Content-Type: text/plain; charset=utf-8\r\n"
-               b"Content-Length: 11\r\n\r\n"
-               b"foo-bar-baz"
-               b"\r\n"
-               b"--:\r\n"
-               b"Content-Type: application/json\r\n"
-               b"Content-Length: 18\r\n\r\n"
-               b'{"test": "passed"}'
-               b"\r\n"
-               b"--:\r\n"
-               b"Content-Type: application/x-www-form-urlencoded\r\n"
-               b"Content-Length: 11\r\n\r\n"
-               b"test=passed"
-               b"\r\n"
-               b"--:\r\n"
-               b"Content-Type: application/x-www-form-urlencoded\r\n"
-               b"Content-Length: 11\r\n\r\n"
-               b"one=1&two=2"
-               b"\r\n"
-           ) == bytes(buf)
+        b"--:\r\n"
+        b"Content-Type: text/plain; charset=utf-8\r\n"
+        b"Content-Length: 11\r\n\r\n"
+        b"foo-bar-baz"
+        b"\r\n"
+        b"--:\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: 18\r\n\r\n"
+        b'{"test": "passed"}'
+        b"\r\n"
+        b"--:\r\n"
+        b"Content-Type: application/x-www-form-urlencoded\r\n"
+        b"Content-Length: 11\r\n\r\n"
+        b"test=passed"
+        b"\r\n"
+        b"--:\r\n"
+        b"Content-Type: application/x-www-form-urlencoded\r\n"
+        b"Content-Length: 11\r\n\r\n"
+        b"one=1&two=2"
+        b"\r\n"
+    ) == bytes(buf)
 
 
 async def test_writer_write_no_parts(buf: Any, stream: Any, writer: Any) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add tests, checking `set_content_disposition()` case works properly


## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

Relates #8326

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
