### PR TITLE
Fix Python parser when chunk separators align

### DIFF
--- a/CHANGES/8720.bugfix.rst
+++ b/CHANGES/8720.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an edge case in the Python parser when chunk separators happen to align with network chunks -- by :user:`Dreamsorcerer`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -845,13 +845,13 @@ class HttpPayloadParser:
                     if self._chunk_size:
                         return False, b""
                     chunk = chunk[required:]
-                    if self._lax and chunk.startswith(b"\r"):
-                        chunk = chunk[1:]
                     self._chunk = ChunkState.PARSE_CHUNKED_CHUNK_EOF
                     self.payload.end_http_chunk_receiving()
 
                 # toss the CRLF at the end of the chunk
                 if self._chunk == ChunkState.PARSE_CHUNKED_CHUNK_EOF:
+                    if self._lax and chunk.startswith(b"\r"):
+                        chunk = chunk[1:]
                     if chunk[: len(SEP)] == SEP:
                         chunk = chunk[len(SEP) :]
                         self._chunk = ChunkState.PARSE_CHUNKED_SIZE

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1463,9 +1463,7 @@ def test_parse_chunked_payload_empty_body_than_another_chunked(
 
 async def test_parse_chunked_payload_split_chunks(response: HttpResponseParser) -> None:
     network_chunks = (
-        b"HTTP/1.1 200 OK\r\n"
-        b"Transfer-Encoding: chunked\r\n\r\n"
-        b"5\r\nfi",
+        b"HTTP/1.1 200 OK\r\n" b"Transfer-Encoding: chunked\r\n\r\n" b"5\r\nfi",
         b"rst",
         # This simulates a bug in lax mode caused when the \r\n separator, before the
         # next HTTP chunk, appears at the start of the next network chunk.
@@ -1474,7 +1472,7 @@ async def test_parse_chunked_payload_split_chunks(response: HttpResponseParser) 
         b"\r",
         b"\n",
         b"second\r",
-        b"\n0\r\n\r\n"
+        b"\n0\r\n\r\n",
     )
     reader = response.feed_data(network_chunks[0])[0][0][1]
     for c in network_chunks[1:]:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1463,7 +1463,9 @@ def test_parse_chunked_payload_empty_body_than_another_chunked(
 
 async def test_parse_chunked_payload_split_chunks(response: HttpResponseParser) -> None:
     network_chunks = (
-        b"HTTP/1.1 200 OK\r\n" b"Transfer-Encoding: chunked\r\n\r\n" b"5\r\nfi",
+        b"HTTP/1.1 200 OK\r\n",
+        b"Transfer-Encoding: chunked\r\n\r\n",
+        b"5\r\nfi",
         b"rst",
         # This simulates a bug in lax mode caused when the \r\n separator, before the
         # next HTTP chunk, appears at the start of the next network chunk.

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1463,8 +1463,7 @@ def test_parse_chunked_payload_empty_body_than_another_chunked(
 
 async def test_parse_chunked_payload_split_chunks(response: HttpResponseParser) -> None:
     network_chunks = (
-        b"HTTP/1.1 200 OK\r\n",
-        b"Transfer-Encoding: chunked\r\n\r\n",
+        b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n",
         b"5\r\nfi",
         b"rst",
         # This simulates a bug in lax mode caused when the \r\n separator, before the


### PR DESCRIPTION
Fixes #3904.