### PR TITLE
Drop Python 3.8

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -141,15 +141,13 @@ jobs:
     needs: gen_llhttp
     strategy:
       matrix:
-        pyver: [3.8, 3.9, '3.10', '3.11', '3.12']
+        pyver: [3.9, '3.10', '3.11', '3.12']
         no-extensions: ['', 'Y']
         os: [ubuntu, macos, windows]
         experimental: [false]
         exclude:
           - os: macos
             no-extensions: 'Y'
-          - os: macos
-            pyver: 3.8
           - os: windows
             no-extensions: 'Y'
         include:

--- a/.github/workflows/update-pre-commit.yml
+++ b/.github/workflows/update-pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run: >-
         pip install -r requirements/lint.in -c requirements/lint.txt
@@ -33,4 +33,4 @@ jobs:
         body: |
           Update versions of tools in pre-commit
           configs to latest version
-        labels: dependencies backport-3.7 backport-3.8
+        labels: dependencies backport-3.10 backport-3.11

--- a/CHANGES/8797.breaking.rst
+++ b/CHANGES/8797.breaking.rst
@@ -1,0 +1,1 @@
+Dropped support for Python 3.8 -- by :user:`Dreamsorcerer`.

--- a/Makefile
+++ b/Makefile
@@ -117,11 +117,7 @@ define run_tests_in_docker
 	docker run --rm -ti -v `pwd`:/src -w /src "aiohttp-test-$(1)-$(2)" $(TEST_SPEC)
 endef
 
-.PHONY: test-3.8-no-extensions test-3.8 test-3.9-no-extensions test
-test-3.8-no-extensions:
-	$(call run_tests_in_docker,3.8,y)
-test-3.8:
-	$(call run_tests_in_docker,3.8,n)
+.PHONY: test-3.9-no-extensions test
 test-3.9-no-extensions:
 	$(call run_tests_in_docker,3.9,y)
 test-3.9:

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -70,7 +70,7 @@ class CookieJar(AbstractCookieJar):
     except (OSError, ValueError):
         # Hit the maximum representable time on Windows
         # https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/localtime-localtime32-localtime64
-        # Throws ValueError on PyPy 3.8 and 3.9, OSError elsewhere
+        # Throws ValueError on PyPy 3.9, OSError elsewhere
         MAX_TIME = calendar.timegm((3000, 12, 31, 23, 59, 59, -1, -1, -1))
     except OverflowError:
         # #4515: datetime.max may not be representable on 32-bit platforms

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -1,6 +1,5 @@
 import asyncio
 import socket
-import sys
 from typing import Any, List, Tuple, Type, Union
 
 from .abc import AbstractResolver, ResolveResult

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -18,7 +18,6 @@ except ImportError:  # pragma: no cover
 
 
 _NUMERIC_SOCKET_FLAGS = socket.AI_NUMERICHOST | socket.AI_NUMERICSERV
-_SUPPORTS_SCOPE_ID = sys.version_info >= (3, 9, 0)
 
 
 class ThreadedResolver(AbstractResolver):
@@ -49,7 +48,7 @@ class ThreadedResolver(AbstractResolver):
                     # IPv6 is not supported by Python build,
                     # or IPv6 is not enabled in the host
                     continue
-                if address[3] and _SUPPORTS_SCOPE_ID:
+                if address[3]:
                     # This is essential for link-local IPv6 addresses.
                     # LL IPv6 is a VERY rare case. Strictly speaking, we should use
                     # getnameinfo() unconditionally, but performance makes sense.
@@ -107,7 +106,7 @@ class AsyncResolver(AbstractResolver):
             address: Union[Tuple[bytes, int], Tuple[bytes, int, int, int]] = node.addr
             family = node.family
             if family == socket.AF_INET6:
-                if len(address) > 3 and address[3] and _SUPPORTS_SCOPE_ID:
+                if len(address) > 3 and address[3]:
                     # This is essential for link-local IPv6 addresses.
                     # LL IPv6 is a VERY rare case. Strictly speaking, we should use
                     # getnameinfo() unconditionally, but performance makes sense.

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -45,9 +45,6 @@ NOSENDFILE: Final[bool] = bool(os.environ.get("AIOHTTP_NOSENDFILE"))
 
 CONTENT_TYPES: Final[MimeTypes] = MimeTypes()
 
-if sys.version_info < (3, 9):
-    CONTENT_TYPES.encodings_map[".br"] = "br"
-
 # File extension to IANA encodings map that will be checked in the order defined.
 ENCODING_EXTENSIONS = MappingProxyType(
     {ext: CONTENT_TYPES.encodings_map[ext] for ext in (".br", ".gz")}

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -1,7 +1,6 @@
 import asyncio
 import os
 import pathlib
-import sys
 from contextlib import suppress
 from mimetypes import MimeTypes
 from stat import S_ISREG

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ classifiers =
 
   Programming Language :: Python
   Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.8
   Programming Language :: Python :: 3.9
   Programming Language :: Python :: 3.10
   Programming Language :: Python :: 3.11
@@ -42,7 +41,7 @@ classifiers =
   Topic :: Internet :: WWW/HTTP
 
 [options]
-python_requires = >=3.8
+python_requires = >=3.9
 packages = aiohttp
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag
 zip_safe = False

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 
 from setuptools import Extension, setup
 
-if sys.version_info < (3, 8):
+if sys.version_info < (3, 9):
     raise RuntimeError("aiohttp 4.x requires Python 3.8+")
 
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 from setuptools import Extension, setup
 
 if sys.version_info < (3, 9):
-    raise RuntimeError("aiohttp 4.x requires Python 3.8+")
+    raise RuntimeError("aiohttp 4.x requires Python 3.9+")
 
 
 NO_EXTENSIONS: bool = bool(os.environ.get("AIOHTTP_NO_EXTENSIONS"))

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -7,7 +7,12 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from aiohttp.resolver import _NUMERIC_SOCKET_FLAGS, AsyncResolver, DefaultResolver, ThreadedResolver
+from aiohttp.resolver import (
+    _NUMERIC_SOCKET_FLAGS,
+    AsyncResolver,
+    DefaultResolver,
+    ThreadedResolver,
+)
 
 try:
     import aiodns

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -7,13 +7,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from aiohttp.resolver import (
-    _NUMERIC_SOCKET_FLAGS,
-    _SUPPORTS_SCOPE_ID,
-    AsyncResolver,
-    DefaultResolver,
-    ThreadedResolver,
-)
+from aiohttp.resolver import _NUMERIC_SOCKET_FLAGS, AsyncResolver, DefaultResolver, ThreadedResolver
 
 try:
     import aiodns
@@ -138,9 +132,6 @@ async def test_async_resolver_positive_ipv4_lookup(loop: Any) -> None:
 
 
 @pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")
-@pytest.mark.skipif(
-    not _SUPPORTS_SCOPE_ID, reason="python version does not support scope id"
-)
 async def test_async_resolver_positive_link_local_ipv6_lookup(loop: Any) -> None:
     with patch("aiodns.DNSResolver") as mock:
         mock().getaddrinfo.return_value = fake_aiodns_getaddrinfo_ipv6_result(
@@ -203,9 +194,6 @@ async def test_threaded_resolver_positive_lookup() -> None:
     ipaddress.ip_address(real[0]["host"])
 
 
-@pytest.mark.skipif(
-    not _SUPPORTS_SCOPE_ID, reason="python version does not support scope id"
-)
 async def test_threaded_resolver_positive_ipv6_link_local_lookup() -> None:
     loop = Mock()
     loop.getaddrinfo = fake_ipv6_addrinfo(["fe80::1"])


### PR DESCRIPTION
The 3.11 release won't happen for some time, so we can start dropping support from the codebase now.