### PR TITLE
Remove use of `typing.ByteString`

### DIFF
--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -11,7 +11,6 @@ from typing import (
     IO,
     TYPE_CHECKING,
     Any,
-    ByteString,
     Dict,
     Final,
     Iterable,
@@ -217,7 +216,9 @@ class Payload(ABC):
 
 
 class BytesPayload(Payload):
-    def __init__(self, value: ByteString, *args: Any, **kwargs: Any) -> None:
+    def __init__(
+        self, value: Union[bytes, bytearray, memoryview], *args: Any, **kwargs: Any
+    ) -> None:
         if not isinstance(value, (bytes, bytearray, memoryview)):
             raise TypeError(f"value argument must be byte-ish, not {type(value)!r}")
 


### PR DESCRIPTION
## What do these changes do?

This PR removes use of `typing.ByteString` from `aiohttp`. `ByteString` has been deprecated since Python 3.12, and has already been removed on the CPython `main` branch (though that change will not be released until Python 3.14 comes out). That means that `aiohttp` currently installs, but fails to be imported, on Python 3.14:

```pytb
    import aiohttp
env/lib/python3.14/site-packages/aiohttp/__init__.py:6: in <module>
    from .client import (
env/lib/python3.14/site-packages/aiohttp/client.py:38: in <module>
    from . import hdrs, http, payload
env/lib/python3.14/site-packages/aiohttp/payload.py:10: in <module>
    from typing import (
E   ImportError: cannot import name 'ByteString' from 'typing' (/Users/alexw/dev/cpython/Lib/typing.py)
```

## Are there changes in behavior for the user?

The user will now be able to import `aiohttp` using Python 3.14+

## Is it a substantial burden for the maintainers to support this?

no

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
