### PR TITLE
Avoid logging exception from run_app() that is also raised (#8951)

### DIFF
--- a/CHANGES/6807.bugfix.rst
+++ b/CHANGES/6807.bugfix.rst
@@ -1,0 +1,1 @@
+Stopped logging exceptions from ``web.run_app()`` that would be raised regardless -- by :user:`Dreamsorcerer`.

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -906,6 +906,23 @@ def test_run_app_context_vars(patched_loop):
     assert count == 3
 
 
+def test_run_app_raises_exception(patched_loop: asyncio.AbstractEventLoop) -> None:
+    async def context(app: web.Application) -> AsyncIterator[None]:
+        raise RuntimeError("foo")
+        yield  # pragma: no cover
+
+    app = web.Application()
+    app.cleanup_ctx.append(context)
+
+    with mock.patch.object(
+        patched_loop, "call_exception_handler", autospec=True, spec_set=True
+    ) as m:
+        with pytest.raises(RuntimeError, match="foo"):
+            web.run_app(app, loop=patched_loop)
+
+    assert not m.called
+
+
 class TestShutdown:
     def raiser(self) -> NoReturn:
         raise KeyboardInterrupt

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -9,7 +9,7 @@ import ssl
 import subprocess
 import sys
 import time
-from typing import Callable, NoReturn, Set
+from typing import AsyncIterator, Callable, NoReturn, Set
 from unittest import mock
 from uuid import uuid4
 


### PR DESCRIPTION
(cherry picked from commit 45d6e4f14572bfc4cfc3f32a2c7c72a9cc28f125)