### PR TITLE
Ensure error is raised when reading from closed client response. (#8878)

### DIFF
--- a/CHANGES/8878.bugfix.rst
+++ b/CHANGES/8878.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed response reading from closed session to throw an error immediately instead of timing out -- by :user:`Dreamsorcerer`.

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -296,6 +296,9 @@ class StreamReader(AsyncStreamReaderMixin):
             set_result(waiter, None)
 
     async def _wait(self, func_name: str) -> None:
+        if not self._protocol.connected:
+            raise RuntimeError("Connection closed.")
+
         # StreamReader uses a future to link the protocol feed_data() method
         # to a read coroutine. Running two read coroutines at the same time
         # would have an unexpected behaviour. It would not possible to know


### PR DESCRIPTION
(cherry picked from commit 50a18d6e5b986001147838147af82d67f571c3d4)