### PR TITLE
Fix url dispatcher index when variable is preceded by a fixed string after a slash

### DIFF
--- a/CHANGES/8566.bugfix.rst
+++ b/CHANGES/8566.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed url dispatcher index not matching when a variable is preceded by a fixed string after a slash -- by :user:`bdraco`.

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1108,8 +1108,11 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
 
     def _get_resource_index_key(self, resource: AbstractResource) -> str:
         """Return a key to index the resource in the resource index."""
-        # strip at the first { to allow for variables
-        return resource.canonical.partition("{")[0].rstrip("/") or "/"
+        if "{" in (index_key := resource.canonical):
+            # strip at the first { to allow for variables, and than
+            # rpartition at / to allow for variable parts in the path
+            index_key = index_key.partition("{")[0].rpartition("/")[0]
+        return index_key.rstrip("/") or "/"
 
     def index_resource(self, resource: AbstractResource) -> None:
         """Add a resource to the resource index."""

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1111,6 +1111,9 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         if "{" in (index_key := resource.canonical):
             # strip at the first { to allow for variables, and than
             # rpartition at / to allow for variable parts in the path
+            # For example if the canonical path is `/core/locations{tail:.*}`
+            # the index key will be `/core` since index is based on the
+            # url parts split by `/`
             index_key = index_key.partition("{")[0].rpartition("/")[0]
         return index_key.rstrip("/") or "/"
 

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -919,7 +919,7 @@ async def test_url_with_many_slashes(aiohttp_client: AiohttpClient) -> None:
 
 
 async def test_route_with_regex(aiohttp_client: AiohttpClient) -> None:
-    """Test a route with a regex."""
+    """Test a route with a regex preceded by a fixed string."""
     app = web.Application()
 
     async def handler(request: web.Request) -> web.Response:

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -916,3 +916,27 @@ async def test_url_with_many_slashes(aiohttp_client: AiohttpClient) -> None:
     r = await client.get("///a")
     assert r.status == 200
     await r.release()
+
+
+async def test_route_with_regex(aiohttp_client: AiohttpClient) -> None:
+    """Test a route with a regex."""
+    app = web.Application()
+
+    async def handler(request: web.Request) -> web.Response:
+        assert isinstance(request.match_info._route.resource, Resource)
+        return web.Response(text=request.match_info._route.resource.canonical)
+
+    app.router.add_get("/core/locations{tail:.*}", handler)
+    client = await aiohttp_client(app)
+
+    r = await client.get("/core/locations/tail/here")
+    assert r.status == 200
+    assert await r.text() == "/core/locations{tail}"
+
+    r = await client.get("/core/locations_tail_here")
+    assert r.status == 200
+    assert await r.text() == "/core/locations{tail}"
+
+    r = await client.get("/core/locations_tail;id=abcdef")
+    assert r.status == 200
+    assert await r.text() == "/core/locations{tail}"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix url dispatcher index when variable is preceded by a fixed string after a slash.  We need to strip off the fixed string when creating the index key so we can match against the path at that part of the url.  

## Are there changes in behavior for the user?

Bugfix for a regression in 3.10.x. Regressed in #7829 fixes #8567

## Is it a substantial burden for the maintainers to support this?
no