### PR TITLE
Improve performance of WebSocketReader

### DIFF
--- a/CHANGES/8736.misc.rst
+++ b/CHANGES/8736.misc.rst
@@ -1,1 +1,1 @@
-Improved performance of :py:class:`~aiohttp.http.WebSocketReader` -- by :user:`bdraco`.
+Improved performance of the WebSocket reader -- by :user:`bdraco`.

--- a/CHANGES/8736.misc.rst
+++ b/CHANGES/8736.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of :py:class:`~aiohttp.http.WebSocketReader` -- by :user:`bdraco`.

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -399,7 +399,6 @@ class WebSocketReader:
 
                 # Decompress process must to be done after all packets
                 # received.
-                payload_merged: Optional[bytes] = None
                 if compressed:
                     if not self._decompressobj:
                         self._decompressobj = ZLibDecompressor(
@@ -416,6 +415,8 @@ class WebSocketReader:
                                 self._max_msg_size + left, self._max_msg_size
                             ),
                         )
+                else:
+                    payload_merged = bytes(assembled_payload)
 
                 if opcode == WSMsgType.TEXT:
                     try:
@@ -428,8 +429,7 @@ class WebSocketReader:
                     self.queue.feed_data(WSMessage(WSMsgType.TEXT, text, ""))
                     continue
 
-                data = payload_merged or bytes(assembled_payload)
-                self.queue.feed_data(WSMessage(WSMsgType.BINARY, data, ""))
+                self.queue.feed_data(WSMessage(WSMsgType.BINARY, payload_merged, ""))
 
     def parse_frame(
         self, buf: bytes

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -305,13 +305,15 @@ class WebSocketReader:
             return True, data
 
         try:
-            return self._feed_data(data)
+            self._feed_data(data)
         except Exception as exc:
             self._exc = exc
             set_exception(self.queue, exc)
             return True, b""
 
-    def _feed_data(self, data: bytes) -> Tuple[bool, bytes]:
+        return False, b""
+
+    def _feed_data(self, data: bytes) -> None:
         feed_data = self.queue.feed_data
         for fin, opcode, payload, compressed in self.parse_frame(data):
             if opcode == WSMsgType.CLOSE:
@@ -428,8 +430,6 @@ class WebSocketReader:
                     feed_data(WSMessage(WSMsgType.TEXT, text, ""))
                 else:
                     feed_data(WSMessage(WSMsgType.BINARY, payload_merged, ""))
-
-        return False, b""
 
     def parse_frame(
         self, buf: bytes

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -373,6 +373,7 @@ class WebSocketReader:
 
                 has_partial = bool(self._partial)
                 if is_continuation:
+                    assert self._opcode is not None
                     opcode = self._opcode
                     self._opcode = None
                 # previous frame was non finished

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -85,6 +85,12 @@ class WSMsgType(IntEnum):
     ERROR = 0x102
 
 
+MESSAGE_TYPES_WITH_CONTENT: Final = (
+    WSMsgType.BINARY,
+    WSMsgType.TEXT,
+    WSMsgType.CONTINUATION,
+)
+
 WS_KEY: Final[bytes] = b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 
 
@@ -314,7 +320,7 @@ class WebSocketReader:
 
     def _feed_data(self, data: bytes) -> None:
         for fin, opcode, payload, compressed in self.parse_frame(data):
-            if opcode in (WSMsgType.TEXT, WSMsgType.BINARY, WSMsgType.CONTINUATION):
+            if opcode in MESSAGE_TYPES_WITH_CONTENT:
                 # load text/binary
                 is_continuation = opcode == WSMsgType.CONTINUATION
                 if not fin:

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -510,23 +510,21 @@ class WebSocketReader:
 
             # read payload length
             if self._state is WSParserState.READ_PAYLOAD_LENGTH:
-                length = self._payload_length_flag
-                if length == 126:
+                length_flag = self._payload_length_flag
+                if length_flag == 126:
                     if buf_length - start_pos < 2:
                         break
                     data = buf[start_pos : start_pos + 2]
                     start_pos += 2
-                    length = UNPACK_LEN2(data)[0]
-                    self._payload_length = length
-                elif length > 126:
+                    self._payload_length = UNPACK_LEN2(data)[0]
+                elif length_flag > 126:
                     if buf_length - start_pos < 8:
                         break
                     data = buf[start_pos : start_pos + 8]
                     start_pos += 8
-                    length = UNPACK_LEN3(data)[0]
-                    self._payload_length = length
+                    self._payload_length = UNPACK_LEN3(data)[0]
                 else:
-                    self._payload_length = length
+                    self._payload_length = length_flag
 
                 self._state = (
                     WSParserState.READ_PAYLOAD_MASK

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -428,11 +428,8 @@ class WebSocketReader:
                     self.queue.feed_data(WSMessage(WSMsgType.TEXT, text, ""))
                     continue
 
-                self.queue.feed_data(
-                    WSMessage(
-                        WSMsgType.BINARY, payload_merged or bytes(assembled_payload), ""
-                    )
-                )
+                data = payload_merged or bytes(assembled_payload)
+                self.queue.feed_data(WSMessage(WSMsgType.BINARY, data, ""))
 
     def parse_frame(
         self, buf: bytes

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -11,7 +11,6 @@ from enum import IntEnum
 from functools import partial
 from struct import Struct
 from typing import (
-    TYPE_CHECKING,
     Any,
     Callable,
     Final,
@@ -563,8 +562,7 @@ class WebSocketReader:
                     assert self._frame_mask is not None
                     _websocket_mask(self._frame_mask, payload)
 
-                if TYPE_CHECKING:
-                    assert self._frame_opcode is not None
+                assert self._frame_opcode is not None
                 frames.append(
                     (self._frame_fin, self._frame_opcode, payload, self._compressed)
                 )

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -420,7 +420,7 @@ class WebSocketReader:
 
                 if opcode == WSMsgType.TEXT:
                     try:
-                        text = (payload_merged or assembled_payload).decode("utf-8")
+                        text = payload_merged.decode("utf-8")
                     except UnicodeDecodeError as exc:
                         raise WebSocketError(
                             WSCloseCode.INVALID_TEXT, "Invalid UTF-8 text message"

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -433,9 +433,9 @@ class WebSocketReader:
 
     def parse_frame(
         self, buf: bytes
-    ) -> List[Tuple[bool, int, bytearray, Optional[bool]]]:
+    ) -> List[Tuple[bool, Optional[int], bytearray, Optional[bool]]]:
         """Return the next frame from the socket."""
-        frames: List[Tuple[bool, int, bytearray, Optional[bool]]] = []
+        frames: List[Tuple[bool, Optional[int], bytearray, Optional[bool]]] = []
         if self._tail:
             buf, self._tail = self._tail + buf, b""
 
@@ -562,7 +562,6 @@ class WebSocketReader:
                     assert self._frame_mask is not None
                     _websocket_mask(self._frame_mask, payload)
 
-                assert self._frame_opcode is not None
                 frames.append(
                     (self._frame_fin, self._frame_opcode, payload, self._compressed)
                 )

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -403,7 +403,6 @@ class WebSocketReader:
                         self._decompressobj = ZLibDecompressor(
                             suppress_deflate_header=True
                         )
-                    # + is much faster than bytearray.extend()
                     payload_merged = self._decompressobj.decompress_sync(
                         assembled_payload + _WS_DEFLATE_TRAILING, self._max_msg_size
                     )


### PR DESCRIPTION
Optimization

- Replace `bytearray.extend` with `+` and `+=` https://stackoverflow.com/questions/40004517/why-does-bytearray-obj-extendbytes-differ-from-bytearray-obj-bytes
- Avoid making copies of the incoming data when there is no continuation. `self._partial` is never needed for the non-continuation case and we can avoid having to `extend` and `clear` it for this case, which is the common case for many use cases.

This is a paired down version of #8735 to better optimize for both the non-continuation and continuation case

Testing `feed_data` on a live HA instance. Testing was done on an Odroid N2+ SBC. Performance numbers will vary based on CPU and memory performance.

~6% faster for the continuation case (real world use case is listening to a unifi instance)
~34% faster for the non-continuation case (real world use case is reading Bluetooth data from a shelly device, web based terminal shows a similar improvement)

Improvement percentages will be less impressive on systems with faster CPU/memory performance.

related discussion https://github.com/aio-libs/aiohttp/discussions/8258

benchmark for non-continuation case
```python
import random
import zlib
from typing import Any
import timeit
import asyncio
import aiohttp
from aiohttp.http import WSMsgType
from aiohttp.http_websocket import (
    _WS_DEFLATE_TRAILING,
    PACK_LEN1,
    PACK_LEN2,
    PACK_LEN3,
    WebSocketReader,
    _websocket_mask,
)


def build_frame(
    message: Any,
    opcode: Any,
    use_mask: bool = False,
    noheader: bool = False,
    is_fin: bool = True,
    compress: bool = False,
):
    # Send a frame over the websocket with message as its payload.
    if compress:
        compressobj = zlib.compressobj(wbits=-9)
        message = compressobj.compress(message)
        message = message + compressobj.flush(zlib.Z_SYNC_FLUSH)
        if message.endswith(_WS_DEFLATE_TRAILING):
            message = message[:-4]
    msg_length = len(message)
    if use_mask:  # pragma: no cover
        mask_bit = 0x80
    else:
        mask_bit = 0

    if is_fin:
        header_first_byte = 0x80 | opcode
    else:
        header_first_byte = opcode

    if compress:
        header_first_byte |= 0x40

    if msg_length < 126:
        header = PACK_LEN1(header_first_byte, msg_length | mask_bit)
    elif msg_length < (1 << 16):  # pragma: no cover
        header = PACK_LEN2(header_first_byte, 126 | mask_bit, msg_length)
    else:
        header = PACK_LEN3(header_first_byte, 127 | mask_bit, msg_length)

    if use_mask:  # pragma: no cover
        mask = random.randrange(0, 0xFFFFFFFF)
        mask = mask.to_bytes(4, "big")
        message = bytearray(message)
        _websocket_mask(mask, message)
        if noheader:
            return message
        else:
            return header + mask + message
    else:
        if noheader:
            return message
        else:
            return header + message


def out(loop):
    return aiohttp.DataQueue(loop)


def parser(out):
    return WebSocketReader(out, 4 * 1024 * 1024)


async def bench():
    data = build_frame(b"thisisthebinaryframe" * 256, WSMsgType.BINARY)
    loop = asyncio.get_running_loop()
    out_queue = out(loop)
    parser_instance = parser(out_queue)
    print(
        timeit.timeit(
            "parser_instance.feed_data(data)", globals=locals(), number=1000000
        )
    )


asyncio.run(bench())
```

profiler
```python
import random
import zlib
from typing import Any
import asyncio
import aiohttp
from aiohttp.http import WSMsgType
import cProfile
from aiohttp.http_websocket import (
    _WS_DEFLATE_TRAILING,
    PACK_LEN1,
    PACK_LEN2,
    PACK_LEN3,
    WebSocketReader,
    _websocket_mask,
)


def build_frame(
    message: Any,
    opcode: Any,
    use_mask: bool = False,
    noheader: bool = False,
    is_fin: bool = True,
    compress: bool = False,
):
    # Send a frame over the websocket with message as its payload.
    if compress:
        compressobj = zlib.compressobj(wbits=-9)
        message = compressobj.compress(message)
        message = message + compressobj.flush(zlib.Z_SYNC_FLUSH)
        if message.endswith(_WS_DEFLATE_TRAILING):
            message = message[:-4]
    msg_length = len(message)
    if use_mask:  # pragma: no cover
        mask_bit = 0x80
    else:
        mask_bit = 0

    if is_fin:
        header_first_byte = 0x80 | opcode
    else:
        header_first_byte = opcode

    if compress:
        header_first_byte |= 0x40

    if msg_length < 126:
        header = PACK_LEN1(header_first_byte, msg_length | mask_bit)
    elif msg_length < (1 << 16):  # pragma: no cover
        header = PACK_LEN2(header_first_byte, 126 | mask_bit, msg_length)
    else:
        header = PACK_LEN3(header_first_byte, 127 | mask_bit, msg_length)

    if use_mask:  # pragma: no cover
        mask = random.randrange(0, 0xFFFFFFFF)
        mask = mask.to_bytes(4, "big")
        message = bytearray(message)
        _websocket_mask(mask, message)
        if noheader:
            return message
        else:
            return header + mask + message
    else:
        if noheader:
            return message
        else:
            return header + message


def out(loop):
    return aiohttp.DataQueue(loop)


def parser(out):
    return WebSocketReader(out, 4 * 1024 * 1024)


async def bench():
    data = build_frame(b"thisisthebinaryframe" * 256, WSMsgType.BINARY)
    loop = asyncio.get_running_loop()
    out_queue = out(loop)
    parser_instance = parser(out_queue)
    pr = cProfile.Profile()
    pr.enable()
    for _ in range(1000000):
        parser_instance.feed_data(data)
    pr.disable()
    pr.create_stats()
    pr.dump_stats("feed.cprof")


asyncio.run(bench())
```