### PR TITLE
Fix Python parser chunked handling with multiple Transfer-Encoding values

### DIFF
--- a/CHANGES/8823.bugfix.rst
+++ b/CHANGES/8823.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed Python parser chunked handling with multiple Transfer-Encoding values -- by :user:`Dreamsorcerer`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -267,12 +267,10 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
         self._headers_parser = HeadersParser(max_line_size, max_field_size, self.lax)
 
     @abc.abstractmethod
-    def parse_message(self, lines: List[bytes]) -> _MsgT:
-        ...
+    def parse_message(self, lines: List[bytes]) -> _MsgT: ...
 
     @abc.abstractmethod
-    def _is_chunked_te(self, te: str) -> bool:
-        ...
+    def _is_chunked_te(self, te: str) -> bool: ...
 
     def feed_eof(self) -> Optional[_MsgT]:
         if self._payload_parser is not None:

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -641,6 +641,7 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
     def _is_chunked_te(self, te: str) -> bool:
         if te.rsplit(",", maxsplit=1)[-1].strip(" \t").lower() == "chunked":
             return True
+        # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.3
         raise BadHttpMessage("Request has invalid `Transfer-Encoding`")
 
 
@@ -729,6 +730,7 @@ class HttpResponseParser(HttpParser[RawResponseMessage]):
         )
 
     def _is_chunked_te(self, te: str) -> bool:
+        # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.2
         return te.rsplit(",", maxsplit=1)[-1].strip(" \t").lower() == "chunked"
 
 

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -268,7 +268,11 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
 
     @abc.abstractmethod
     def parse_message(self, lines: List[bytes]) -> _MsgT:
-        pass
+        ...
+
+    @abc.abstractmethod
+    def _is_chunked_te(self, te: str) -> bool:
+        ...
 
     def feed_eof(self) -> Optional[_MsgT]:
         if self._payload_parser is not None:
@@ -525,10 +529,8 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
         # chunking
         te = headers.get(hdrs.TRANSFER_ENCODING)
         if te is not None:
-            if "chunked" == te.lower():
+            if self._is_chunked_te(te):
                 chunked = True
-            else:
-                raise BadHttpMessage("Request has invalid `Transfer-Encoding`")
 
             if hdrs.CONTENT_LENGTH in headers:
                 raise BadHttpMessage(
@@ -638,6 +640,11 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
             url,
         )
 
+    def _is_chunked_te(self, te: str) -> bool:
+        if te.rsplit(",", maxsplit=1)[-1].strip(" \t").lower() == "chunked":
+            return True
+        raise BadHttpMessage("Request has invalid `Transfer-Encoding`")
+
 
 class HttpResponseParser(HttpParser[RawResponseMessage]):
     """Read response status line and headers.
@@ -722,6 +729,9 @@ class HttpResponseParser(HttpParser[RawResponseMessage]):
             upgrade,
             chunked,
         )
+
+    def _is_chunked_te(self, te: str) -> bool:
+        return te.rsplit(",", maxsplit=1)[-1].strip(" \t").lower() == "chunked"
 
 
 class HttpPayloadParser:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1216,7 +1216,7 @@ async def test_http_response_parser_notchunked(
     messages, upgrade, tail = response.feed_data(text)
     response.feed_eof()
 
-    https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.2
+    # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.2
     assert await messages[0][1].read() == b"1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -536,11 +536,13 @@ def test_request_te_chunked123(parser: HttpRequestParser) -> None:
 async def test_request_te_last_chunked(parser: HttpRequestParser) -> None:
     text = b"GET /test HTTP/1.1\r\nTransfer-Encoding: not, chunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
+    # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.3
     assert await messages[0][1].read() == b"Test"
 
 
 def test_request_te_first_chunked(parser: HttpRequestParser) -> None:
     text = b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked, not\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+    # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.3
     with pytest.raises(
         http_exceptions.BadHttpMessage,
         match="nvalid `Transfer-Encoding`",
@@ -1214,6 +1216,7 @@ async def test_http_response_parser_notchunked(
     messages, upgrade, tail = response.feed_data(text)
     response.feed_eof()
 
+    https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.2
     assert await messages[0][1].read() == b"1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
 
 
@@ -1223,6 +1226,7 @@ async def test_http_response_parser_last_chunked(
     text = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: not, chunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
     messages, upgrade, tail = response.feed_data(text)
 
+    # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.2
     assert await messages[0][1].read() == b"Test"
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -92,6 +92,7 @@ def response(
         2**16,
         max_line_size=8190,
         max_field_size=8190,
+        read_until_eof=True,
     )
 
 
@@ -528,6 +529,21 @@ def test_request_te_chunked123(parser: HttpRequestParser) -> None:
     with pytest.raises(
         http_exceptions.BadHttpMessage,
         match="Request has invalid `Transfer-Encoding`",
+    ):
+        parser.feed_data(text)
+
+
+async def test_request_te_last_chunked(parser: HttpRequestParser) -> None:
+    text = b"GET /test HTTP/1.1\r\nTransfer-Encoding: not, chunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+    messages, upgrade, tail = parser.feed_data(text)
+    assert await messages[0][1].read() == b"Test"
+
+
+def test_request_te_first_chunked(parser: HttpRequestParser) -> None:
+    text = b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked, not\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+    with pytest.raises(
+        http_exceptions.BadHttpMessage,
+        match="nvalid `Transfer-Encoding`",
     ):
         parser.feed_data(text)
 
@@ -1189,6 +1205,29 @@ async def test_http_response_parser_bad_chunked_strict_c(
     )
     with pytest.raises(http_exceptions.BadHttpMessage):
         response.feed_data(text)
+
+
+async def test_http_response_parser_notchunked(
+    response: HttpResponseParser,
+) -> None:
+    text = (
+        b"HTTP/1.1 200 OK\r\nTransfer-Encoding: notchunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+    )
+    messages, upgrade, tail = response.feed_data(text)
+    response.feed_eof()
+
+    assert await messages[0][1].read() == b"1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+
+
+async def test_http_response_parser_last_chunked(
+    response: HttpResponseParser,
+) -> None:
+    text = (
+        b"HTTP/1.1 200 OK\r\nTransfer-Encoding: not, chunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+    )
+    messages, upgrade, tail = response.feed_data(text)
+
+    assert await messages[0][1].read() == b"Test"
 
 
 def test_http_response_parser_bad(response: HttpResponseParser) -> None:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1210,9 +1210,7 @@ async def test_http_response_parser_bad_chunked_strict_c(
 async def test_http_response_parser_notchunked(
     response: HttpResponseParser,
 ) -> None:
-    text = (
-        b"HTTP/1.1 200 OK\r\nTransfer-Encoding: notchunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
-    )
+    text = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: notchunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
     messages, upgrade, tail = response.feed_data(text)
     response.feed_eof()
 
@@ -1222,9 +1220,7 @@ async def test_http_response_parser_notchunked(
 async def test_http_response_parser_last_chunked(
     response: HttpResponseParser,
 ) -> None:
-    text = (
-        b"HTTP/1.1 200 OK\r\nTransfer-Encoding: not, chunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
-    )
+    text = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: not, chunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
     messages, upgrade, tail = response.feed_data(text)
 
     assert await messages[0][1].read() == b"Test"


### PR DESCRIPTION
Fixes #4436 