### PR TITLE
Fix status not being set when ClientResponse.json raises ContentTypeError

### DIFF
--- a/CHANGES/8742.bugfix.rst
+++ b/CHANGES/8742.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed :meth:`ClientResponse.json()` not setting ``status`` when :exc:`ContentTypeError` is raised -- by :user:`bdraco`.
+Fixed :meth:`aiohttp.client.ClientResponse.json()` not setting ``status`` when :exc:`aiohttp.client_exceptions.ContentTypeError` is raised -- by :user:`bdraco`.

--- a/CHANGES/8742.bugfix.rst
+++ b/CHANGES/8742.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed :meth:`aiohttp.client.ClientResponse.json()` not setting ``status`` when :exc:`aiohttp.client_exceptions.ContentTypeError` is raised -- by :user:`bdraco`.
+Fixed :meth:`aiohttp.ClientResponse.json()` not setting ``status`` when :exc:`aiohttp.ContentTypeError` is raised -- by :user:`bdraco`.

--- a/CHANGES/8742.bugfix.rst
+++ b/CHANGES/8742.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :meth:`ClientResponse.json()` not setting ``status`` when :exc:`ContentTypeError` is raised -- by :user:`bdraco`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1127,6 +1127,7 @@ class ClientResponse(HeadersMixin):
                 raise ContentTypeError(
                     self.request_info,
                     self.history,
+                    status=self.status,
                     message=(
                         "Attempt to decode JSON with "
                         "unexpected mimetype: %s" % self.content_type

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -676,11 +676,13 @@ async def test_json_invalid_content_type(
     h = {"Content-Type": "data/octet-stream"}
     response._headers = CIMultiDictProxy(CIMultiDict(h))
     response._body = b""
+    response.status = 500
 
     with pytest.raises(aiohttp.ContentTypeError) as info:
         await response.json()
 
     assert info.value.request_info == response.request_info
+    assert info.value.status == 500
 
 
 async def test_json_no_content(


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

Fix status not being set when ClientResponse.json raises ContentTypeError

## Are there changes in behavior for the user?

The status will be set

## Is it a substantial burden for the maintainers to support this?

no
## Related issue number
fixes #8741