### PR TITLE
[PR #8495/549c95b9 backport][3.10] Shutdown logic: Only wait on handlers

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -6,8 +6,6 @@ import sys
 import warnings
 from argparse import ArgumentParser
 from collections.abc import Iterable
-from contextlib import suppress
-from functools import partial
 from importlib import import_module
 from typing import (
     Any,
@@ -21,7 +19,6 @@ from typing import (
     Union,
     cast,
 )
-from weakref import WeakSet
 
 from .abc import AbstractAccessLogger
 from .helpers import AppKey as AppKey
@@ -320,23 +317,6 @@ async def _run_app(
     reuse_port: Optional[bool] = None,
     handler_cancellation: bool = False,
 ) -> None:
-    async def wait(
-        starting_tasks: "WeakSet[asyncio.Task[object]]", shutdown_timeout: float
-    ) -> None:
-        # Wait for pending tasks for a given time limit.
-        t = asyncio.current_task()
-        assert t is not None
-        starting_tasks.add(t)
-        with suppress(asyncio.TimeoutError):
-            await asyncio.wait_for(_wait(starting_tasks), timeout=shutdown_timeout)
-
-    async def _wait(exclude: "WeakSet[asyncio.Task[object]]") -> None:
-        t = asyncio.current_task()
-        assert t is not None
-        exclude.add(t)
-        while tasks := asyncio.all_tasks().difference(exclude):
-            await asyncio.wait(tasks)
-
     # An internal function to actually do all dirty job for application running
     if asyncio.iscoroutine(app):
         app = await app
@@ -355,12 +335,6 @@ async def _run_app(
     )
 
     await runner.setup()
-    # On shutdown we want to avoid waiting on tasks which run forever.
-    # It's very likely that all tasks which run forever will have been created by
-    # the time we have completed the application startup (in runner.setup()),
-    # so we just record all running tasks here and exclude them later.
-    starting_tasks: "WeakSet[asyncio.Task[object]]" = WeakSet(asyncio.all_tasks())
-    runner.shutdown_callback = partial(wait, starting_tasks, shutdown_timeout)
 
     sites: List[BaseSite] = []
 

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -3,7 +3,7 @@ import signal
 import socket
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Awaitable, Callable, List, Optional, Set
+from typing import Any, List, Optional, Set
 
 from yarl import URL
 
@@ -238,14 +238,7 @@ class SockSite(BaseSite):
 
 
 class BaseRunner(ABC):
-    __slots__ = (
-        "shutdown_callback",
-        "_handle_signals",
-        "_kwargs",
-        "_server",
-        "_sites",
-        "_shutdown_timeout",
-    )
+    __slots__ = ("_handle_signals", "_kwargs", "_server", "_sites", "_shutdown_timeout")
 
     def __init__(
         self,
@@ -254,7 +247,6 @@ class BaseRunner(ABC):
         shutdown_timeout: float = 60.0,
         **kwargs: Any,
     ) -> None:
-        self.shutdown_callback: Optional[Callable[[], Awaitable[None]]] = None
         self._handle_signals = handle_signals
         self._kwargs = kwargs
         self._server: Optional[Server] = None
@@ -312,10 +304,6 @@ class BaseRunner(ABC):
             await asyncio.sleep(0)
             self._server.pre_shutdown()
             await self.shutdown()
-
-            if self.shutdown_callback:
-                await self.shutdown_callback()
-
             await self._server.shutdown(self._shutdown_timeout)
         await self._cleanup_server()
 

--- a/aiohttp/web_server.py
+++ b/aiohttp/web_server.py
@@ -43,7 +43,12 @@ class Server:
         self, handler: RequestHandler, exc: Optional[BaseException] = None
     ) -> None:
         if handler in self._connections:
-            del self._connections[handler]
+            if handler._task_handler:
+                handler._task_handler.add_done_callback(
+                    lambda f: self._connections.pop(handler, None)
+                )
+            else:
+                del self._connections[handler]
 
     def _make_request(
         self,

--- a/tests/test_web_request_handler.py
+++ b/tests/test_web_request_handler.py
@@ -22,19 +22,21 @@ async def test_connections() -> None:
     manager = web.Server(serve)
     assert manager.connections == []
 
-    handler = object()
+    handler = mock.Mock(spec_set=web.RequestHandler)
+    handler._task_handler = None
     transport = object()
     manager.connection_made(handler, transport)  # type: ignore[arg-type]
     assert manager.connections == [handler]
 
-    manager.connection_lost(handler, None)  # type: ignore[arg-type]
+    manager.connection_lost(handler, None)
     assert manager.connections == []
 
 
 async def test_shutdown_no_timeout() -> None:
     manager = web.Server(serve)
 
-    handler = mock.Mock()
+    handler = mock.Mock(spec_set=web.RequestHandler)
+    handler._task_handler = None
     handler.shutdown = make_mocked_coro(mock.Mock())
     transport = mock.Mock()
     manager.connection_made(handler, transport)


### PR DESCRIPTION
Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
Co-authored-by: J. Nick Koston <nick@koston.org>
(cherry picked from commit 549c95b948dcddd6588f95545ad6c856f693c503)
