### PR TITLE
Remove old backwards-compatibility stub

### DIFF
--- a/CHANGES/8596.breaking.rst
+++ b/CHANGES/8596.breaking.rst
@@ -1,0 +1,1 @@
+Removed old async compatibility from ``ClientResponse.release()`` -- by :user:`Dreamsorcerer`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -50,7 +50,6 @@ from .helpers import (
     basicauth_from_netrc,
     is_expected_content_type,
     netrc_from_env,
-    noop,
     parse_mimetype,
     reify,
     set_exception,
@@ -993,7 +992,7 @@ class ClientResponse(HeadersMixin):
             self._connection.close()
             self._connection = None
 
-    def release(self) -> Any:
+    def release(self) -> None:
         if not self._released:
             self._notify_content()
 
@@ -1001,7 +1000,6 @@ class ClientResponse(HeadersMixin):
 
         self._cleanup_writer()
         self._release_connection()
-        return noop()
 
     @property
     def ok(self) -> bool:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -30,7 +30,6 @@ from typing import (
     Callable,
     ContextManager,
     Dict,
-    Generator,
     Generic,
     Iterable,
     Iterator,
@@ -107,11 +106,6 @@ SEPARATORS = {
     chr(9),
 }
 TOKEN = CHAR ^ CTL ^ SEPARATORS
-
-
-class noop:
-    def __await__(self) -> Generator[None, None, None]:
-        yield
 
 
 json_re = re.compile(r"(?:application/|[\w.-]+/[\w.+-]+?\+)json$", re.IGNORECASE)

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -247,7 +247,7 @@ class MultipartResponseWrapper:
 
         All remaining content is read to the void.
         """
-        await self.resp.release()
+        self.resp.release()
 
 
 class BodyPartReader:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -546,7 +546,7 @@ async def test_cookie_jar_usage(loop: Any, aiohttp_client: Any) -> None:
 
     jar.update_cookies.reset_mock()
     resp = await session.get("/")
-    await resp.release()
+    resp.release()
 
     # Filtering the cookie jar before sending the request,
     # getting the request URL as only parameter

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -107,13 +107,11 @@ class TestMultipartResponseWrapper:
 
     async def test_release(self) -> None:
         wrapper = MultipartResponseWrapper(mock.Mock(), mock.Mock())
-        wrapper.resp.release = make_mocked_coro(None)
         await wrapper.release()
         assert wrapper.resp.release.called
 
     async def test_release_when_stream_at_eof(self) -> None:
         wrapper = MultipartResponseWrapper(mock.Mock(), mock.Mock())
-        wrapper.resp.release = make_mocked_coro(None)
         wrapper.stream.next = make_mocked_coro(b"")
         wrapper.stream.at_eof.return_value = True
         await wrapper.next()

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -68,7 +68,7 @@ async def test_simple_get(aiohttp_client: Any) -> None:
     txt = await resp.text()
     assert "OK" == txt
 
-    await resp.release()
+    resp.release()
 
 
 async def test_simple_get_with_text(aiohttp_client: Any) -> None:
@@ -86,7 +86,7 @@ async def test_simple_get_with_text(aiohttp_client: Any) -> None:
     txt = await resp.text()
     assert "OK" == txt
 
-    await resp.release()
+    resp.release()
 
 
 async def test_handler_returns_not_response(
@@ -165,7 +165,7 @@ async def test_response_before_complete(aiohttp_client: Any) -> None:
     text = await resp.text()
     assert "OK" == text
 
-    await resp.release()
+    resp.release()
 
 
 async def test_post_form(aiohttp_client: Any) -> None:
@@ -183,7 +183,7 @@ async def test_post_form(aiohttp_client: Any) -> None:
     txt = await resp.text()
     assert "OK" == txt
 
-    await resp.release()
+    resp.release()
 
 
 async def test_post_text(aiohttp_client: Any) -> None:
@@ -203,7 +203,7 @@ async def test_post_text(aiohttp_client: Any) -> None:
     txt = await resp.text()
     assert "русский" == txt
 
-    await resp.release()
+    resp.release()
 
 
 async def test_post_json(aiohttp_client: Any) -> None:
@@ -229,7 +229,7 @@ async def test_post_json(aiohttp_client: Any) -> None:
     data = await resp.json()
     assert dct == data
 
-    await resp.release()
+    resp.release()
 
 
 async def test_multipart(aiohttp_client: Any) -> None:
@@ -263,7 +263,7 @@ async def test_multipart(aiohttp_client: Any) -> None:
 
     resp = await client.post("/", data=writer)
     assert 200 == resp.status
-    await resp.release()
+    resp.release()
 
 
 async def test_multipart_empty(aiohttp_client: Any) -> None:
@@ -283,7 +283,7 @@ async def test_multipart_empty(aiohttp_client: Any) -> None:
 
     resp = await client.post("/", data=writer)
     assert 200 == resp.status
-    await resp.release()
+    resp.release()
 
 
 async def test_multipart_content_transfer_encoding(aiohttp_client: Any) -> None:
@@ -312,7 +312,7 @@ async def test_multipart_content_transfer_encoding(aiohttp_client: Any) -> None:
 
     resp = await client.post("/", data=writer)
     assert 200 == resp.status
-    await resp.release()
+    resp.release()
 
 
 async def test_render_redirect(aiohttp_client: Any) -> None:
@@ -329,7 +329,7 @@ async def test_render_redirect(aiohttp_client: Any) -> None:
     assert "301: Moved Permanently" == txt
     assert "/path" == resp.headers["location"]
 
-    await resp.release()
+    resp.release()
 
 
 async def test_post_single_file(aiohttp_client: Any) -> None:
@@ -361,7 +361,7 @@ async def test_post_single_file(aiohttp_client: Any) -> None:
         resp = await client.post("/", data=[fd])
     assert 200 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_files_upload_with_same_key(aiohttp_client: Any) -> None:
@@ -396,7 +396,7 @@ async def test_files_upload_with_same_key(aiohttp_client: Any) -> None:
     resp = await client.post("/", data=data)
     assert 200 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_post_files(aiohttp_client: Any) -> None:
@@ -427,12 +427,12 @@ async def test_post_files(aiohttp_client: Any) -> None:
             resp = await client.post("/", data=[f1, f2])
             assert 200 == resp.status
 
-            await resp.release()
+            resp.release()
 
 
 async def test_release_post_data(aiohttp_client: Any) -> None:
     async def handler(request):
-        await request.release()
+        request.release()
         chunk = await request.content.readany()
         assert chunk == b""
         return web.Response()
@@ -444,7 +444,7 @@ async def test_release_post_data(aiohttp_client: Any) -> None:
     resp = await client.post("/", data="post text")
     assert 200 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_post_form_with_duplicate_keys(aiohttp_client: Any) -> None:
@@ -461,7 +461,7 @@ async def test_post_form_with_duplicate_keys(aiohttp_client: Any) -> None:
     resp = await client.post("/", data=MultiDict([("a", 1), ("a", 2)]))
     assert 200 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 def test_repr_for_application() -> None:
@@ -494,7 +494,7 @@ async def test_expect_default_handler_unknown(aiohttp_client: Any) -> None:
     resp = await client.post("/", headers={"Expect": "SPAM"})
     assert 417 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_100_continue(aiohttp_client: Any) -> None:
@@ -513,7 +513,7 @@ async def test_100_continue(aiohttp_client: Any) -> None:
     resp = await client.post("/", data=form, expect100=True)
     assert 200 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_100_continue_custom(aiohttp_client: Any) -> None:
@@ -538,7 +538,7 @@ async def test_100_continue_custom(aiohttp_client: Any) -> None:
     assert 200 == resp.status
     assert expect_received
 
-    await resp.release()
+    resp.release()
 
 
 async def test_100_continue_custom_response(aiohttp_client: Any) -> None:
@@ -561,12 +561,12 @@ async def test_100_continue_custom_response(aiohttp_client: Any) -> None:
     auth_err = False
     resp = await client.post("/", data=new_dummy_form(), expect100=True)
     assert 200 == resp.status
-    await resp.release()
+    resp.release()
 
     auth_err = True
     resp = await client.post("/", data=new_dummy_form(), expect100=True)
     assert 403 == resp.status
-    await resp.release()
+    resp.release()
 
 
 async def test_expect_handler_custom_response(aiohttp_client: Any) -> None:
@@ -602,7 +602,7 @@ async def test_100_continue_for_not_found(aiohttp_client: Any) -> None:
     resp = await client.post("/not_found", data="data", expect100=True)
     assert 404 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_100_continue_for_not_allowed(aiohttp_client: Any) -> None:
@@ -616,7 +616,7 @@ async def test_100_continue_for_not_allowed(aiohttp_client: Any) -> None:
     resp = await client.get("/", expect100=True)
     assert 405 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_http11_keep_alive_default(aiohttp_client: Any) -> None:
@@ -632,7 +632,7 @@ async def test_http11_keep_alive_default(aiohttp_client: Any) -> None:
     assert resp.version == HttpVersion11
     assert "Connection" not in resp.headers
 
-    await resp.release()
+    resp.release()
 
 
 @pytest.mark.xfail
@@ -649,7 +649,7 @@ async def test_http10_keep_alive_default(aiohttp_client: Any) -> None:
     assert resp.version == HttpVersion10
     assert resp.headers["Connection"] == "keep-alive"
 
-    await resp.release()
+    resp.release()
 
 
 async def test_http10_keep_alive_with_headers_close(aiohttp_client: Any) -> None:
@@ -667,7 +667,7 @@ async def test_http10_keep_alive_with_headers_close(aiohttp_client: Any) -> None
     assert resp.version == HttpVersion10
     assert "Connection" not in resp.headers
 
-    await resp.release()
+    resp.release()
 
 
 async def test_http10_keep_alive_with_headers(aiohttp_client: Any) -> None:
@@ -685,7 +685,7 @@ async def test_http10_keep_alive_with_headers(aiohttp_client: Any) -> None:
     assert resp.version == HttpVersion10
     assert resp.headers["Connection"] == "keep-alive"
 
-    await resp.release()
+    resp.release()
 
 
 async def test_upload_file(aiohttp_client: Any) -> None:
@@ -708,7 +708,7 @@ async def test_upload_file(aiohttp_client: Any) -> None:
     resp = await client.post("/", data={"file": io.BytesIO(data)})
     assert 200 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_upload_file_object(aiohttp_client: Any) -> None:
@@ -732,7 +732,7 @@ async def test_upload_file_object(aiohttp_client: Any) -> None:
         resp = await client.post("/", data={"file": f})
         assert 200 == resp.status
 
-        await resp.release()
+        resp.release()
 
 
 @pytest.mark.parametrize(
@@ -768,7 +768,7 @@ async def test_empty_content_for_query_with_body(aiohttp_client: Any) -> None:
     resp = await client.post("/", data=b"data")
     assert 200 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_get_with_empty_arg(aiohttp_client: Any) -> None:
@@ -784,7 +784,7 @@ async def test_get_with_empty_arg(aiohttp_client: Any) -> None:
     resp = await client.get("/?arg")
     assert 200 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_large_header(aiohttp_client: Any) -> None:
@@ -799,7 +799,7 @@ async def test_large_header(aiohttp_client: Any) -> None:
     resp = await client.get("/", headers=headers)
     assert 400 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_large_header_allowed(aiohttp_client: Any, aiohttp_server: Any) -> None:
@@ -815,7 +815,7 @@ async def test_large_header_allowed(aiohttp_client: Any, aiohttp_server: Any) ->
     resp = await client.post("/", headers=headers)
     assert 200 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_get_with_empty_arg_with_equal(aiohttp_client: Any) -> None:
@@ -831,7 +831,7 @@ async def test_get_with_empty_arg_with_equal(aiohttp_client: Any) -> None:
     resp = await client.get("/?arg=")
     assert 200 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_response_with_async_gen(aiohttp_client: Any, fname: Any) -> None:
@@ -861,7 +861,7 @@ async def test_response_with_async_gen(aiohttp_client: Any, fname: Any) -> None:
     assert resp_data == data
     assert resp.headers.get("Content-Length") == str(len(resp_data))
 
-    await resp.release()
+    resp.release()
 
 
 async def test_response_with_async_gen_no_params(
@@ -893,7 +893,7 @@ async def test_response_with_async_gen_no_params(
     assert resp_data == data
     assert resp.headers.get("Content-Length") == str(len(resp_data))
 
-    await resp.release()
+    resp.release()
 
 
 async def test_response_with_file(aiohttp_client: Any, fname: Any) -> None:
@@ -924,7 +924,7 @@ async def test_response_with_file(aiohttp_client: Any, fname: Any) -> None:
     assert resp.headers.get("Content-Length") == str(len(resp_data))
     assert resp.headers.get("Content-Disposition") == expected_content_disposition
 
-    await resp.release()
+    resp.release()
 
     outer_file_descriptor.close()
 
@@ -956,7 +956,7 @@ async def test_response_with_file_ctype(aiohttp_client: Any, fname: Any) -> None
     assert resp.headers.get("Content-Length") == str(len(resp_data))
     assert resp.headers.get("Content-Disposition") == expected_content_disposition
 
-    await resp.release()
+    resp.release()
 
     outer_file_descriptor.close()
 
@@ -986,7 +986,7 @@ async def test_response_with_payload_disp(aiohttp_client: Any, fname: Any) -> No
     assert resp.headers.get("Content-Length") == str(len(resp_data))
     assert resp.headers.get("Content-Disposition") == 'inline; filename="test.txt"'
 
-    await resp.release()
+    resp.release()
 
     outer_file_descriptor.close()
 
@@ -1004,7 +1004,7 @@ async def test_response_with_payload_stringio(aiohttp_client: Any, fname: Any) -
     resp_data = await resp.read()
     assert resp_data == b"test"
 
-    await resp.release()
+    resp.release()
 
 
 @pytest.mark.parametrize(
@@ -1035,7 +1035,7 @@ async def test_response_with_precompressed_body(
     assert b"mydata" == data
     assert resp.headers.get("Content-Encoding") == encoding
 
-    await resp.release()
+    resp.release()
 
 
 async def test_response_with_precompressed_body_brotli(aiohttp_client: Any) -> None:
@@ -1053,7 +1053,7 @@ async def test_response_with_precompressed_body_brotli(aiohttp_client: Any) -> N
     assert b"mydata" == data
     assert resp.headers.get("Content-Encoding") == "br"
 
-    await resp.release()
+    resp.release()
 
 
 async def test_bad_request_payload(aiohttp_client: Any) -> None:
@@ -1072,7 +1072,7 @@ async def test_bad_request_payload(aiohttp_client: Any) -> None:
     resp = await client.post("/", data=b"test", headers={"content-encoding": "gzip"})
     assert 200 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_stream_response_multiple_chunks(aiohttp_client: Any) -> None:
@@ -1094,7 +1094,7 @@ async def test_stream_response_multiple_chunks(aiohttp_client: Any) -> None:
     data = await resp.read()
     assert b"xyz" == data
 
-    await resp.release()
+    resp.release()
 
 
 async def test_start_without_routes(aiohttp_client: Any) -> None:
@@ -1104,7 +1104,7 @@ async def test_start_without_routes(aiohttp_client: Any) -> None:
     resp = await client.get("/")
     assert 404 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_requests_count(aiohttp_client: Any) -> None:
@@ -1119,17 +1119,17 @@ async def test_requests_count(aiohttp_client: Any) -> None:
     resp = await client.get("/")
     assert 200 == resp.status
     assert client.server.handler.requests_count == 1
-    await resp.release()
+    resp.release()
 
     resp = await client.get("/")
     assert 200 == resp.status
     assert client.server.handler.requests_count == 2
-    await resp.release()
+    resp.release()
 
     resp = await client.get("/")
     assert 200 == resp.status
     assert client.server.handler.requests_count == 3
-    await resp.release()
+    resp.release()
 
 
 async def test_redirect_url(aiohttp_client: Any) -> None:
@@ -1147,7 +1147,7 @@ async def test_redirect_url(aiohttp_client: Any) -> None:
     resp = await client.get("/redirector")
     assert resp.status == 200
 
-    await resp.release()
+    resp.release()
 
 
 async def test_simple_subapp(aiohttp_client: Any) -> None:
@@ -1165,7 +1165,7 @@ async def test_simple_subapp(aiohttp_client: Any) -> None:
     txt = await resp.text()
     assert "OK" == txt
 
-    await resp.release()
+    resp.release()
 
 
 async def test_subapp_reverse_url(aiohttp_client: Any) -> None:
@@ -1188,7 +1188,7 @@ async def test_subapp_reverse_url(aiohttp_client: Any) -> None:
     assert "OK" == txt
     assert resp.url.path == "/path/final"
 
-    await resp.release()
+    resp.release()
 
 
 async def test_subapp_reverse_variable_url(aiohttp_client: Any) -> None:
@@ -1213,7 +1213,7 @@ async def test_subapp_reverse_variable_url(aiohttp_client: Any) -> None:
     assert "OK" == txt
     assert resp.url.path == "/path/final"
 
-    await resp.release()
+    resp.release()
 
 
 async def test_subapp_reverse_static_url(aiohttp_client: Any) -> None:
@@ -1237,7 +1237,7 @@ async def test_subapp_reverse_static_url(aiohttp_client: Any) -> None:
     assert resp.status == 200
     body = await resp.read()
 
-    await resp.release()
+    resp.release()
 
     with (here / fname).open("rb") as f:
         assert body == f.read()
@@ -1259,7 +1259,7 @@ async def test_subapp_app(aiohttp_client: Any) -> None:
     txt = await resp.text()
     assert "OK" == txt
 
-    await resp.release()
+    resp.release()
 
 
 async def test_subapp_not_found(aiohttp_client: Any) -> None:
@@ -1275,7 +1275,7 @@ async def test_subapp_not_found(aiohttp_client: Any) -> None:
     resp = await client.get("/path/other")
     assert resp.status == 404
 
-    await resp.release()
+    resp.release()
 
 
 async def test_subapp_not_found2(aiohttp_client: Any) -> None:
@@ -1291,7 +1291,7 @@ async def test_subapp_not_found2(aiohttp_client: Any) -> None:
     resp = await client.get("/invalid/other")
     assert resp.status == 404
 
-    await resp.release()
+    resp.release()
 
 
 async def test_subapp_not_allowed(aiohttp_client: Any) -> None:
@@ -1308,7 +1308,7 @@ async def test_subapp_not_allowed(aiohttp_client: Any) -> None:
     assert resp.status == 405
     assert resp.headers["Allow"] == "GET,HEAD"
 
-    await resp.release()
+    resp.release()
 
 
 async def test_subapp_cannot_add_app_in_handler(aiohttp_client: Any) -> None:
@@ -1325,7 +1325,7 @@ async def test_subapp_cannot_add_app_in_handler(aiohttp_client: Any) -> None:
     resp = await client.get("/path/to")
     assert resp.status == 500
 
-    await resp.release()
+    resp.release()
 
 
 async def test_old_style_subapp_middlewares(aiohttp_client: Any) -> None:
@@ -1372,7 +1372,7 @@ async def test_old_style_subapp_middlewares(aiohttp_client: Any) -> None:
         (2, "app"),
     ] == order
 
-    await resp.release()
+    resp.release()
 
 
 async def test_subapp_on_response_prepare(aiohttp_client: Any) -> None:
@@ -1402,7 +1402,7 @@ async def test_subapp_on_response_prepare(aiohttp_client: Any) -> None:
     assert resp.status == 200
     assert [app, subapp1, subapp2] == order
 
-    await resp.release()
+    resp.release()
 
 
 async def test_subapp_on_startup(aiohttp_server: Any) -> None:
@@ -1519,7 +1519,7 @@ async def test_subapp_middleware_context(
     assert "Ok" == await resp.text()
     assert expected == values
 
-    await resp.release()
+    resp.release()
 
 
 async def test_custom_date_header(aiohttp_client: Any) -> None:
@@ -1534,7 +1534,7 @@ async def test_custom_date_header(aiohttp_client: Any) -> None:
     assert 200 == resp.status
     assert resp.headers["Date"] == "Sun, 30 Oct 2016 03:13:52 GMT"
 
-    await resp.release()
+    resp.release()
 
 
 async def test_response_prepared_with_clone(aiohttp_client: Any) -> None:
@@ -1551,7 +1551,7 @@ async def test_response_prepared_with_clone(aiohttp_client: Any) -> None:
     resp = await client.get("/")
     assert 200 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_app_max_client_size(aiohttp_client: Any) -> None:
@@ -1575,7 +1575,7 @@ async def test_app_max_client_size(aiohttp_client: Any) -> None:
     body_size = int(resp_text.split()[-1])
     assert body_size >= max_size
 
-    await resp.release()
+    resp.release()
 
 
 async def test_app_max_client_size_adjusted(aiohttp_client: Any) -> None:
@@ -1595,7 +1595,7 @@ async def test_app_max_client_size_adjusted(aiohttp_client: Any) -> None:
     assert 200 == resp.status
     resp_text = await resp.text()
     assert "ok" == resp_text
-    await resp.release()
+    resp.release()
 
     too_large_data = {"log_string": custom_max_size * "x" + "xxx"}
     with pytest.warns(ResourceWarning):
@@ -1609,7 +1609,7 @@ async def test_app_max_client_size_adjusted(aiohttp_client: Any) -> None:
     body_size = int(resp_text.split()[-1])
     assert body_size >= custom_max_size
 
-    await resp.release()
+    resp.release()
 
 
 async def test_app_max_client_size_none(aiohttp_client: Any) -> None:
@@ -1629,7 +1629,7 @@ async def test_app_max_client_size_none(aiohttp_client: Any) -> None:
     assert 200 == resp.status
     resp_text = await resp.text()
     assert "ok" == resp_text
-    await resp.release()
+    resp.release()
 
     too_large_data = {"log_string": default_max_size * 2 * "x"}
     with pytest.warns(ResourceWarning):
@@ -1637,7 +1637,7 @@ async def test_app_max_client_size_none(aiohttp_client: Any) -> None:
     assert 200 == resp.status
     resp_text = await resp.text()
     assert resp_text == "ok"
-    await resp.release()
+    resp.release()
 
 
 async def test_post_max_client_size(aiohttp_client: Any) -> None:
@@ -1661,7 +1661,7 @@ async def test_post_max_client_size(aiohttp_client: Any) -> None:
         )
         data["file"].close()
 
-        await resp.release()
+        resp.release()
 
 
 async def test_post_max_client_size_for_file(aiohttp_client: Any) -> None:
@@ -1679,7 +1679,7 @@ async def test_post_max_client_size_for_file(aiohttp_client: Any) -> None:
 
     assert 413 == resp.status
 
-    await resp.release()
+    resp.release()
 
 
 async def test_response_with_bodypart(aiohttp_client: Any) -> None:
@@ -1703,7 +1703,7 @@ async def test_response_with_bodypart(aiohttp_client: Any) -> None:
         disp = multipart.parse_content_disposition(resp.headers["content-disposition"])
         assert disp == ("attachment", {"name": "file", "filename": "file"})
 
-        await resp.release()
+        resp.release()
 
 
 async def test_response_with_bodypart_named(aiohttp_client: Any, tmp_path: Any) -> None:
@@ -1729,7 +1729,7 @@ async def test_response_with_bodypart_named(aiohttp_client: Any, tmp_path: Any) 
     disp = multipart.parse_content_disposition(resp.headers["content-disposition"])
     assert disp == ("attachment", {"name": "file", "filename": "foobar.txt"})
 
-    await resp.release()
+    resp.release()
 
 
 async def test_response_with_bodypart_invalid_name(aiohttp_client: Any) -> None:
@@ -1752,7 +1752,7 @@ async def test_response_with_bodypart_invalid_name(aiohttp_client: Any) -> None:
 
     assert "content-disposition" not in resp.headers
 
-    await resp.release()
+    resp.release()
 
 
 async def test_request_clone(aiohttp_client: Any) -> None:
@@ -1768,7 +1768,7 @@ async def test_request_clone(aiohttp_client: Any) -> None:
 
     resp = await client.get("/")
     assert 200 == resp.status
-    await resp.release()
+    resp.release()
 
 
 async def test_await(aiohttp_server: Any) -> None:
@@ -1794,7 +1794,7 @@ async def test_await(aiohttp_server: Any) -> None:
         assert resp.status == 200
         assert resp.connection is not None
         await resp.read()
-        await resp.release()
+        resp.release()
         assert resp.connection is None
 
 
@@ -1878,7 +1878,7 @@ async def test_context_manager_close_on_release(
         assert resp.connection is None
         assert proto.close.called
 
-        await resp.release()  # Trigger handler completion
+        resp.release()  # Trigger handler completion
 
 
 async def test_iter_any(aiohttp_server: Any) -> None:
@@ -1968,7 +1968,7 @@ async def test_request_tracing(aiohttp_server: Any) -> None:
     assert on_connection_create_start.called
     assert on_connection_create_end.called
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -1982,7 +1982,7 @@ async def test_raise_http_exception(aiohttp_client: Any) -> None:
 
     resp = await client.get("/")
     assert resp.status == 403
-    await resp.release()
+    resp.release()
 
 
 async def test_request_path(aiohttp_client: Any) -> None:
@@ -2000,7 +2000,7 @@ async def test_request_path(aiohttp_client: Any) -> None:
     assert 200 == resp.status
     txt = await resp.text()
     assert "OK" == txt
-    await resp.release()
+    resp.release()
 
 
 async def test_app_add_routes(aiohttp_client: Any) -> None:
@@ -2013,7 +2013,7 @@ async def test_app_add_routes(aiohttp_client: Any) -> None:
     client = await aiohttp_client(app)
     resp = await client.get("/get")
     assert resp.status == 200
-    await resp.release()
+    resp.release()
 
 
 async def test_request_headers_type(aiohttp_client: Any) -> None:
@@ -2027,7 +2027,7 @@ async def test_request_headers_type(aiohttp_client: Any) -> None:
     client = await aiohttp_client(app)
     resp = await client.get("/get")
     assert resp.status == 200
-    await resp.release()
+    resp.release()
 
 
 async def test_signal_on_error_handler(aiohttp_client: Any) -> None:
@@ -2041,7 +2041,7 @@ async def test_signal_on_error_handler(aiohttp_client: Any) -> None:
     resp = await client.get("/")
     assert resp.status == 404
     assert resp.headers["X-Custom"] == "val"
-    await resp.release()
+    resp.release()
 
 
 @pytest.mark.skipif(
@@ -2069,7 +2069,7 @@ async def test_read_bufsize(aiohttp_client: Any) -> None:
     resp = await client.post("/", data=b"data")
     assert resp.status == 200
     assert await resp.text() == "data (2, 4)"
-    await resp.release()
+    resp.release()
 
 
 @pytest.mark.parametrize(
@@ -2096,7 +2096,7 @@ async def test_auto_decompress(
     resp = await client.post("/", data=compressed, headers=headers)
     assert resp.status == 200
     assert await resp.text() == str(len(locals()[len_of]))
-    await resp.release()
+    resp.release()
 
 
 @pytest.mark.parametrize(
@@ -2115,7 +2115,7 @@ async def test_response_101_204_no_content_length_http11(
     resp = await client.get("/")
     assert CONTENT_LENGTH not in resp.headers
     assert TRANSFER_ENCODING not in resp.headers
-    await resp.release()
+    resp.release()
 
 
 async def test_stream_response_headers_204(aiohttp_client: Any):
@@ -2128,7 +2128,7 @@ async def test_stream_response_headers_204(aiohttp_client: Any):
     resp = await client.get("/")
     assert CONTENT_TYPE not in resp.headers
     assert TRANSFER_ENCODING not in resp.headers
-    await resp.release()
+    resp.release()
 
 
 async def test_httpfound_cookies_302(aiohttp_client: Any) -> None:
@@ -2143,7 +2143,7 @@ async def test_httpfound_cookies_302(aiohttp_client: Any) -> None:
 
     resp = await client.get("/", allow_redirects=False)
     assert "my-cookie" in resp.cookies
-    await resp.release()
+    resp.release()
 
 
 @pytest.mark.parametrize("status", (101, 204, 304))
@@ -2163,4 +2163,4 @@ async def test_no_body_for_1xx_204_304_responses(
     assert CONTENT_TYPE not in resp.headers
     assert TRANSFER_ENCODING not in resp.headers
     await resp.read() == b""
-    await resp.release()
+    resp.release()

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -432,7 +432,7 @@ async def test_post_files(aiohttp_client: Any) -> None:
 
 async def test_release_post_data(aiohttp_client: Any) -> None:
     async def handler(request):
-        request.release()
+        await request.release()
         chunk = await request.content.readany()
         assert chunk == b""
         return web.Response()

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -103,7 +103,7 @@ async def test_static_file_ok(
     assert "file content" == txt.rstrip()
     assert "application/octet-stream" == resp.headers["Content-Type"]
     assert resp.headers.get("Content-Encoding") is None
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -127,7 +127,7 @@ async def test_zero_bytes_file_ok(aiohttp_client: Any, sender: Any) -> None:
         assert "" == txt.rstrip()
         assert "application/octet-stream" == resp.headers["Content-Type"]
         assert resp.headers.get("Content-Encoding") is None
-        await resp.release()
+        resp.release()
 
     await client.close()
 
@@ -156,7 +156,7 @@ async def test_zero_bytes_file_mocked_native_sendfile(
         assert "application/octet-stream" == resp.headers["Content-Type"]
         assert resp.headers.get("Content-Encoding") is None
         assert resp.headers.get("Content-Length") == "0"
-        await resp.release()
+        resp.release()
 
     await client.close()
 
@@ -172,7 +172,7 @@ async def test_static_file_ok_string_path(
     assert "file content" == txt.rstrip()
     assert "application/octet-stream" == resp.headers["Content-Type"]
     assert resp.headers.get("Content-Encoding") is None
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -182,7 +182,7 @@ async def test_static_file_not_exists(aiohttp_client: Any) -> None:
 
     resp = await client.get("/fake")
     assert resp.status == 404
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -192,7 +192,7 @@ async def test_static_file_name_too_long(aiohttp_client: Any) -> None:
 
     resp = await client.get("/x*500")
     assert resp.status == 404
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -202,7 +202,7 @@ async def test_static_file_upper_directory(aiohttp_client: Any) -> None:
 
     resp = await client.get("/../../")
     assert resp.status == 404
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -225,7 +225,7 @@ async def test_static_file_with_content_type(aiohttp_client: Any, sender: Any) -
     assert resp.headers["Content-Type"] == "image/jpeg"
     assert resp.headers.get("Content-Encoding") is None
     resp.close()
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -250,7 +250,7 @@ async def test_static_file_custom_content_type(
     assert resp.headers["Content-Type"] == "application/pdf"
     assert await resp.read() == hello_txt.read_bytes()
     resp.close()
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -282,7 +282,7 @@ async def test_static_file_custom_content_type_compress(
     assert resp.headers["Content-Type"] == "application/pdf"
     assert await resp.read() == HELLO_AIOHTTP
     resp.close()
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -316,7 +316,7 @@ async def test_static_file_with_encoding_and_enable_compression(
     assert resp.headers["Content-Type"] == "text/plain"
     assert await resp.read() == HELLO_AIOHTTP
     resp.close()
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -348,7 +348,7 @@ async def test_static_file_with_content_encoding(
     assert await resp.read() == hello_txt.read_bytes()
     resp.close()
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -362,7 +362,7 @@ async def test_static_file_if_modified_since(
     lastmod = resp.headers.get("Last-Modified")
     assert lastmod is not None
     resp.close()
-    await resp.release()
+    resp.release()
 
     resp = await client.get("/", headers={"If-Modified-Since": lastmod})
     body = await resp.read()
@@ -371,7 +371,7 @@ async def test_static_file_if_modified_since(
     assert resp.headers.get("Last-Modified") == lastmod
     assert b"" == body
     resp.close()
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -386,7 +386,7 @@ async def test_static_file_if_modified_since_past_date(
     assert 200 == resp.status
     resp.close()
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -401,7 +401,7 @@ async def test_static_file_if_modified_since_invalid_date(
     assert 200 == resp.status
     resp.close()
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -420,7 +420,7 @@ async def test_static_file_if_modified_since_future_date(
     assert b"" == body
     resp.close()
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -438,7 +438,7 @@ async def test_static_file_if_match(
 
     assert original_etag is not None
     resp.close()
-    await resp.release()
+    resp.release()
 
     headers = {"If-Match": original_etag, "If-Unmodified-Since": if_unmodified_since}
     resp = await client.head("/", headers=headers)
@@ -448,7 +448,7 @@ async def test_static_file_if_match(
     assert resp.headers.get("Last-Modified")
     assert b"" == body
     resp.close()
-    await resp.release()
+    resp.release()
 
     await client.close()
 
@@ -478,7 +478,7 @@ async def test_static_file_if_match_custom_tags(
     assert b"" == body
     resp.close()
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -505,7 +505,7 @@ async def test_static_file_if_none_match(
     assert resp.headers.get("Last-Modified") is not None
     assert original_etag is not None
     resp.close()
-    await resp.release()
+    resp.release()
 
     etag = ",".join((original_etag, *additional_etags))
 
@@ -518,7 +518,7 @@ async def test_static_file_if_none_match(
     assert resp.headers.get("ETag") == original_etag
     assert b"" == body
     resp.close()
-    await resp.release()
+    resp.release()
 
     await client.close()
 
@@ -538,7 +538,7 @@ async def test_static_file_if_none_match_star(
     assert b"" == body
     resp.close()
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -565,7 +565,7 @@ async def test_static_file_ssl(
     assert "application/octet-stream" == ct
     assert resp.headers.get("CONTENT-ENCODING") is None
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -581,17 +581,17 @@ async def test_static_file_directory_traversal_attack(aiohttp_client: Any) -> No
 
     resp = await client.get("/static/" + relpath)
     assert 404 == resp.status
-    await resp.release()
+    resp.release()
 
     url_relpath2 = "/static/dir/../" + relpath
     resp = await client.get(url_relpath2)
     assert 404 == resp.status
-    await resp.release()
+    resp.release()
 
     url_abspath = "/static/" + str(full_path.resolve())
     resp = await client.get(url_abspath)
     assert 403 == resp.status
-    await resp.release()
+    resp.release()
 
     await client.close()
 
@@ -628,7 +628,7 @@ async def test_static_file_huge(aiohttp_client: Any, tmp_path: Any) -> None:
         cnt += 1
     f.close()
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -683,9 +683,8 @@ async def test_static_file_range(aiohttp_client: Any, sender: Any) -> None:
     responses[1].close()
     responses[2].close()
 
-    await asyncio.gather(
-        *(resp.release() for resp in responses),
-    )
+    for resp in responses:
+        resp.release()
 
     assert content == b"".join(body)
 
@@ -722,7 +721,7 @@ async def test_static_file_range_end_bigger_than_size(aiohttp_client: Any, sende
 
         assert content[54000:] == body
 
-    await response.release()
+    response.release()
     await client.close()
 
 
@@ -743,7 +742,7 @@ async def test_static_file_range_beyond_eof(aiohttp_client: Any, sender: Any) ->
         "failed 'bytes=1000000-1200000': %s" % response.reason
     )
 
-    await response.release()
+    response.release()
     await client.close()
 
 
@@ -768,7 +767,7 @@ async def test_static_file_range_tail(aiohttp_client: Any, sender: Any) -> None:
     ), "failed: Content-Range Error"
     body4 = await resp.read()
     resp.close()
-    await resp.release()
+    resp.release()
     assert content[-500:] == body4
 
     # Ensure out-of-range tails could be handled
@@ -777,7 +776,7 @@ async def test_static_file_range_tail(aiohttp_client: Any, sender: Any) -> None:
     assert (
         resp2.headers["Content-Range"] == "bytes 0-54996/54997"
     ), "failed: Content-Range Error"
-    await resp2.release()
+    resp2.release()
 
     await client.close()
 
@@ -796,37 +795,37 @@ async def test_static_file_invalid_range(aiohttp_client: Any, sender: Any) -> No
     resp = await client.get("/", headers={"Range": "blocks=0-10"})
     assert resp.status == 416, "Range must be in bytes"
     resp.close()
-    await resp.release()
+    resp.release()
 
     # start > end
     resp = await client.get("/", headers={"Range": "bytes=100-0"})
     assert resp.status == 416, "Range start can't be greater than end"
     resp.close()
-    await resp.release()
+    resp.release()
 
     # start > end
     resp = await client.get("/", headers={"Range": "bytes=10-9"})
     assert resp.status == 416, "Range start can't be greater than end"
     resp.close()
-    await resp.release()
+    resp.release()
 
     # non-number range
     resp = await client.get("/", headers={"Range": "bytes=a-f"})
     assert resp.status == 416, "Range must be integers"
     resp.close()
-    await resp.release()
+    resp.release()
 
     # double dash range
     resp = await client.get("/", headers={"Range": "bytes=0--10"})
     assert resp.status == 416, "double dash in range"
     resp.close()
-    await resp.release()
+    resp.release()
 
     # no range
     resp = await client.get("/", headers={"Range": "bytes=-"})
     assert resp.status == 416, "no range given"
     resp.close()
-    await resp.release()
+    resp.release()
 
     await client.close()
 
@@ -843,7 +842,7 @@ async def test_static_file_if_unmodified_since_past_with_range(
     )
     assert 412 == resp.status
     resp.close()
-    await resp.release()
+    resp.release()
 
     await client.close()
 
@@ -862,7 +861,7 @@ async def test_static_file_if_unmodified_since_future_with_range(
     assert resp.headers["Content-Range"] == "bytes 2-12/13"
     assert resp.headers["Content-Length"] == "11"
     resp.close()
-    await resp.release()
+    resp.release()
 
     await client.close()
 
@@ -878,7 +877,7 @@ async def test_static_file_if_range_past_with_range(
     assert 200 == resp.status
     assert resp.headers["Content-Length"] == "13"
     resp.close()
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -895,7 +894,7 @@ async def test_static_file_if_range_future_with_range(
     assert resp.headers["Content-Length"] == "11"
     resp.close()
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -910,7 +909,7 @@ async def test_static_file_if_unmodified_since_past_without_range(
     assert 412 == resp.status
     resp.close()
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -926,7 +925,7 @@ async def test_static_file_if_unmodified_since_future_without_range(
     assert resp.headers["Content-Length"] == "13"
     resp.close()
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -942,7 +941,7 @@ async def test_static_file_if_range_past_without_range(
     assert resp.headers["Content-Length"] == "13"
     resp.close()
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -958,7 +957,7 @@ async def test_static_file_if_range_future_without_range(
     assert resp.headers["Content-Length"] == "13"
     resp.close()
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -973,7 +972,7 @@ async def test_static_file_if_unmodified_since_invalid_date(
     assert 200 == resp.status
     resp.close()
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -987,7 +986,7 @@ async def test_static_file_if_range_invalid_date(
     resp = await client.get("/", headers={"If-Range": lastmod})
     assert 200 == resp.status
     resp.close()
-    await resp.release()
+    resp.release()
 
     await client.close()
 
@@ -1011,7 +1010,7 @@ async def test_static_file_compression(aiohttp_client: Any, sender: Any) -> None
     assert expected_body == await resp.read()
     assert "application/octet-stream" == resp.headers["Content-Type"]
     assert resp.headers.get("Content-Encoding") == "deflate"
-    await resp.release()
+    resp.release()
 
     await client.close()
 
@@ -1053,7 +1052,7 @@ async def test_static_file_huge_cancel(aiohttp_client: Any, tmp_path: Any) -> No
             break
     assert len(data) < 1024 * 1024 * 20
 
-    await resp.release()
+    resp.release()
     await client.close()
 
 
@@ -1083,5 +1082,5 @@ async def test_static_file_huge_error(aiohttp_client: Any, tmp_path: Any) -> Non
     # raise an exception on server side
     resp.close()
 
-    await resp.release()
+    resp.release()
     await client.close()

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -633,19 +633,19 @@ async def test_allow_head(aiohttp_client: AiohttpClient) -> None:
 
     r = await client.get("/a")
     assert r.status == 200
-    await r.release()
+    r.release()
 
     r = await client.head("/a")
     assert r.status == 200
-    await r.release()
+    r.release()
 
     r = await client.get("/b")
     assert r.status == 200
-    await r.release()
+    r.release()
 
     r = await client.head("/b")
     assert r.status == 405
-    await r.release()
+    r.release()
 
 
 @pytest.mark.parametrize(
@@ -703,15 +703,15 @@ async def test_add_view(aiohttp_client: AiohttpClient) -> None:
 
     r = await client.get("/a")
     assert r.status == 200
-    await r.release()
+    r.release()
 
     r = await client.post("/a")
     assert r.status == 200
-    await r.release()
+    r.release()
 
     r = await client.put("/a")
     assert r.status == 405
-    await r.release()
+    r.release()
 
 
 async def test_decorate_view(aiohttp_client: AiohttpClient) -> None:
@@ -732,15 +732,15 @@ async def test_decorate_view(aiohttp_client: AiohttpClient) -> None:
 
     r = await client.get("/a")
     assert r.status == 200
-    await r.release()
+    r.release()
 
     r = await client.post("/a")
     assert r.status == 200
-    await r.release()
+    r.release()
 
     r = await client.put("/a")
     assert r.status == 405
-    await r.release()
+    r.release()
 
 
 async def test_web_view(aiohttp_client: AiohttpClient) -> None:
@@ -759,15 +759,15 @@ async def test_web_view(aiohttp_client: AiohttpClient) -> None:
 
     r = await client.get("/a")
     assert r.status == 200
-    await r.release()
+    r.release()
 
     r = await client.post("/a")
     assert r.status == 200
-    await r.release()
+    r.release()
 
     r = await client.put("/a")
     assert r.status == 405
-    await r.release()
+    r.release()
 
 
 async def test_static_absolute_url(
@@ -832,7 +832,7 @@ async def test_decoded_url_match(
 
     r = await client.get(yarl.URL(urlencoded_path, encoded=True))
     assert r.status == expected_http_resp_status
-    await r.release()
+    r.release()
 
 
 async def test_order_is_preserved(aiohttp_client: AiohttpClient) -> None:
@@ -915,7 +915,7 @@ async def test_url_with_many_slashes(aiohttp_client: AiohttpClient) -> None:
 
     r = await client.get("///a")
     assert r.status == 200
-    await r.release()
+    r.release()
 
 
 async def test_route_with_regex(aiohttp_client: AiohttpClient) -> None:


### PR DESCRIPTION
Closes #2164.

According to the linked issue this was supposed to be removed in v3.