### PR TITLE
Reduce code indent in ResponseHandler.data_received

### DIFF
--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -258,7 +258,7 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
         if not data:
             return
 
-        # custom payload parser
+        # custom payload parser - currently always WebSocketReader
         if self._payload_parser is not None:
             payload_eof, payload_tail = self._payload_parser.feed_data(data)
             if payload_eof:

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -319,8 +319,5 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
             else:
                 self._drop_timeout()
 
-        if tail:
-            if upgraded:
-                self.data_received(tail)
-            else:
-                self._tail = tail
+        if upgraded and tail:
+            self.data_received(tail)

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -260,13 +260,13 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
 
         # custom payload parser - currently always WebSocketReader
         if self._payload_parser is not None:
-            payload_eof, payload_tail = self._payload_parser.feed_data(data)
-            if payload_eof:
+            eof, tail = self._payload_parser.feed_data(data)
+            if eof:
                 self._payload = None
                 self._payload_parser = None
 
-                if payload_tail:
-                    self.data_received(payload_tail)
+                if tail:
+                    self.data_received(tail)
             return
 
         if self._upgraded or self._parser is None:

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -260,13 +260,13 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
 
         # custom payload parser
         if self._payload_parser is not None:
-            eof, tail = self._payload_parser.feed_data(data)
-            if eof:
+            payload_eof, payload_tail = self._payload_parser.feed_data(data)
+            if payload_eof:
                 self._payload = None
                 self._payload_parser = None
 
-                if tail:
-                    self.data_received(tail)
+                if payload_tail:
+                    self.data_received(payload_tail)
             return
 
         if self._upgraded or self._parser is None:

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -268,57 +268,59 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
                 if tail:
                     self.data_received(tail)
             return
-        else:
-            if self._upgraded or self._parser is None:
-                # i.e. websocket connection, websocket parser is not set yet
-                self._tail += data
+
+        if self._upgraded or self._parser is None:
+            # i.e. websocket connection, websocket parser is not set yet
+            self._tail += data
+            return
+
+        # parse http messages
+        try:
+            messages, upgraded, tail = self._parser.feed_data(data)
+        except BaseException as underlying_exc:
+            if self.transport is not None:
+                # connection.release() could be called BEFORE
+                # data_received(), the transport is already
+                # closed in this case
+                self.transport.close()
+            # should_close is True after the call
+            if isinstance(underlying_exc, HttpProcessingError):
+                exc = HttpProcessingError(
+                    code=underlying_exc.code,
+                    message=underlying_exc.message,
+                    headers=underlying_exc.headers,
+                )
             else:
-                # parse http messages
-                try:
-                    messages, upgraded, tail = self._parser.feed_data(data)
-                except BaseException as underlying_exc:
-                    if self.transport is not None:
-                        # connection.release() could be called BEFORE
-                        # data_received(), the transport is already
-                        # closed in this case
-                        self.transport.close()
-                    # should_close is True after the call
-                    if isinstance(underlying_exc, HttpProcessingError):
-                        exc = HttpProcessingError(
-                            code=underlying_exc.code,
-                            message=underlying_exc.message,
-                            headers=underlying_exc.headers,
-                        )
-                    else:
-                        exc = HttpProcessingError()
-                    self.set_exception(exc, underlying_exc)
-                    return
+                exc = HttpProcessingError()
+            self.set_exception(exc, underlying_exc)
+            return
 
-                self._upgraded = upgraded
+        self._upgraded = upgraded
 
-                payload: Optional[StreamReader] = None
-                for message, payload in messages:
-                    if message.should_close:
-                        self._should_close = True
+        payload: Optional[StreamReader] = None
+        for message, payload in messages:
+            if message.should_close:
+                self._should_close = True
 
-                    self._payload = payload
+            self._payload = payload
 
-                    if self._skip_payload or message.code in EMPTY_BODY_STATUS_CODES:
-                        self.feed_data((message, EMPTY_PAYLOAD))
-                    else:
-                        self.feed_data((message, payload))
-                if payload is not None:
-                    # new message(s) was processed
-                    # register timeout handler unsubscribing
-                    # either on end-of-stream or immediately for
-                    # EMPTY_PAYLOAD
-                    if payload is not EMPTY_PAYLOAD:
-                        payload.on_eof(self._drop_timeout)
-                    else:
-                        self._drop_timeout()
+            if self._skip_payload or message.code in EMPTY_BODY_STATUS_CODES:
+                self.feed_data((message, EMPTY_PAYLOAD))
+            else:
+                self.feed_data((message, payload))
 
-                if tail:
-                    if upgraded:
-                        self.data_received(tail)
-                    else:
-                        self._tail = tail
+        if payload is not None:
+            # new message(s) was processed
+            # register timeout handler unsubscribing
+            # either on end-of-stream or immediately for
+            # EMPTY_PAYLOAD
+            if payload is not EMPTY_PAYLOAD:
+                payload.on_eof(self._drop_timeout)
+            else:
+                self._drop_timeout()
+
+        if tail:
+            if upgraded:
+                self.data_received(tail)
+            else:
+                self._tail = tail

--- a/tests/test_client_proto.py
+++ b/tests/test_client_proto.py
@@ -97,29 +97,30 @@ async def test_multiple_responses_one_byte_at_a_time(
     conn = mock.Mock(protocol=proto)
     proto.set_response_params(read_until_eof=True)
 
-    messages = (
-        b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nab"
-        b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\ncd"
-        b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nef"
-    )
-    for i in range(len(messages)):
-        proto.data_received(messages[i : i + 1])
-
-    expected = [b"ab", b"cd", b"ef"]
-    for payload in expected:
-        response = ClientResponse(
-            "get",
-            URL("http://def-cl-resp.org"),
-            writer=mock.Mock(),
-            continue100=None,
-            timer=TimerNoop(),
-            request_info=mock.Mock(),
-            traces=[],
-            loop=loop,
-            session=mock.Mock(),
+    for _ in range(2):
+        messages = (
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nab"
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\ncd"
+            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nef"
         )
-        await response.start(conn)
-        await response.read() == payload
+        for i in range(len(messages)):
+            proto.data_received(messages[i : i + 1])
+
+        expected = [b"ab", b"cd", b"ef"]
+        for payload in expected:
+            response = ClientResponse(
+                "get",
+                URL("http://def-cl-resp.org"),
+                writer=mock.Mock(),
+                continue100=None,
+                timer=TimerNoop(),
+                request_info=mock.Mock(),
+                traces=[],
+                loop=loop,
+                session=mock.Mock(),
+            )
+            await response.start(conn)
+            await response.read() == payload
 
 
 async def test_client_protocol_readuntil_eof(loop: asyncio.AbstractEventLoop) -> None:

--- a/tests/test_client_proto.py
+++ b/tests/test_client_proto.py
@@ -81,11 +81,13 @@ async def test_multiple_responses_single_read(loop: asyncio.AbstractEventLoop) -
     conn = mock.Mock(protocol=proto)
     proto.set_response_params(read_until_eof=True)
 
-    proto.data_received(
+    messages = (
         b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nab"
         b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\ncd"
         b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nef"
     )
+    for i in range(len(messages)):
+        proto.data_received(messages[i : i + 1])
 
     expected = [b"ab", b"cd", b"ef"]
     for payload in expected:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Code cleanup only, no functional change

There were some else after returns that could be converted to guards to reduce code indent.

While looking at the full WebSockets path for https://github.com/aio-libs/aiohttp/discussions/8258 I noticed this could be improved a bit

Additionally, some missing test coverage is added and [unreachable code](https://github.com/aio-libs/aiohttp/pull/8699#issuecomment-2502632262) is removed.

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no