### PR TITLE
Fix connecting to npipe://, tcp://, and unix:// urls

### DIFF
--- a/CHANGES/8632.bugfix.rst
+++ b/CHANGES/8632.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed connecting to ``unix://`` urls -- by :user:`bdraco`.

--- a/CHANGES/8632.bugfix.rst
+++ b/CHANGES/8632.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed connecting to ``unix://`` urls -- by :user:`bdraco`.
+Fixed connecting to ``npipe://`` and ``unix://`` urls -- by :user:`bdraco`.

--- a/CHANGES/8632.bugfix.rst
+++ b/CHANGES/8632.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed connecting to ``npipe://`` and ``unix://`` urls -- by :user:`bdraco`.
+Fixed connecting to ``npipe://``, ``tcp://``, and ``unix://`` urls -- by :user:`bdraco`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -80,11 +80,16 @@ from .client_ws import (
     ClientWebSocketResponse,
     ClientWSTimeout,
 )
-from .connector import BaseConnector, NamedPipeConnector, TCPConnector, UnixConnector
+from .connector import (
+    HTTP_AND_EMPTY_SCHEMA_SET,
+    BaseConnector,
+    NamedPipeConnector,
+    TCPConnector,
+    UnixConnector,
+)
 from .cookiejar import CookieJar
 from .helpers import (
     _SENTINEL,
-    HTTP_SCHEMA_SET,
     BasicAuth,
     TimeoutHandle,
     ceil_timeout,
@@ -681,7 +686,7 @@ class ClientSession:
                             ) from e
 
                         scheme = parsed_redirect_url.scheme
-                        if scheme not in HTTP_SCHEMA_SET:
+                        if scheme not in HTTP_AND_EMPTY_SCHEMA_SET:
                             resp.close()
                             raise NonHttpUrlRedirectClientError(r_url)
                         elif not scheme:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -84,6 +84,7 @@ from .connector import BaseConnector, NamedPipeConnector, TCPConnector, UnixConn
 from .cookiejar import CookieJar
 from .helpers import (
     _SENTINEL,
+    HTTP_SCHEMA_SET,
     BasicAuth,
     TimeoutHandle,
     ceil_timeout,
@@ -210,10 +211,7 @@ DEFAULT_TIMEOUT: Final[ClientTimeout] = ClientTimeout(total=5 * 60)
 
 # https://www.rfc-editor.org/rfc/rfc9110#section-9.2.2
 IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE", "PUT", "DELETE"})
-HTTP_SCHEMA_SET = frozenset({"http", "https", ""})
-WS_SCHEMA_SET = frozenset({"ws", "wss"})
-PROTOCOL_SCHEMA_SET = frozenset({"npipe", "unix"})
-ALLOWED_PROTOCOL_SCHEMA_SET = HTTP_SCHEMA_SET | WS_SCHEMA_SET | PROTOCOL_SCHEMA_SET
+
 
 _RetType = TypeVar("_RetType")
 _CharsetResolver = Callable[[ClientResponse, bytes], str]
@@ -456,7 +454,7 @@ class ClientSession:
         except ValueError as e:
             raise InvalidUrlClientError(str_or_url) from e
 
-        if url.scheme not in ALLOWED_PROTOCOL_SCHEMA_SET:
+        if url.scheme not in self._connector.allowed_protocol_schema_set:
             raise NonHttpUrlClientError(url)
 
         skip_headers = set(self._skip_auto_headers)

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -217,7 +217,6 @@ DEFAULT_TIMEOUT: Final[ClientTimeout] = ClientTimeout(total=5 * 60)
 # https://www.rfc-editor.org/rfc/rfc9110#section-9.2.2
 IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE", "PUT", "DELETE"})
 
-
 _RetType = TypeVar("_RetType")
 _CharsetResolver = Callable[[ClientResponse, bytes], str]
 

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -212,7 +212,7 @@ DEFAULT_TIMEOUT: Final[ClientTimeout] = ClientTimeout(total=5 * 60)
 IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE", "PUT", "DELETE"})
 HTTP_SCHEMA_SET = frozenset({"http", "https", ""})
 WS_SCHEMA_SET = frozenset({"ws", "wss"})
-PROTOCOL_SCHEMA_SET = frozenset({"unix"})
+PROTOCOL_SCHEMA_SET = frozenset({"npipe", "unix"})
 ALLOWED_PROTOCOL_SCHEMA_SET = HTTP_SCHEMA_SET | WS_SCHEMA_SET | PROTOCOL_SCHEMA_SET
 
 _RetType = TypeVar("_RetType")

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -212,7 +212,8 @@ DEFAULT_TIMEOUT: Final[ClientTimeout] = ClientTimeout(total=5 * 60)
 IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE", "PUT", "DELETE"})
 HTTP_SCHEMA_SET = frozenset({"http", "https", ""})
 WS_SCHEMA_SET = frozenset({"ws", "wss"})
-ALLOWED_PROTOCOL_SCHEMA_SET = HTTP_SCHEMA_SET | WS_SCHEMA_SET
+PROTOCOL_SCHEMA_SET = frozenset({"unix"})
+ALLOWED_PROTOCOL_SCHEMA_SET = HTTP_SCHEMA_SET | WS_SCHEMA_SET | PROTOCOL_SCHEMA_SET
 
 _RetType = TypeVar("_RetType")
 _CharsetResolver = Callable[[ClientResponse, bytes], str]

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -459,6 +459,7 @@ class ClientSession:
         except ValueError as e:
             raise InvalidUrlClientError(str_or_url) from e
 
+        assert self._connector is not None
         if url.scheme not in self._connector.allowed_protocol_schema_set:
             raise NonHttpUrlClientError(url)
 
@@ -590,7 +591,6 @@ class ClientSession:
                             real_timeout.connect,
                             ceil_threshold=real_timeout.ceil_threshold,
                         ):
-                            assert self._connector is not None
                             conn = await self._connector.connect(
                                 req, traces=traces, timeout=real_timeout
                             )

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -259,7 +259,7 @@ class BaseConnector:
     def allowed_protocol_schema_set(self) -> frozenset[str]:
         """Return allowed protocol schema set.
 
-        By default we allow all protocols.
+        By default we allow all protocols for backwards compatibility.
         """
         return ALLOWED_PROTOCOL_SCHEMA_SET
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -21,7 +21,6 @@ from typing import (  # noqa
     Callable,
     DefaultDict,
     Dict,
-    FrozenSet,
     Iterator,
     List,
     Literal,

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -74,7 +74,7 @@ NAMED_PIPE_PROTOCOL_SCHEMA_SET = frozenset({"npipe"})
 
 HTTP_AND_EMPTY_SCHEMA_SET = HTTP_SCHEMA_SET | EMPTY_SCHEMA_SET
 HIGH_LEVEL_SCHEMA_SET = HTTP_AND_EMPTY_SCHEMA_SET | WS_SCHEMA_SET
-ALLOWED_PROTOCOL_SCHEMA_SET = (
+BASE_PROTOCOL_SCHEMA_SET = (
     HIGH_LEVEL_SCHEMA_SET
     | TCP_PROTOCOL_SCHEMA_SET
     | UNIX_PROTOCOL_SCHEMA_SET
@@ -268,7 +268,7 @@ class BaseConnector:
 
         By default we allow all protocols for backwards compatibility.
         """
-        return ALLOWED_PROTOCOL_SCHEMA_SET
+        return BASE_PROTOCOL_SCHEMA_SET
 
     def __del__(self, _warnings: Any = warnings) -> None:
         if self._closed:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -67,13 +67,18 @@ except ImportError:  # pragma: no cover
 
 EMPTY_SCHEMA_SET = frozenset({""})
 HTTP_SCHEMA_SET = frozenset({"http", "https"})
-HTTP_AND_EMPTY_SCHEMA_SET = HTTP_SCHEMA_SET | EMPTY_SCHEMA_SET
 WS_SCHEMA_SET = frozenset({"ws", "wss"})
-HIGH_LEVEL_SCHEMA_SET = HTTP_AND_EMPTY_SCHEMA_SET | WS_SCHEMA_SET
-UNIX_PROTCOL_SCHEMA_SET = frozenset({"unix"})
+TCP_PROTOCOL_SCHEMA_SET = frozenset({"tcp"})
+UNIX_PROTOCOL_SCHEMA_SET = frozenset({"unix"})
 NAMED_PIPE_PROTOCOL_SCHEMA_SET = frozenset({"npipe"})
+
+HTTP_AND_EMPTY_SCHEMA_SET = HTTP_SCHEMA_SET | EMPTY_SCHEMA_SET
+HIGH_LEVEL_SCHEMA_SET = HTTP_AND_EMPTY_SCHEMA_SET | WS_SCHEMA_SET
 ALLOWED_PROTOCOL_SCHEMA_SET = (
-    HIGH_LEVEL_SCHEMA_SET | UNIX_PROTCOL_SCHEMA_SET | NAMED_PIPE_PROTOCOL_SCHEMA_SET
+    HIGH_LEVEL_SCHEMA_SET
+    | TCP_PROTOCOL_SCHEMA_SET
+    | UNIX_PROTOCOL_SCHEMA_SET
+    | NAMED_PIPE_PROTOCOL_SCHEMA_SET
 )
 
 
@@ -815,7 +820,7 @@ class TCPConnector(BaseConnector):
     @cached_property
     def allowed_protocol_schema_set(self) -> FrozenSet[str]:
         """Return allowed protocol schema set."""
-        return HIGH_LEVEL_SCHEMA_SET
+        return HIGH_LEVEL_SCHEMA_SET | TCP_PROTOCOL_SCHEMA_SET
 
     @property
     def family(self) -> int:
@@ -1387,7 +1392,7 @@ class UnixConnector(BaseConnector):
     @cached_property
     def allowed_protocol_schema_set(self) -> FrozenSet[str]:
         """Return allowed protocol schema set."""
-        return HIGH_LEVEL_SCHEMA_SET | UNIX_PROTCOL_SCHEMA_SET
+        return HIGH_LEVEL_SCHEMA_SET | UNIX_PROTOCOL_SCHEMA_SET
 
     @property
     def path(self) -> str:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -51,19 +51,7 @@ from .client_exceptions import (
 )
 from .client_proto import ResponseHandler
 from .client_reqrep import SSL_ALLOWED_TYPES, ClientRequest, Fingerprint
-from .helpers import (
-    _SENTINEL,
-    ALLOWED_PROTOCOL_SCHEMA_SET,
-    EMPTY_SCHEMA_SET,
-    HTTP_SCHEMA_SET,
-    NAMED_PIPE_PROTOCOL_SCHEMA_SET,
-    UNIX_PROTCOL_SCHEMA_SET,
-    WS_SCHEMA_SET,
-    ceil_timeout,
-    is_ip_address,
-    sentinel,
-    set_result,
-)
+from .helpers import _SENTINEL, ceil_timeout, is_ip_address, sentinel, set_result
 from .locks import EventResultOrError
 from .resolver import DefaultResolver
 
@@ -74,6 +62,18 @@ try:
 except ImportError:  # pragma: no cover
     ssl = None  # type: ignore[assignment]
     SSLContext = object  # type: ignore[misc,assignment]
+
+
+EMPTY_SCHEMA_SET = frozenset({""})
+HTTP_SCHEMA_SET = frozenset({"http", "https"})
+HTTP_AND_EMPTY_SCHEMA_SET = HTTP_SCHEMA_SET | EMPTY_SCHEMA_SET
+WS_SCHEMA_SET = frozenset({"ws", "wss"})
+HIGH_LEVEL_SCHEMA_SET = HTTP_AND_EMPTY_SCHEMA_SET | WS_SCHEMA_SET
+UNIX_PROTCOL_SCHEMA_SET = frozenset({"unix"})
+NAMED_PIPE_PROTOCOL_SCHEMA_SET = frozenset({"npipe"})
+ALLOWED_PROTOCOL_SCHEMA_SET = (
+    HIGH_LEVEL_SCHEMA_SET | UNIX_PROTCOL_SCHEMA_SET | NAMED_PIPE_PROTOCOL_SCHEMA_SET
+)
 
 
 __all__ = ("BaseConnector", "TCPConnector", "UnixConnector", "NamedPipeConnector")
@@ -814,7 +814,7 @@ class TCPConnector(BaseConnector):
     @cached_property
     def allowed_protocol_schema_set(self) -> frozenset[str]:
         """Return allowed protocol schema set."""
-        return EMPTY_SCHEMA_SET | HTTP_SCHEMA_SET | WS_SCHEMA_SET
+        return HIGH_LEVEL_SCHEMA_SET
 
     @property
     def family(self) -> int:
@@ -1386,9 +1386,7 @@ class UnixConnector(BaseConnector):
     @cached_property
     def allowed_protocol_schema_set(self) -> frozenset[str]:
         """Return allowed protocol schema set."""
-        return (
-            EMPTY_SCHEMA_SET | HTTP_SCHEMA_SET | WS_SCHEMA_SET | UNIX_PROTCOL_SCHEMA_SET
-        )
+        return HIGH_LEVEL_SCHEMA_SET | UNIX_PROTCOL_SCHEMA_SET
 
     @property
     def path(self) -> str:
@@ -1453,12 +1451,7 @@ class NamedPipeConnector(BaseConnector):
     @cached_property
     def allowed_protocol_schema_set(self) -> frozenset[str]:
         """Return allowed protocol schema set."""
-        return (
-            EMPTY_SCHEMA_SET
-            | HTTP_SCHEMA_SET
-            | WS_SCHEMA_SET
-            | NAMED_PIPE_PROTOCOL_SCHEMA_SET
-        )
+        return HIGH_LEVEL_SCHEMA_SET | NAMED_PIPE_PROTOCOL_SCHEMA_SET
 
     @property
     def path(self) -> str:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -7,7 +7,7 @@ import socket
 import sys
 import traceback
 import warnings
-from collections import defaultdict, deque
+from collections import defaultdict, deque, frozenset
 from contextlib import suppress
 from functools import cached_property
 from http import HTTPStatus
@@ -256,7 +256,7 @@ class BaseConnector:
         self._cleanup_closed()
 
     @cached_property
-    def allowed_protocol_schema_set(self) -> Set[str]:
+    def allowed_protocol_schema_set(self) -> frozenset[str]:
         """Return allowed protocol schema set.
 
         By default we allow all protocols.
@@ -811,7 +811,7 @@ class TCPConnector(BaseConnector):
         return super()._close_immediately()
 
     @cached_property
-    def allowed_protocol_schema_set(self) -> Set[str]:
+    def allowed_protocol_schema_set(self) -> frozenset[str]:
         """Return allowed protocol schema set."""
         return HTTP_SCHEMA_SET | WS_SCHEMA_SET
 
@@ -1383,7 +1383,7 @@ class UnixConnector(BaseConnector):
         self._path = path
 
     @cached_property
-    def allowed_protocol_schema_set(self) -> Set[str]:
+    def allowed_protocol_schema_set(self) -> frozenset[str]:
         """Return allowed protocol schema set."""
         return UNIX_PROTCOL_SCHEMA_SET
 
@@ -1448,7 +1448,7 @@ class NamedPipeConnector(BaseConnector):
         self._path = path
 
     @cached_property
-    def allowed_protocol_schema_set(self) -> Set[str]:
+    def allowed_protocol_schema_set(self) -> frozenset[str]:
         """Return allowed protocol schema set."""
         return NAMED_PIPE_PROTOCOL_SCHEMA_SET
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -22,6 +22,7 @@ from typing import (  # noqa
     Callable,
     DefaultDict,
     Dict,
+    FrozenSet,
     Iterator,
     List,
     Literal,
@@ -257,7 +258,7 @@ class BaseConnector:
         self._cleanup_closed()
 
     @cached_property
-    def allowed_protocol_schema_set(self) -> frozenset[str]:
+    def allowed_protocol_schema_set(self) -> FrozenSet[str]:
         """Return allowed protocol schema set.
 
         By default we allow all protocols for backwards compatibility.
@@ -812,7 +813,7 @@ class TCPConnector(BaseConnector):
         return super()._close_immediately()
 
     @cached_property
-    def allowed_protocol_schema_set(self) -> frozenset[str]:
+    def allowed_protocol_schema_set(self) -> FrozenSet[str]:
         """Return allowed protocol schema set."""
         return HIGH_LEVEL_SCHEMA_SET
 
@@ -1384,7 +1385,7 @@ class UnixConnector(BaseConnector):
         self._path = path
 
     @cached_property
-    def allowed_protocol_schema_set(self) -> frozenset[str]:
+    def allowed_protocol_schema_set(self) -> FrozenSet[str]:
         """Return allowed protocol schema set."""
         return HIGH_LEVEL_SCHEMA_SET | UNIX_PROTCOL_SCHEMA_SET
 
@@ -1449,7 +1450,7 @@ class NamedPipeConnector(BaseConnector):
         self._path = path
 
     @cached_property
-    def allowed_protocol_schema_set(self) -> frozenset[str]:
+    def allowed_protocol_schema_set(self) -> FrozenSet[str]:
         """Return allowed protocol schema set."""
         return HIGH_LEVEL_SCHEMA_SET | NAMED_PIPE_PROTOCOL_SCHEMA_SET
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -7,7 +7,7 @@ import socket
 import sys
 import traceback
 import warnings
-from collections import defaultdict, deque, frozenset
+from collections import defaultdict, deque
 from contextlib import suppress
 from functools import cached_property
 from http import HTTPStatus

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -261,7 +261,7 @@ class BaseConnector:
     def allowed_protocol_schema_set(self) -> FrozenSet[str]:
         """Return allowed protocol schema set.
 
-        By default we allow all protocols for backwards compatibility.
+        By default we allow all high level protocols for backwards compatibility.
         """
         return HIGH_LEVEL_SCHEMA_SET
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -54,6 +54,7 @@ from .client_reqrep import SSL_ALLOWED_TYPES, ClientRequest, Fingerprint
 from .helpers import (
     _SENTINEL,
     ALLOWED_PROTOCOL_SCHEMA_SET,
+    EMPTY_SCHEMA_SET,
     HTTP_SCHEMA_SET,
     NAMED_PIPE_PROTOCOL_SCHEMA_SET,
     UNIX_PROTCOL_SCHEMA_SET,
@@ -813,7 +814,7 @@ class TCPConnector(BaseConnector):
     @cached_property
     def allowed_protocol_schema_set(self) -> frozenset[str]:
         """Return allowed protocol schema set."""
-        return HTTP_SCHEMA_SET | WS_SCHEMA_SET
+        return EMPTY_SCHEMA_SET | HTTP_SCHEMA_SET | WS_SCHEMA_SET
 
     @property
     def family(self) -> int:
@@ -1385,7 +1386,9 @@ class UnixConnector(BaseConnector):
     @cached_property
     def allowed_protocol_schema_set(self) -> frozenset[str]:
         """Return allowed protocol schema set."""
-        return UNIX_PROTCOL_SCHEMA_SET
+        return (
+            EMPTY_SCHEMA_SET | HTTP_SCHEMA_SET | WS_SCHEMA_SET | UNIX_PROTCOL_SCHEMA_SET
+        )
 
     @property
     def path(self) -> str:
@@ -1450,7 +1453,12 @@ class NamedPipeConnector(BaseConnector):
     @cached_property
     def allowed_protocol_schema_set(self) -> frozenset[str]:
         """Return allowed protocol schema set."""
-        return NAMED_PIPE_PROTOCOL_SCHEMA_SET
+        return (
+            EMPTY_SCHEMA_SET
+            | HTTP_SCHEMA_SET
+            | WS_SCHEMA_SET
+            | NAMED_PIPE_PROTOCOL_SCHEMA_SET
+        )
 
     @property
     def path(self) -> str:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -75,12 +75,6 @@ NAMED_PIPE_PROTOCOL_SCHEMA_SET = frozenset({"npipe"})
 
 HTTP_AND_EMPTY_SCHEMA_SET = HTTP_SCHEMA_SET | EMPTY_SCHEMA_SET
 HIGH_LEVEL_SCHEMA_SET = HTTP_AND_EMPTY_SCHEMA_SET | WS_SCHEMA_SET
-BASE_PROTOCOL_SCHEMA_SET = (
-    HIGH_LEVEL_SCHEMA_SET
-    | TCP_PROTOCOL_SCHEMA_SET
-    | UNIX_PROTOCOL_SCHEMA_SET
-    | NAMED_PIPE_PROTOCOL_SCHEMA_SET
-)
 
 
 __all__ = ("BaseConnector", "TCPConnector", "UnixConnector", "NamedPipeConnector")
@@ -269,7 +263,7 @@ class BaseConnector:
 
         By default we allow all protocols for backwards compatibility.
         """
-        return BASE_PROTOCOL_SCHEMA_SET
+        return HIGH_LEVEL_SCHEMA_SET
 
     def __del__(self, _warnings: Any = warnings) -> None:
         if self._closed:
@@ -821,7 +815,7 @@ class TCPConnector(BaseConnector):
     @cached_property
     def allowed_protocol_schema_set(self) -> FrozenSet[str]:
         """Return allowed protocol schema set."""
-        return HIGH_LEVEL_SCHEMA_SET | TCP_PROTOCOL_SCHEMA_SET
+        return super().allowed_protocol_schema_set | TCP_PROTOCOL_SCHEMA_SET
 
     @property
     def family(self) -> int:
@@ -1393,7 +1387,7 @@ class UnixConnector(BaseConnector):
     @cached_property
     def allowed_protocol_schema_set(self) -> FrozenSet[str]:
         """Return allowed protocol schema set."""
-        return HIGH_LEVEL_SCHEMA_SET | UNIX_PROTOCOL_SCHEMA_SET
+        return super().allowed_protocol_schema_set | UNIX_PROTOCOL_SCHEMA_SET
 
     @property
     def path(self) -> str:
@@ -1458,7 +1452,7 @@ class NamedPipeConnector(BaseConnector):
     @cached_property
     def allowed_protocol_schema_set(self) -> FrozenSet[str]:
         """Return allowed protocol schema set."""
-        return HIGH_LEVEL_SCHEMA_SET | NAMED_PIPE_PROTOCOL_SCHEMA_SET
+        return super().allowed_protocol_schema_set | NAMED_PIPE_PROTOCOL_SCHEMA_SET
 
     @property
     def path(self) -> str:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -107,6 +107,17 @@ SEPARATORS = {
 }
 TOKEN = CHAR ^ CTL ^ SEPARATORS
 
+HTTP_SCHEMA_SET = frozenset({"http", "https", ""})
+WS_SCHEMA_SET = frozenset({"ws", "wss"})
+UNIX_PROTCOL_SCHEMA_SET = frozenset({"unix"})
+NAMED_PIPE_PROTOCOL_SCHEMA_SET = frozenset({"npipe"})
+ALLOWED_PROTOCOL_SCHEMA_SET = (
+    HTTP_SCHEMA_SET
+    | WS_SCHEMA_SET
+    | UNIX_PROTCOL_SCHEMA_SET
+    | NAMED_PIPE_PROTOCOL_SCHEMA_SET
+)
+
 
 json_re = re.compile(r"(?:application/|[\w.-]+/[\w.+-]+?\+)json$", re.IGNORECASE)
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -107,19 +107,6 @@ SEPARATORS = {
 }
 TOKEN = CHAR ^ CTL ^ SEPARATORS
 
-EMPTY_SCHEMA_SET = frozenset({""})
-HTTP_SCHEMA_SET = frozenset({"http", "https"})
-WS_SCHEMA_SET = frozenset({"ws", "wss"})
-UNIX_PROTCOL_SCHEMA_SET = frozenset({"unix"})
-NAMED_PIPE_PROTOCOL_SCHEMA_SET = frozenset({"npipe"})
-ALLOWED_PROTOCOL_SCHEMA_SET = (
-    EMPTY_SCHEMA_SET
-    | HTTP_SCHEMA_SET
-    | WS_SCHEMA_SET
-    | UNIX_PROTCOL_SCHEMA_SET
-    | NAMED_PIPE_PROTOCOL_SCHEMA_SET
-)
-
 
 json_re = re.compile(r"(?:application/|[\w.-]+/[\w.+-]+?\+)json$", re.IGNORECASE)
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -107,12 +107,14 @@ SEPARATORS = {
 }
 TOKEN = CHAR ^ CTL ^ SEPARATORS
 
-HTTP_SCHEMA_SET = frozenset({"http", "https", ""})
+EMPTY_SCHEMA_SET = frozenset({""})
+HTTP_SCHEMA_SET = frozenset({"http", "https"})
 WS_SCHEMA_SET = frozenset({"ws", "wss"})
 UNIX_PROTCOL_SCHEMA_SET = frozenset({"unix"})
 NAMED_PIPE_PROTOCOL_SCHEMA_SET = frozenset({"npipe"})
 ALLOWED_PROTOCOL_SCHEMA_SET = (
-    HTTP_SCHEMA_SET
+    EMPTY_SCHEMA_SET
+    | HTTP_SCHEMA_SET
     | WS_SCHEMA_SET
     | UNIX_PROTCOL_SCHEMA_SET
     | NAMED_PIPE_PROTOCOL_SCHEMA_SET

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -489,8 +489,10 @@ async def test_ws_connect_allowed_protocols(
     req = mock.create_autospec(aiohttp.ClientRequest, spec_set=True)
     req_factory = mock.Mock(return_value=req)
     req.send = mock.AsyncMock(return_value=resp)
+    # BaseConnector allows all protocols by default
+    connector = BaseConnector()
 
-    session = await create_session(request_class=req_factory)
+    session = await create_session(connector=connector, request_class=req_factory)
 
     connections = []
     original_connect = session._connector.connect

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -604,7 +604,7 @@ async def test_ws_connect_unix_socket_allowed_protocols(
     req = mock.create_autospec(aiohttp.ClientRequest, spec_set=True)
     req_factory = mock.Mock(return_value=req)
     req.send = mock.AsyncMock(return_value=resp)
-    # UnixConnector allows all protocols by default and unix sockets
+    # UnixConnector allows all high level protocols by default and unix sockets
     connector = UnixConnector(path="")
 
     session = await create_session(connector=connector, request_class=req_factory)

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -467,7 +467,7 @@ async def test_close_conn_on_error(
         c.__del__()
 
 
-@pytest.mark.parametrize("protocol", ["http", "https", "ws", "wss", "unix"])
+@pytest.mark.parametrize("protocol", ["http", "https", "npipe", "ws", "wss", "unix"])
 async def test_ws_connect_allowed_protocols(
     create_session: Any,
     create_mocked_conn: Any,

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -605,9 +605,9 @@ async def test_ws_connect_unix_socket_allowed_protocols(
     req_factory = mock.Mock(return_value=req)
     req.send = mock.AsyncMock(return_value=resp)
     # UnixConnector allows all protocols by default and unix sockets
-    connector = UnixConnector(path="")
-
-    session = await create_session(connector=connector, request_class=req_factory)
+    session = await create_session(
+        connector=UnixConnector(path=""), request_class=req_factory
+    )
 
     connections = []
     assert session._connector is not None

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -543,7 +543,7 @@ async def test_ws_connect_allowed_protocols(
     req = mock.create_autospec(aiohttp.ClientRequest, spec_set=True)
     req_factory = mock.Mock(return_value=req)
     req.send = mock.AsyncMock(return_value=resp)
-    # BaseConnector allows all protocols by default
+    # BaseConnector allows all high level protocols by default
     connector = BaseConnector()
 
     session = await create_session(connector=connector, request_class=req_factory)

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -521,9 +521,7 @@ async def test_close_conn_on_error(
                     c.__del__()
 
 
-@pytest.mark.parametrize(
-    "protocol", ["http", "https", "npipe", "ws", "wss", "unix", "tcp"]
-)
+@pytest.mark.parametrize("protocol", ["http", "https", "ws", "wss"])
 async def test_ws_connect_allowed_protocols(
     create_session: Callable[..., Awaitable[ClientSession]],
     create_mocked_conn: Callable[[], ResponseHandler],

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -467,7 +467,9 @@ async def test_close_conn_on_error(
         c.__del__()
 
 
-@pytest.mark.parametrize("protocol", ["http", "https", "npipe", "ws", "wss", "unix"])
+@pytest.mark.parametrize(
+    "protocol", ["http", "https", "npipe", "ws", "wss", "unix", "tcp"]
+)
 async def test_ws_connect_allowed_protocols(
     create_session: Any,
     create_mocked_conn: Any,

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -467,7 +467,7 @@ async def test_close_conn_on_error(
         c.__del__()
 
 
-@pytest.mark.parametrize("protocol", ["http", "https", "ws", "wss"])
+@pytest.mark.parametrize("protocol", ["http", "https", "ws", "wss", "unix"])
 async def test_ws_connect_allowed_protocols(
     create_session: Any,
     create_mocked_conn: Any,
@@ -482,7 +482,7 @@ async def test_ws_connect_allowed_protocols(
         hdrs.CONNECTION: "upgrade",
         hdrs.SEC_WEBSOCKET_ACCEPT: ws_key,
     }
-    resp.url = URL(f"{protocol}://example.com")
+    resp.url = URL(f"{protocol}://example")
     resp.cookies = SimpleCookie()
     resp.start = mock.AsyncMock()
 
@@ -510,7 +510,7 @@ async def test_ws_connect_allowed_protocols(
         "aiohttp.client.os"
     ) as m_os:
         m_os.urandom.return_value = key_data
-        await session.ws_connect(f"{protocol}://example.com")
+        await session.ws_connect(f"{protocol}://example")
 
     # normally called during garbage collection.  triggers an exception
     # if the connection wasn't already closed

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -604,7 +604,7 @@ async def test_ws_connect_unix_socket_allowed_protocols(
     req = mock.create_autospec(aiohttp.ClientRequest, spec_set=True)
     req_factory = mock.Mock(return_value=req)
     req.send = mock.AsyncMock(return_value=resp)
-    # UnixConnector allows all protocols by default and unix sockets
+    # UnixConnector allows all high level protocols by default and unix sockets
     session = await create_session(
         connector=UnixConnector(path=""), request_class=req_factory
     )

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1662,6 +1662,7 @@ async def test_base_connector_allows_all_protocols(loop: Any) -> None:
         "https",
         "ws",
         "wss",
+        "tcp",
         "unix",
         "npipe",
     }

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1490,6 +1490,11 @@ async def test_tcp_connector_ctor(loop: Any) -> None:
     assert conn.family == 0
 
 
+async def test_tcp_connector_allowed_protocols(loop: Any) -> None:
+    conn = aiohttp.TCPConnector()
+    assert conn.allowed_protocol_schema_set == {"http", "https", "ws", "wss"}
+
+
 async def test_invalid_ssl_param() -> None:
     with pytest.raises(TypeError):
         aiohttp.TCPConnector(ssl=object())
@@ -1647,6 +1652,18 @@ async def test_close_cancels_cleanup_closed_handle(loop: Any) -> None:
 async def test_ctor_with_default_loop(loop: Any) -> None:
     conn = aiohttp.BaseConnector()
     assert loop is conn._loop
+
+
+async def test_base_connector_allows_all_protocols(loop: Any) -> None:
+    conn = aiohttp.BaseConnector()
+    assert conn.allowed_protocol_schema_set == {
+        "http",
+        "https",
+        "ws",
+        "wss",
+        "unix",
+        "npipe",
+    }
 
 
 async def test_connect_with_limit(loop: Any, key: Any) -> None:
@@ -2420,6 +2437,7 @@ async def test_unix_connector(unix_server: Any, unix_sockname: Any) -> None:
 
     connector = aiohttp.UnixConnector(unix_sockname)
     assert unix_sockname == connector.path
+    assert connector.allowed_protocol_schema_set == {"unix"}
 
     session = client.ClientSession(connector=connector)
     r = await session.get(url)
@@ -2445,6 +2463,7 @@ async def test_named_pipe_connector(
 
     connector = aiohttp.NamedPipeConnector(pipe_name)
     assert pipe_name == connector.path
+    assert connector.allowed_protocol_schema_set == {"npipe"}
 
     session = client.ClientSession(connector=connector)
     r = await session.get(url)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1824,7 +1824,7 @@ async def test_ctor_with_default_loop(loop: asyncio.AbstractEventLoop) -> None:
     assert loop is conn._loop
 
 
-async def test_base_connector_allows_all_protocols(
+async def test_base_connector_allows_high_level_protocols(
     loop: asyncio.AbstractEventLoop,
 ) -> None:
     conn = aiohttp.BaseConnector()
@@ -1834,9 +1834,6 @@ async def test_base_connector_allows_all_protocols(
         "https",
         "ws",
         "wss",
-        "tcp",
-        "unix",
-        "npipe",
     }
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1492,7 +1492,7 @@ async def test_tcp_connector_ctor(loop: Any) -> None:
 
 async def test_tcp_connector_allowed_protocols(loop: Any) -> None:
     conn = aiohttp.TCPConnector()
-    assert conn.allowed_protocol_schema_set == {"http", "https", "ws", "wss"}
+    assert conn.allowed_protocol_schema_set == {"", "http", "https", "ws", "wss"}
 
 
 async def test_invalid_ssl_param() -> None:
@@ -1657,6 +1657,7 @@ async def test_ctor_with_default_loop(loop: Any) -> None:
 async def test_base_connector_allows_all_protocols(loop: Any) -> None:
     conn = aiohttp.BaseConnector()
     assert conn.allowed_protocol_schema_set == {
+        "",
         "http",
         "https",
         "ws",
@@ -2437,7 +2438,14 @@ async def test_unix_connector(unix_server: Any, unix_sockname: Any) -> None:
 
     connector = aiohttp.UnixConnector(unix_sockname)
     assert unix_sockname == connector.path
-    assert connector.allowed_protocol_schema_set == {"unix"}
+    assert connector.allowed_protocol_schema_set == {
+        "",
+        "http",
+        "https",
+        "ws",
+        "wss",
+        "unix",
+    }
 
     session = client.ClientSession(connector=connector)
     r = await session.get(url)
@@ -2463,7 +2471,14 @@ async def test_named_pipe_connector(
 
     connector = aiohttp.NamedPipeConnector(pipe_name)
     assert pipe_name == connector.path
-    assert connector.allowed_protocol_schema_set == {"npipe"}
+    assert connector.allowed_protocol_schema_set == {
+        "",
+        "http",
+        "https",
+        "ws",
+        "wss",
+        "npipe",
+    }
 
     session = client.ClientSession(connector=connector)
     r = await session.get(url)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1492,7 +1492,7 @@ async def test_tcp_connector_ctor(loop: Any) -> None:
 
 async def test_tcp_connector_allowed_protocols(loop: Any) -> None:
     conn = aiohttp.TCPConnector()
-    assert conn.allowed_protocol_schema_set == {"", "http", "https", "ws", "wss"}
+    assert conn.allowed_protocol_schema_set == {"", "tcp", "http", "https", "ws", "wss"}
 
 
 async def test_invalid_ssl_param() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixes a regression in 3.10.x connecting to `npipe://`, `tcp://`, and `unix://` urls

A future PR should remove `allowed_protocol_schema_set` in `BaseConnector` as its only there for backwards compat

## Are there changes in behavior for the user?
no

## Is it a substantial burden for the maintainers to support this?
no

## Related issue number
 fixes #8600
