### PR TITLE
Add followup changelog message for #5278

### DIFF
--- a/CHANGES/8555.breaking.rst
+++ b/CHANGES/8555.breaking.rst
@@ -1,6 +1,6 @@
 Creating :class:`aiohttp.TCPConnector` or :class:`aiohttp.CookieJar`,
- instances without a running event loop
- was deprecated in :issue:`3372`. After :issue:`5278`, attempting
- attempting to do so will raise a :exc:`RuntimeError`.
+ instances without a running event loop was deprecated
+ in :issue:`3372`. After :issue:`5278`, attempting
+ to do so will raise a :exc:`RuntimeError`.
 
 -- by :user:`asvetlov`

--- a/CHANGES/8555.breaking.rst
+++ b/CHANGES/8555.breaking.rst
@@ -1,0 +1,6 @@
+Creating :class:`aiohttp.TCPConnector`, :class:`aiohttp.CookieJar`,
+ or :class:`aiohttp.Client` instances without a running event loop
+ was deprecated in :issue:`3372`. After :issue:`5278`, attempting
+ attempting to do so will raise a :exc:`RuntimeError`.
+
+-- by :user:`asvetlov`

--- a/CHANGES/8555.breaking.rst
+++ b/CHANGES/8555.breaking.rst
@@ -1,5 +1,5 @@
-Creating :class:`aiohttp.TCPConnector`, :class:`aiohttp.CookieJar`,
- or :class:`aiohttp.Client` instances without a running event loop
+Creating :class:`aiohttp.TCPConnector` or :class:`aiohttp.CookieJar`,
+ instances without a running event loop
  was deprecated in :issue:`3372`. After :issue:`5278`, attempting
  attempting to do so will raise a :exc:`RuntimeError`.
 

--- a/CHANGES/8555.breaking.rst
+++ b/CHANGES/8555.breaking.rst
@@ -1,5 +1,6 @@
 Creating :class:`aiohttp.TCPConnector` or :class:`aiohttp.CookieJar`
  instances without a running event loop now raises a :exc:`RuntimeError`.
+
  -- by :user:`asvetlov`
 
 Creating these objects without a running event loop was deprecated

--- a/CHANGES/8555.breaking.rst
+++ b/CHANGES/8555.breaking.rst
@@ -1,5 +1,6 @@
-Creating :class:`aiohttp.TCPConnector` or :class:`aiohttp.CookieJar`
- instances without a running event loop now raises a :exc:`RuntimeError`.
+Creating :class:`aiohttp.TCPConnector`, :class:`aiohttp.ClientSession`, or
+ :class:`aiohttp.CookieJar` instances without a running event loop now
+ raises a :exc:`RuntimeError`.
 
  -- by :user:`asvetlov`
 

--- a/CHANGES/8555.breaking.rst
+++ b/CHANGES/8555.breaking.rst
@@ -1,4 +1,4 @@
-Creating :class:`aiohttp.TCPConnector` or :class:`aiohttp.CookieJar`,
+Creating :class:`aiohttp.TCPConnector` or :class:`aiohttp.CookieJar`
  instances without a running event loop was deprecated
  in :issue:`3372`. After :issue:`5278`, attempting
  to do so will raise a :exc:`RuntimeError`.

--- a/CHANGES/8555.breaking.rst
+++ b/CHANGES/8555.breaking.rst
@@ -1,6 +1,6 @@
 Creating :class:`aiohttp.TCPConnector` or :class:`aiohttp.CookieJar`
- instances without a running event loop was deprecated
- in :issue:`3372`. After :issue:`5278`, attempting
- to do so will raise a :exc:`RuntimeError`.
+ instances without a running event loop now raises a :exc:`RuntimeError`.
+ -- by :user:`asvetlov`
 
--- by :user:`asvetlov`
+Creating these objects without a running event loop was deprecated
+in :issue:`3372` which was released in version 3.5.0.


### PR DESCRIPTION
closes #8555


## What do these changes do?

Improve the changelog documentation for #5278

#5278 removed the deprecation warning about having a running event loop and replaced it with 
`asyncio.get_running_loop()` which will raise `RuntimeError` if there is no running loop.

Since the deprecation was done in #3372, which first appeared in https://github.com/aio-libs/aiohttp/releases/tag/v3.5.0 (~5 years, 7 months ago), reverting and extending the deprecation period did not seem warranted as five years should be enough notice.


