### PR TITLE
Fix Python parser chunked handling with multiple Transfer-Encoding values

### DIFF
--- a/CHANGES/8823.bugfix.rst
+++ b/CHANGES/8823.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed Python parser chunked handling with multiple Transfer-Encoding values -- by :user:`Dreamsorcerer`.

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -84,6 +84,7 @@ def response(loop: Any, protocol: Any, request: Any):
         max_line_size=8190,
         max_headers=32768,
         max_field_size=8190,
+        read_until_eof=True,
     )
 
 
@@ -510,6 +511,23 @@ def test_request_te_chunked123(parser: Any) -> None:
     with pytest.raises(
         http_exceptions.BadHttpMessage,
         match="Request has invalid `Transfer-Encoding`",
+    ):
+        parser.feed_data(text)
+
+
+async def test_request_te_last_chunked(parser: Any) -> None:
+    text = b"GET /test HTTP/1.1\r\nTransfer-Encoding: not, chunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+    messages, upgrade, tail = parser.feed_data(text)
+    # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.3
+    assert await messages[0][1].read() == b"Test"
+
+
+def test_request_te_first_chunked(parser: Any) -> None:
+    text = b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked, not\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+    # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.3
+    with pytest.raises(
+        http_exceptions.BadHttpMessage,
+        match="nvalid `Transfer-Encoding`",
     ):
         parser.feed_data(text)
 
@@ -1152,6 +1170,23 @@ async def test_http_response_parser_bad_chunked_strict_c(loop, protocol) -> None
     )
     with pytest.raises(http_exceptions.BadHttpMessage):
         response.feed_data(text)
+
+
+async def test_http_response_parser_notchunked(response) -> None:
+    text = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: notchunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+    messages, upgrade, tail = response.feed_data(text)
+    response.feed_eof()
+
+    # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.2
+    assert await messages[0][1].read() == b"1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+
+
+async def test_http_response_parser_last_chunked(response) -> None:
+    text = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: not, chunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+    messages, upgrade, tail = response.feed_data(text)
+
+    # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.2
+    assert await messages[0][1].read() == b"Test"
 
 
 def test_http_response_parser_bad(response) -> None:


### PR DESCRIPTION
(cherry picked from commit faa15fd7d1bea808a64f979c1a7ace8340d68d61)