### PR TITLE
Improve performance of starting request handlers with Python 3.12+

### DIFF
--- a/CHANGES/8661.misc.rst
+++ b/CHANGES/8661.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of starting request handlers with Python 3.12+ -- by :user:`bdraco`.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -546,9 +546,9 @@ class RequestHandler(BaseProtocol):
                 # a new task is used for copy context vars (#3406)
                 coro = self._handle_request(request, start, request_handler)
                 if sys.version_info >= (3, 12):
-                    task = asyncio.create_task(coro, eager_start=True)
+                    task = asyncio.Task(coro, loop=loop, eager_start=True)
                 else:
-                    task = self._loop.create_task(coro)
+                    task = loop.create_task(coro)
                 try:
                     resp, reset = await task
                 except (asyncio.CancelledError, ConnectionError):

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -1,6 +1,7 @@
 import asyncio
 import asyncio.streams
 import dataclasses
+import sys
 import traceback
 from collections import deque
 from contextlib import suppress
@@ -543,9 +544,11 @@ class RequestHandler(BaseProtocol):
             request = self._request_factory(message, payload, self, writer, handler)
             try:
                 # a new task is used for copy context vars (#3406)
-                task = self._loop.create_task(
-                    self._handle_request(request, start, request_handler)
-                )
+                coro = self._handle_request(request, start, request_handler)
+                if sys.version_info >= (3, 12):
+                    task = asyncio.create_task(coro, eager_start=True)
+                else:
+                    task = self._loop.create_task(coro)
                 try:
                     resp, reset = await task
                 except (asyncio.CancelledError, ConnectionError):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

#3406 wrapped _handle_request in a task to copy the contextvars which delays the start of the request by one iteration of the event loop and increases event loop overhead by forcing it to be scheduled which many of the handlers can finish synchronously.

In https://github.com/aio-libs/aiohttp/discussions/8170#discussioncomment-8802876 we did not have a way to improve with without removing the task, however since Python 3.12+ has eager start for tasks, we can now avoid the delay and scheduling overhead.


## Are there changes in behavior for the user?

Performance improvement

## Is it a substantial burden for the maintainers to support this?
no