### PR TITLE
Fix handler waiting on shutdown

### DIFF
--- a/CHANGES/8611.bugfix.rst
+++ b/CHANGES/8611.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an edge case where shutdown would wait for timeout when handler was already completed -- by :user:`Dreamsorcerer`.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -282,7 +282,9 @@ class RequestHandler(BaseProtocol):
 
         # Wait for graceful handler completion
         if self._handler_waiter is not None:
-            await self._handler_waiter
+            with suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                async with ceil_timeout(timeout):
+                    await self._handler_waiter
         # Then cancel handler and wait
         with suppress(asyncio.CancelledError, asyncio.TimeoutError):
             async with ceil_timeout(timeout):

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -163,6 +163,7 @@ class RequestHandler(BaseProtocol):
         "_lingering_time",
         "_messages",
         "_message_tail",
+        "_handler_waiter",
         "_waiter",
         "_task_handler",
         "_upgrade",
@@ -215,6 +216,7 @@ class RequestHandler(BaseProtocol):
         self._message_tail = b""
 
         self._waiter: Optional[asyncio.Future[None]] = None
+        self._handler_waiter: Optional[asyncio.Future[None]] = None
         self._task_handler: Optional[asyncio.Task[None]] = None
 
         self._upgrade = False
@@ -278,11 +280,9 @@ class RequestHandler(BaseProtocol):
         if self._waiter:
             self._waiter.cancel()
 
-        # Wait for graceful disconnection
-        if self._current_request is not None:
-            with suppress(asyncio.CancelledError, asyncio.TimeoutError):
-                async with ceil_timeout(timeout):
-                    await self._current_request.wait_for_disconnection()
+        # Wait for graceful handler completion
+        if self._handler_waiter is not None:
+            await self._handler_waiter
         # Then cancel handler and wait
         with suppress(asyncio.CancelledError, asyncio.TimeoutError):
             async with ceil_timeout(timeout):
@@ -466,6 +466,7 @@ class RequestHandler(BaseProtocol):
         start_time: float,
         request_handler: Callable[[BaseRequest], Awaitable[StreamResponse]],
     ) -> Tuple[StreamResponse, bool]:
+        self._handler_waiter = self._loop.create_future()
         try:
             try:
                 self._current_request = request
@@ -489,6 +490,8 @@ class RequestHandler(BaseProtocol):
             reset = await self.finish_response(request, resp, start_time)
         else:
             reset = await self.finish_response(request, resp, start_time)
+        finally:
+            self._handler_waiter.set_result(None)
 
         return resp, reset
 


### PR DESCRIPTION
There seems to be some kind of race condition in certain circumstance which can lead to .wait_for_disconnection() being called after the request has already been cancelled.

Additionally, I see no guarantee that when .wait_for_disconnection() completes, that the handler itself has completed (and not suppressed a cancellation etc.).

However, I couldn't figure out a shutdown test in test_run_app.py that triggers this edge case.