### PR TITLE
Improve performance of starting request handlers with Python 3.12+

### DIFF
--- a/CHANGES/8681.misc.rst
+++ b/CHANGES/8681.misc.rst
@@ -1,1 +1,3 @@
 Improved performance of starting request handlers with Python 3.12+ -- by :user:`bdraco`.
+
+This change is a followup to :issue:`8661` to make the same optimization for Python 3.12+ where the request is connected.

--- a/CHANGES/8681.misc.rst
+++ b/CHANGES/8681.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of starting request handlers with Python 3.12+ -- by :user:`bdraco`.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -510,7 +510,7 @@ class RequestHandler(BaseProtocol):
         keep_alive(True) specified.
         """
         loop = self._loop
-        handler = self._task_handler
+        handler = asyncio.current_task(loop)
         assert handler is not None
         manager = self._manager
         assert manager is not None

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -308,9 +308,15 @@ class RequestHandler(BaseProtocol):
         if self._tcp_keepalive:
             tcp_keepalive(real_transport)
 
-        self._task_handler = self._loop.create_task(self.start())
         assert self._manager is not None
         self._manager.connection_made(self, real_transport)
+
+        loop = self._loop
+        if sys.version_info >= (3, 12):
+            task = asyncio.Task(self.start(), loop=loop, eager_start=True)
+        else:
+            task = loop.create_task(self.start())
+        self._task_handler = task
 
     def connection_lost(self, exc: Optional[BaseException]) -> None:
         if self._manager is None:


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Improve performance of starting request handlers with Python 3.12+ by starting the task eagerly.

followup to #8661 as I missed one more place we create a task

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no
