### PR TITLE
Update docs for ssl param in client

### DIFF
--- a/CHANGES/8403.doc.rst
+++ b/CHANGES/8403.doc.rst
@@ -1,0 +1,1 @@
+Improve the docs for the `ssl` params.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -357,7 +357,7 @@ The client session supports the context manager protocol for self closing.
                          read_until_eof=True, \
                          read_bufsize=None, \
                          proxy=None, proxy_auth=None,\
-                         timeout=sentinel, ssl=None, \
+                         timeout=sentinel, ssl=True, \
                          verify_ssl=None, fingerprint=None, \
                          ssl_context=None, proxy_headers=None, \
                          server_hostname=None, auto_decompress=None)
@@ -475,7 +475,7 @@ The client session supports the context manager protocol for self closing.
 
             If :class:`float` is passed it is a *total* timeout (in seconds).
 
-      :param ssl: SSL validation mode. ``None`` for default SSL check
+      :param ssl: SSL validation mode. ``True`` for default SSL check
                   (:func:`ssl.create_default_context` is used),
                   ``False`` for skip SSL certificate validation,
                   :class:`aiohttp.Fingerprint` for fingerprint
@@ -680,7 +680,7 @@ The client session supports the context manager protocol for self closing.
                             origin=None, \
                             params=None, \
                             headers=None, \
-                            proxy=None, proxy_auth=None, ssl=None, \
+                            proxy=None, proxy_auth=None, ssl=True, \
                             verify_ssl=None, fingerprint=None, \
                             ssl_context=None, proxy_headers=None, \
                             compress=0, max_msg_size=4194304)
@@ -744,7 +744,7 @@ The client session supports the context manager protocol for self closing.
       :param aiohttp.BasicAuth proxy_auth: an object that represents proxy HTTP
                                            Basic Authorization (optional)
 
-      :param ssl: SSL validation mode. ``None`` for default SSL check
+      :param ssl: SSL validation mode. ``True`` for default SSL check
                   (:func:`ssl.create_default_context` is used),
                   ``False`` for skip SSL certificate validation,
                   :class:`aiohttp.Fingerprint` for fingerprint
@@ -1050,7 +1050,7 @@ is controlled by *force_close* constructor's parameter).
       overridden in subclasses.
 
 
-.. class:: TCPConnector(*, ssl=None, verify_ssl=True, fingerprint=None, \
+.. class:: TCPConnector(*, ssl=True, verify_ssl=True, fingerprint=None, \
                  use_dns_cache=True, ttl_dns_cache=10, \
                  family=0, ssl_context=None, local_addr=None, \
                  resolver=None, keepalive_timeout=sentinel, \
@@ -1068,7 +1068,7 @@ is controlled by *force_close* constructor's parameter).
    Constructor accepts all parameters suitable for
    :class:`BaseConnector` plus several TCP-specific ones:
 
-      :param ssl: SSL validation mode. ``None`` for default SSL check
+      :param ssl: SSL validation mode. ``True`` for default SSL check
                   (:func:`ssl.create_default_context` is used),
                   ``False`` for skip SSL certificate validation,
                   :class:`aiohttp.Fingerprint` for fingerprint


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Improve the docs for the `ssl` params. 

In the current docs, the following is written:
> **ssl** –
> SSL validation mode. `None` for default SSL check

However, `None` is deprecated since #8048 and the default is actually `True` as [shown in the code](https://github.com/aio-libs/aiohttp/blob/b844d4293a5bd4921bd7267550294122e83617a8/aiohttp/client.py#L413):

```python
ssl: Union[SSLContext, bool, Fingerprint] = True
```

## Are there changes in behavior for the user?

Just docs.

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->
No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->
No.

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
