### PR TITLE
Use async fixture in testing docs

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -111,11 +111,11 @@ app test client::
             body='value: {}'.format(request.app[value]).encode('utf-8'))
 
     @pytest.fixture
-    def cli(loop, aiohttp_client):
+    async def cli(aiohttp_client):
         app = web.Application()
         app.router.add_get('/', previous)
         app.router.add_post('/', previous)
-        return loop.run_until_complete(aiohttp_client(app))
+        return await aiohttp_client(app)
 
     async def test_set_value(cli):
         resp = await cli.post('/', data={'value': 'foo'})


### PR DESCRIPTION
Instead of low-level asyncio APIs, which regular users shouldn't be using.