### PR TITLE
Restore AsyncResolver to be the default resolver

### DIFF
--- a/CHANGES/8522.misc.rst
+++ b/CHANGES/8522.misc.rst
@@ -1,0 +1,5 @@
+Restore :py:class:`~aiohttp.resolver.AsyncResolver` to be the default resolver. -- by :user:`bdraco`.
+
+:py:class:`~aiohttp.resolver.AsyncResolver` was disabled by default because
+of IPv6 compatibility issues. These issues have been resolved and
+:py:class:`~aiohttp.resolver.AsyncResolver` is again now the default resolver.

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -7,15 +7,15 @@ from .abc import AbstractResolver, ResolveResult
 
 __all__ = ("ThreadedResolver", "AsyncResolver", "DefaultResolver")
 
+
 try:
     import aiodns
 
-    # aiodns_default = hasattr(aiodns.DNSResolver, 'getaddrinfo')
+    aiodns_default = hasattr(aiodns.DNSResolver, "getaddrinfo")
 except ImportError:  # pragma: no cover
     aiodns = None  # type: ignore[assignment]
+    aiodns_default = False
 
-
-aiodns_default = False
 
 _NUMERIC_SOCKET_FLAGS = socket.AI_NUMERICHOST | socket.AI_NUMERICSERV
 _SUPPORTS_SCOPE_ID = sys.version_info >= (3, 9, 0)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -311,9 +311,11 @@ async def test_async_resolver_aiodns_not_present(loop: Any, monkeypatch: Any) ->
         AsyncResolver()
 
 
-def test_default_resolver() -> None:
-    # if getaddrinfo:
-    #     assert DefaultResolver is AsyncResolver
-    # else:
-    #     assert DefaultResolver is ThreadedResolver
+@pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")
+def test_aio_dns_is_default() -> None:
+    assert DefaultResolver is AsyncResolver
+
+
+@pytest.mark.skipif(getaddrinfo, reason="aiodns <3.2.0 required")
+def test_threaded_resolver_is_default() -> None:
     assert DefaultResolver is ThreadedResolver


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Restore `AsyncResolver` to be the default resolver

Note that we do not install aiodns on windows because it uses protractor event loop by default, and the `DefaultResolver` will end up being `ThreadedResolver` on windows.

## Are there changes in behavior for the user?

Reduction in executor jobs and thread switching. This can result in a significant performance boost.

## Is it a substantial burden for the maintainers to support this?

no

## Related issue number

The `AsyncResolver` was disabled in 9fbb7d708375e0ba01d435c1e8cf41912381c0fc because of problems with IPv6 (see #559).  This is no longer an issue as the `AsyncResolver` uses the same underlying `getaddrinfo` call to match `ThreadedResolver`.  Home Assistant has been using `AsyncResolver` for months now, and nobody noticed the change over.
