### PR TITLE
Fix dependabot configuration for 3.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
     directory: "/"
     labels:
       - dependencies
-    target-branch: "3.10"
+    target-branch: "3.11"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
@@ -33,7 +33,7 @@ updates:
     directory: "/"
     labels:
       - dependencies
-    target-branch: "3.10"
+    target-branch: "3.11"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10


### PR DESCRIPTION
I had adjusted this on the 3.11 branch without realizing that dependabot only looks at master
