### PR TITLE
[PR #8546/a561fa99 backport][3.11] Fix WebSocket server heartbeat timeout logic (#8546)

### DIFF
--- a/CHANGES/8540.bugfix.rst
+++ b/CHANGES/8540.bugfix.rst
@@ -1,0 +1,7 @@
+Fixed WebSocket server heartbeat timeout logic to terminate `receive` and return :py:class:`~aiohttp.ServerTimeoutError` -- by :user:`arcivanov`.
+
+When a WebSocket pong message was not received, the
+ :py:meth:`~aiohttp.ClientWebSocketResponse.receive` operation did not terminate.
+ This change causes `_pong_not_received` to feed the `reader` an error message, causing
+ pending `receive` to terminate and return the error message. The error message contains
+ the exception :py:class:`~aiohttp.ServerTimeoutError`.

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -4,7 +4,7 @@ import asyncio
 import sys
 from typing import Any, Optional, cast
 
-from .client_exceptions import ClientError
+from .client_exceptions import ClientError, ServerTimeoutError
 from .client_reqrep import ClientResponse
 from .helpers import call_later, set_result
 from .http import (
@@ -122,8 +122,12 @@ class ClientWebSocketResponse:
         if not self._closed:
             self._closed = True
             self._close_code = WSCloseCode.ABNORMAL_CLOSURE
-            self._exception = asyncio.TimeoutError()
+            self._exception = ServerTimeoutError()
             self._response.close()
+            if self._waiting and not self._closing:
+                self._reader.feed_data(
+                    WSMessage(WSMsgType.ERROR, self._exception, None)
+                )
 
     @property
     def closed(self) -> bool:


### PR DESCRIPTION
Co-authored-by: J. Nick Koston <nick@koston.org>
(cherry picked from commit 4140b0eda3658a3f6bd5a9479553aae4a0c14bb8)
