### PR TITLE
Fix slowdown in tests waiting for server to close

### DIFF
--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -113,11 +113,7 @@ class BaseTestServer(ABC):
         if self.runner:
             return
         self._ssl = kwargs.pop("ssl", None)
-        self.runner = await self._make_runner(
-            handler_cancellation=True,
-            shutdown_timeout=MONOTONIC_CLOCK_RESOLUTION,
-            **kwargs,
-        )
+        self.runner = await self._make_runner(handler_cancellation=True, **kwargs)
         await self.runner.setup()
         if not self.port:
             self.port = 0
@@ -222,7 +218,9 @@ class TestServer(BaseTestServer):
         super().__init__(scheme=scheme, host=host, port=port, **kwargs)
 
     async def _make_runner(self, **kwargs: Any) -> BaseRunner:
-        return AppRunner(self.app, **kwargs)
+        return AppRunner(
+            self.app, shutdown_timeout=MONOTONIC_CLOCK_RESOLUTION, **kwargs
+        )
 
 
 class RawTestServer(BaseTestServer):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

There were a few tests that had to wait 60s to teardown because we would wait for the server to close in places we were not testing the server close logic. This added a few minutes to the test runs (18 minutes vs 5 minutes). Set the timeout to the monotonic clock resolution to reduce test time. 

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?

no