### PR TITLE
Re-enable keep-alive on proxies

### DIFF
--- a/CHANGES/8920.misc.rst
+++ b/CHANGES/8920.misc.rst
@@ -1,0 +1,1 @@
+Enabled keep-alive support on proxies (which was originally disabled several years ago) -- by :user:`Dreamsorcerer`.

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -66,9 +66,6 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
             or bool(self._tail)
         )
 
-    def force_close(self) -> None:
-        self._should_close = True
-
     def close(self) -> None:
         transport = self.transport
         if transport is not None:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1284,11 +1284,6 @@ class TCPConnector(BaseConnector):
             proxy_req, [], timeout, client_error=ClientProxyConnectionError
         )
 
-        # Many HTTP proxies has buggy keepalive support.  Let's not
-        # reuse connection but close it after processing every
-        # response.
-        proto.force_close()
-
         auth = proxy_req.headers.pop(hdrs.AUTHORIZATION, None)
         if auth is not None:
             if not req.is_ssl():


### PR DESCRIPTION
Fixes #5765.

This was disabled a long time ago in #3070. From what I've seen of various issues, the sentiment from users is that this causes problems and makes proxies too slow. asvetlov himself has suggested that modern proxies today may not have the issues he was experiencing when the change was made originally.

The original change had no test and I'm not familiar enough with the proxy code to write a new test. I suggest we put this into 3.11 and see if any users report regressions.