### PR TITLE
Fix cancelled payload send leading to hung connection

### DIFF
--- a/CHANGES/8992.bugfix.rst
+++ b/CHANGES/8992.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed client incorrectly reusing a connection when the previous message had not been fully sent -- by :user:`Dreamsorcerer`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -592,7 +592,8 @@ class ClientRequest:
 
             set_exception(protocol, reraised_exc, underlying_exc)
         except asyncio.CancelledError:
-            await writer.write_eof()
+            # Body hasn't been fully sent, so connection can't be reused.
+            conn.close()
         except Exception as underlying_exc:
             set_exception(
                 protocol,

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3882,7 +3882,6 @@ async def test_max_line_size_request_explicit(aiohttp_client: AiohttpClient) -> 
         assert resp.reason == "x" * 8191
 
 
-@pytest.mark.xfail(raises=asyncio.TimeoutError, reason="#7599")
 async def test_rejected_upload(
     aiohttp_client: AiohttpClient, tmp_path: pathlib.Path
 ) -> None:
@@ -3903,13 +3902,11 @@ async def test_rejected_upload(
 
     with open(file_path, "rb") as file:
         data = {"file": file}
-        async with await client.post("/not_ok", data=data) as resp_not_ok:
-            assert 400 == resp_not_ok.status
+        async with client.post("/not_ok", data=data) as resp_not_ok:
+            assert resp_not_ok.status == 400
 
-    async with await client.get(
-        "/ok", timeout=aiohttp.ClientTimeout(total=0.01)
-    ) as resp_ok:
-        assert 200 == resp_ok.status
+    async with client.get("/ok", timeout=aiohttp.ClientTimeout(total=1)) as resp_ok:
+        assert resp_ok.status == 200
 
 
 async def test_request_with_wrong_ssl_type(aiohttp_client: AiohttpClient) -> None:


### PR DESCRIPTION
I've thought it through here, and I don't think we can safely reuse the connection at this point when we haven't finished sending the payload.
If it's not chunked, and therefore has a Content-Length, reusing the connection will result in the server thinking it's still reading the last message.
If it is chunked, then we can technically send a closing chunk to complete the message and then reuse it. However, that may lead the server to think that it has received the full message when it hasn't.

Fixes #7599.