### PR TITLE
Small speed up to cookiejar filter_cookies

### DIFF
--- a/CHANGES/8535.misc.rst
+++ b/CHANGES/8535.misc.rst
@@ -1,0 +1,3 @@
+Improve performance of filtering cookies -- by :user:`bdraco`.
+
+This change is a followup to the improvements in :issue:`7583`

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -36,6 +36,9 @@ __all__ = ("CookieJar", "DummyCookieJar")
 
 CookieItem = Union[str, "Morsel[str]"]
 
+_FORMAT_PATH = "{}/{}".format
+_FORMAT_DOMAIN_REVERSED = "{1}.{0}".format
+
 
 class CookieJar(AbstractCookieJar):
     """Implements cookie storage adhering to RFC 6265."""
@@ -279,12 +282,11 @@ class CookieJar(AbstractCookieJar):
         else:
             # Get all the subdomains that might match a cookie (e.g. "foo.bar.com", "bar.com", "com")
             domains = itertools.accumulate(
-                reversed(hostname.split(".")), lambda x, y: f"{y}.{x}"
+                reversed(hostname.split(".")), _FORMAT_DOMAIN_REVERSED
             )
+
         # Get all the path prefixes that might match a cookie (e.g. "", "/foo", "/foo/bar")
-        paths = itertools.accumulate(
-            request_url.path.split("/"), lambda x, y: f"{x}/{y}"
-        )
+        paths = itertools.accumulate(request_url.path.split("/"), _FORMAT_PATH)
         # Create every combination of (domain, path) pairs.
         pairs = itertools.product(domains, paths)
 

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -36,6 +36,7 @@ __all__ = ("CookieJar", "DummyCookieJar")
 
 CookieItem = Union[str, "Morsel[str]"]
 
+# We cache these string methods here as their use is in performance critical code.
 _FORMAT_PATH = "{}/{}".format
 _FORMAT_DOMAIN_REVERSED = "{1}.{0}".format
 


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?
 
Small speed up to cookiejar

Using `str.format` is ~16% faster than the lambda

followup to https://github.com/aio-libs/aiohttp/pull/7944#discussion_r1430823536. I was hoping to use `join` there but later realized `str.format` will take `*args`

## Are there changes in behavior for the user?

no
## Is it a substantial burden for the maintainers to support this?

no


benchmark
```python
import timeit
import itertools

_FORMAT_PATH = "{0}/{1}".format

path = "lolonglonglonglonglonglongng/path/to/a/file"

print(
    timeit.timeit(
        'itertools.accumulate(path.split("/"), _FORMAT_PATH)', globals=globals()
    )
)


print(
    timeit.timeit(
        'itertools.accumulate(path.split("/"), lambda x, y: f"{x}/{y}")',
        globals=globals(),
    )
)
```