### PR TITLE
add: asgi library to third party list

### DIFF
--- a/docs/third_party.rst
+++ b/docs/third_party.rst
@@ -299,3 +299,6 @@ ask to raise the status.
 
 - `nacl_middleware <https://github.com/CosmicDNA/nacl_middleware>`_
   An aiohttp middleware library for asymmetric encryption of data transmitted via http and/or websocket connections.
+
+- `aiohttp-asgi-connector <https://github.com/thearchitector/aiohttp-asgi-connector>`_
+  An aiohttp connector for directly interfacing with ASGI applications.

--- a/docs/third_party.rst
+++ b/docs/third_party.rst
@@ -301,4 +301,4 @@ ask to raise the status.
   An aiohttp middleware library for asymmetric encryption of data transmitted via http and/or websocket connections.
 
 - `aiohttp-asgi-connector <https://github.com/thearchitector/aiohttp-asgi-connector>`_
-  An aiohttp connector for directly interfacing with ASGI applications.
+  An aiohttp connector for using a ``ClientSession`` to interface directly with separate ASGI applications.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adding [aiohttp-asgi-connector](https://github.com/thearchitector/aiohttp-asgi-connector) to the list of third party libraries. It implements a custom connector to allow interacting directly with ASGI applications instead of going through a web server.

## Are there changes in behavior for the user?

N/A

## Is it a substantial burden for the maintainers to support this?

N/A

## Related issue number

N/A

## Checklist

N/A