### PR TITLE
Close stale issues without info

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,17 @@
+name: 'Close stale issues'
+on:
+  schedule:
+    - cron: '50 5 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 30
+          any-of-labels: needs-info
+          labels-to-remove-when-unstale: needs-info


### PR DESCRIPTION
The goal here is to allow triagers to add a label to issues when they request more info from the reporter.
If nobody provides further info, then the issue will be closed automatically, instead of being left open indefinitely.