### PR TITLE
Fix exceptions from WebSocket ping task not being consumed

### DIFF
--- a/CHANGES/8685.bugfix.rst
+++ b/CHANGES/8685.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed unconsumed exceptions raised by the WebSocket heartbeat -- by :user:`bdraco`.
+
+If the heartbeat ping raised an exception, it would not be consumed and would be logged as an warning.

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -157,19 +157,22 @@ class ClientWebSocketResponse:
     def _ping_task_done(self, task: "asyncio.Task[None]") -> None:
         """Callback for when the ping task completes."""
         if not task.cancelled() and (exc := task.exception()):
-            self._reader.feed_data(WSMessage(WSMsgType.ERROR, exc, None))
+            self._handle_ping_pong_exception(exc)
         self._ping_task = None
 
     def _pong_not_received(self) -> None:
-        if not self._closed:
-            self._set_closed()
-            self._close_code = WSCloseCode.ABNORMAL_CLOSURE
-            self._exception = ServerTimeoutError()
-            self._response.close()
-            if self._waiting and not self._closing:
-                self._reader.feed_data(
-                    WSMessage(WSMsgType.ERROR, self._exception, None)
-                )
+        self._handle_ping_pong_exception(ServerTimeoutError())
+
+    def _handle_ping_pong_exception(self, exc: BaseException) -> None:
+        """Handle exceptions raised during ping/pong processing."""
+        if self._closed:
+            return
+        self._set_closed()
+        self._close_code = WSCloseCode.ABNORMAL_CLOSURE
+        self._exception = exc
+        self._response.close()
+        if self._waiting and not self._closing:
+            self._reader.feed_data(WSMessage(WSMsgType.ERROR, exc, None))
 
     def _set_closed(self) -> None:
         """Set the connection to closed.

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -151,9 +151,13 @@ class ClientWebSocketResponse:
         if not ping_task.done():
             self._ping_task = ping_task
             ping_task.add_done_callback(self._ping_task_done)
+        else:
+            self._ping_task_done(ping_task)
 
     def _ping_task_done(self, task: "asyncio.Task[None]") -> None:
         """Callback for when the ping task completes."""
+        if not task.cancelled() and (exc := task.exception()):
+            self._reader.feed_data(WSMessage(WSMsgType.ERROR, exc, None))
         self._ping_task = None
 
     def _pong_not_received(self) -> None:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -195,6 +195,7 @@ class WebSocketResponse(StreamResponse):
     def _ping_task_done(self, task: "asyncio.Task[None]") -> None:
         """Callback for when the ping task completes."""
         if not task.cancelled() and (exc := task.exception()):
+            assert self._reader is not None
             self._reader.feed_data(WSMessage(WSMsgType.ERROR, exc, None))
         self._ping_task = None
 

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -195,15 +195,22 @@ class WebSocketResponse(StreamResponse):
     def _ping_task_done(self, task: "asyncio.Task[None]") -> None:
         """Callback for when the ping task completes."""
         if not task.cancelled() and (exc := task.exception()):
-            assert self._reader is not None
-            self._reader.feed_data(WSMessage(WSMsgType.ERROR, exc, None))
+            self._handle_ping_pong_exception(exc)
         self._ping_task = None
 
     def _pong_not_received(self) -> None:
         if self._req is not None and self._req.transport is not None:
-            self._set_closed()
-            self._set_code_close_transport(WSCloseCode.ABNORMAL_CLOSURE)
-            self._exception = asyncio.TimeoutError()
+            self._handle_ping_pong_exception(asyncio.TimeoutError())
+
+    def _handle_ping_pong_exception(self, exc: BaseException) -> None:
+        """Handle exceptions raised during ping/pong processing."""
+        if self._closed:
+            return
+        self._set_closed()
+        self._set_code_close_transport(WSCloseCode.ABNORMAL_CLOSURE)
+        self._exception = exc
+        if self._waiting and not self._closing:
+            self._reader.feed_data(WSMessage(WSMsgType.ERROR, exc, None))
 
     def _set_closed(self) -> None:
         """Set the connection to closed.

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -209,7 +209,7 @@ class WebSocketResponse(StreamResponse):
         self._set_closed()
         self._set_code_close_transport(WSCloseCode.ABNORMAL_CLOSURE)
         self._exception = exc
-        if self._waiting and not self._closing and self._reader:
+        if self._waiting and not self._closing and self._reader is not None:
             self._reader.feed_data(WSMessage(WSMsgType.ERROR, exc, None))
 
     def _set_closed(self) -> None:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -189,9 +189,13 @@ class WebSocketResponse(StreamResponse):
         if not ping_task.done():
             self._ping_task = ping_task
             ping_task.add_done_callback(self._ping_task_done)
+        else:
+            self._ping_task_done(ping_task)
 
     def _ping_task_done(self, task: "asyncio.Task[None]") -> None:
         """Callback for when the ping task completes."""
+        if not task.cancelled() and (exc := task.exception()):
+            self._reader.feed_data(WSMessage(WSMsgType.ERROR, exc, None))
         self._ping_task = None
 
     def _pong_not_received(self) -> None:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -209,7 +209,7 @@ class WebSocketResponse(StreamResponse):
         self._set_closed()
         self._set_code_close_transport(WSCloseCode.ABNORMAL_CLOSURE)
         self._exception = exc
-        if self._waiting and not self._closing:
+        if self._waiting and not self._closing and self._reader:
             self._reader.feed_data(WSMessage(WSMsgType.ERROR, exc, None))
 
     def _set_closed(self) -> None:

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -679,6 +679,7 @@ async def test_heartbeat_connection_closed(aiohttp_client: AiohttpClient) -> Non
     # We patch write here to simulate a connection reset error
     # since if we closed the connection normally, the server would
     # would cancel the heartbeat task and we wouldn't get a ping
+    assert resp._conn is not None
     with mock.patch.object(
         resp._conn.transport, "write", side_effect=ConnectionResetError
     ), mock.patch.object(resp._writer, "ping", wraps=resp._writer.ping) as ping:

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -677,7 +677,7 @@ async def test_heartbeat_connection_closed(aiohttp_client: AiohttpClient) -> Non
     resp = await client.ws_connect("/", heartbeat=0.1)
     ping_count = 0
     # We patch write here to simulate a connection reset error
-    # since if we closed the connection normally, the server would
+    # since if we closed the connection normally, the client would
     # would cancel the heartbeat task and we wouldn't get a ping
     with mock.patch.object(
         resp._conn.transport, "write", side_effect=ConnectionResetError

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -736,8 +736,10 @@ async def test_heartbeat_connection_closed(
         ), mock.patch.object(
             ws_server._writer, "ping", wraps=ws_server._writer.ping
         ) as ping:
-            await ws_server.receive()
-            ping_count = ping.call_count
+            try:
+                await ws_server.receive()
+            finally:
+                ping_count = ping.call_count
         return ws
 
     app = web.Application()

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -5,12 +5,14 @@ import asyncio
 import contextlib
 import sys
 from typing import Any, Optional
+from unittest import mock
 
 import pytest
 
 import aiohttp
 from aiohttp import WSServerHandshakeError, web
 from aiohttp.http import WSCloseCode, WSMsgType
+from aiohttp.pytest_plugin import AiohttpClient
 
 
 async def test_websocket_can_prepare(loop: Any, aiohttp_client: Any) -> None:
@@ -712,6 +714,40 @@ async def test_heartbeat_no_pong(loop: Any, aiohttp_client: Any) -> None:
     ws = await client.ws_connect("/", autoping=False)
     msg = await ws.receive()
     assert msg.type == aiohttp.WSMsgType.PING
+    await ws.close()
+
+
+async def test_heartbeat_connection_closed(
+    loop: asyncio.AbstractEventLoop, aiohttp_client: AiohttpClient
+) -> None:
+    """Test that the connection is closed while ping is in progress."""
+    ping_count = 0
+
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+        nonlocal ping_count
+        ws_server = web.WebSocketResponse(heartbeat=0.05)
+        await ws_server.prepare(request)
+        # We patch write here to simulate a connection reset error
+        # since if we closed the connection normally, the server would
+        # would cancel the heartbeat task and we wouldn't get a ping
+        with mock.patch.object(
+            ws_server._req.transport, "write", side_effect=ConnectionResetError
+        ), mock.patch.object(
+            ws_server._writer, "ping", wraps=ws_server._writer.ping
+        ) as ping:
+            await ws_server.receive()
+            ping_count = ping.call_count
+        return ws
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+
+    client = await aiohttp_client(app)
+    ws = await client.ws_connect("/", autoping=False)
+    msg = await ws.receive()
+    assert msg.type is aiohttp.WSMsgType.CLOSED
+    assert msg.extra is None
+    assert ping_count == 1
     await ws.close()
 
 

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -750,6 +750,7 @@ async def test_heartbeat_connection_closed(
     msg = await ws.receive()
     assert msg.type is aiohttp.WSMsgType.CLOSED
     assert msg.extra is None
+    assert ws.close_code == WSCloseCode.ABNORMAL_CLOSURE
     assert ping_count == 1
     await ws.close()
 

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -5,7 +5,7 @@ import asyncio
 import contextlib
 import sys
 import weakref
-from typing import Any, Optional
+from typing import Any, NoReturn, Optional
 from unittest import mock
 
 import pytest
@@ -724,7 +724,7 @@ async def test_heartbeat_connection_closed(
     """Test that the connection is closed while ping is in progress."""
     ping_count = 0
 
-    async def handler(request: web.Request) -> web.WebSocketResponse:
+    async def handler(request: web.Request) -> NoReturn:
         nonlocal ping_count
         ws_server = web.WebSocketResponse(heartbeat=0.05)
         await ws_server.prepare(request)
@@ -740,7 +740,7 @@ async def test_heartbeat_connection_closed(
                 await ws_server.receive()
             finally:
                 ping_count = ping.call_count
-        return ws
+        assert False
 
     app = web.Application()
     app.router.add_get("/", handler)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix exceptions from WebSocket ping task not being consumed

## Are there changes in behavior for the user?

No more unexpected un-retrieved exceptions from ping tasks

## Is it a substantial burden for the maintainers to support this?
no
## Related issue number
related issue https://github.com/home-assistant/core/issues/123653
replaces and closes #7238
fixes #5182
fixes #4153
fixes #2309