### PR TITLE
Increase minimum python version to 3.8.2

### DIFF
--- a/CHANGES/8557.breaking.rst
+++ b/CHANGES/8557.breaking.rst
@@ -1,0 +1,1 @@
+Increased minimum python version to 3.8.2 as earlier versions suffer from https://github.com/python/cpython/pull/17693 -- by :user:`bdraco`.

--- a/CHANGES/8557.breaking.rst
+++ b/CHANGES/8557.breaking.rst
@@ -1,1 +1,1 @@
-Increased minimum python version to 3.8.2 as earlier versions suffer from https://github.com/python/cpython/pull/17693 -- by :user:`bdraco`.
+Increased minimum python version to 3.8.2 as earlier versions suffer from https://bugs.python.org/issue39129 -- by :user:`bdraco`.

--- a/CHANGES/8557.breaking.rst
+++ b/CHANGES/8557.breaking.rst
@@ -1,3 +1,1 @@
-Increased minimum python version to 3.8.2
- as earlier versions suffer from
- https://bugs.python.org/issue39129 -- by :user:`bdraco`.
+Increased minimum python version to 3.8.2 as earlier versions suffer from https://bugs.python.org/issue39129 -- by :user:`bdraco`.

--- a/CHANGES/8557.breaking.rst
+++ b/CHANGES/8557.breaking.rst
@@ -1,1 +1,3 @@
-Increased minimum python version to 3.8.2 as earlier versions suffer from https://bugs.python.org/issue39129 -- by :user:`bdraco`.
+Increased minimum python version to 3.8.2
+ as earlier versions suffer from
+ https://bugs.python.org/issue39129 -- by :user:`bdraco`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ classifiers =
   Topic :: Internet :: WWW/HTTP
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.8.2
 packages = aiohttp
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag
 zip_safe = False


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Increase minimum python version to 3.8.2

cpython versions older than 3.8.2 have a broken import path in `asyncio.staggered` which is used in `aiohttp >= 3.10.0`. See https://bugs.python.org/issue39129 https://github.com/python/cpython/pull/17693

## Are there changes in behavior for the user?

cpython older than 3.8.2 cannot be used with 3.10.x because of bugs in `asyncio.staggered` that were not fixed until 3.8.2, however its already broken anyways since cpython stdlib itself has the bug.

closes aio-libs/aiohappyeyeballs#70
