### PR TITLE
[PR #8676/2915102 backport][3.10] Fix type ignore in SSLContext creation connector test

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -10,7 +10,7 @@ import sys
 import uuid
 from collections import deque
 from contextlib import closing
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Type
 from unittest import mock
 
 import pytest
@@ -1630,16 +1630,14 @@ async def test_ssl_context_once() -> None:
 
 
 @pytest.mark.parametrize("exception", [OSError, ssl.SSLError, asyncio.CancelledError])
-async def test_ssl_context_creation_raises(exception: BaseException) -> None:
+async def test_ssl_context_creation_raises(exception: Type[BaseException]) -> None:
     """Test that we try again if SSLContext creation fails the first time."""
     conn = aiohttp.TCPConnector()
     conn._made_ssl_context.clear()
 
     with mock.patch.object(
         conn, "_make_ssl_context", side_effect=exception
-    ), pytest.raises(  # type: ignore[call-overload]
-        exception
-    ):
+    ), pytest.raises(exception):
         await conn._make_or_get_ssl_context(True)
 
     assert isinstance(await conn._make_or_get_ssl_context(True), ssl.SSLContext)


### PR DESCRIPTION
(cherry picked from commit 29151021f957a524f612e9effc20ede8538195ab)
