### PR TITLE
[PR #8749/5e30b49 backport][3.10] Bump cffi to 1.17.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ attrs==23.2.0
     # via -r requirements/runtime-deps.in
 brotli==1.1.0 ; platform_python_implementation == "CPython"
     # via -r requirements/runtime-deps.in
-cffi==1.15.1
+cffi==1.17.0
     # via pycares
 frozenlist==1.4.1
     # via

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -38,7 +38,7 @@ build==1.0.3
     # via pip-tools
 certifi==2023.7.22
     # via requests
-cffi==1.15.0
+cffi==1.17.0
     # via
     #   cryptography
     #   pycares

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -36,7 +36,7 @@ build==1.0.3
     # via pip-tools
 certifi==2023.7.22
     # via requests
-cffi==1.15.1
+cffi==1.17.0
     # via
     #   cryptography
     #   pycares

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -14,8 +14,10 @@ async-timeout==4.0.3
     # via aioredis
 certifi==2024.2.2
     # via requests
-cffi==1.16.0
-    # via pycares
+cffi==1.17.0
+    # via
+    #   cryptography
+    #   pycares
 cfgv==3.3.1
     # via pre-commit
 charset-normalizer==3.3.2

--- a/requirements/runtime-deps.txt
+++ b/requirements/runtime-deps.txt
@@ -16,7 +16,7 @@ attrs==23.2.0
     # via -r requirements/runtime-deps.in
 brotli==1.1.0 ; platform_python_implementation == "CPython"
     # via -r requirements/runtime-deps.in
-cffi==1.15.1
+cffi==1.17.0
     # via pycares
 frozenlist==1.4.1
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -20,7 +20,7 @@ brotli==1.1.0 ; platform_python_implementation == "CPython"
     # via -r requirements/runtime-deps.in
 certifi==2023.7.22
     # via requests
-cffi==1.15.1
+cffi==1.17.0
     # via
     #   cryptography
     #   pycares


### PR DESCRIPTION
(cherry picked from commit 5e30b490e78cb5ceabb92fb3cf16205ed7cd9f1e)
