### PR TITLE
Support credentials in URL with empty user (#6494) (#6495)

### DIFF
--- a/CHANGES/6494.bugfix.rst
+++ b/CHANGES/6494.bugfix.rst
@@ -1,0 +1,1 @@
+Added support for URL credentials with empty (zero-length) username, e.g. ``https://:password@host`` -- by :user:`shuckc`

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -74,6 +74,7 @@ Chih-Yuan Chen
 Chris AtLee
 Chris Laws
 Chris Moore
+Chris Shucksmith
 Christopher Schmitt
 Claudiu Popa
 Colin Dunklau

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -408,8 +408,8 @@ class ClientRequest:
 
         # basic auth info
         username, password = url.user, url.password
-        if username:
-            self.auth = helpers.BasicAuth(username, password or "")
+        if username or password:
+            self.auth = helpers.BasicAuth(username or "", password or "")
 
     def update_version(self, version: Union[http.HttpVersion, str]) -> None:
         """Convert request version to two elements tuple.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -164,9 +164,9 @@ class BasicAuth(namedtuple("BasicAuth", ["login", "password", "encoding"])):
         """Create BasicAuth from url."""
         if not isinstance(url, URL):
             raise TypeError("url should be yarl.URL instance")
-        if url.user is None:
+        if url.user is None and url.password is None:
             return None
-        return cls(url.user, url.password or "", encoding=encoding)
+        return cls(url.user or "", url.password or "", encoding=encoding)
 
     def encode(self) -> str:
         """Encode credentials."""

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -453,6 +453,13 @@ def test_basic_auth_from_url(make_request) -> None:
     assert "python.org" == req.host
 
 
+def test_basic_auth_no_user_from_url(make_request) -> None:
+    req = make_request("get", "http://:1234@python.org")
+    assert "AUTHORIZATION" in req.headers
+    assert "Basic OjEyMzQ=" == req.headers["AUTHORIZATION"]
+    assert "python.org" == req.host
+
+
 def test_basic_auth_from_url_overridden(make_request) -> None:
     req = make_request(
         "get", "http://garbage@python.org", auth=aiohttp.BasicAuth("nkim", "1234")

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -189,6 +189,14 @@ def test_basic_auth_from_url() -> None:
     assert auth.password == "pass"
 
 
+def test_basic_auth_no_user_from_url() -> None:
+    url = URL("http://:pass@example.com")
+    auth = helpers.BasicAuth.from_url(url)
+    assert auth is not None
+    assert auth.login == ""
+    assert auth.password == "pass"
+
+
 def test_basic_auth_from_not_url() -> None:
     with pytest.raises(TypeError):
         helpers.BasicAuth.from_url("http://user:pass@example.com")


### PR DESCRIPTION
(cherry picked from commit ce9c4eb0f895f356e775ca268d7ccef908f4c936)