### PR TITLE
Remove version from set_cookie()

### DIFF
--- a/CHANGES/8957.breaking.rst
+++ b/CHANGES/8957.breaking.rst
@@ -1,0 +1,1 @@
+Removed ``version`` parameter from ``.set_cookie()`` (this shouldn't exist in cookies today) -- by :user:`Dreamsorcerer`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -979,7 +979,6 @@ class CookieMixin:
         path: str = "/",
         secure: Optional[bool] = None,
         httponly: Optional[bool] = None,
-        version: Optional[str] = None,
         samesite: Optional[str] = None,
     ) -> None:
         """Set or update response cookie.
@@ -1014,8 +1013,6 @@ class CookieMixin:
             c["secure"] = secure
         if httponly is not None:
             c["httponly"] = httponly
-        if version is not None:
-            c["version"] = version
         if samesite is not None:
             c["samesite"] = samesite
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -702,8 +702,7 @@ and :ref:`aiohttp-web-signals` handlers::
 
    .. method:: set_cookie(name, value, *, path='/', expires=None, \
                           domain=None, max_age=None, \
-                          secure=None, httponly=None, version=None, \
-                          samesite=None)
+                          secure=None, httponly=None, samesite=None)
 
       Convenient way for setting :attr:`cookies`, allows to specify
       some additional properties like *max_age* in a single call.
@@ -743,11 +742,6 @@ and :ref:`aiohttp-web-signals` handlers::
 
       :param bool httponly: ``True`` if the cookie HTTP only (optional)
 
-      :param int version: a decimal integer, identifies to which
-                          version of the state management
-                          specification the cookie
-                          conforms. (optional)
-
       :param str samesite: Asserts that a cookie must not be sent with
          cross-origin requests, providing some protection
          against cross-site request forgery attacks.
@@ -755,12 +749,6 @@ and :ref:`aiohttp-web-signals` handlers::
          ``Lax`` or ``Strict``. (optional)
 
             .. versionadded:: 3.7
-
-      .. warning::
-
-         In HTTP version 1.1, ``expires`` was deprecated and replaced with
-         the easier-to-use ``max-age``, but Internet Explorer (IE6, IE7,
-         and IE8) **does not** support ``max-age``.
 
    .. method:: del_cookie(name, *, path='/', domain=None)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -982,7 +982,6 @@ def test_cookies_mixin_path() -> None:
         max_age="10",
         secure=True,
         httponly=True,
-        version="2.0",
         samesite="lax",
     )
     assert (
@@ -993,8 +992,7 @@ def test_cookies_mixin_path() -> None:
         "max-age=10; "
         "path=/home; "
         "samesite=lax; "
-        "secure; "
-        "version=2.0"
+        "secure"
     )
 
 


### PR DESCRIPTION
The version attribute no longer exists in https://datatracker.ietf.org/doc/html/rfc6265