### PR TITLE
[3.10] Downgrade upload/download artifact to v3 to fix CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -114,7 +114,7 @@ jobs:
       run: |
         make generate-llhttp
     - name: Upload llhttp generated files
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: llhttp
         path: vendor/llhttp/build
@@ -179,7 +179,7 @@ jobs:
         python -m pip install -r requirements/test.in -c requirements/test.txt
     - name: Restore llhttp generated files
       if: ${{ matrix.no-extensions == '' }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: llhttp
         path: vendor/llhttp/build/
@@ -280,7 +280,7 @@ jobs:
         python -m
         pip install -r requirements/cython.in -c requirements/cython.txt
     - name: Restore llhttp generated files
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: llhttp
         path: vendor/llhttp/build/
@@ -291,7 +291,7 @@ jobs:
       run: |
         python -m build --sdist
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v3
       with:
         name: dist
         path: dist
@@ -343,7 +343,7 @@ jobs:
         python -m
         pip install -r requirements/cython.in -c requirements/cython.txt
     - name: Restore llhttp generated files
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: llhttp
         path: vendor/llhttp/build/
@@ -354,7 +354,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.19.2
       env:
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v3
       with:
         name: dist
         path: ./wheelhouse/*.whl
@@ -381,7 +381,7 @@ jobs:
       run: |
         echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
     - name: Download distributions
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
         name: dist
         path: dist


### PR DESCRIPTION
Releases are currently broken since `master` is at v3, and 3.10 is at v4 which has [breaking changes](https://github.com/actions/upload-artifact/issues/478) and a migration is needed https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact