### PR TITLE
Add regression test for #8395

### DIFF
--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3656,6 +3656,8 @@ async def test_header_too_large_error(aiohttp_client: Any) -> None:
     app.add_routes([web.get("/", handler)])
     client = await aiohttp_client(app)
 
-    with pytest.raises(aiohttp.ClientResponseError, match="Got more than 8190 bytes*") as exc_info:
+    with pytest.raises(
+        aiohttp.ClientResponseError, match="Got more than 8190 bytes*"
+    ) as exc_info:
         await client.get("/")
     assert exc_info.value.status == 400

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3646,6 +3646,10 @@ async def test_raise_for_status_is_none(aiohttp_client: AiohttpClient) -> None:
     await session.get("/")
 
 
+@pytest.mark.xfail(
+    reason="#8395 Error message regression for large headers in 3.9.4",
+    raises=AssertionError,
+)
 async def test_header_too_large_error(aiohttp_client: Any) -> None:
     """By default when not specifying `max_field_size` requests should fail with a 400 status code."""
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3646,10 +3646,6 @@ async def test_raise_for_status_is_none(aiohttp_client: AiohttpClient) -> None:
     await session.get("/")
 
 
-@pytest.mark.xfail(
-    reason="#8395 Error message regression for large headers in 3.9.4",
-    raises=AssertionError,
-)
 async def test_header_too_large_error(aiohttp_client: Any) -> None:
     """By default when not specifying `max_field_size` requests should fail with a 400 status code."""
 
@@ -3660,10 +3656,6 @@ async def test_header_too_large_error(aiohttp_client: Any) -> None:
     app.add_routes([web.get("/", handler)])
     client = await aiohttp_client(app)
 
-    try:
+    with pytest.raises(aiohttp.ClientResponseError, match="Got more than 8190 bytes*") as exc_info:
         await client.get("/")
-    except aiohttp.ClientResponseError as e:
-        assert e.status == 400
-        assert "Got more than 8190 bytes" in e.message
-    else:
-        raise AssertionError("Expected ClientResponseError")
+    assert exc_info.value.status == 400


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Introduce a regression test to help fixing #8395.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No this is just a test.

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

Shouldn't be :) The idea here is to help with catching regressions like these in the future.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

#8395

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
