### PR TITLE
Backport 3.9: Add tests, accidentally dropped before (#8088)

### DIFF
--- a/CHANGES/8088.contrib.rst
+++ b/CHANGES/8088.contrib.rst
@@ -1,0 +1,1 @@
+Enabled HTTP parser tests originally intended for 3.9.2 release -- by :user:`pajod`.


### PR DESCRIPTION
Cherry picked from commit https://github.com/aio-libs/aiohttp/commit/0016004f0e5b861d35afc56a9a59040769af3122 (https://github.com/aio-libs/aiohttp/pull/8088)

Better [late ](https://github.com/aio-libs/aiohttp/pull/8088#event-11769114751) than never (3.10 backport in https://github.com/aio-libs/aiohttp/pull/8141) - but since its submitted after https://github.com/aio-libs/aiohttp/pull/8146 out of 4 tests to be conditionally re-enabled 2 are already unconditionally re-enabled.