### PR TITLE
Cache the hash generation of the ConnectionKey

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -209,7 +209,7 @@ def _merge_ssl_params(
     return ssl
 
 
-@attr.s(auto_attribs=True, slots=True, frozen=True)
+@attr.s(auto_attribs=True, slots=True, frozen=True, cache_hash=True)
 class ConnectionKey:
     # the key should contain an information about used proxy / TLS
     # to prevent reusing wrong connections from a pool


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

This hash is a bit expensive to compute and BaseConnector.connect needs to compute it many times, turn on the cache.  I noticed this kept showing up in the profile when looking for another issue.

Note that `master` has moved to dataclasses so this is only relevant for 3.11/3.10

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no


before
![before_hash](https://github.com/user-attachments/assets/f579fc64-12b7-40ed-b312-38c3f66bacf6)



after
![after_hash](https://github.com/user-attachments/assets/9a0a7667-2643-464f-9c7f-08f106bb0e42)
