### PR TITLE
[3.11] Restore the ability to create objects without a running event loop

### DIFF
--- a/CHANGES/8555.breaking.rst
+++ b/CHANGES/8555.breaking.rst
@@ -1,8 +1,0 @@
-Creating :class:`aiohttp.TCPConnector`, :class:`aiohttp.ClientSession`, or
- :class:`aiohttp.CookieJar` instances without a running event loop now
- raises a :exc:`RuntimeError`.
-
- -- by :user:`asvetlov`
-
-Creating these objects without a running event loop was deprecated
-in :issue:`3372` which was released in version 3.5.0.

--- a/CHANGES/8555.bugfix.rst
+++ b/CHANGES/8555.bugfix.rst
@@ -1,0 +1,20 @@
+Restored the ability to create
+ :py:class:`aiohttp.TCPConnector`,
+ :py:class:`aiohttp.ClientSession`,
+ :py:class:`~aiohttp.resolver.ThreadedResolver`
+ :py:class:`aiohttp.web.Server`,
+ and :py:class:`aiohttp.CookieJar` instances
+ without a running event loop -- by :user:`bdraco`.
+
+This is a partial revert of :issue:`5278`. Creating these
+objects without a running event loop is highly discouraged
+because it can lead to confusing behavior.
+
+This is accomplished by falling back to calling
+``asyncio.get_event_loop()`` if ``asyncio.get_running_loop()``
+raises :exc:`RuntimeError`. As of Python 3.12, calling
+``asyncio.get_running_loop()`` without a running event loop
+also emits a Deprecation warning.
+
+As with Python, creating these objects without a running event
+loop will become an error in a future version of ``aiohttp``.

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -21,6 +21,7 @@ from typing import (
 from multidict import CIMultiDict
 from yarl import URL
 
+from .helpers import get_running_loop
 from .typedefs import LooseCookies
 
 if TYPE_CHECKING:
@@ -169,7 +170,7 @@ class AbstractCookieJar(Sized, IterableBase):
     """Abstract Cookie Jar."""
 
     def __init__(self, *, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
-        self._loop = loop or asyncio.get_running_loop()
+        self._loop = loop or get_running_loop()
 
     @abstractmethod
     def clear(self, predicate: Optional[ClearCookiePredicate] = None) -> None:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -88,6 +88,7 @@ from .helpers import (
     TimeoutHandle,
     ceil_timeout,
     get_env_proxy_for_url,
+    get_running_loop,
     method_must_be_empty_body,
     sentinel,
     strip_auth_from_url,
@@ -293,7 +294,7 @@ class ClientSession:
             if connector is not None:
                 loop = connector._loop
 
-        loop = loop or asyncio.get_running_loop()
+        loop = loop or get_running_loop()
 
         if base_url is None or isinstance(base_url, URL):
             self._base_url: Optional[URL] = base_url

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -49,7 +49,7 @@ from .client_exceptions import (
 )
 from .client_proto import ResponseHandler
 from .client_reqrep import ClientRequest, Fingerprint, _merge_ssl_params
-from .helpers import ceil_timeout, is_ip_address, noop, sentinel
+from .helpers import ceil_timeout, get_running_loop, is_ip_address, noop, sentinel
 from .locks import EventResultOrError
 from .resolver import DefaultResolver
 
@@ -105,7 +105,7 @@ class Connection:
     ) -> None:
         self._key = key
         self._connector = connector
-        self._loop = loop
+        self._loop = loop or get_running_loop()
         self._protocol: Optional[ResponseHandler] = protocol
         self._callbacks: List[Callable[[], None]] = []
 

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -4,6 +4,7 @@ import sys
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from .abc import AbstractResolver, ResolveResult
+from .helpers import get_running_loop
 
 __all__ = ("ThreadedResolver", "AsyncResolver", "DefaultResolver")
 
@@ -29,7 +30,7 @@ class ThreadedResolver(AbstractResolver):
     """
 
     def __init__(self, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
-        self._loop = loop or asyncio.get_running_loop()
+        self._loop = loop or get_running_loop()
 
     async def resolve(
         self, host: str, port: int = 0, family: socket.AddressFamily = socket.AF_INET

--- a/aiohttp/web_server.py
+++ b/aiohttp/web_server.py
@@ -4,6 +4,7 @@ import asyncio
 from typing import Any, Awaitable, Callable, Dict, List, Optional  # noqa
 
 from .abc import AbstractStreamWriter
+from .helpers import get_running_loop
 from .http_parser import RawRequestMessage
 from .streams import StreamReader
 from .web_protocol import RequestHandler, _RequestFactory, _RequestHandler
@@ -22,7 +23,7 @@ class Server:
         loop: Optional[asyncio.AbstractEventLoop] = None,
         **kwargs: Any
     ) -> None:
-        self._loop = loop or asyncio.get_running_loop()
+        self._loop = loop or get_running_loop()
         self._connections: Dict[RequestHandler, asyncio.Transport] = {}
         self._kwargs = kwargs
         self.requests_count = 0

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -607,6 +607,30 @@ def test_proxies_from_env_http_with_auth(url_input, expected_scheme) -> None:
     assert proxy_auth.encoding == "latin1"
 
 
+# ------------ get_running_loop ---------------------------------
+
+
+def test_get_running_loop_not_running(
+    loop: asyncio.AbstractEventLoop, caplog: pytest.LogCaptureFixture
+) -> None:
+    with pytest.warns(DeprecationWarning):
+        helpers.get_running_loop()
+    assert "The object should be created within an async function" not in caplog.text
+    loop.set_debug(True)
+    with pytest.warns(DeprecationWarning):
+        helpers.get_running_loop()
+    assert "The object should be created within an async function" in caplog.text
+    loop.set_debug(False)
+    caplog.clear()
+    with pytest.warns(DeprecationWarning):
+        helpers.get_running_loop()
+    assert "The object should be created within an async function" not in caplog.text
+
+
+async def test_get_running_loop_ok(loop: asyncio.AbstractEventLoop) -> None:
+    assert helpers.get_running_loop() is loop
+
+
 # --------------------- get_env_proxy_for_url ------------------------------
 
 


### PR DESCRIPTION
Alternate solution for #8555, partial revert of #8512 (originally #5278)

I'm not sold on that idea because Python has deprecated calling `asyncio.get_event_loop()` without a running event loop. After all, the behavior is confusing. Even if we did revert this, it's kicking the can down the road until it becomes an error. 

https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop
<img width="826" alt="Screenshot 2024-08-01 at 2 27 12 PM" src="https://github.com/user-attachments/assets/7e615dea-8227-46c2-88a3-772e36b6587a">
