### PR TITLE
Fix response to circular symlinks with Python v3.13

### DIFF
--- a/CHANGES/8565.bugfix.rst
+++ b/CHANGES/8565.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed server checks for circular symbolic links to be compatible with Python 3.13 -- by :user:`steverep`.

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -188,7 +188,9 @@ class FileResponse(StreamResponse):
             file_path, st, file_encoding = await loop.run_in_executor(
                 None, self._get_file_path_stat_encoding, accept_encoding
             )
-        except FileNotFoundError:
+        except OSError:
+            # Most likely to be FileNotFoundError or OSError for circular
+            # symlinks in python >= 3.13, so respond with 404.
             self.set_status(HTTPNotFound.status_code)
             return await super().prepare(request)
 

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -77,9 +77,9 @@ else:
     BaseDict = dict
 
 CIRCULAR_SYMLINK_ERROR = (
-    OSError
+    (OSError,)
     if sys.version_info < (3, 10) and sys.platform.startswith("win32")
-    else RuntimeError
+    else (RuntimeError,) if sys.version_info < (3, 13) else ()
 )
 
 YARL_VERSION: Final[Tuple[int, ...]] = tuple(map(int, yarl_version.split(".")[:2]))
@@ -672,8 +672,9 @@ class StaticResource(PrefixResource):
             else:
                 file_path = unresolved_path.resolve()
                 file_path.relative_to(self._directory)
-        except (ValueError, CIRCULAR_SYMLINK_ERROR) as error:
-            # ValueError for relative check; RuntimeError for circular symlink.
+        except (ValueError, *CIRCULAR_SYMLINK_ERROR) as error:
+            # ValueError is raised for  the relative check. Circular symlinks
+            # raise here on resolving for python < 3.13.
             raise HTTPNotFound() from error
 
         # if path is a directory, return the contents if permitted. Note the

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -673,7 +673,7 @@ class StaticResource(PrefixResource):
                 file_path = unresolved_path.resolve()
                 file_path.relative_to(self._directory)
         except (ValueError, *CIRCULAR_SYMLINK_ERROR) as error:
-            # ValueError is raised for  the relative check. Circular symlinks
+            # ValueError is raised for the relative check. Circular symlinks
             # raise here on resolving for python < 3.13.
             raise HTTPNotFound() from error
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
In 3.13, `pathlib` has changed `Path.resolve()` from always raising `RuntimeError` on circular symlinks to raising `OSError` only when `strict=True`.  To adapt, we either need to resolve strictly, or just catch the error later in `FileResponse`.  I chose the latter because resolving strictly creates a mess in order to keep the ability to store only compressed files.

I also think just catching `OSError` instead of `FileNotFoundError` in `FileResponse` is better overall since it may also catch just random file system glitches that would otherwise end up causing a server disconnect.

_Full disclosure: I did not test this on the 3.13 RC but will ask the issue author to do so._

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->
No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->
Fixes #8565 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
