### PR TITLE
Fix response headers for compressed file requests

### DIFF
--- a/CHANGES/4462.bugfix.rst
+++ b/CHANGES/4462.bugfix.rst
@@ -1,1 +1,7 @@
-Fixed server response headers for ``Content-Type`` and ``Content-Encoding`` for static compressed files -- by :user:`steverep`.
+Fixed server response headers for ``Content-Type`` and ``Content-Encoding`` for
+static compressed files -- by :user:`steverep`.
+
+Server will now respond with a ``Content-Type`` appropriate for the compressed
+file (e.g. ``"application/gzip"``), and omit the ``Content-Encoding`` header.
+Users should expect that most clients will no longer decompress such responses
+by default.

--- a/CHANGES/4462.bugfix.rst
+++ b/CHANGES/4462.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed server response headers for ``Content-Type`` and ``Content-Encoding`` for static compressed files -- by :user:`steverep`.

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -40,14 +40,14 @@ _T_OnChunkSent = Optional[Callable[[bytes], Awaitable[None]]]
 
 NOSENDFILE: Final[bool] = bool(os.environ.get("AIOHTTP_NOSENDFILE"))
 
-content_types = MimeTypes()
+CONTENT_TYPES: Final[MimeTypes] = MimeTypes()
 
 if sys.version_info < (3, 9):
-    content_types.encodings_map[".br"] = "br"
+    CONTENT_TYPES.encodings_map[".br"] = "br"
 
 # File extension to IANA encodings map that will be checked in the order defined.
 ENCODING_EXTENSIONS = MappingProxyType(
-    {ext: content_types.encodings_map[ext] for ext in (".br", ".gz")}
+    {ext: CONTENT_TYPES.encodings_map[ext] for ext in (".br", ".gz")}
 )
 
 FALLBACK_CONTENT_TYPE = "application/octet-stream"
@@ -65,9 +65,9 @@ ADDITIONAL_CONTENT_TYPES = MappingProxyType(
 )
 
 # Add custom pairs and clear the encodings map so guess_type ignores them.
-content_types.encodings_map.clear()
+CONTENT_TYPES.encodings_map.clear()
 for content_type, extension in ADDITIONAL_CONTENT_TYPES.items():
-    content_types.add_type(content_type, extension)  # type: ignore[attr-defined]
+    CONTENT_TYPES.add_type(content_type, extension)  # type: ignore[attr-defined]
 
 
 class FileResponse(StreamResponse):
@@ -292,7 +292,7 @@ class FileResponse(StreamResponse):
         #  can be ignored since the map was cleared above.
         if hdrs.CONTENT_TYPE not in self.headers:
             self.content_type = (
-                content_types.guess_type(self._path)[0] or FALLBACK_CONTENT_TYPE
+                CONTENT_TYPES.guess_type(self._path)[0] or FALLBACK_CONTENT_TYPE
             )
 
         if file_encoding:

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -51,10 +51,10 @@ ENCODING_EXTENSIONS = MappingProxyType(
 FALLBACK_CONTENT_TYPE = "application/octet-stream"
 
 # Provide additional MIME type/extension pairs to be recognized.
-# IANA-registered types can be skipped (e.g. application/gzip).
 # https://en.wikipedia.org/wiki/List_of_archive_formats#Compression_only
 ADDITIONAL_CONTENT_TYPES = MappingProxyType(
     {
+        "application/gzip": ".gz",
         "application/x-brotli": ".br",
         "application/x-bzip2": ".bz2",
         "application/x-compress": ".Z",

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -48,6 +48,19 @@ ENCODING_EXTENSIONS = MappingProxyType(
     {ext: mimetypes.encodings_map[ext] for ext in (".br", ".gz")}
 )
 
+FALLBACK_CONTENT_TYPE = "application/octet-stream"
+
+# https://en.wikipedia.org/wiki/List_of_archive_formats#Compression_only
+ENCODING_CONTENT_TYPES = MappingProxyType(
+    {
+        "gzip": "application/gzip",
+        "br": "application/x-brotli",
+        "bzip2": "application/x-bzip2",
+        "compress": "application/x-compress",
+        "xz": "application/x-xz",
+    }
+)
+
 
 class FileResponse(StreamResponse):
     """A response object can be used to send files."""
@@ -192,13 +205,16 @@ class FileResponse(StreamResponse):
         ):
             return await self._not_modified(request, etag_value, last_modified)
 
+        # If the Content-Type header is not already set, guess it based on the
+        # extension of the request path. If the request is for a compressed
+        # file, map the encoding back to the correct content type.
         ct = None
         if hdrs.CONTENT_TYPE not in self.headers:
-            ct, encoding = mimetypes.guess_type(str(file_path))
-            if not ct:
-                ct = "application/octet-stream"
-        else:
-            encoding = file_encoding
+            ct, encoding = mimetypes.guess_type(str(self._path))
+            if encoding:
+                ct = ENCODING_CONTENT_TYPES.get(encoding, FALLBACK_CONTENT_TYPE)
+            elif not ct:
+                ct = FALLBACK_CONTENT_TYPE
 
         status = self._status
         file_size = st.st_size
@@ -276,9 +292,8 @@ class FileResponse(StreamResponse):
 
         if ct:
             self.content_type = ct
-        if encoding:
-            self.headers[hdrs.CONTENT_ENCODING] = encoding
         if file_encoding:
+            self.headers[hdrs.CONTENT_ENCODING] = file_encoding
             self.headers[hdrs.VARY] = hdrs.ACCEPT_ENCODING
             # Disable compression if we are already sending
             # a compressed file since we don't want to double

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -67,7 +67,7 @@ ADDITIONAL_CONTENT_TYPES = MappingProxyType(
 # Add custom pairs and clear the encodings map so guess_type ignores them.
 content_types.encodings_map.clear()
 for content_type, extension in ADDITIONAL_CONTENT_TYPES.items():
-    content_types.add_type(content_type, extension)
+    content_types.add_type(content_type, extension)  # type: ignore[attr-defined]
 
 
 class FileResponse(StreamResponse):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Currently the server responds to requests for compressed files with a `Content-Encoding` header based on the extension.  This is not correct as the encoding is supposed to be a transformation applied to the content type, and the type should be a representation of the request (i.e. if the request is for a compressed file, then the type should represent a compressed file).  The reasoning is further explained in https://github.com/aio-libs/aiohttp/issues/4462#issuecomment-2108230866.

Note this also addresses problems when non-standard or unsupported encodings are involved.  The server will currently respond to "/hello.txt.bz2" with encoding "bzip2" to an `aiohttp` client, despite the fact that it's not supported or sent in the `Accept-Encoding` header.  That header check is completely bypassed ATM.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Requests for static compressed files will no longer be decompressed by most clients (when the encoding is supported).  However this is not a server behavior change so much as an expected reaction to the server correction.


## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->
No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->
Fixes #4462 and helps advance #8104 (by eliminating some ignorance of `Accept-Encoding`)

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
