### PR TITLE
Improve performance of keepalive rescheduling

### DIFF
--- a/CHANGES/8662.misc.rst
+++ b/CHANGES/8662.misc.rst
@@ -1,0 +1,3 @@
+Reduce frequency of HTTP keep-alive checks -- by :user:`bdraco`.
+
+Previously, when processing a request for a keep-alive connection, the keep-alive check would happen every second; the check now occurs when the keep-alive is expected to timeout or 1s later, whichever is later.

--- a/CHANGES/8662.misc.rst
+++ b/CHANGES/8662.misc.rst
@@ -1,3 +1,3 @@
 Improved performance of HTTP keep-alive checks -- by :user:`bdraco`.
 
-Previously, when processing a request for a keep-alive connection, the keep-alive check would happen every second; the check now occurs when the keep-alive is expected to timeout or 1s later, whichever is later.
+Previously, when processing a request for a keep-alive connection, the keep-alive check would happen every second; the check is now rescheduled if it fires too early instead.

--- a/CHANGES/8662.misc.rst
+++ b/CHANGES/8662.misc.rst
@@ -1,3 +1,3 @@
-Reduce frequency of HTTP keep-alive checks -- by :user:`bdraco`.
+Improved performance of HTTP keep-alive checks -- by :user:`bdraco`.
 
 Previously, when processing a request for a keep-alive connection, the keep-alive check would happen every second; the check now occurs when the keep-alive is expected to timeout or 1s later, whichever is later.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -443,6 +443,7 @@ class RequestHandler(BaseProtocol):
         self.logger.exception(*args, **kw)
 
     def _process_keepalive(self) -> None:
+        self._keepalive_handle = None
         if self._force_close or not self._keepalive:
             return
 

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -149,8 +149,6 @@ class RequestHandler(BaseProtocol):
 
     """
 
-    KEEPALIVE_RESCHEDULE_DELAY = 1
-
     __slots__ = (
         "_request_count",
         "_keepalive",
@@ -158,7 +156,7 @@ class RequestHandler(BaseProtocol):
         "_request_handler",
         "_request_factory",
         "_tcp_keepalive",
-        "_keepalive_time",
+        "_next_keepalive_close_time",
         "_keepalive_handle",
         "_keepalive_timeout",
         "_lingering_time",
@@ -208,7 +206,7 @@ class RequestHandler(BaseProtocol):
 
         self._tcp_keepalive = tcp_keepalive
         # placeholder to be replaced on keepalive timeout setup
-        self._keepalive_time = 0.0
+        self._next_keepalive_close_time = 0.0
         self._keepalive_handle: Optional[asyncio.Handle] = None
         self._keepalive_timeout = keepalive_timeout
         self._lingering_time = float(lingering_time)
@@ -448,22 +446,17 @@ class RequestHandler(BaseProtocol):
         if self._force_close or not self._keepalive:
             return
 
-        next = self._keepalive_time + self._keepalive_timeout
-        now = self._loop.time()
-
-        # handler in idle state
-        if self._waiter and now > next:
-            self.force_close()
+        loop = self._loop
+        now = loop.time()
+        close_time = self._next_keepalive_close_time
+        if now <= close_time:
+            # Keep alive fired close fired too early, reschedule
+            self._keepalive_handle = loop.call_at(close_time, self._process_keepalive)
             return
 
-        # not all request handlers are done,
-        # reschedule itself to next or
-        # the next second, whichever is later
-        reschedule_time = max(next, now + self.KEEPALIVE_RESCHEDULE_DELAY)
-        self._keepalive_handle = self._loop.call_at(
-            reschedule_time,
-            self._process_keepalive,
-        )
+        # handler in idle state
+        if self._waiter:
+            self.force_close()
 
     async def _handle_request(
         self,
@@ -610,11 +603,12 @@ class RequestHandler(BaseProtocol):
                     if self._keepalive and not self._close:
                         # start keep-alive timer
                         if keepalive_timeout is not None:
-                            now = self._loop.time()
-                            self._keepalive_time = now
+                            now = loop.time()
+                            close_time = now + keepalive_timeout
+                            self._next_keepalive_close_time = close_time
                             if self._keepalive_handle is None:
                                 self._keepalive_handle = loop.call_at(
-                                    now + keepalive_timeout, self._process_keepalive
+                                    close_time, self._process_keepalive
                                 )
                     else:
                         break

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -451,7 +451,7 @@ class RequestHandler(BaseProtocol):
         now = loop.time()
         close_time = self._next_keepalive_close_time
         if now <= close_time:
-            # Keep alive fired close fired too early, reschedule
+            # Keep alive close check fired too early, reschedule
             self._keepalive_handle = loop.call_at(close_time, self._process_keepalive)
             return
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

If not all handlers were done, the keep alive would get rescheduled every second until the current time was greater than self._keepalive_time + self._keepalive_timeout

Instead we will reschedule the timer for the expected keep alive close time if the timer handle fires too early.

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no


related issue #8613


Before we would see 1 timer handle created every second for 60s per connection. After we get 1 timer handle total for when the keepalive timeout is due.


before
![before](https://github.com/user-attachments/assets/26e67c15-769e-4b19-a016-341b38d5f3a2)

after
~~![after](~~https://github.com/user-attachments/assets/738882b2-a8c6-4513-b0ee-02a5b6a79e6d~~)~~

![after_take_2](https://github.com/user-attachments/assets/6768fc63-77c5-4f6c-a2ef-3382b1a43988)

