### PR TITLE
Avoid scheduling the writer if it can finish synchronously

### DIFF
--- a/CHANGES/8510.misc.rst
+++ b/CHANGES/8510.misc.rst
@@ -1,0 +1,1 @@
+Avoid scheduling the writer if it can finish synchronously -- by :user:`bdraco`.

--- a/CHANGES/8510.misc.rst
+++ b/CHANGES/8510.misc.rst
@@ -1,1 +1,1 @@
-Avoid scheduling the writer if it can finish synchronously -- by :user:`bdraco`.
+When using Python 3.12 or later, the writer is no longer scheduled on the event loop if it can finish synchronously. Avoiding event loop scheduling reduces latency and improves performance. -- by :user:`bdraco`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -283,12 +283,13 @@ class ClientRequest:
         if self.__writer is not None:
             self.__writer.remove_done_callback(self.__reset_writer)
         self.__writer = writer
-        if writer is not None:
-            if writer.done():
-                # The writer is already done, so we can reset it immediately.
-                self.__reset_writer()
-            else:
-                writer.add_done_callback(self.__reset_writer)
+        if writer is None:
+            return
+        if writer.done():
+            # The writer is already done, so we can reset it immediately.
+            self.__reset_writer()
+        else:
+            writer.add_done_callback(self.__reset_writer)
 
     def is_ssl(self) -> bool:
         return self.url.scheme in ("https", "wss")
@@ -788,12 +789,13 @@ class ClientResponse(HeadersMixin):
         if self.__writer is not None:
             self.__writer.remove_done_callback(self.__reset_writer)
         self.__writer = writer
-        if writer is not None:
-            if writer.done():
-                # The writer is already done, so we can reset it immediately.
-                self.__reset_writer()
-            else:
-                writer.add_done_callback(self.__reset_writer)
+        if writer is None:
+            return
+        if writer.done():
+            # The writer is already done, so we can reset it immediately.
+            self.__reset_writer()
+        else:
+            writer.add_done_callback(self.__reset_writer)
 
     @reify
     def url(self) -> URL:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

python3.12 introduces eager_start for asyncio.Task, and in most cases writing the http request can be done synchronously because its a small amount of data and will never fill up the buffer causing the task to suspend. This means that the task never has to be scheduled on the event loop, and we avoid a call_soon to schedule the task, and we avoid a call_soon to cleanup the writer since its done right away.

## Are there changes in behavior for the user?

requests will finish much faster in many cases

## Is it a substantial burden for the maintainers to support this?

We have to maintain two branches until we only support python 3.12+ https://github.com/aio-libs/aiohttp/pull/8510/files#diff-720910fd022b9ba8b7ddf0cb446ce5e1afe443f4287ad26a1eb4dc4b5b5f4508R671. This should be minimal

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
