### PR TITLE
Improve performance of WebSockets when there is no timeout

### DIFF
--- a/CHANGES/8660.misc.rst
+++ b/CHANGES/8660.misc.rst
@@ -1,3 +1,3 @@
-Improved performance of :py:meth:`~aiohttp.ClientWebSocketResponse.receive` and :py:meth:`~aiohttp.web.WebSocketResponse.receive` when there is timeout. -- by :user:`bdraco`.
+Improved performance of :py:meth:`~aiohttp.ClientWebSocketResponse.receive` and :py:meth:`~aiohttp.web.WebSocketResponse.receive` when there is no timeout. -- by :user:`bdraco`.
 
 The timeout context manager is now avoided when there is no timeout as it accounted for up to 50% of the time spent in the :py:meth:`~aiohttp.ClientWebSocketResponse.receive` and :py:meth:`~aiohttp.web.WebSocketResponse.receive` methods.

--- a/CHANGES/8660.misc.rst
+++ b/CHANGES/8660.misc.rst
@@ -1,3 +1,3 @@
-Improved performance of :py:meth:`~aiohttp.ClientWebSocketResponse.receive` and :py:meth:`~web.WebSocketResponse.receive` when there is timeout. -- by :user:`bdraco`.
+Improved performance of :py:meth:`~aiohttp.ClientWebSocketResponse.receive` and :py:meth:`~aiohttp.web.WebSocketResponse.receive` when there is timeout. -- by :user:`bdraco`.
 
-The timeout context manager is now avoided when there is no timeout as it accounted for up to 50% of the time spent in the :py:meth:`~aiohttp.ClientWebSocketResponse.receive` and :py:meth:`~web.WebSocketResponse.receive` methods.
+The timeout context manager is now avoided when there is no timeout as it accounted for up to 50% of the time spent in the :py:meth:`~aiohttp.ClientWebSocketResponse.receive` and :py:meth:`~aiohttp.web.WebSocketResponse.receive` methods.

--- a/CHANGES/8660.misc.rst
+++ b/CHANGES/8660.misc.rst
@@ -1,3 +1,3 @@
-Improved performance of :py:meth:`~aiohttp.ClientWebSocketResponse.receive` and :py:meth:`~aiohttp.WebSocketResponse.receive` when there is timeout. -- by :user:`bdraco`.
+Improved performance of :py:meth:`~aiohttp.ClientWebSocketResponse.receive` and :py:meth:`~web.WebSocketResponse.receive` when there is timeout. -- by :user:`bdraco`.
 
-The timeout context manager is now avoided when there is no timeout as it accounted for up to 50% of the time spent in the :py:meth:`~aiohttp.ClientWebSocketResponse.receive` and :py:meth:`~aiohttp.WebSocketResponse.receive` methods.
+The timeout context manager is now avoided when there is no timeout as it accounted for up to 50% of the time spent in the :py:meth:`~aiohttp.ClientWebSocketResponse.receive` and :py:meth:`~web.WebSocketResponse.receive` methods.

--- a/CHANGES/8660.misc.rst
+++ b/CHANGES/8660.misc.rst
@@ -1,0 +1,3 @@
+Improved performance of :py:meth:`~aiohttp.ClientWebSocketResponse.receive` and :py:meth:`~aiohttp.WebSocketResponse.receive` when there is timeout. -- by :user:`bdraco`.
+
+The timeout context manager is now avoided when there is no timeout as it accounted for up to 50% of the time spent in the :py:meth:`~aiohttp.ClientWebSocketResponse.receive` and :py:meth:`~aiohttp.WebSocketResponse.receive` methods.

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -291,6 +291,8 @@ class ClientWebSocketResponse:
             return False
 
     async def receive(self, timeout: Optional[float] = None) -> WSMessage:
+        receive_timeout = timeout or self._timeout.ws_receive
+
         while True:
             if self._waiting:
                 raise RuntimeError("Concurrent call to receive() is not allowed")
@@ -304,9 +306,14 @@ class ClientWebSocketResponse:
             try:
                 self._waiting = True
                 try:
-                    async with async_timeout.timeout(
-                        timeout or self._timeout.ws_receive
-                    ):
+                    if receive_timeout:
+                        # Entering the context manager and creating
+                        # Timeout() object can take almost 50% of the
+                        # run time in this loop so we avoid it if
+                        # there is no read timeout.
+                        async with async_timeout.timeout(receive_timeout):
+                            msg = await self._reader.read()
+                    else:
                         msg = await self._reader.read()
                     self._reset_heartbeat()
                 finally:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -509,6 +509,7 @@ class WebSocketResponse(StreamResponse):
 
         loop = self._loop
         assert loop is not None
+        receive_timeout = timeout or self._receive_timeout
         while True:
             if self._waiting:
                 raise RuntimeError("Concurrent call to receive() is not allowed")
@@ -524,7 +525,14 @@ class WebSocketResponse(StreamResponse):
             try:
                 self._waiting = True
                 try:
-                    async with async_timeout.timeout(timeout or self._receive_timeout):
+                    if receive_timeout:
+                        # Entering the context manager and creating
+                        # Timeout() object can take almost 50% of the
+                        # run time in this loop so we avoid it if
+                        # there is no read timeout.
+                        async with async_timeout.timeout(receive_timeout):
+                            msg = await self._reader.read()
+                    else:
                         msg = await self._reader.read()
                     self._reset_heartbeat()
                 finally:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The common case for WebSockets is to call receive without a timeout, or use the WebSocketResponse as an async iterator. The read was always wrapped with an async timeout even if the timeout was not used which accounted for as much as 50% of the run time each loop. If there is no timeout, avoid wrapping the read call in the context manager which creates a new Timeout() object each time.


## Are there changes in behavior for the user?
Performance improvement

related reading https://www.researchgate.net/publication/348993267_An_Analysis_of_the_Performance_of_Websockets_in_Various_Programming_Languages_and_Libraries

## Is it a substantial burden for the maintainers to support this?
no

before
![timeout](https://github.com/user-attachments/assets/25e740e6-9fbb-403c-aa17-11c9855fdc9f)

after
![after](https://github.com/user-attachments/assets/e98e293e-c22d-4702-9713-d6881ba6300c)

