### PR TITLE
[3.10] Simplify static path checks and resolve strictly (#8491)

### DIFF
--- a/CHANGES/8491.misc.rst
+++ b/CHANGES/8491.misc.rst
@@ -1,0 +1,1 @@
+Simplified path checks for ``UrlDispatcher.add_static()`` method -- by :user:`steverep`.

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -557,14 +557,11 @@ class StaticResource(PrefixResource):
     ) -> None:
         super().__init__(prefix, name=name)
         try:
-            directory = Path(directory)
-            if str(directory).startswith("~"):
-                directory = Path(os.path.expanduser(str(directory)))
-            directory = directory.resolve()
-            if not directory.is_dir():
-                raise ValueError("Not a directory")
-        except (FileNotFoundError, ValueError) as error:
-            raise ValueError(f"No directory exists at '{directory}'") from error
+            directory = Path(directory).expanduser().resolve(strict=True)
+        except FileNotFoundError as error:
+            raise ValueError(f"'{directory}' does not exist") from error
+        if not directory.is_dir():
+            raise ValueError(f"'{directory}' is not a directory")
         self._directory = directory
         self._show_index = show_index
         self._chunk_size = chunk_size

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -339,6 +339,21 @@ def test_route_dynamic(router) -> None:
     assert route is route2
 
 
+def test_add_static_path_checks(router: any, tmp_path: pathlib.Path) -> None:
+    """Test that static paths must exist and be directories."""
+    with pytest.raises(ValueError, match="does not exist"):
+        router.add_static("/", tmp_path / "does-not-exist")
+        with pytest.raises(ValueError, match="is not a directory"):
+            router.add_static("/", __file__)
+
+
+def test_add_static_path_resolution(router: any) -> None:
+    """Test that static paths are expanded and absolute."""
+    res = router.add_static("/", "~/..")
+    directory = str(res.get_info()["directory"])
+    assert directory == str(pathlib.Path.home().parent)
+
+
 def test_add_static(router) -> None:
     resource = router.add_static(
         "/st", pathlib.Path(aiohttp.__file__).parent, name="static"

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -595,15 +595,6 @@ async def test_static_file_directory_traversal_attack(aiohttp_client) -> None:
     await client.close()
 
 
-def test_static_route_path_existence_check() -> None:
-    directory = pathlib.Path(__file__).parent
-    web.StaticResource("/", directory)
-
-    nodirectory = directory / "nonexistent-uPNiOEAg5d"
-    with pytest.raises(ValueError):
-        web.StaticResource("/", nodirectory)
-
-
 async def test_static_file_huge(aiohttp_client, tmp_path) -> None:
     file_path = tmp_path / "huge_data.unknown_mime_type"
 


### PR DESCRIPTION
(cherry picked from commit 20d5f6e5421b1794b1d8370ab80b9deddf24f6da)

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
