### PR TITLE
Fix typing errors on content_disposition_header()

### DIFF
--- a/CHANGES/8698.breaking.rst
+++ b/CHANGES/8698.breaking.rst
@@ -1,0 +1,1 @@
+Changed signature of ``content_disposition_header()`` so ``params`` is not passed as a dict, in order to reduce typing errors -- by :user:`Dreamsorcerer`.

--- a/CHANGES/8698.breaking.rst
+++ b/CHANGES/8698.breaking.rst
@@ -1,1 +1,1 @@
-Changed signature of ``content_disposition_header()`` so ``params`` is not passed as a dict, in order to reduce typing errors -- by :user:`Dreamsorcerer`.
+Changed signature of ``content_disposition_header()`` so ``params`` is now passed as a dict, in order to reduce typing errors -- by :user:`Dreamsorcerer`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -373,7 +373,7 @@ def quoted_string(content: str) -> str:
 
 
 def content_disposition_header(
-    disptype: str, quote_fields: bool = True, _charset: str = "utf-8", params: Dict[str, str]
+    disptype: str, quote_fields: bool = True, _charset: str = "utf-8", params: Optional[Dict[str, str]] = None
 ) -> str:
     """Sets ``Content-Disposition`` header for MIME.
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -373,7 +373,7 @@ def quoted_string(content: str) -> str:
 
 
 def content_disposition_header(
-    disptype: str, quote_fields: bool = True, _charset: str = "utf-8", **params: str
+    disptype: str, quote_fields: bool = True, _charset: str = "utf-8", params: Dict[str, str]
 ) -> str:
     """Sets ``Content-Disposition`` header for MIME.
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -373,7 +373,10 @@ def quoted_string(content: str) -> str:
 
 
 def content_disposition_header(
-    disptype: str, quote_fields: bool = True, _charset: str = "utf-8", params: Optional[Dict[str, str]] = None
+    disptype: str,
+    quote_fields: bool = True,
+    _charset: str = "utf-8",
+    params: Optional[Dict[str, str]] = None,
 ) -> str:
     """Sets ``Content-Disposition`` header for MIME.
 

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -204,7 +204,7 @@ class Payload(ABC):
     ) -> None:
         """Sets ``Content-Disposition`` header."""
         self._headers[hdrs.CONTENT_DISPOSITION] = content_disposition_header(
-            disptype, quote_fields=quote_fields, _charset=_charset, params
+            disptype, quote_fields=quote_fields, _charset=_charset, params=params
         )
 
     @abstractmethod

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -200,11 +200,11 @@ class Payload(ABC):
         disptype: str,
         quote_fields: bool = True,
         _charset: str = "utf-8",
-        **params: Any,
+        **params: str,
     ) -> None:
         """Sets ``Content-Disposition`` header."""
         self._headers[hdrs.CONTENT_DISPOSITION] = content_disposition_header(
-            disptype, quote_fields=quote_fields, _charset=_charset, **params
+            disptype, quote_fields=quote_fields, _charset=_charset, params
         )
 
     @abstractmethod

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -511,7 +511,7 @@ async def test_ceil_timeout_small_with_overriden_threshold(loop) -> None:
         ),
     ],
 )
-def test_content_disposition(params, quote_fields, _charset, result) -> None:
+def test_content_disposition(params, quote_fields, _charset, expected) -> None:
     result = helpers.content_disposition_header(
         "attachment", quote_fields=quote_fields, _charset=_charset, params=params
     )

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -493,7 +493,7 @@ async def test_ceil_timeout_small_with_overriden_threshold(loop) -> None:
 
 
 @pytest.mark.parametrize(
-    "params, quote_fields, _charset, result",
+    "params, quote_fields, _charset, expected",
     [
         (dict(foo="bar"), True, "utf-8", 'attachment; foo="bar"'),
         (dict(foo="bar[]"), True, "utf-8", 'attachment; foo="bar[]"'),
@@ -512,12 +512,10 @@ async def test_ceil_timeout_small_with_overriden_threshold(loop) -> None:
     ],
 )
 def test_content_disposition(params, quote_fields, _charset, result) -> None:
-    assert (
-        helpers.content_disposition_header(
-            "attachment", quote_fields=quote_fields, _charset=_charset, params=params
-        )
-        == result
+    result = helpers.content_disposition_header(
+        "attachment", quote_fields=quote_fields, _charset=_charset, params=params
     )
+    assert result == expected
 
 
 def test_content_disposition_bad_type() -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -510,7 +510,7 @@ async def test_ceil_timeout_small_with_overriden_threshold(loop) -> None:
     ],
 )
 def test_content_disposition(kwargs, result) -> None:
-    assert helpers.content_disposition_header("attachment", **kwargs) == result
+    assert helpers.content_disposition_header("attachment", params=kwargs) == result
 
 
 def test_content_disposition_bad_type() -> None:
@@ -526,13 +526,13 @@ def test_content_disposition_bad_type() -> None:
 
 def test_set_content_disposition_bad_param() -> None:
     with pytest.raises(ValueError):
-        helpers.content_disposition_header("inline", **{"foo bar": "baz"})
+        helpers.content_disposition_header("inline", params={"foo bar": "baz"})
     with pytest.raises(ValueError):
-        helpers.content_disposition_header("inline", **{"—Ç–µ—Å—Ç": "baz"})
+        helpers.content_disposition_header("inline", params={"—Ç–µ—Å—Ç": "baz"})
     with pytest.raises(ValueError):
-        helpers.content_disposition_header("inline", **{"": "baz"})
+        helpers.content_disposition_header("inline", params={"": "baz"})
     with pytest.raises(ValueError):
-        helpers.content_disposition_header("inline", **{"foo\x00bar": "baz"})
+        helpers.content_disposition_header("inline", params={"foo\x00bar": "baz"})
 
 
 # --------------------- proxies_from_env ------------------------------

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -512,7 +512,12 @@ async def test_ceil_timeout_small_with_overriden_threshold(loop) -> None:
     ],
 )
 def test_content_disposition(params, quote_fields, _charset, result) -> None:
-    assert helpers.content_disposition_header("attachment", quote_fields=quote_fields, _charset=_charset, params=params) == result
+    assert (
+        helpers.content_disposition_header(
+            "attachment", quote_fields=quote_fields, _charset=_charset, params=params
+        )
+        == result
+    )
 
 
 def test_content_disposition_bad_type() -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -493,24 +493,26 @@ async def test_ceil_timeout_small_with_overriden_threshold(loop) -> None:
 
 
 @pytest.mark.parametrize(
-    "kwargs, result",
+    "params, quote_fields, _charset, result",
     [
-        (dict(foo="bar"), 'attachment; foo="bar"'),
-        (dict(foo="bar[]"), 'attachment; foo="bar[]"'),
-        (dict(foo=' a""b\\'), 'attachment; foo="\\ a\\"\\"b\\\\"'),
-        (dict(foo="bär"), "attachment; foo*=utf-8''b%C3%A4r"),
-        (dict(foo='bär "\\', quote_fields=False), 'attachment; foo="bär \\"\\\\"'),
-        (dict(foo="bär", _charset="latin-1"), "attachment; foo*=latin-1''b%E4r"),
-        (dict(filename="bär"), 'attachment; filename="b%C3%A4r"'),
-        (dict(filename="bär", _charset="latin-1"), 'attachment; filename="b%E4r"'),
+        (dict(foo="bar"), True, "utf-8", 'attachment; foo="bar"'),
+        (dict(foo="bar[]"), True, "utf-8", 'attachment; foo="bar[]"'),
+        (dict(foo=' a""b\\'), True, "utf-8", 'attachment; foo="\\ a\\"\\"b\\\\"'),
+        (dict(foo="bär"), True, "utf-8", "attachment; foo*=utf-8''b%C3%A4r"),
+        (dict(foo='bär "\\'), False, "utf-8", 'attachment; foo="bär \\"\\\\"'),
+        (dict(foo="bär"), True, "latin-1", "attachment; foo*=latin-1''b%E4r"),
+        (dict(filename="bär"), True, "utf-8", 'attachment; filename="b%C3%A4r"'),
+        (dict(filename="bär"), True, "latin-1", 'attachment; filename="b%E4r"'),
         (
-            dict(filename='bär "\\', quote_fields=False),
+            dict(filename='bär "\\'),
+            False,
+            "utf-8",
             'attachment; filename="bär \\"\\\\"',
         ),
     ],
 )
-def test_content_disposition(kwargs, result) -> None:
-    assert helpers.content_disposition_header("attachment", params=kwargs) == result
+def test_content_disposition(params, quote_fields, _charset, result) -> None:
+    assert helpers.content_disposition_header("attachment", quote_fields=quote_fields, _charset=_charset, params=params) == result
 
 
 def test_content_disposition_bad_type() -> None:


### PR DESCRIPTION
The signature for the function doesn't type check well. If we unpack a `dict[str, str]`, we'll get a type error because quote_fields requires a bool and could be included in the unpacked arguments. All locations using the function seem to have a dict anyway...

This appears to be an internal function, not documented in our API, so risk should be low by changing the signature. Though will only do it on master anyway.