### PR TITLE
Fix type ignore in SSLContext creation connector test

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1799,7 +1799,7 @@ async def test_ssl_context_once() -> None:
 
 
 @pytest.mark.parametrize("exception", [OSError, ssl.SSLError, asyncio.CancelledError])
-async def test_ssl_context_creation_raises(exception: BaseException) -> None:
+async def test_ssl_context_creation_raises(exception: type[BaseException]) -> None:
     """Test that we try again if SSLContext creation fails the first time."""
     conn = aiohttp.TCPConnector()
     conn._made_ssl_context.clear()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1806,9 +1806,7 @@ async def test_ssl_context_creation_raises(exception: BaseException) -> None:
 
     with mock.patch.object(
         conn, "_make_ssl_context", side_effect=exception
-    ), pytest.raises(  # type: ignore[call-overload]
-        exception
-    ):
+    ), pytest.raises(exception):
         await conn._make_or_get_ssl_context(True)
 
     assert isinstance(await conn._make_or_get_ssl_context(True), ssl.SSLContext)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -20,6 +20,7 @@ from typing import (
     Optional,
     Sequence,
     Tuple,
+    Type,
 )
 from unittest import mock
 
@@ -1799,7 +1800,7 @@ async def test_ssl_context_once() -> None:
 
 
 @pytest.mark.parametrize("exception", [OSError, ssl.SSLError, asyncio.CancelledError])
-async def test_ssl_context_creation_raises(exception: type[BaseException]) -> None:
+async def test_ssl_context_creation_raises(exception: Type[BaseException]) -> None:
     """Test that we try again if SSLContext creation fails the first time."""
     conn = aiohttp.TCPConnector()
     conn._made_ssl_context.clear()


### PR DESCRIPTION
Fixes the typing in `test_ssl_context_creation_raises`. This is not a runtime change.

https://github.com/aio-libs/aiohttp/pull/8672#discussion_r1712663038