### PR TITLE
Fix TCPConnector doing blocking I/O in the event loop to create the SSLContext

### DIFF
--- a/CHANGES/8672.bugfix.rst
+++ b/CHANGES/8672.bugfix.rst
@@ -1,3 +1,3 @@
-Fix TCPConnector doing blocking I/O in the event loop to create the SSLContext -- by :user:`bdraco`.
+Fix :py:class:`aiohttp.TCPConnector` doing blocking I/O in the event loop to create the ``SSLContext`` -- by :user:`bdraco`.
 
-The blocking I/O would only happen once per verify mode. However, it could cause the event loop to block for a long time if the SSLContext creation is slow, which is more likely during startup when the disk cache is not yet present.
+The blocking I/O would only happen once per verify mode. However, it could cause the event loop to block for a long time if the ``SSLContext`` creation is slow, which is more likely during startup when the disk cache is not yet present.

--- a/CHANGES/8672.bugfix.rst
+++ b/CHANGES/8672.bugfix.rst
@@ -1,3 +1,3 @@
-Fix TCPConnector doing blocking I/O in the event loop to create the SSLContext -- by :user:`bdraco`.
+Fixed TCPConnector doing blocking I/O in the event loop to create the SSLContext -- by :user:`bdraco`.
 
 The blocking I/O would only happen once per verify mode. However, it could cause the event loop to block for a long time if the SSLContext creation is slow, which is more likely during startup when the disk cache is not yet present.

--- a/CHANGES/8672.bugfix.rst
+++ b/CHANGES/8672.bugfix.rst
@@ -1,0 +1,3 @@
+Fix TCPConnector doing blocking I/O in the event loop to create the SSLContext -- by :user:`bdraco`.
+
+The blocking I/O would only happen once per verify mode. However, it could cause the event loop to block for a long time if the SSLContext creation is slow, which is more likely during startup when the disk cache is not yet present.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -752,6 +752,7 @@ class TCPConnector(BaseConnector):
     """
 
     allowed_protocol_schema_set = HIGH_LEVEL_SCHEMA_SET | frozenset({"tcp"})
+    _made_ssl_context: Set[bool] = set()
 
     def __init__(
         self,
@@ -948,27 +949,31 @@ class TCPConnector(BaseConnector):
     @staticmethod
     @functools.lru_cache(None)
     def _make_ssl_context(verified: bool) -> SSLContext:
+        """Create SSL context.
+
+        This method is not async-friendly and should be called from a thread
+        because it will load certificates from disk and do other blocking I/O.
+        """
         if verified:
             return ssl.create_default_context()
-        else:
-            sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-            sslcontext.options |= ssl.OP_NO_SSLv2
-            sslcontext.options |= ssl.OP_NO_SSLv3
-            sslcontext.check_hostname = False
-            sslcontext.verify_mode = ssl.CERT_NONE
-            try:
-                sslcontext.options |= ssl.OP_NO_COMPRESSION
-            except AttributeError as attr_err:
-                warnings.warn(
-                    "{!s}: The Python interpreter is compiled "
-                    "against OpenSSL < 1.0.0. Ref: "
-                    "https://docs.python.org/3/library/ssl.html"
-                    "#ssl.OP_NO_COMPRESSION".format(attr_err),
-                )
-            sslcontext.set_default_verify_paths()
-            return sslcontext
+        sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        sslcontext.options |= ssl.OP_NO_SSLv2
+        sslcontext.options |= ssl.OP_NO_SSLv3
+        sslcontext.check_hostname = False
+        sslcontext.verify_mode = ssl.CERT_NONE
+        try:
+            sslcontext.options |= ssl.OP_NO_COMPRESSION
+        except AttributeError as attr_err:
+            warnings.warn(
+                "{!s}: The Python interpreter is compiled "
+                "against OpenSSL < 1.0.0. Ref: "
+                "https://docs.python.org/3/library/ssl.html"
+                "#ssl.OP_NO_COMPRESSION".format(attr_err),
+            )
+        sslcontext.set_default_verify_paths()
+        return sslcontext
 
-    def _get_ssl_context(self, req: ClientRequest) -> Optional[SSLContext]:
+    async def _get_ssl_context(self, req: ClientRequest) -> Optional[SSLContext]:
         """Logic to get the correct SSL context
 
         0. if req.ssl is false, return None
@@ -982,24 +987,36 @@ class TCPConnector(BaseConnector):
             3. if verify_ssl is False in req, generate a SSL context that
                won't verify
         """
-        if req.is_ssl():
-            if ssl is None:  # pragma: no cover
-                raise RuntimeError("SSL is not supported.")
-            sslcontext = req.ssl
-            if isinstance(sslcontext, ssl.SSLContext):
-                return sslcontext
-            if sslcontext is not True:
-                # not verified or fingerprinted
-                return self._make_ssl_context(False)
-            sslcontext = self._ssl
-            if isinstance(sslcontext, ssl.SSLContext):
-                return sslcontext
-            if sslcontext is not True:
-                # not verified or fingerprinted
-                return self._make_ssl_context(False)
-            return self._make_ssl_context(True)
-        else:
+        if not req.is_ssl():
             return None
+
+        if ssl is None:  # pragma: no cover
+            raise RuntimeError("SSL is not supported.")
+        sslcontext = req.ssl
+        if isinstance(sslcontext, ssl.SSLContext):
+            return sslcontext
+        if sslcontext is not True:
+            # not verified or fingerprinted
+            return await self._make_or_get_cached_ssl_context(False)
+        sslcontext = self._ssl
+        if isinstance(sslcontext, ssl.SSLContext):
+            return sslcontext
+        if sslcontext is not True:
+            # not verified or fingerprinted
+            return await self._make_or_get_cached_ssl_context(False)
+        return await self._make_or_get_cached_ssl_context(True)
+
+    async def _make_or_get_cached_ssl_context(self, verified: bool) -> SSLContext:
+        """Create or get cached SSL context."""
+        if verified in self._made_ssl_context:
+            return self._make_ssl_context(verified)
+        # _make_ssl_context does blocking I/O to load certificates
+        # from disk, so we run it in a separate thread.
+        context = await self._loop.run_in_executor(
+            None, self._make_ssl_context, verified
+        )
+        self._made_ssl_context.add(verified)
+        return context
 
     def _get_fingerprint(self, req: ClientRequest) -> Optional["Fingerprint"]:
         ret = req.ssl
@@ -1092,7 +1109,7 @@ class TCPConnector(BaseConnector):
         # `req.is_ssl()` evaluates to `False` which is never gonna happen
         # in this code path. Of course, it's rather fragile
         # maintainability-wise but this is to be solved separately.
-        sslcontext = cast(ssl.SSLContext, self._get_ssl_context(req))
+        sslcontext = cast(ssl.SSLContext, await self._get_ssl_context(req))
 
         try:
             async with ceil_timeout(
@@ -1170,7 +1187,7 @@ class TCPConnector(BaseConnector):
         *,
         client_error: Type[Exception] = ClientConnectorError,
     ) -> Tuple[asyncio.Transport, ResponseHandler]:
-        sslcontext = self._get_ssl_context(req)
+        sslcontext = await self._get_ssl_context(req)
         fingerprint = self._get_fingerprint(req)
 
         host = req.url.raw_host

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1013,11 +1013,14 @@ class TCPConnector(BaseConnector):
             future = loop.create_future()
             self._made_ssl_context[verified] = future
             try:
-                result = await self._loop.run_in_executor(None, self._make_ssl_context)
+                result = await self._loop.run_in_executor(
+                    None, self._make_ssl_context, verified
+                )
             # BaseException is used since we might get CancelledError
             except BaseException as ex:
                 del self._made_ssl_context[verified]
                 set_exception(future, ex)
+                raise
             else:
                 set_result(future, result)
             return result

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -759,7 +759,7 @@ class TCPConnector(BaseConnector):
     """
 
     allowed_protocol_schema_set = HIGH_LEVEL_SCHEMA_SET | frozenset({"tcp"})
-    _made_ssl_context: Dict[bool, asyncio.Future[SSLContext]] = {}
+    _made_ssl_context: Dict[bool, "asyncio.Future[SSLContext]"] = {}
 
     def __init__(
         self,

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -962,15 +962,7 @@ class TCPConnector(BaseConnector):
         sslcontext.options |= ssl.OP_NO_SSLv3
         sslcontext.check_hostname = False
         sslcontext.verify_mode = ssl.CERT_NONE
-        try:
-            sslcontext.options |= ssl.OP_NO_COMPRESSION
-        except AttributeError as attr_err:
-            warnings.warn(
-                "{!s}: The Python interpreter is compiled "
-                "against OpenSSL < 1.0.0. Ref: "
-                "https://docs.python.org/3/library/ssl.html"
-                "#ssl.OP_NO_COMPRESSION".format(attr_err),
-            )
+        sslcontext.options |= ssl.OP_NO_COMPRESSION
         sslcontext.set_default_verify_paths()
         return sslcontext
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1007,9 +1007,7 @@ class TCPConnector(BaseConnector):
             future = asyncio.Future()
             self._make_ssl_context[verified] = future
             try:
-                result = await self._loop.run_in_executor(
-                    None, self._make_ssl_context
-                )
+                result = await self._loop.run_in_executor(None, self._make_ssl_context)
             except Exception as e:
                 future.set_exception(e)
                 self._make_ssl_context.pop(verified)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1016,8 +1016,8 @@ class TCPConnector(BaseConnector):
                 result = await self._loop.run_in_executor(None, self._make_ssl_context)
             # BaseException is used since we might get CancelledError
             except BaseException as ex:
-                set_exception(future, ex)
                 self._made_ssl_context.pop(verified)
+                set_exception(future, ex)
             else:
                 set_result(future, result)
             return result

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -759,7 +759,7 @@ class TCPConnector(BaseConnector):
     """
 
     allowed_protocol_schema_set = HIGH_LEVEL_SCHEMA_SET | frozenset({"tcp"})
-    _made_ssl_context: Dict[bool, SSLContext] = {}
+    _made_ssl_context: Dict[bool, asyncio.Future[SSLContext]] = {}
 
     def __init__(
         self,

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -752,8 +752,7 @@ class TCPConnector(BaseConnector):
     """
 
     allowed_protocol_schema_set = HIGH_LEVEL_SCHEMA_SET | frozenset({"tcp"})
-    _made_ssl_context: Set[bool] = set()
-    _make_ssl_context_lock: Optional[asyncio.Lock] = None
+    _made_ssl_context: Dict[bool, asyncio.Lock] = {}
 
     def __init__(
         self,
@@ -1013,13 +1012,10 @@ class TCPConnector(BaseConnector):
             return self._make_ssl_context(verified)
         # _make_ssl_context does blocking I/O to load certificates
         # from disk, so we run it in a separate thread.
-        if not self._make_ssl_context_lock:
-            self._make_ssl_context_lock = asyncio.Lock()
-        async with self._make_ssl_context_lock:
+        async with self._made_ssl_context.setdefault(verified, asyncio.Lock()):
             context = await self._loop.run_in_executor(
                 None, self._make_ssl_context, verified
             )
-            self._made_ssl_context.add(verified)
         return context
 
     def _get_fingerprint(self, req: ClientRequest) -> Optional["Fingerprint"]:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1013,7 +1013,7 @@ class TCPConnector(BaseConnector):
             future = loop.create_future()
             self._made_ssl_context[verified] = future
             try:
-                result = await self._loop.run_in_executor(
+                result = await loop.run_in_executor(
                     None, self._make_ssl_context, verified
                 )
             # BaseException is used since we might get CancelledError

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -995,16 +995,16 @@ class TCPConnector(BaseConnector):
             return sslcontext
         if sslcontext is not True:
             # not verified or fingerprinted
-            return await self._make_or_get_cached_ssl_context(False)
+            return await self._make_or_get_ssl_context(False)
         sslcontext = self._ssl
         if isinstance(sslcontext, ssl.SSLContext):
             return sslcontext
         if sslcontext is not True:
             # not verified or fingerprinted
-            return await self._make_or_get_cached_ssl_context(False)
-        return await self._make_or_get_cached_ssl_context(True)
+            return await self._make_or_get_ssl_context(False)
+        return await self._make_or_get_ssl_context(True)
 
-    async def _make_or_get_cached_ssl_context(self, verified: bool) -> SSLContext:
+    async def _make_or_get_ssl_context(self, verified: bool) -> SSLContext:
         """Create or get cached SSL context."""
         try:
             return await self._made_ssl_context[verified]

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -759,7 +759,7 @@ class TCPConnector(BaseConnector):
     """
 
     allowed_protocol_schema_set = HIGH_LEVEL_SCHEMA_SET | frozenset({"tcp"})
-    _made_ssl_context: Dict[bool, asyncio.Lock] = {}
+    _made_ssl_context: Dict[bool, SSLContext] = {}
 
     def __init__(
         self,

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1016,7 +1016,7 @@ class TCPConnector(BaseConnector):
                 result = await self._loop.run_in_executor(None, self._make_ssl_context)
             # BaseException is used since we might get CancelledError
             except BaseException as ex:
-                self._made_ssl_context.pop(verified)
+                del self._made_ssl_context[verified]
                 set_exception(future, ex)
             else:
                 set_result(future, result)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1709,26 +1709,26 @@ async def test_tcp_connector_clear_dns_cache_bad_args(
         conn.clear_dns_cache("localhost")
 
 
-async def test_dont_recreate_ssl_context(loop: asyncio.AbstractEventLoop) -> None:
+async def test_dont_recreate_ssl_context() -> None:
     conn = aiohttp.TCPConnector()
     ctx = await conn._make_or_get_ssl_context(True)
     assert ctx is await conn._make_or_get_ssl_context(True)
 
 
-async def test_dont_recreate_ssl_context2(loop: asyncio.AbstractEventLoop) -> None:
+async def test_dont_recreate_ssl_context2() -> None:
     conn = aiohttp.TCPConnector()
     ctx = await conn._make_or_get_ssl_context(False)
     assert ctx is await conn._make_or_get_ssl_context(False)
 
 
-async def test___get_ssl_context1(loop: asyncio.AbstractEventLoop) -> None:
+async def test___get_ssl_context1() -> None:
     conn = aiohttp.TCPConnector()
     req = mock.Mock()
     req.is_ssl.return_value = False
     assert await conn._get_ssl_context(req) is None
 
 
-async def test___get_ssl_context2(loop: asyncio.AbstractEventLoop) -> None:
+async def test___get_ssl_context2() -> None:
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     conn = aiohttp.TCPConnector()
     req = mock.Mock()
@@ -1737,7 +1737,7 @@ async def test___get_ssl_context2(loop: asyncio.AbstractEventLoop) -> None:
     assert await conn._get_ssl_context(req) is ctx
 
 
-async def test___get_ssl_context3(loop: asyncio.AbstractEventLoop) -> None:
+async def test___get_ssl_context3() -> None:
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     conn = aiohttp.TCPConnector(ssl=ctx)
     req = mock.Mock()
@@ -1746,7 +1746,7 @@ async def test___get_ssl_context3(loop: asyncio.AbstractEventLoop) -> None:
     assert await conn._get_ssl_context(req) is ctx
 
 
-async def test___get_ssl_context4(loop: asyncio.AbstractEventLoop) -> None:
+async def test___get_ssl_context4() -> None:
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     conn = aiohttp.TCPConnector(ssl=ctx)
     req = mock.Mock()
@@ -1757,7 +1757,7 @@ async def test___get_ssl_context4(loop: asyncio.AbstractEventLoop) -> None:
     )
 
 
-async def test___get_ssl_context5(loop: asyncio.AbstractEventLoop) -> None:
+async def test___get_ssl_context5() -> None:
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     conn = aiohttp.TCPConnector(ssl=ctx)
     req = mock.Mock()
@@ -1768,7 +1768,7 @@ async def test___get_ssl_context5(loop: asyncio.AbstractEventLoop) -> None:
     )
 
 
-async def test___get_ssl_context6(loop: asyncio.AbstractEventLoop) -> None:
+async def test___get_ssl_context6() -> None:
     conn = aiohttp.TCPConnector()
     req = mock.Mock()
     req.is_ssl.return_value = True
@@ -1776,7 +1776,7 @@ async def test___get_ssl_context6(loop: asyncio.AbstractEventLoop) -> None:
     assert await conn._get_ssl_context(req) is await conn._make_or_get_ssl_context(True)
 
 
-async def test_ssl_context_once(loop: asyncio.AbstractEventLoop) -> None:
+async def test_ssl_context_once() -> None:
     """Test the ssl context is created only once and shared between connectors."""
     conn1 = aiohttp.TCPConnector()
     conn2 = aiohttp.TCPConnector()
@@ -1799,9 +1799,7 @@ async def test_ssl_context_once(loop: asyncio.AbstractEventLoop) -> None:
 
 
 @pytest.mark.parametrize("exception", [OSError, ssl.SSLError, asyncio.CancelledError])
-async def test_ssl_context_creation_raises(
-    loop: asyncio.AbstractEventLoop, exception: BaseException
-) -> None:
+async def test_ssl_context_creation_raises(exception: BaseException) -> None:
     """Test that we try again if SSLContext creation fails the first time."""
     conn = aiohttp.TCPConnector()
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1802,14 +1802,13 @@ async def test_ssl_context_once() -> None:
 async def test_ssl_context_creation_raises(exception: BaseException) -> None:
     """Test that we try again if SSLContext creation fails the first time."""
     conn = aiohttp.TCPConnector()
+    conn._made_ssl_context.clear()
 
     with mock.patch.object(
         conn, "_make_ssl_context", side_effect=exception
     ), pytest.raises(exception):
-        conn._made_ssl_context.clear()
         await conn._make_or_get_ssl_context(True)
 
-    conn._made_ssl_context.clear()
     assert isinstance(await conn._make_or_get_ssl_context(True), ssl.SSLContext)
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1806,7 +1806,9 @@ async def test_ssl_context_creation_raises(exception: BaseException) -> None:
 
     with mock.patch.object(
         conn, "_make_ssl_context", side_effect=exception
-    ), pytest.raises(exception):
+    ), pytest.raises(
+        exception
+    ):  # type: ignore[call-overload]
         await conn._make_or_get_ssl_context(True)
 
     assert isinstance(await conn._make_or_get_ssl_context(True), ssl.SSLContext)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1806,9 +1806,9 @@ async def test_ssl_context_creation_raises(exception: BaseException) -> None:
 
     with mock.patch.object(
         conn, "_make_ssl_context", side_effect=exception
-    ), pytest.raises(
+    ), pytest.raises(  # type: ignore[call-overload]
         exception
-    ):  # type: ignore[call-overload]
+    ):
         await conn._make_or_get_ssl_context(True)
 
     assert isinstance(await conn._make_or_get_ssl_context(True), ssl.SSLContext)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1725,7 +1725,7 @@ async def test___get_ssl_context1(loop: asyncio.AbstractEventLoop) -> None:
     conn = aiohttp.TCPConnector()
     req = mock.Mock()
     req.is_ssl.return_value = False
-    assert conn._get_ssl_context(req) is None
+    assert await conn._get_ssl_context(req) is None
 
 
 async def test___get_ssl_context2(loop: asyncio.AbstractEventLoop) -> None:
@@ -1734,7 +1734,7 @@ async def test___get_ssl_context2(loop: asyncio.AbstractEventLoop) -> None:
     req = mock.Mock()
     req.is_ssl.return_value = True
     req.ssl = ctx
-    assert conn._get_ssl_context(req) is ctx
+    assert await conn._get_ssl_context(req) is ctx
 
 
 async def test___get_ssl_context3(loop: asyncio.AbstractEventLoop) -> None:
@@ -1743,7 +1743,7 @@ async def test___get_ssl_context3(loop: asyncio.AbstractEventLoop) -> None:
     req = mock.Mock()
     req.is_ssl.return_value = True
     req.ssl = True
-    assert conn._get_ssl_context(req) is ctx
+    assert await conn._get_ssl_context(req) is ctx
 
 
 async def test___get_ssl_context4(loop: asyncio.AbstractEventLoop) -> None:
@@ -1752,7 +1752,7 @@ async def test___get_ssl_context4(loop: asyncio.AbstractEventLoop) -> None:
     req = mock.Mock()
     req.is_ssl.return_value = True
     req.ssl = False
-    assert conn._get_ssl_context(req) is conn._make_ssl_context(False)
+    assert await conn._get_ssl_context(req) is conn._make_ssl_context(False)
 
 
 async def test___get_ssl_context5(loop: asyncio.AbstractEventLoop) -> None:
@@ -1761,7 +1761,7 @@ async def test___get_ssl_context5(loop: asyncio.AbstractEventLoop) -> None:
     req = mock.Mock()
     req.is_ssl.return_value = True
     req.ssl = aiohttp.Fingerprint(hashlib.sha256(b"1").digest())
-    assert conn._get_ssl_context(req) is conn._make_ssl_context(False)
+    assert await conn._get_ssl_context(req) is conn._make_ssl_context(False)
 
 
 async def test___get_ssl_context6(loop: asyncio.AbstractEventLoop) -> None:
@@ -1769,7 +1769,7 @@ async def test___get_ssl_context6(loop: asyncio.AbstractEventLoop) -> None:
     req = mock.Mock()
     req.is_ssl.return_value = True
     req.ssl = True
-    assert conn._get_ssl_context(req) is conn._make_ssl_context(True)
+    assert await conn._get_ssl_context(req) is conn._make_ssl_context(True)
 
 
 async def test_close_twice(loop: asyncio.AbstractEventLoop, key: ConnectionKey) -> None:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1772,6 +1772,22 @@ async def test___get_ssl_context6(loop: asyncio.AbstractEventLoop) -> None:
     assert await conn._get_ssl_context(req) is conn._make_ssl_context(True)
 
 
+async def test_ssl_context_once(loop: asyncio.AbstractEventLoop) -> None:
+    """Test the ssl context is created only once and shared between connectors."""
+    conn1 = aiohttp.TCPConnector()
+    conn2 = aiohttp.TCPConnector()
+    conn3 = aiohttp.TCPConnector()
+
+    req = mock.Mock()
+    req.is_ssl.return_value = True
+    req.ssl = True
+    assert await conn1._get_ssl_context(req) is conn1._make_ssl_context(True)
+    assert await conn2._get_ssl_context(req) is conn1._make_ssl_context(True)
+    assert await conn3._get_ssl_context(req) is conn1._make_ssl_context(True)
+    assert conn1._made_ssl_context is conn2._made_ssl_context is conn3._made_ssl_context
+    assert True in conn1._made_ssl_context
+
+
 async def test_close_twice(loop: asyncio.AbstractEventLoop, key: ConnectionKey) -> None:
     proto: ResponseHandler = create_mocked_conn(loop)
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1711,14 +1711,14 @@ async def test_tcp_connector_clear_dns_cache_bad_args(
 
 async def test_dont_recreate_ssl_context(loop: asyncio.AbstractEventLoop) -> None:
     conn = aiohttp.TCPConnector()
-    ctx = conn._make_ssl_context(True)
-    assert ctx is conn._make_ssl_context(True)
+    ctx = await conn._make_or_get_ssl_context(True)
+    assert ctx is await conn._make_or_get_ssl_context(True)
 
 
 async def test_dont_recreate_ssl_context2(loop: asyncio.AbstractEventLoop) -> None:
     conn = aiohttp.TCPConnector()
-    ctx = conn._make_ssl_context(False)
-    assert ctx is conn._make_ssl_context(False)
+    ctx = await conn._make_or_get_ssl_context(False)
+    assert ctx is await conn._make_or_get_ssl_context(False)
 
 
 async def test___get_ssl_context1(loop: asyncio.AbstractEventLoop) -> None:
@@ -1752,7 +1752,9 @@ async def test___get_ssl_context4(loop: asyncio.AbstractEventLoop) -> None:
     req = mock.Mock()
     req.is_ssl.return_value = True
     req.ssl = False
-    assert await conn._get_ssl_context(req) is conn._make_ssl_context(False)
+    assert await conn._get_ssl_context(req) is await conn._make_or_get_ssl_context(
+        False
+    )
 
 
 async def test___get_ssl_context5(loop: asyncio.AbstractEventLoop) -> None:
@@ -1761,7 +1763,9 @@ async def test___get_ssl_context5(loop: asyncio.AbstractEventLoop) -> None:
     req = mock.Mock()
     req.is_ssl.return_value = True
     req.ssl = aiohttp.Fingerprint(hashlib.sha256(b"1").digest())
-    assert await conn._get_ssl_context(req) is conn._make_ssl_context(False)
+    assert await conn._get_ssl_context(req) is await conn._make_or_get_ssl_context(
+        False
+    )
 
 
 async def test___get_ssl_context6(loop: asyncio.AbstractEventLoop) -> None:
@@ -1769,7 +1773,7 @@ async def test___get_ssl_context6(loop: asyncio.AbstractEventLoop) -> None:
     req = mock.Mock()
     req.is_ssl.return_value = True
     req.ssl = True
-    assert await conn._get_ssl_context(req) is conn._make_ssl_context(True)
+    assert await conn._get_ssl_context(req) is await conn._make_or_get_ssl_context(True)
 
 
 async def test_ssl_context_once(loop: asyncio.AbstractEventLoop) -> None:
@@ -1781,9 +1785,15 @@ async def test_ssl_context_once(loop: asyncio.AbstractEventLoop) -> None:
     req = mock.Mock()
     req.is_ssl.return_value = True
     req.ssl = True
-    assert await conn1._get_ssl_context(req) is conn1._make_ssl_context(True)
-    assert await conn2._get_ssl_context(req) is conn1._make_ssl_context(True)
-    assert await conn3._get_ssl_context(req) is conn1._make_ssl_context(True)
+    assert await conn1._get_ssl_context(req) is await conn1._make_or_get_ssl_context(
+        True
+    )
+    assert await conn2._get_ssl_context(req) is await conn1._make_or_get_ssl_context(
+        True
+    )
+    assert await conn3._get_ssl_context(req) is await conn1._make_or_get_ssl_context(
+        True
+    )
     assert conn1._made_ssl_context is conn2._made_ssl_context is conn3._made_ssl_context
     assert True in conn1._made_ssl_context
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -813,7 +813,7 @@ class TestProxy(unittest.TestCase):
         self.loop.start_tls.assert_called_with(
             mock.ANY,
             mock.ANY,
-            connector._make_ssl_context(True),
+            self.loop.run_until_complete(connector._make_or_get_ssl_context(True)),
             server_hostname="www.python.org",
             ssl_handshake_timeout=mock.ANY,
         )


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

Create the SSLContext in the executor since it does blocking I/O to read the certificates from disk.

related issue #3080


## Are there changes in behavior for the user?

no


## Is it a substantial burden for the maintainers to support this?
no