### PR TITLE
Bump yarl to 1.9.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -36,5 +36,5 @@ pycparser==2.22
     # via cffi
 uvloop==0.20.0 ; platform_system != "Windows" and implementation_name == "cpython"
     # via -r requirements/base.in
-yarl==1.9.5
+yarl==1.9.6
     # via -r requirements/runtime-deps.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -36,5 +36,5 @@ pycparser==2.22
     # via cffi
 uvloop==0.20.0 ; platform_system != "Windows" and implementation_name == "cpython"
     # via -r requirements/base.in
-yarl==1.9.4
+yarl==1.9.5
     # via -r requirements/runtime-deps.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -286,7 +286,7 @@ webcolors==24.8.0
     # via blockdiag
 wheel==0.44.0
     # via pip-tools
-yarl==1.9.5
+yarl==1.9.6
     # via -r requirements/runtime-deps.in
 zipp==3.20.1
     # via

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -286,7 +286,7 @@ webcolors==24.8.0
     # via blockdiag
 wheel==0.44.0
     # via pip-tools
-yarl==1.9.4
+yarl==1.9.5
     # via -r requirements/runtime-deps.in
 zipp==3.20.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -278,7 +278,7 @@ webcolors==24.8.0
     # via blockdiag
 wheel==0.44.0
     # via pip-tools
-yarl==1.9.4
+yarl==1.9.5
     # via -r requirements/runtime-deps.in
 zipp==3.20.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -278,7 +278,7 @@ webcolors==24.8.0
     # via blockdiag
 wheel==0.44.0
     # via pip-tools
-yarl==1.9.5
+yarl==1.9.6
     # via -r requirements/runtime-deps.in
 zipp==3.20.1
     # via

--- a/requirements/runtime-deps.txt
+++ b/requirements/runtime-deps.txt
@@ -30,5 +30,5 @@ pycares==4.4.0
     # via aiodns
 pycparser==2.22
     # via cffi
-yarl==1.9.4
+yarl==1.9.5
     # via -r requirements/runtime-deps.in

--- a/requirements/runtime-deps.txt
+++ b/requirements/runtime-deps.txt
@@ -30,5 +30,5 @@ pycares==4.4.0
     # via aiodns
 pycparser==2.22
     # via cffi
-yarl==1.9.5
+yarl==1.9.6
     # via -r requirements/runtime-deps.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -134,5 +134,5 @@ uvloop==0.20.0 ; platform_system != "Windows" and implementation_name == "cpytho
     # via -r requirements/base.in
 wait-for-it==2.2.2
     # via -r requirements/test.in
-yarl==1.9.5
+yarl==1.9.6
     # via -r requirements/runtime-deps.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -134,5 +134,5 @@ uvloop==0.20.0 ; platform_system != "Windows" and implementation_name == "cpytho
     # via -r requirements/base.in
 wait-for-it==2.2.2
     # via -r requirements/test.in
-yarl==1.9.4
+yarl==1.9.5
     # via -r requirements/runtime-deps.in


### PR DESCRIPTION
changelog: https://github.com/aio-libs/yarl/compare/v1.9.4...v1.9.6

Doing a manual bump instead of waiting for the bot to get a clean run with https://github.com/aio-libs/aiohttp/pull/8898
