### PR TITLE
Drop legacy yarl compatibility

### DIFF
--- a/CHANGES/8909.breaking.rst
+++ b/CHANGES/8909.breaking.rst
@@ -1,0 +1,1 @@
+Dropped support for yarl<1.6 -- by :user:`Dreamsorcerer`.

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -36,7 +36,7 @@ from typing import (
     cast,
 )
 
-from yarl import URL, __version__ as yarl_version  # type: ignore[attr-defined]
+from yarl import URL
 
 from . import hdrs
 from .abc import AbstractMatchInfo, AbstractRouter, AbstractView
@@ -81,8 +81,6 @@ CIRCULAR_SYMLINK_ERROR = (
     if sys.version_info < (3, 10) and sys.platform.startswith("win32")
     else (RuntimeError,) if sys.version_info < (3, 13) else ()
 )
-
-YARL_VERSION: Final[Tuple[int, ...]] = tuple(map(int, yarl_version.split(".")[:2]))
 
 HTTP_METHOD_RE: Final[Pattern[str]] = re.compile(
     r"^[0-9A-Za-z!#\$%&'\*\+\-\.\^_`\|~]+$"
@@ -577,10 +575,7 @@ class StaticResource(PrefixResource):
 
         url = URL.build(path=self._prefix, encoded=True)
         # filename is not encoded
-        if YARL_VERSION < (1, 6):
-            url = url / filename.replace("%", "%25")
-        else:
-            url = url / filename
+        url = url / filename
 
         if append_version:
             unresolved_path = self._directory.joinpath(filename)
@@ -1263,8 +1258,6 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
 
 
 def _quote_path(value: str) -> str:
-    if YARL_VERSION < (1, 6):
-        value = value.replace("%", "%25")
     return URL.build(path=value, encoded=False).raw_path
 
 

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -8,4 +8,4 @@ Brotli; platform_python_implementation == 'CPython'
 brotlicffi; platform_python_implementation != 'CPython'
 frozenlist >= 1.1.1
 multidict >=4.5, < 7.0
-yarl >= 1.0, < 2.0
+yarl >= 1.6, < 2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
   async-timeout >= 4.0, < 5.0 ; python_version < "3.11"
   frozenlist >= 1.1.1
   multidict >=4.5, < 7.0
-  yarl >= 1.0, < 2.0
+  yarl >= 1.6, < 2.0
 
 [options.exclude_package_data]
 * =


### PR DESCRIPTION
Will leave it for v4 though.