### PR TITLE
Avoid creating a future on every websocket receive

### DIFF
--- a/CHANGES/8498.misc.rst
+++ b/CHANGES/8498.misc.rst
@@ -1,0 +1,1 @@
+Avoid creating a future on every websocket receive -- by :user:`bdraco`.

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -197,10 +197,10 @@ class ClientWebSocketResponse:
         # we need to break `receive()` cycle first,
         # `close()` may be called from different task
         if self._waiting and not self._closing:
-            assert self._loop is not None
             if not self._close_wait:
+                assert self._loop is not None
                 self._close_wait = self._loop.create_future()
-                self._closing = True
+            self._closing = True
             self._reader.feed_data(WS_CLOSING_MESSAGE)
             await self._close_wait
 

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -198,8 +198,9 @@ class ClientWebSocketResponse:
         # `close()` may be called from different task
         if self._waiting and not self._closing:
             assert self._loop is not None
-            self._close_wait = self._loop.create_future()
-            self._closing = True
+            if not self._close_wait:
+                self._close_wait = self._loop.create_future()
+                self._closing = True
             self._reader.feed_data(WS_CLOSING_MESSAGE)
             await self._close_wait
 

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -197,9 +197,8 @@ class ClientWebSocketResponse:
         # we need to break `receive()` cycle first,
         # `close()` may be called from different task
         if self._waiting and not self._closing:
-            if not self._close_wait:
-                assert self._loop is not None
-                self._close_wait = self._loop.create_future()
+            assert self._loop is not None
+            self._close_wait = self._loop.create_future()
             self._closing = True
             self._reader.feed_data(WS_CLOSING_MESSAGE)
             await self._close_wait

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -264,8 +264,8 @@ class ClientWebSocketResponse:
                     self._reset_heartbeat()
                 finally:
                     self._waiting = False
-                    if close_wait := self._close_wait:
-                        set_result(close_wait, None)
+                    if self._close_wait:
+                        set_result(self._close_wait, None)
             except (asyncio.CancelledError, asyncio.TimeoutError):
                 self._close_code = WSCloseCode.ABNORMAL_CLOSURE
                 raise

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -76,7 +76,8 @@ class ClientWebSocketResponse:
             self._pong_heartbeat = heartbeat / 2.0
         self._pong_response_cb: Optional[asyncio.TimerHandle] = None
         self._loop = loop
-        self._waiting: Optional[asyncio.Future[bool]] = None
+        self._waiting: bool = False
+        self._close_wait: Optional[asyncio.Future[None]] = None
         self._exception: Optional[BaseException] = None
         self._compress = compress
         self._client_notakeover = client_notakeover
@@ -195,10 +196,12 @@ class ClientWebSocketResponse:
     async def close(self, *, code: int = WSCloseCode.OK, message: bytes = b"") -> bool:
         # we need to break `receive()` cycle first,
         # `close()` may be called from different task
-        if self._waiting is not None and not self._closing:
+        if self._waiting and not self._closing:
+            assert self._loop is not None
+            self._close_wait = self._loop.create_future()
             self._closing = True
             self._reader.feed_data(WS_CLOSING_MESSAGE)
-            await self._waiting
+            await self._close_wait
 
         if not self._closed:
             self._cancel_heartbeat()
@@ -242,7 +245,7 @@ class ClientWebSocketResponse:
 
     async def receive(self, timeout: Optional[float] = None) -> WSMessage:
         while True:
-            if self._waiting is not None:
+            if self._waiting:
                 raise RuntimeError("Concurrent call to receive() is not allowed")
 
             if self._closed:
@@ -252,7 +255,7 @@ class ClientWebSocketResponse:
                 return WS_CLOSED_MESSAGE
 
             try:
-                self._waiting = self._loop.create_future()
+                self._waiting = True
                 try:
                     async with async_timeout.timeout(
                         timeout or self._timeout.ws_receive
@@ -260,9 +263,9 @@ class ClientWebSocketResponse:
                         msg = await self._reader.read()
                     self._reset_heartbeat()
                 finally:
-                    waiter = self._waiting
-                    self._waiting = None
-                    set_result(waiter, True)
+                    self._waiting = False
+                    if close_wait := self._close_wait:
+                        set_result(close_wait, None)
             except (asyncio.CancelledError, asyncio.TimeoutError):
                 self._close_code = WSCloseCode.ABNORMAL_CLOSURE
                 raise

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -491,8 +491,8 @@ class WebSocketResponse(StreamResponse):
                     self._reset_heartbeat()
                 finally:
                     self._waiting = False
-                    if close_wait := self._close_wait:
-                        set_result(close_wait, None)
+                    if self._close_wait:
+                        set_result(self._close_wait, None)
             except asyncio.TimeoutError:
                 raise
             except EofStream:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -401,8 +401,9 @@ class WebSocketResponse(StreamResponse):
         # we need to break `receive()` cycle first,
         # `close()` may be called from different task
         if self._waiting and not self._closed:
-            assert self._loop is not None
-            self._close_wait = self._loop.create_future()
+            if not self._close_wait:
+                assert self._loop is not None
+                self._close_wait = self._loop.create_future()
             reader.feed_data(WS_CLOSING_MESSAGE)
             await self._close_wait
 

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -325,6 +325,9 @@ async def test_concurrent_close_multiple_tasks(aiohttp_client: Any) -> None:
     await task1
     await task2
 
+    msg = await ws.receive()
+    assert msg.type == aiohttp.WSMsgType.CLOSED
+
 
 async def test_close_from_server(aiohttp_client: Any) -> None:
     loop = asyncio.get_event_loop()

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -276,7 +276,7 @@ async def test_concurrent_close(aiohttp_client: Any) -> None:
         await client_ws.close()
 
         msg = await ws.receive()
-        assert msg.type == aiohttp.WSMsgType.CLOSE
+        assert msg.type is aiohttp.WSMsgType.CLOSE
         return ws
 
     app = web.Application()
@@ -287,11 +287,11 @@ async def test_concurrent_close(aiohttp_client: Any) -> None:
     await ws.send_bytes(b"ask")
 
     msg = await ws.receive()
-    assert msg.type == aiohttp.WSMsgType.CLOSING
+    assert msg.type is aiohttp.WSMsgType.CLOSING
 
     await asyncio.sleep(0.01)
     msg = await ws.receive()
-    assert msg.type == aiohttp.WSMsgType.CLOSED
+    assert msg.type is aiohttp.WSMsgType.CLOSED
 
 
 async def test_concurrent_close_multiple_tasks(aiohttp_client: Any) -> None:
@@ -306,7 +306,7 @@ async def test_concurrent_close_multiple_tasks(aiohttp_client: Any) -> None:
         await ws.send_str("test")
 
         msg = await ws.receive()
-        assert msg.type == aiohttp.WSMsgType.CLOSE
+        assert msg.type is aiohttp.WSMsgType.CLOSE
         return ws
 
     app = web.Application()
@@ -320,13 +320,13 @@ async def test_concurrent_close_multiple_tasks(aiohttp_client: Any) -> None:
     task2 = asyncio.create_task(ws.close())
 
     msg = await ws.receive()
-    assert msg.type == aiohttp.WSMsgType.CLOSED
+    assert msg.type is aiohttp.WSMsgType.CLOSED
 
     await task1
     await task2
 
     msg = await ws.receive()
-    assert msg.type == aiohttp.WSMsgType.CLOSED
+    assert msg.type is aiohttp.WSMsgType.CLOSED
 
 
 async def test_close_from_server(aiohttp_client: Any) -> None:

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -295,10 +295,7 @@ async def test_concurrent_close(aiohttp_client: Any) -> None:
 
 
 async def test_concurrent_close_multiple_tasks(aiohttp_client: Any) -> None:
-    client_ws = None
-
     async def handler(request):
-        nonlocal client_ws
         ws = web.WebSocketResponse()
         await ws.prepare(request)
 

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -312,7 +312,7 @@ async def test_concurrent_close_multiple_tasks(aiohttp_client: Any) -> None:
     app = web.Application()
     app.router.add_route("GET", "/", handler)
     client = await aiohttp_client(app)
-    ws = client_ws = await client.ws_connect("/")
+    ws = await client.ws_connect("/")
 
     await ws.send_bytes(b"ask")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

We should only create a future on close if we wait for the receive to finish. Instead of making the future every time `receive` is called, we should only create it when we are closing and let the `close` call await it only if `receive` is waiting. Since `close` is called far less frequently than `receive` in most cases, this is far more efficient.

There was also a nice decrease in `set_result` calls and a reduction of ~1000 future creations per minute on an HA install with 14 WebSocket connections open. Users with many WebSocket connections will see a much more substantial drop. WebSockets should scale better with this change, especially if they are highly active.

The future was added in https://github.com/aio-libs/aiohttp/commit/ae38c4ac7647d4b904a949088f44ed539553a26e , and the `test_concurrent_close` tests still pass with only creating the future on close

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
