### PR TITLE
Add full request typing signatures for session HTTP methods

### DIFF
--- a/CHANGES/8463.misc.rst
+++ b/CHANGES/8463.misc.rst
@@ -1,0 +1,1 @@
+Added a 3.11-specific overloads to ``ClientSession``  -- by :user:`max-muoto`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -32,6 +32,8 @@ from typing import (
     TypeVar,
     Union,
     final,
+    TypedDict,
+    overload,
 )
 
 from multidict import CIMultiDict, MultiDict, MultiDictProxy, istr
@@ -150,6 +152,34 @@ else:
     SSLContext = None
 
 
+class _RequestOptions(TypedDict, total=False):
+    params: Union[Mapping[str, str], None]
+    data: Any
+    json: Any
+    cookies: Union[LooseCookies, None]
+    headers: Union[LooseHeaders, None]
+    skip_auto_headers: Union[Iterable[str], None]
+    auth: Union[BasicAuth, None]
+    allow_redirects: bool
+    max_redirects: int
+    compress: Union[str, None]
+    chunked: Union[bool, None]
+    expect100: bool
+    raise_for_status: Union[None, bool, Callable[[ClientResponse], Awaitable[None]]]
+    read_until_eof: bool
+    proxy: Union[StrOrURL, None]
+    proxy_auth: Union[BasicAuth, None]
+    timeout: "Union[ClientTimeout, _SENTINEL, None]"
+    ssl: Union[SSLContext, bool, Fingerprint]
+    server_hostname: Union[str, None]
+    proxy_headers: Union[LooseHeaders, None]
+    trace_request_ctx: Union[SimpleNamespace, None]
+    read_bufsize: Union[int, None]
+    auto_decompress: Union[bool, None]
+    max_line_size: Union[int, None]
+    max_field_size: Union[int, None]
+
+
 @dataclasses.dataclass(frozen=True)
 class ClientTimeout:
     total: Optional[float] = None
@@ -186,6 +216,44 @@ _CharsetResolver = Callable[[ClientResponse, bytes], str]
 @final
 class ClientSession:
     """First-class interface for making HTTP requests."""
+
+    if sys.version_info >= (3, 11):
+        from typing import Unpack
+
+        @overload
+        def get(
+            self,
+            url: StrOrURL,
+            **kwargs: Unpack["_RequestOptions"],
+        ) -> "_RequestContextManager": ...
+
+        @overload
+        def put(
+            self,
+            url: StrOrURL,
+            **kwargs: Unpack["_RequestOptions"],
+        ) -> "_RequestContextManager": ...
+
+        @overload
+        def post(
+            self,
+            url: StrOrURL,
+            **kwargs: Unpack["_RequestOptions"],
+        ) -> "_RequestContextManager": ...
+
+        @overload
+        def delete(
+            self,
+            url: StrOrURL,
+            **kwargs: Unpack["_RequestOptions"],
+        ) -> "_RequestContextManager": ...
+
+        @overload
+        def head(
+            self,
+            url: StrOrURL,
+            **kwargs: Unpack["_RequestOptions"],
+        ) -> "_RequestContextManager": ...
 
     __slots__ = (
         "_base_url",

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -352,9 +352,8 @@ class ClientSession:
 
     def __init_subclass__(cls: Type["ClientSession"]) -> None:
         raise TypeError(
-            "Inheritance class {} from ClientSession " "is forbidden".format(
-                cls.__name__
-            )
+            "Inheritance class {} from ClientSession "
+            "is forbidden".format(cls.__name__)
         )
 
     def __del__(self, _warnings: Any = warnings) -> None:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -217,44 +217,6 @@ _CharsetResolver = Callable[[ClientResponse, bytes], str]
 class ClientSession:
     """First-class interface for making HTTP requests."""
 
-    if sys.version_info >= (3, 11):
-        from typing import Unpack
-
-        @overload
-        def get(
-            self,
-            url: StrOrURL,
-            **kwargs: Unpack["_RequestOptions"],
-        ) -> "_RequestContextManager": ...
-
-        @overload
-        def put(
-            self,
-            url: StrOrURL,
-            **kwargs: Unpack["_RequestOptions"],
-        ) -> "_RequestContextManager": ...
-
-        @overload
-        def post(
-            self,
-            url: StrOrURL,
-            **kwargs: Unpack["_RequestOptions"],
-        ) -> "_RequestContextManager": ...
-
-        @overload
-        def delete(
-            self,
-            url: StrOrURL,
-            **kwargs: Unpack["_RequestOptions"],
-        ) -> "_RequestContextManager": ...
-
-        @overload
-        def head(
-            self,
-            url: StrOrURL,
-            **kwargs: Unpack["_RequestOptions"],
-        ) -> "_RequestContextManager": ...
-
     __slots__ = (
         "_base_url",
         "_source_traceback",
@@ -1054,61 +1016,112 @@ class ClientSession:
                     added_names.add(key)
         return result
 
-    def get(
-        self, url: StrOrURL, *, allow_redirects: bool = True, **kwargs: Any
-    ) -> "_RequestContextManager":
-        """Perform HTTP GET request."""
-        return _RequestContextManager(
-            self._request(hdrs.METH_GET, url, allow_redirects=allow_redirects, **kwargs)
-        )
+    if sys.version_info >= (3, 11) and TYPE_CHECKING:
+        import typing
 
-    def options(
-        self, url: StrOrURL, *, allow_redirects: bool = True, **kwargs: Any
-    ) -> "_RequestContextManager":
-        """Perform HTTP OPTIONS request."""
-        return _RequestContextManager(
-            self._request(
-                hdrs.METH_OPTIONS, url, allow_redirects=allow_redirects, **kwargs
+        def get(
+            self,
+            url: StrOrURL,
+            **kwargs: typing.Unpack[_RequestOptions],
+        ) -> "_RequestContextManager": ...
+
+        def options(
+            self,
+            url: StrOrURL,
+            **kwargs: typing.Unpack[_RequestOptions],
+        ) -> "_RequestContextManager": ...
+
+        def head(
+            self,
+            url: StrOrURL,
+            **kwargs: typing.Unpack[_RequestOptions],
+        ) -> "_RequestContextManager": ...
+
+        def post(
+            self,
+            url: StrOrURL,
+            **kwargs: typing.Unpack[_RequestOptions],
+        ) -> "_RequestContextManager": ...
+
+        def put(
+            self,
+            url: StrOrURL,
+            **kwargs: typing.Unpack[_RequestOptions],
+        ) -> "_RequestContextManager": ...
+
+        def patch(
+            self,
+            url: StrOrURL,
+            **kwargs: typing.Unpack[_RequestOptions],
+        ) -> "_RequestContextManager": ...
+
+        def delete(
+            self,
+            url: StrOrURL,
+            **kwargs: typing.Unpack[_RequestOptions],
+        ) -> "_RequestContextManager": ...
+
+    else:
+
+        def get(
+            self, url: StrOrURL, *, allow_redirects: bool = True, **kwargs: Any
+        ) -> "_RequestContextManager":
+            """Perform HTTP GET request."""
+            return _RequestContextManager(
+                self._request(
+                    hdrs.METH_GET, url, allow_redirects=allow_redirects, **kwargs
+                )
             )
-        )
 
-    def head(
-        self, url: StrOrURL, *, allow_redirects: bool = False, **kwargs: Any
-    ) -> "_RequestContextManager":
-        """Perform HTTP HEAD request."""
-        return _RequestContextManager(
-            self._request(
-                hdrs.METH_HEAD, url, allow_redirects=allow_redirects, **kwargs
+        def options(
+            self, url: StrOrURL, *, allow_redirects: bool = True, **kwargs: Any
+        ) -> "_RequestContextManager":
+            """Perform HTTP OPTIONS request."""
+            return _RequestContextManager(
+                self._request(
+                    hdrs.METH_OPTIONS, url, allow_redirects=allow_redirects, **kwargs
+                )
             )
-        )
 
-    def post(
-        self, url: StrOrURL, *, data: Any = None, **kwargs: Any
-    ) -> "_RequestContextManager":
-        """Perform HTTP POST request."""
-        return _RequestContextManager(
-            self._request(hdrs.METH_POST, url, data=data, **kwargs)
-        )
+        def head(
+            self, url: StrOrURL, *, allow_redirects: bool = False, **kwargs: Any
+        ) -> "_RequestContextManager":
+            """Perform HTTP HEAD request."""
+            return _RequestContextManager(
+                self._request(
+                    hdrs.METH_HEAD, url, allow_redirects=allow_redirects, **kwargs
+                )
+            )
 
-    def put(
-        self, url: StrOrURL, *, data: Any = None, **kwargs: Any
-    ) -> "_RequestContextManager":
-        """Perform HTTP PUT request."""
-        return _RequestContextManager(
-            self._request(hdrs.METH_PUT, url, data=data, **kwargs)
-        )
+        def post(
+            self, url: StrOrURL, *, data: Any = None, **kwargs: Any
+        ) -> "_RequestContextManager":
+            """Perform HTTP POST request."""
+            return _RequestContextManager(
+                self._request(hdrs.METH_POST, url, data=data, **kwargs)
+            )
 
-    def patch(
-        self, url: StrOrURL, *, data: Any = None, **kwargs: Any
-    ) -> "_RequestContextManager":
-        """Perform HTTP PATCH request."""
-        return _RequestContextManager(
-            self._request(hdrs.METH_PATCH, url, data=data, **kwargs)
-        )
+        def put(
+            self, url: StrOrURL, *, data: Any = None, **kwargs: Any
+        ) -> "_RequestContextManager":
+            """Perform HTTP PUT request."""
+            return _RequestContextManager(
+                self._request(hdrs.METH_PUT, url, data=data, **kwargs)
+            )
 
-    def delete(self, url: StrOrURL, **kwargs: Any) -> "_RequestContextManager":
-        """Perform HTTP DELETE request."""
-        return _RequestContextManager(self._request(hdrs.METH_DELETE, url, **kwargs))
+        def patch(
+            self, url: StrOrURL, *, data: Any = None, **kwargs: Any
+        ) -> "_RequestContextManager":
+            """Perform HTTP PATCH request."""
+            return _RequestContextManager(
+                self._request(hdrs.METH_PATCH, url, data=data, **kwargs)
+            )
+
+        def delete(self, url: StrOrURL, **kwargs: Any) -> "_RequestContextManager":
+            """Perform HTTP DELETE request."""
+            return _RequestContextManager(
+                self._request(hdrs.METH_DELETE, url, **kwargs)
+            )
 
     async def close(self) -> None:
         """Close underlying connector.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -150,6 +150,9 @@ if TYPE_CHECKING:
 else:
     SSLContext = None
 
+if sys.version_info >= (3, 11) and TYPE_CHECKING:
+    from typing import Unpack
+
 
 class _RequestOptions(TypedDict, total=False):
     params: Union[Mapping[str, str], None]
@@ -1017,48 +1020,47 @@ class ClientSession:
         return result
 
     if sys.version_info >= (3, 11) and TYPE_CHECKING:
-        import typing
 
         def get(
             self,
             url: StrOrURL,
-            **kwargs: typing.Unpack[_RequestOptions],
+            **kwargs: Unpack[_RequestOptions],
         ) -> "_RequestContextManager": ...
 
         def options(
             self,
             url: StrOrURL,
-            **kwargs: typing.Unpack[_RequestOptions],
+            **kwargs: Unpack[_RequestOptions],
         ) -> "_RequestContextManager": ...
 
         def head(
             self,
             url: StrOrURL,
-            **kwargs: typing.Unpack[_RequestOptions],
+            **kwargs: Unpack[_RequestOptions],
         ) -> "_RequestContextManager": ...
 
         def post(
             self,
             url: StrOrURL,
-            **kwargs: typing.Unpack[_RequestOptions],
+            **kwargs: Unpack[_RequestOptions],
         ) -> "_RequestContextManager": ...
 
         def put(
             self,
             url: StrOrURL,
-            **kwargs: typing.Unpack[_RequestOptions],
+            **kwargs: Unpack[_RequestOptions],
         ) -> "_RequestContextManager": ...
 
         def patch(
             self,
             url: StrOrURL,
-            **kwargs: typing.Unpack[_RequestOptions],
+            **kwargs: Unpack[_RequestOptions],
         ) -> "_RequestContextManager": ...
 
         def delete(
             self,
             url: StrOrURL,
-            **kwargs: typing.Unpack[_RequestOptions],
+            **kwargs: Unpack[_RequestOptions],
         ) -> "_RequestContextManager": ...
 
     else:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -29,10 +29,10 @@ from typing import (
     Set,
     Tuple,
     Type,
+    TypedDict,
     TypeVar,
     Union,
     final,
-    TypedDict,
     overload,
 )
 

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -33,7 +33,6 @@ from typing import (
     TypeVar,
     Union,
     final,
-    overload,
 )
 
 from multidict import CIMultiDict, MultiDict, MultiDictProxy, istr
@@ -353,8 +352,9 @@ class ClientSession:
 
     def __init_subclass__(cls: Type["ClientSession"]) -> None:
         raise TypeError(
-            "Inheritance class {} from ClientSession "
-            "is forbidden".format(cls.__name__)
+            "Inheritance class {} from ClientSession " "is forbidden".format(
+                cls.__name__
+            )
         )
 
     def __del__(self, _warnings: Any = warnings) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Improve the request typing by using 3.11's new `Unpack`  operator to properly type the kwargs that live on each HTTP method. Using `typing_extensions`, this is supported on older versions of Python as well.

To do this, I did add `typing-extensions` as a requirement on versions of Python before 3.11. I think this trade-off is well worth it, as it drastically improves the static typing checking experience, and the intellisense experience for VSCode users on Pylance. `typing-extensions` will also let `aiohttp` use other typing backports without having to wait multiple years until the minimum supported version Python catches up.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Users will be improved type-checking when making requests, if improper/unexpected types are being used, they might notice new typing warnings.

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

No, updates to the request arguments simply need to be mirrored with the typed dict added, which will update all of the core HTTP methods.

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

Fixes https://github.com/aio-libs/aiohttp/issues/4749

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (not applicable, no logic changes)
- [x] Documentation reflects the changes (type-checking changes)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
