### PR TITLE
Backport tests 3.9

### DIFF
--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -6,6 +6,7 @@ import json
 from http.cookies import SimpleCookie
 from typing import Any, List
 from unittest import mock
+from uuid import uuid4
 
 import pytest
 from multidict import CIMultiDict, MultiDict
@@ -895,3 +896,23 @@ async def test_instantiation_with_invalid_timeout_value(loop):
         ClientSession(timeout=1)
     # should not have "Unclosed client session" warning
     assert not logs
+
+
+@pytest.mark.parametrize(
+    ("outer_name", "inner_name"),
+    [
+        ("skip_auto_headers", "_skip_auto_headers"),
+        ("auth", "_default_auth"),
+        ("json_serialize", "_json_serialize"),
+        ("connector_owner", "_connector_owner"),
+        ("raise_for_status", "_raise_for_status"),
+        ("trust_env", "_trust_env"),
+        ("trace_configs", "_trace_configs"),
+    ],
+)
+async def test_properties(
+    session: ClientSession, outer_name: str, inner_name: str
+) -> None:
+    value = uuid4()
+    setattr(session, inner_name, value)
+    assert value == getattr(session, outer_name)

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -6,6 +6,7 @@ import pytest
 import aiohttp
 from aiohttp import hdrs, web
 from aiohttp.http import WSCloseCode
+from aiohttp.pytest_plugin import AiohttpClient
 
 if sys.version_info >= (3, 11):
     import asyncio as async_timeout
@@ -835,3 +836,11 @@ async def test_peer_connection_lost_iter(aiohttp_client) -> None:
         assert "answer" == msg.data
 
     await resp.close()
+
+
+async def test_ws_connect_with_wrong_ssl_type(aiohttp_client: AiohttpClient) -> None:
+    app = web.Application()
+    session = await aiohttp_client(app)
+
+    with pytest.raises(TypeError, match="ssl should be SSLContext, .*"):
+        await session.ws_connect("/", ssl=42)

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -259,7 +259,7 @@ async def test_test_client_props(loop) -> None:
 
 async def test_test_client_raw_server_props(loop) -> None:
     async def hello(request):
-        return web.Response(body=_hello_world_bytes)
+        return web.Response()  # pragma: no cover
 
     client = _TestClient(_RawTestServer(hello, host="127.0.0.1", loop=loop), loop=loop)
     assert client.host == "127.0.0.1"

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -331,7 +331,7 @@ def test_app_run_middlewares() -> None:
 
     @web.middleware
     async def middleware(request: web.Request, handler: Handler) -> web.StreamResponse:
-        return await handler(request)
+        return await handler(request)  # pragma: no cover
 
     root = web.Application(middlewares=[middleware])
     sub = web.Application()

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -1,3 +1,4 @@
+# type: ignore
 import asyncio
 import platform
 import signal
@@ -7,6 +8,7 @@ from unittest.mock import patch
 import pytest
 
 from aiohttp import web
+from aiohttp.abc import AbstractAccessLogger
 from aiohttp.test_utils import get_unused_port_socket
 
 
@@ -16,7 +18,7 @@ def app():
 
 
 @pytest.fixture
-def make_runner(loop, app):
+def make_runner(loop: Any, app: Any):
     asyncio.set_event_loop(loop)
     runners = []
 
@@ -30,7 +32,7 @@ def make_runner(loop, app):
         loop.run_until_complete(runner.cleanup())
 
 
-async def test_site_for_nonfrozen_app(make_runner) -> None:
+async def test_site_for_nonfrozen_app(make_runner: Any) -> None:
     runner = make_runner()
     with pytest.raises(RuntimeError):
         web.TCPSite(runner)
@@ -40,7 +42,7 @@ async def test_site_for_nonfrozen_app(make_runner) -> None:
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="the test is not valid for Windows"
 )
-async def test_runner_setup_handle_signals(make_runner) -> None:
+async def test_runner_setup_handle_signals(make_runner: Any) -> None:
     runner = make_runner(handle_signals=True)
     await runner.setup()
     assert signal.getsignal(signal.SIGTERM) is not signal.SIG_DFL
@@ -51,7 +53,7 @@ async def test_runner_setup_handle_signals(make_runner) -> None:
 @pytest.mark.skipif(
     platform.system() == "Windows", reason="the test is not valid for Windows"
 )
-async def test_runner_setup_without_signal_handling(make_runner) -> None:
+async def test_runner_setup_without_signal_handling(make_runner: Any) -> None:
     runner = make_runner(handle_signals=False)
     await runner.setup()
     assert signal.getsignal(signal.SIGTERM) is signal.SIG_DFL
@@ -59,7 +61,7 @@ async def test_runner_setup_without_signal_handling(make_runner) -> None:
     assert signal.getsignal(signal.SIGTERM) is signal.SIG_DFL
 
 
-async def test_site_double_added(make_runner) -> None:
+async def test_site_double_added(make_runner: Any) -> None:
     _sock = get_unused_port_socket("127.0.0.1")
     runner = make_runner()
     await runner.setup()
@@ -71,7 +73,7 @@ async def test_site_double_added(make_runner) -> None:
     assert len(runner.sites) == 1
 
 
-async def test_site_stop_not_started(make_runner) -> None:
+async def test_site_stop_not_started(make_runner: Any) -> None:
     runner = make_runner()
     await runner.setup()
     site = web.TCPSite(runner)
@@ -81,13 +83,13 @@ async def test_site_stop_not_started(make_runner) -> None:
     assert len(runner.sites) == 0
 
 
-async def test_custom_log_format(make_runner) -> None:
+async def test_custom_log_format(make_runner: Any) -> None:
     runner = make_runner(access_log_format="abc")
     await runner.setup()
     assert runner.server._kwargs["access_log_format"] == "abc"
 
 
-async def test_unreg_site(make_runner) -> None:
+async def test_unreg_site(make_runner: Any) -> None:
     runner = make_runner()
     await runner.setup()
     site = web.TCPSite(runner)
@@ -95,7 +97,7 @@ async def test_unreg_site(make_runner) -> None:
         runner._unreg_site(site)
 
 
-async def test_app_property(make_runner, app) -> None:
+async def test_app_property(make_runner: Any, app: Any) -> None:
     runner = make_runner()
     assert runner.app is app
 
@@ -105,7 +107,83 @@ def test_non_app() -> None:
         web.AppRunner(object())
 
 
-async def test_addresses(make_runner, unix_sockname) -> None:
+def test_app_handler_args() -> None:
+    app = web.Application(handler_args={"test": True})
+    runner = web.AppRunner(app)
+    assert runner._kwargs == {"access_log_class": web.AccessLogger, "test": True}
+
+
+async def test_app_handler_args_failure() -> None:
+    app = web.Application(handler_args={"unknown_parameter": 5})
+    runner = web.AppRunner(app)
+    await runner.setup()
+    assert runner._server
+    rh = runner._server()
+    assert rh._timeout_ceil_threshold == 5
+    await runner.cleanup()
+    assert app
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    (
+        (2, 2),
+        (None, 5),
+        ("2", 2),
+    ),
+)
+async def test_app_handler_args_ceil_threshold(value: Any, expected: Any) -> None:
+    app = web.Application(handler_args={"timeout_ceil_threshold": value})
+    runner = web.AppRunner(app)
+    await runner.setup()
+    assert runner._server
+    rh = runner._server()
+    assert rh._timeout_ceil_threshold == expected
+    await runner.cleanup()
+    assert app
+
+
+async def test_app_make_handler_access_log_class_bad_type1() -> None:
+    class Logger:
+        pass
+
+    app = web.Application()
+
+    with pytest.raises(TypeError):
+        web.AppRunner(app, access_log_class=Logger)
+
+
+async def test_app_make_handler_access_log_class_bad_type2() -> None:
+    class Logger:
+        pass
+
+    app = web.Application(handler_args={"access_log_class": Logger})
+
+    with pytest.raises(TypeError):
+        web.AppRunner(app)
+
+
+async def test_app_make_handler_access_log_class1() -> None:
+    class Logger(AbstractAccessLogger):
+        def log(self, request, response, time):
+            """Pass log method."""
+
+    app = web.Application()
+    runner = web.AppRunner(app, access_log_class=Logger)
+    assert runner._kwargs["access_log_class"] is Logger
+
+
+async def test_app_make_handler_access_log_class2() -> None:
+    class Logger(AbstractAccessLogger):
+        def log(self, request, response, time):
+            """Pass log method."""
+
+    app = web.Application(handler_args={"access_log_class": Logger})
+    runner = web.AppRunner(app)
+    assert runner._kwargs["access_log_class"] is Logger
+
+
+async def test_addresses(make_runner: Any, unix_sockname: Any) -> None:
     _sock = get_unused_port_socket("127.0.0.1")
     runner = make_runner()
     await runner.setup()
@@ -121,7 +199,9 @@ async def test_addresses(make_runner, unix_sockname) -> None:
 @pytest.mark.skipif(
     platform.system() != "Windows", reason="Proactor Event loop present only in Windows"
 )
-async def test_named_pipe_runner_wrong_loop(app, selector_loop, pipe_name) -> None:
+async def test_named_pipe_runner_wrong_loop(
+    app: Any, selector_loop: Any, pipe_name: Any
+) -> None:
     runner = web.AppRunner(app)
     await runner.setup()
     with pytest.raises(RuntimeError):
@@ -131,7 +211,9 @@ async def test_named_pipe_runner_wrong_loop(app, selector_loop, pipe_name) -> No
 @pytest.mark.skipif(
     platform.system() != "Windows", reason="Proactor Event loop present only in Windows"
 )
-async def test_named_pipe_runner_proactor_loop(proactor_loop, app, pipe_name) -> None:
+async def test_named_pipe_runner_proactor_loop(
+    proactor_loop: Any, app: Any, pipe_name: Any
+) -> None:
     runner = web.AppRunner(app)
     await runner.setup()
     pipe = web.NamedPipeSite(runner, pipe_name)
@@ -139,7 +221,7 @@ async def test_named_pipe_runner_proactor_loop(proactor_loop, app, pipe_name) ->
     await runner.cleanup()
 
 
-async def test_tcpsite_default_host(make_runner):
+async def test_tcpsite_default_host(make_runner: Any) -> None:
     runner = make_runner()
     await runner.setup()
     site = web.TCPSite(runner)
@@ -183,33 +265,3 @@ def test_run_after_asyncio_run() -> None:
 
     web.run_app(app)
     assert spy.called, "run_app() should work after asyncio.run()."
-
-
-async def test_app_handler_args_failure() -> None:
-    app = web.Application(handler_args={"unknown_parameter": 5})
-    runner = web.AppRunner(app)
-    await runner.setup()
-    assert runner._server
-    rh = runner._server()
-    assert rh._timeout_ceil_threshold == 5
-    await runner.cleanup()
-    assert app
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    (
-        (2, 2),
-        (None, 5),
-        ("2", 2),
-    ),
-)
-async def test_app_handler_args_ceil_threshold(value: Any, expected: Any) -> None:
-    app = web.Application(handler_args={"timeout_ceil_threshold": value})
-    runner = web.AppRunner(app)
-    await runner.setup()
-    assert runner._server
-    rh = runner._server()
-    assert rh._timeout_ceil_threshold == expected
-    await runner.cleanup()
-    assert app

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -380,7 +380,7 @@ async def test_handler_metadata_persistence() -> None:
 
     async def async_handler(request: web.Request) -> web.Response:
         """Doc"""
-        return web.Response()
+        return web.Response()  # pragma: no cover
 
     def sync_handler(request):
         """Doc"""
@@ -580,7 +580,7 @@ def test_reuse_last_added_resource(path: str) -> None:
     app = web.Application()
 
     async def handler(request: web.Request) -> web.Response:
-        return web.Response()
+        return web.Response()  # pragma: no cover
 
     app.router.add_get(path, handler, name="a")
     app.router.add_post(path, handler, name="a")
@@ -592,7 +592,7 @@ def test_resource_raw_match() -> None:
     app = web.Application()
 
     async def handler(request: web.Request) -> web.Response:
-        return web.Response()
+        return web.Response()  # pragma: no cover
 
     route = app.router.add_get("/a", handler, name="a")
     assert route.resource is not None


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Backport https://github.com/aio-libs/aiohttp/pull/8338

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

Relates https://github.com/aio-libs/aiohttp/pull/8338

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
