### PR TITLE
Fix CancelledError stopping other cleanup contexts completing

### DIFF
--- a/CHANGES/8908.bugfix.rst
+++ b/CHANGES/8908.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``CancelledError`` from one cleanup context stopping other contexts from completng -- by :user:`Dreamsorcerer`.

--- a/CHANGES/8908.bugfix.rst
+++ b/CHANGES/8908.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``CancelledError`` from one cleanup context stopping other contexts from completng -- by :user:`Dreamsorcerer`.
+Fixed ``CancelledError`` from one cleanup context stopping other contexts from completing -- by :user:`Dreamsorcerer`.

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -430,7 +430,7 @@ class CleanupContext(_CleanupContextBase):
                 await it.__anext__()
             except StopAsyncIteration:
                 pass
-            except Exception as exc:
+            except (Exception, asyncio.CancelledError) as exc:
                 errors.append(exc)
             else:
                 errors.append(RuntimeError(f"{it!r} has more than one 'yield'"))

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -1068,13 +1068,10 @@ below::
       async with client.pubsub() as pubsub:
           await pubsub.subscribe(channel)
           while True:
-              try:
-                  msg = await pubsub.get_message(ignore_subscribe_messages=True)
-                  if msg is not None:
-                      for ws in app["websockets"]:
-                          await ws.send_str("{}: {}".format(channel, msg))
-              except asyncio.CancelledError:
-                  break
+              msg = await pubsub.get_message(ignore_subscribe_messages=True)
+              if msg is not None:
+                  for ws in app["websockets"]:
+                      await ws.send_str("{}: {}".format(channel, msg))
 
 
   async def background_tasks(app):
@@ -1083,7 +1080,8 @@ below::
       yield
 
       app[redis_listener].cancel()
-      await app[redis_listener]
+      with contextlib.suppress(asyncio.CancelledError):
+          await app[redis_listener]
 
 
   app = web.Application()

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -334,9 +334,9 @@ async def test_cleanup_ctx_cleanup_after_exception() -> None:
     assert ctx_state == "CLEAN"
 
 
-@pytest.mark.parametrize("exc", (Exception, asyncio.CancelledError))
+@pytest.mark.parametrize("exc_cls", (Exception, asyncio.CancelledError))
 async def test_cleanup_ctx_exception_on_cleanup_multiple(
-    exc: Type[BaseException],
+    exc_cls: Type[BaseException],
 ) -> None:
     app = web.Application()
     out = []
@@ -349,7 +349,7 @@ async def test_cleanup_ctx_exception_on_cleanup_multiple(
             yield None
             out.append("post_" + str(num))
             if fail:
-                raise exc("fail_" + str(num))
+                raise exc_cls("fail_" + str(num))
 
         return inner
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Any, AsyncIterator, Callable, Iterator, NoReturn
+from typing import Any, AsyncIterator, Callable, Iterator, NoReturn, Type
 from unittest import mock
 
 import pytest
@@ -334,7 +334,8 @@ async def test_cleanup_ctx_cleanup_after_exception() -> None:
     assert ctx_state == "CLEAN"
 
 
-async def test_cleanup_ctx_exception_on_cleanup_multiple() -> None:
+@pytest.mark.parametrize("exc", (Exception, asyncio.CancelledError))
+async def test_cleanup_ctx_exception_on_cleanup_multiple(exc: Type[BaseException]) -> None:
     app = web.Application()
     out = []
 
@@ -346,7 +347,7 @@ async def test_cleanup_ctx_exception_on_cleanup_multiple() -> None:
             yield None
             out.append("post_" + str(num))
             if fail:
-                raise Exception("fail_" + str(num))
+                raise exc("fail_" + str(num))
 
         return inner
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -335,7 +335,9 @@ async def test_cleanup_ctx_cleanup_after_exception() -> None:
 
 
 @pytest.mark.parametrize("exc", (Exception, asyncio.CancelledError))
-async def test_cleanup_ctx_exception_on_cleanup_multiple(exc: Type[BaseException]) -> None:
+async def test_cleanup_ctx_exception_on_cleanup_multiple(
+    exc: Type[BaseException],
+) -> None:
     app = web.Application()
     out = []
 


### PR DESCRIPTION
I wonder if we should even just catch BaseException here...?
Then a KeyboardInterrupt or similar could cancel each context individually.

Fixes #5672.