### PR TITLE
Update sphinxcontrib-towncrier entry point @ conf

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ extensions = [
     "sphinx.ext.viewcode",
     # Third-party extensions:
     "sphinxcontrib.blockdiag",
-    "sphinxcontrib.towncrier",  # provides `towncrier-draft-entries` directive
+    "sphinxcontrib.towncrier.ext",  # provides `towncrier-draft-entries` directive
 ]
 
 


### PR DESCRIPTION
It has moved to a `.ext` module in the extension.