### PR TITLE
Improve performance of generating random WebSocket mask

### DIFF
--- a/CHANGES/8667.misc.rst
+++ b/CHANGES/8667.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of generating random WebSocket mask -- by :user:`bdraco`.

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -8,6 +8,7 @@ import re
 import sys
 import zlib
 from enum import IntEnum
+from functools import partial
 from struct import Struct
 from typing import (
     Any,
@@ -94,6 +95,7 @@ PACK_LEN1 = Struct("!BB").pack
 PACK_LEN2 = Struct("!BBH").pack
 PACK_LEN3 = Struct("!BBQ").pack
 PACK_CLOSE_CODE = Struct("!H").pack
+PACK_RANDBITS = Struct("!L").pack
 MSG_SIZE: Final[int] = 2**14
 DEFAULT_LIMIT: Final[int] = 2**16
 
@@ -596,7 +598,7 @@ class WebSocketWriter:
         self.protocol = protocol
         self.transport = transport
         self.use_mask = use_mask
-        self.randrange = random.randrange
+        self.get_random_bits = partial(random.getrandbits, 32)
         self.compress = compress
         self.notakeover = notakeover
         self._closing = False
@@ -652,8 +654,7 @@ class WebSocketWriter:
         else:
             header = PACK_LEN3(0x80 | rsv | opcode, 127 | mask_bit, msg_length)
         if use_mask:
-            mask_int = self.randrange(0, 0xFFFFFFFF)
-            mask = mask_int.to_bytes(4, "big")
+            mask = PACK_RANDBITS(self.get_random_bits())
             message = bytearray(message)
             _websocket_mask(mask, message)
             self._write(header + mask + message)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The mask was being generated with randint and than converted to bytes. We can skip a few steps and generate it with getrandbits() and pack it into bytes.

related RFC: https://datatracker.ietf.org/doc/html/rfc6455#section-5.3

## Are there changes in behavior for the user?

No

## Is it a substantial burden for the maintainers to support this?
no

I was looking at pings and noticed that most of the time is spent in randrange
<img width="1417" alt="Screenshot 2024-08-08 at 9 13 27 PM" src="https://github.com/user-attachments/assets/ffb3a77a-7937-4e02-a20d-ccdc5495bce8">

