### PR TITLE
Fix monkey patches for pathlib changes in Python 3.13

### DIFF
--- a/CHANGES/8551.contrib.rst
+++ b/CHANGES/8551.contrib.rst
@@ -1,0 +1,1 @@
+Fixed monkey patches for ``Path.stat()`` and ``Path.is_dir()`` for python 3.13 compatibility -- by :user:`steverep`.

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -428,10 +428,10 @@ async def test_static_directory_with_mock_permission_error(
             raise PermissionError()
         return real_iterdir(self)
 
-    def mock_is_dir(self: pathlib.Path) -> bool:
+    def mock_is_dir(self: pathlib.Path, **kwargs: Any) -> bool:
         if my_dir.samefile(self.parent):
             raise PermissionError()
-        return real_is_dir(self)
+        return real_is_dir(self, **kwargs)
 
     monkeypatch.setattr("pathlib.Path.iterdir", mock_iterdir)
     monkeypatch.setattr("pathlib.Path.is_dir", mock_is_dir)
@@ -548,8 +548,8 @@ async def test_access_mock_special_resource(
     real_result = my_special.stat()
     real_stat = pathlib.Path.stat
 
-    def mock_stat(self: pathlib.Path) -> os.stat_result:
-        s = real_stat(self)
+    def mock_stat(self: pathlib.Path, **kwargs: Any) -> os.stat_result:
+        s = real_stat(self, **kwargs)
         if os.path.samestat(s, real_result):
             mock_mode = S_IFIFO | S_IMODE(s.st_mode)
             s = os.stat_result([mock_mode] + list(s)[1:])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Just alters a couple of mocks to accept `**kwargs`.  This makes them compatible with `follow_symlinks` added to `is_file()` and `is_dir()` in 3.13.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->
No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->
Fixes #8551 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
