### PR TITLE
Add flake8-no-implicit-concat (#7731)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,6 +107,7 @@ repos:
   - id: flake8
     additional_dependencies:
       - flake8-docstrings==1.6.0
+      - flake8-no-implicit-concat==0.3.4
       - flake8-requirements==1.7.8
     exclude: "^docs/"
 - repo: https://github.com/Lucas-C/pre-commit-hooks-markup

--- a/CHANGES/7731.misc.rst
+++ b/CHANGES/7731.misc.rst
@@ -1,0 +1,1 @@
+Added flake8 settings to avoid some forms of implicit concatenation. -- by :user:`booniepepper`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -310,7 +310,7 @@ class ClientSession:
             self._timeout = DEFAULT_TIMEOUT
             if read_timeout is not sentinel:
                 warnings.warn(
-                    "read_timeout is deprecated, " "use timeout argument instead",
+                    "read_timeout is deprecated, use timeout argument instead",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -318,7 +318,7 @@ class ClientSession:
             if conn_timeout is not None:
                 self._timeout = attr.evolve(self._timeout, connect=conn_timeout)
                 warnings.warn(
-                    "conn_timeout is deprecated, " "use timeout argument instead",
+                    "conn_timeout is deprecated, use timeout argument instead",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -1255,7 +1255,7 @@ class ClientSession:
     def requote_redirect_url(self, val: bool) -> None:
         """Do URL requoting on redirection handling."""
         warnings.warn(
-            "session.requote_redirect_url modification " "is deprecated #2778",
+            "session.requote_redirect_url modification is deprecated #2778",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -127,9 +127,7 @@ class Fingerprint:
         if not hashfunc:
             raise ValueError("fingerprint has invalid length")
         elif hashfunc is md5 or hashfunc is sha1:
-            raise ValueError(
-                "md5 and sha1 are insecure and " "not supported. Use sha256."
-            )
+            raise ValueError("md5 and sha1 are insecure and not supported. Use sha256.")
         self._hashfunc = hashfunc
         self._fingerprint = fingerprint
 
@@ -190,7 +188,7 @@ def _merge_ssl_params(
             ssl = ssl_context
     if fingerprint is not None:
         warnings.warn(
-            "fingerprint is deprecated, " "use ssl=Fingerprint(fingerprint) instead",
+            "fingerprint is deprecated, use ssl=Fingerprint(fingerprint) instead",
             DeprecationWarning,
             stacklevel=3,
         )
@@ -505,7 +503,7 @@ class ClientRequest:
         if enc:
             if self.compress:
                 raise ValueError(
-                    "compress can not be set " "if Content-Encoding header is set"
+                    "compress can not be set if Content-Encoding header is set"
                 )
         elif self.compress:
             if not isinstance(self.compress, str):
@@ -527,7 +525,7 @@ class ClientRequest:
         elif self.chunked:
             if hdrs.CONTENT_LENGTH in self.headers:
                 raise ValueError(
-                    "chunked can not be set " "if Content-Length header is set"
+                    "chunked can not be set if Content-Length header is set"
                 )
 
             self.headers[hdrs.TRANSFER_ENCODING] = "chunked"
@@ -1205,7 +1203,7 @@ class ClientResponse(HeadersMixin):
                     self.history,
                     status=self.status,
                     message=(
-                        "Attempt to decode JSON with " "unexpected mimetype: %s" % ctype
+                        "Attempt to decode JSON with unexpected mimetype: %s" % ctype
                     ),
                     headers=self.headers,
                 )

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -243,7 +243,7 @@ class BaseConnector:
         if force_close:
             if keepalive_timeout is not None and keepalive_timeout is not sentinel:
                 raise ValueError(
-                    "keepalive_timeout cannot " "be set if force_close is True"
+                    "keepalive_timeout cannot be set if force_close is True"
                 )
         else:
             if keepalive_timeout is sentinel:
@@ -853,7 +853,7 @@ class TCPConnector(BaseConnector):
         if host is not None and port is not None:
             self._cached_hosts.remove((host, port))
         elif host is not None or port is not None:
-            raise ValueError("either both host and port " "or none of them are allowed")
+            raise ValueError("either both host and port or none of them are allowed")
         else:
             self._cached_hosts.clear()
 
@@ -1575,7 +1575,7 @@ class NamedPipeConnector(BaseConnector):
             self._loop, asyncio.ProactorEventLoop  # type: ignore[attr-defined]
         ):
             raise RuntimeError(
-                "Named Pipes only available in proactor " "loop under windows"
+                "Named Pipes only available in proactor loop under windows"
             )
         self._path = path
 

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -54,7 +54,7 @@ class CookieJar(AbstractCookieJar):
     DATE_DAY_OF_MONTH_RE = re.compile(r"(\d{1,2})")
 
     DATE_MONTH_RE = re.compile(
-        "(jan)|(feb)|(mar)|(apr)|(may)|(jun)|(jul)|" "(aug)|(sep)|(oct)|(nov)|(dec)",
+        "(jan)|(feb)|(mar)|(apr)|(may)|(jun)|(jul)|(aug)|(sep)|(oct)|(nov)|(dec)",
         re.I,
     )
 

--- a/aiohttp/formdata.py
+++ b/aiohttp/formdata.py
@@ -64,9 +64,7 @@ class FormData:
 
         type_options: MultiDict[str] = MultiDict({"name": name})
         if filename is not None and not isinstance(filename, str):
-            raise TypeError(
-                "filename must be an instance of str. " "Got: %s" % filename
-            )
+            raise TypeError("filename must be an instance of str. Got: %s" % filename)
         if filename is None and isinstance(value, io.IOBase):
             filename = guess_filename(value, name)
         if filename is not None:
@@ -77,7 +75,7 @@ class FormData:
         if content_type is not None:
             if not isinstance(content_type, str):
                 raise TypeError(
-                    "content_type must be an instance of str. " "Got: %s" % content_type
+                    "content_type must be an instance of str. Got: %s" % content_type
                 )
             headers[hdrs.CONTENT_TYPE] = content_type
             self._is_multipart = True
@@ -131,7 +129,7 @@ class FormData:
         if charset == "utf-8":
             content_type = "application/x-www-form-urlencoded"
         else:
-            content_type = "application/x-www-form-urlencoded; " "charset=%s" % charset
+            content_type = "application/x-www-form-urlencoded; charset=%s" % charset
 
         return payload.BytesPayload(
             urlencode(data, doseq=True, encoding=charset).encode(),

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -393,16 +393,14 @@ def content_disposition_header(
     params is a dict with disposition params.
     """
     if not disptype or not (TOKEN > set(disptype)):
-        raise ValueError("bad content disposition type {!r}" "".format(disptype))
+        raise ValueError(f"bad content disposition type {disptype!r}")
 
     value = disptype
     if params:
         lparams = []
         for key, val in params.items():
             if not key or not (TOKEN > set(key)):
-                raise ValueError(
-                    "bad content disposition parameter" " {!r}={!r}".format(key, val)
-                )
+                raise ValueError(f"bad content disposition parameter {key!r}={val!r}")
             if quote_fields:
                 if key.lower() == "filename":
                     qval = quote(val, "", encoding=_charset)
@@ -690,9 +688,7 @@ class TimerContext(BaseTimerContext):
         task = asyncio.current_task(loop=self._loop)
 
         if task is None:
-            raise RuntimeError(
-                "Timeout context manager should be used " "inside a task"
-            )
+            raise RuntimeError("Timeout context manager should be used inside a task")
 
         if self._cancelled:
             raise asyncio.TimeoutError from None

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -267,7 +267,7 @@ def ws_ext_gen(
     # compress wbit 8 does not support in zlib
     if compress < 9 or compress > 15:
         raise ValueError(
-            "Compress wbits must between 9 and 15, " "zlib does not support wbits=8"
+            "Compress wbits must between 9 and 15, zlib does not support wbits=8"
         )
     enabledext = ["permessage-deflate"]
     if not isserver:
@@ -512,7 +512,7 @@ class WebSocketReader:
                 if opcode > 0x7 and length > 125:
                     raise WebSocketError(
                         WSCloseCode.PROTOCOL_ERROR,
-                        "Control frame payload cannot be " "larger than 125 bytes",
+                        "Control frame payload cannot be larger than 125 bytes",
                     )
 
                 # Set compress status if last package is FIN

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -530,9 +530,7 @@ class BodyPartReader:
         elif encoding in ("binary", "8bit", "7bit"):
             return data
         else:
-            raise RuntimeError(
-                "unknown content transfer encoding: {}" "".format(encoding)
-            )
+            raise RuntimeError(f"unknown content transfer encoding: {encoding}")
 
     def get_charset(self, default: str) -> str:
         """Returns charset parameter from Content-Type header or default."""

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -261,7 +261,7 @@ class StreamReader(AsyncStreamReaderMixin):
         if self._http_chunk_splits is None:
             if self.total_bytes:
                 raise RuntimeError(
-                    "Called begin_http_chunk_receiving when" "some data was already fed"
+                    "Called begin_http_chunk_receiving when some data was already fed"
                 )
             self._http_chunk_splits = []
 

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -266,7 +266,7 @@ class TestClient:
     ) -> None:
         if not isinstance(server, BaseTestServer):
             raise TypeError(
-                "server must be TestServer " "instance, found type: %r" % type(server)
+                "server must be TestServer instance, found type: %r" % type(server)
             )
         self._server = server
         self._loop = loop

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -581,7 +581,7 @@ def main(argv: List[str]) -> None:
     # Compatibility logic
     if args.path is not None and not hasattr(socket, "AF_UNIX"):
         arg_parser.error(
-            "file system paths not supported by your operating" " environment"
+            "file system paths not supported by your operating environment"
         )
 
     logging.basicConfig(level=logging.DEBUG)

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -195,7 +195,7 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
     def _check_frozen(self) -> None:
         if self._frozen:
             warnings.warn(
-                "Changing state of started or joined " "application is deprecated",
+                "Changing state of started or joined application is deprecated",
                 DeprecationWarning,
                 stacklevel=3,
             )
@@ -433,7 +433,7 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
     ) -> Server:
 
         warnings.warn(
-            "Application.make_handler(...) is deprecated, " "use AppRunner API instead",
+            "Application.make_handler(...) is deprecated, use AppRunner API instead",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -492,7 +492,7 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
                 yield m, True
             else:
                 warnings.warn(
-                    'old-style middleware "{!r}" deprecated, ' "see #2252".format(m),
+                    f'old-style middleware "{m!r}" deprecated, see #2252',
                     DeprecationWarning,
                     stacklevel=2,
                 )

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -226,7 +226,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         will reuse the one from the current request object.
         """
         if self._read_bytes:
-            raise RuntimeError("Cannot clone request " "after reading its content")
+            raise RuntimeError("Cannot clone request after reading its content")
 
         dct: Dict[str, Any] = {}
         if method is not sentinel:
@@ -773,7 +773,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
                             )
                 else:
                     raise ValueError(
-                        "To decode nested multipart you need " "to use custom reader",
+                        "To decode nested multipart you need to use custom reader",
                     )
 
                 field = await multipart.next()

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -134,9 +134,9 @@ class StreamResponse(BaseClass, HeadersMixin):
         status: int,
         reason: Optional[str] = None,
     ) -> None:
-        assert not self.prepared, (
-            "Cannot change the response status code after " "the headers have been sent"
-        )
+        assert (
+            not self.prepared
+        ), "Cannot change the response status code after the headers have been sent"
         self._status = int(status)
         if reason is None:
             try:
@@ -168,7 +168,7 @@ class StreamResponse(BaseClass, HeadersMixin):
 
         if hdrs.CONTENT_LENGTH in self._headers:
             raise RuntimeError(
-                "You can't enable chunked encoding when " "a content length is set"
+                "You can't enable chunked encoding when a content length is set"
             )
         if chunk_size is not None:
             warnings.warn("Chunk size is deprecated #1615", DeprecationWarning)
@@ -184,9 +184,9 @@ class StreamResponse(BaseClass, HeadersMixin):
                 "Using boolean for force is deprecated #3318", DeprecationWarning
             )
         elif force is not None:
-            assert isinstance(force, ContentCoding), (
-                "force should one of " "None, bool or " "ContentEncoding"
-            )
+            assert isinstance(
+                force, ContentCoding
+            ), "force should one of None, bool or ContentEncoding"
 
         self._compression = True
         self._compression_force = force
@@ -289,7 +289,7 @@ class StreamResponse(BaseClass, HeadersMixin):
             value = int(value)
             if self._chunked:
                 raise RuntimeError(
-                    "You can't set content length when " "chunked encoding is enable"
+                    "You can't set content length when chunked encoding is enable"
                 )
             self._headers[hdrs.CONTENT_LENGTH] = str(value)
         else:
@@ -611,7 +611,7 @@ class Response(StreamResponse):
             real_headers = headers  # = cast('CIMultiDict[str]', headers)
 
         if content_type is not None and "charset" in content_type:
-            raise ValueError("charset must not be in content_type " "argument")
+            raise ValueError("charset must not be in content_type argument")
 
         if text is not None:
             if hdrs.CONTENT_TYPE in real_headers:

--- a/aiohttp/web_routedef.py
+++ b/aiohttp/web_routedef.py
@@ -66,7 +66,7 @@ class RouteDef(AbstractRouteDef):
         info = []
         for name, value in sorted(self.kwargs.items()):
             info.append(f", {name}={value!r}")
-        return "<RouteDef {method} {path} -> {handler.__name__!r}" "{info}>".format(
+        return "<RouteDef {method} {path} -> {handler.__name__!r}{info}>".format(
             method=self.method, path=self.path, handler=self.handler, info="".join(info)
         )
 
@@ -90,7 +90,7 @@ class StaticDef(AbstractRouteDef):
         info = []
         for name, value in sorted(self.kwargs.items()):
             info.append(f", {name}={value!r}")
-        return "<StaticDef {prefix} -> {path}" "{info}>".format(
+        return "<StaticDef {prefix} -> {path}{info}>".format(
             prefix=self.prefix, path=self.path, info="".join(info)
         )
 

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -176,7 +176,7 @@ class NamedPipeSite(BaseSite):
             loop, asyncio.ProactorEventLoop  # type: ignore[attr-defined]
         ):
             raise RuntimeError(
-                "Named Pipes only available in proactor" "loop under windows"
+                "Named Pipes only available in proactor loop under windows"
             )
         super().__init__(runner, shutdown_timeout=shutdown_timeout)
         self._path = path

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -194,14 +194,14 @@ class AbstractRoute(abc.ABC):
             pass
         elif inspect.isgeneratorfunction(handler):
             warnings.warn(
-                "Bare generators are deprecated, " "use @coroutine wrapper",
+                "Bare generators are deprecated, use @coroutine wrapper",
                 DeprecationWarning,
             )
         elif isinstance(handler, type) and issubclass(handler, AbstractView):
             pass
         else:
             warnings.warn(
-                "Bare functions are deprecated, " "use async ones", DeprecationWarning
+                "Bare functions are deprecated, use async ones", DeprecationWarning
             )
 
             @wraps(handler)
@@ -777,7 +777,7 @@ class PrefixedSubAppResource(PrefixResource):
             router.index_resource(resource)
 
     def url_for(self, *args: str, **kwargs: str) -> URL:
-        raise RuntimeError(".url_for() is not supported " "by sub-application root")
+        raise RuntimeError(".url_for() is not supported by sub-application root")
 
     def get_info(self) -> _InfoDict:
         return {"app": self._app, "prefix": self._prefix}
@@ -900,7 +900,7 @@ class MatchedSubAppResource(PrefixedSubAppResource):
         return match_info, methods
 
     def __repr__(self) -> str:
-        return "<MatchedSubAppResource -> {app!r}>" "".format(app=self._app)
+        return f"<MatchedSubAppResource -> {self._app!r}>"
 
 
 class ResourceRoute(AbstractRoute):

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,9 +86,14 @@ max-line-length=79
 zip_ok = false
 
 [flake8]
-extend-select = B950
+extend-select =
+  B950,
+  # NIC001 -- "Implicitly concatenated str literals on one line"
+  NIC001,
+  # NIC101 -- "Implicitly concatenated bytes literals on one line"
+  NIC101,
 # TODO: don't disable D*, fix up issues instead
-ignore = N801,N802,N803,E203,E226,E305,W504,E252,E301,E302,E501,E704,W503,W504,D1,D4
+ignore = N801,N802,N803,NIC002,NIC102,E203,E226,E305,W504,E252,E301,E302,E501,E704,W503,W504,D1,D4
 max-line-length = 88
 per-file-ignores =
     # I900: Shouldn't appear in requirements for examples.

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -83,9 +83,7 @@ class TestClientResponseError:
             message="Something wrong",
             headers=CIMultiDict(),
         )
-        assert str(err) == (
-            "400, message='Something wrong', " "url='http://example.com'"
-        )
+        assert str(err) == ("400, message='Something wrong', url='http://example.com'")
 
 
 def test_response_status() -> None:
@@ -254,7 +252,7 @@ class TestServerDisconnectedError:
 
     def test_repr(self) -> None:
         err = client.ServerDisconnectedError()
-        assert repr(err) == ("ServerDisconnectedError" "('Server disconnected')")
+        assert repr(err) == ("ServerDisconnectedError('Server disconnected')")
 
         err = client.ServerDisconnectedError(message="No connection")
         assert repr(err) == "ServerDisconnectedError('No connection')"

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2361,7 +2361,7 @@ async def test_set_cookies_expired(aiohttp_client) -> None:
         ret.set_cookie("c2", "cookie2")
         ret.headers.add(
             "Set-Cookie",
-            "c3=cookie3; " "HttpOnly; Path=/" " Expires=Tue, 1 Jan 1980 12:00:00 GMT; ",
+            "c3=cookie3; HttpOnly; Path=/ Expires=Tue, 1 Jan 1980 12:00:00 GMT; ",
         )
         return ret
 
@@ -2380,7 +2380,7 @@ async def test_set_cookies_max_age(aiohttp_client) -> None:
         ret = web.Response()
         ret.set_cookie("c1", "cookie1")
         ret.set_cookie("c2", "cookie2")
-        ret.headers.add("Set-Cookie", "c3=cookie3; " "HttpOnly; Path=/" " Max-Age=1; ")
+        ret.headers.add("Set-Cookie", "c3=cookie3; HttpOnly; Path=/ Max-Age=1; ")
         return ret
 
     app = web.Application()
@@ -2401,7 +2401,7 @@ async def test_set_cookies_max_age_overflow(aiohttp_client) -> None:
         ret = web.Response()
         ret.headers.add(
             "Set-Cookie",
-            "overflow=overflow; " "HttpOnly; Path=/" " Max-Age=" + str(overflow) + "; ",
+            "overflow=overflow; HttpOnly; Path=/ Max-Age=" + str(overflow) + "; ",
         )
         return ret
 
@@ -3379,9 +3379,7 @@ async def test_handle_keepalive_on_closed_connection() -> None:
         def data_received(self, data):
             self.data += data
             if data.endswith(b"\r\n\r\n"):
-                self.transp.write(
-                    b"HTTP/1.1 200 OK\r\n" b"CONTENT-LENGTH: 2\r\n" b"\r\n" b"ok"
-                )
+                self.transp.write(b"HTTP/1.1 200 OK\r\nCONTENT-LENGTH: 2\r\n\r\nok")
                 self.transp.close()
 
         def connection_lost(self, exc):

--- a/tests/test_client_proto.py
+++ b/tests/test_client_proto.py
@@ -50,7 +50,7 @@ async def test_uncompleted_message(loop) -> None:
     proto.set_response_params(read_until_eof=True)
 
     proto.data_received(
-        b"HTTP/1.1 301 Moved Permanently\r\n" b"Location: http://python.org/"
+        b"HTTP/1.1 301 Moved Permanently\r\nLocation: http://python.org/"
     )
     proto.connection_lost(None)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -325,7 +325,8 @@ def test_ipv6_addresses() -> None:
 
 def test_host_addresses() -> None:
     hosts = [
-        "www.four.part.host" "www.python.org",
+        "www.four.part.host",
+        "www.python.org",
         "foo.bar",
         "localhost",
     ]

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -81,7 +81,7 @@ class TestLineTooLong:
             pickled = pickle.dumps(err, proto)
             err2 = pickle.loads(pickled)
             assert err2.code == 400
-            assert err2.message == ("Got more than 10 bytes (12) " "when reading spam.")
+            assert err2.message == ("Got more than 10 bytes (12) when reading spam.")
             assert err2.headers is None
             assert err2.foo == "bar"
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -443,49 +443,49 @@ def test_conn_default_1_1(parser) -> None:
 
 
 def test_conn_close(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"connection: close\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nconnection: close\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.should_close
 
 
 def test_conn_close_1_0(parser) -> None:
-    text = b"GET /test HTTP/1.0\r\n" b"connection: close\r\n\r\n"
+    text = b"GET /test HTTP/1.0\r\nconnection: close\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.should_close
 
 
 def test_conn_keep_alive_1_0(parser) -> None:
-    text = b"GET /test HTTP/1.0\r\n" b"connection: keep-alive\r\n\r\n"
+    text = b"GET /test HTTP/1.0\r\nconnection: keep-alive\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert not msg.should_close
 
 
 def test_conn_keep_alive_1_1(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"connection: keep-alive\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nconnection: keep-alive\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert not msg.should_close
 
 
 def test_conn_other_1_0(parser) -> None:
-    text = b"GET /test HTTP/1.0\r\n" b"connection: test\r\n\r\n"
+    text = b"GET /test HTTP/1.0\r\nconnection: test\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.should_close
 
 
 def test_conn_other_1_1(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"connection: test\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nconnection: test\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert not msg.should_close
 
 
 def test_request_chunked(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"transfer-encoding: chunked\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg, payload = messages[0]
     assert msg.chunked
@@ -507,7 +507,7 @@ def test_request_te_chunked_with_content_length(parser: Any) -> None:
 
 
 def test_request_te_chunked123(parser: Any) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"transfer-encoding: chunked123\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ntransfer-encoding: chunked123\r\n\r\n"
     with pytest.raises(
         http_exceptions.BadHttpMessage,
         match="Request has invalid `Transfer-Encoding`",
@@ -555,21 +555,21 @@ def test_bad_upgrade(parser) -> None:
 
 
 def test_compression_empty(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"content-encoding: \r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ncontent-encoding: \r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.compression is None
 
 
 def test_compression_deflate(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"content-encoding: deflate\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ncontent-encoding: deflate\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.compression == "deflate"
 
 
 def test_compression_gzip(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"content-encoding: gzip\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ncontent-encoding: gzip\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.compression == "gzip"
@@ -577,21 +577,21 @@ def test_compression_gzip(parser) -> None:
 
 @pytest.mark.skipif(brotli is None, reason="brotli is not installed")
 def test_compression_brotli(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"content-encoding: br\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ncontent-encoding: br\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.compression == "br"
 
 
 def test_compression_unknown(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"content-encoding: compress\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ncontent-encoding: compress\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.compression is None
 
 
 def test_url_connect(parser: Any) -> None:
-    text = b"CONNECT www.google.com HTTP/1.1\r\n" b"content-length: 0\r\n\r\n"
+    text = b"CONNECT www.google.com HTTP/1.1\r\ncontent-length: 0\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg, payload = messages[0]
     assert upgrade
@@ -599,7 +599,7 @@ def test_url_connect(parser: Any) -> None:
 
 
 def test_headers_connect(parser: Any) -> None:
-    text = b"CONNECT www.google.com HTTP/1.1\r\n" b"content-length: 0\r\n\r\n"
+    text = b"CONNECT www.google.com HTTP/1.1\r\ncontent-length: 0\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg, payload = messages[0]
     assert upgrade
@@ -619,21 +619,21 @@ def test_url_absolute(parser: Any) -> None:
 
 
 def test_headers_old_websocket_key1(parser: Any) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"SEC-WEBSOCKET-KEY1: line\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nSEC-WEBSOCKET-KEY1: line\r\n\r\n"
 
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
 
 
 def test_headers_content_length_err_1(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"content-length: line\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ncontent-length: line\r\n\r\n"
 
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
 
 
 def test_headers_content_length_err_2(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"content-length: -1\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ncontent-length: -1\r\n\r\n"
 
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
@@ -656,7 +656,7 @@ _pad: Dict[bytes, str] = {
 @pytest.mark.parametrize("pad2", _pad.keys(), ids=["post-" + n for n in _pad.values()])
 @pytest.mark.parametrize("pad1", _pad.keys(), ids=["pre-" + n for n in _pad.values()])
 def test_invalid_header_spacing(parser, pad1: bytes, pad2: bytes, hdr: bytes) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"%s%s%s: value\r\n\r\n" % (pad1, hdr, pad2)
+    text = b"GET /test HTTP/1.1\r\n%s%s%s: value\r\n\r\n" % (pad1, hdr, pad2)
     expectation = pytest.raises(http_exceptions.BadHttpMessage)
     if pad1 == pad2 == b"" and hdr != b"":
         # one entry in param matrix is correct: non-empty name, not padded
@@ -666,19 +666,19 @@ def test_invalid_header_spacing(parser, pad1: bytes, pad2: bytes, hdr: bytes) ->
 
 
 def test_empty_header_name(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b":test\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\n:test\r\n\r\n"
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
 
 
 def test_invalid_header(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"test line\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ntest line\r\n\r\n"
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
 
 
 def test_invalid_name(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"test[]: line\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ntest[]: line\r\n\r\n"
 
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
@@ -715,7 +715,7 @@ def test_max_header_field_size_under_limit(parser) -> None:
 @pytest.mark.parametrize("size", [40960, 8191])
 def test_max_header_value_size(parser, size) -> None:
     name = b"t" * size
-    text = b"GET /test HTTP/1.1\r\n" b"data:" + name + b"\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ndata:" + name + b"\r\n\r\n"
 
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
@@ -724,7 +724,7 @@ def test_max_header_value_size(parser, size) -> None:
 
 def test_max_header_value_size_under_limit(parser) -> None:
     value = b"A" * 8190
-    text = b"GET /test HTTP/1.1\r\n" b"data:" + value + b"\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ndata:" + value + b"\r\n\r\n"
 
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
@@ -1216,7 +1216,7 @@ def test_http_response_parser_code_not_ascii(response, nonascii_digit: bytes) ->
 
 
 def test_http_request_chunked_payload(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"transfer-encoding: chunked\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
 
     assert msg.chunked
@@ -1231,7 +1231,7 @@ def test_http_request_chunked_payload(parser) -> None:
 
 
 def test_http_request_chunked_payload_and_next_message(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"transfer-encoding: chunked\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
 
     messages, upgraded, tail = parser.feed_data(
@@ -1253,7 +1253,7 @@ def test_http_request_chunked_payload_and_next_message(parser) -> None:
 
 
 def test_http_request_chunked_payload_chunks(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"transfer-encoding: chunked\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
 
     parser.feed_data(b"4\r\ndata\r")
@@ -1275,7 +1275,7 @@ def test_http_request_chunked_payload_chunks(parser) -> None:
 
 
 def test_parse_chunked_payload_chunk_extension(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n" b"transfer-encoding: chunked\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
 
     parser.feed_data(b"4;test\r\ndata\r\n4\r\nline\r\n0\r\ntest: test\r\n\r\n")
@@ -1295,14 +1295,14 @@ def test_parse_no_length_or_te_on_post(loop: Any, protocol: Any, request_cls: An
 
 def test_parse_payload_response_without_body(loop, protocol, response_cls) -> None:
     parser = response_cls(protocol, loop, 2**16, response_with_body=False)
-    text = b"HTTP/1.1 200 Ok\r\n" b"content-length: 10\r\n\r\n"
+    text = b"HTTP/1.1 200 Ok\r\ncontent-length: 10\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
 
     assert payload.is_eof()
 
 
 def test_parse_length_payload(response) -> None:
-    text = b"HTTP/1.1 200 Ok\r\n" b"content-length: 4\r\n\r\n"
+    text = b"HTTP/1.1 200 Ok\r\ncontent-length: 4\r\n\r\n"
     msg, payload = response.feed_data(text)[0][0]
     assert not payload.is_eof()
 
@@ -1627,7 +1627,7 @@ class TestParsePayload:
     async def test_parse_chunked_payload_split_end_trailers4(self, protocol) -> None:
         out = aiohttp.StreamReader(protocol, 2**16, loop=None)
         p = HttpPayloadParser(out, chunked=True)
-        p.feed_data(b"4\r\nasdf\r\n0\r\n" b"C")
+        p.feed_data(b"4\r\nasdf\r\n0\r\nC")
         p.feed_data(b"ontent-MD5: 912ec803b2ce49e4a541068d495ab570\r\n\r\n")
 
         assert out.is_eof()

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -108,7 +108,7 @@ async def test_write_payload_chunked_filter_mutiple_chunks(protocol, transport, 
     await msg.write_eof()
     content = b"".join([c[1][0] for c in list(write.mock_calls)])
     assert content.endswith(
-        b"2\r\nda\r\n2\r\nta\r\n2\r\n1d\r\n2\r\nat\r\n" b"2\r\na2\r\n0\r\n\r\n"
+        b"2\r\nda\r\n2\r\nta\r\n2\r\n1d\r\n2\r\nat\r\n2\r\na2\r\n0\r\n\r\n"
     )
 
 
@@ -136,7 +136,7 @@ async def test_write_payload_deflate_and_chunked(buf, protocol, transport, loop)
     await msg.write(b"ta")
     await msg.write_eof()
 
-    thing = b"2\r\nx\x9c\r\n" b"a\r\nKI,I\x04\x00\x04\x00\x01\x9b\r\n" b"0\r\n\r\n"
+    thing = b"2\r\nx\x9c\r\na\r\nKI,I\x04\x00\x04\x00\x01\x9b\r\n0\r\n\r\n"
     assert thing == buf
 
 
@@ -163,8 +163,8 @@ async def test_write_payload_short_ints_memoryview(buf, protocol, transport, loo
     await msg.write_eof()
 
     endians = (
-        (b"6\r\n" b"\x00A\x00B\x00C\r\n" b"0\r\n\r\n"),
-        (b"6\r\n" b"A\x00B\x00C\x00\r\n" b"0\r\n\r\n"),
+        (b"6\r\n\x00A\x00B\x00C\r\n0\r\n\r\n"),
+        (b"6\r\nA\x00B\x00C\x00\r\n0\r\n\r\n"),
     )
     assert buf in endians
 
@@ -179,7 +179,7 @@ async def test_write_payload_2d_shape_memoryview(buf, protocol, transport, loop)
     await msg.write(payload)
     await msg.write_eof()
 
-    thing = b"6\r\n" b"ABCDEF\r\n" b"0\r\n\r\n"
+    thing = b"6\r\nABCDEF\r\n0\r\n\r\n"
     assert thing == buf
 
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -463,7 +463,7 @@ class TestPartReader:
         assert data == result
 
     async def test_read_text_compressed(self) -> None:
-        data = b"\x0b\xc9\xccMU(\xc9W\x08J\xcdI\xacP\x04\x00" b"%s--:--" % newline
+        data = b"\x0b\xc9\xccMU(\xc9W\x08J\xcdI\xacP\x04\x00%s--:--" % newline
         with Stream(data) as stream:
             obj = aiohttp.BodyPartReader(
                 BOUNDARY,
@@ -515,9 +515,7 @@ class TestPartReader:
         assert {"тест": "пассед"} == result
 
     async def test_read_json_compressed(self) -> None:
-        with Stream(
-            b"\xabV*I-.Q\xb2RP*H,.NMQ\xaa\x05\x00" b"%s--:--" % newline
-        ) as stream:
+        with Stream(b"\xabV*I-.Q\xb2RP*H,.NMQ\xaa\x05\x00%s--:--" % newline) as stream:
             obj = aiohttp.BodyPartReader(
                 BOUNDARY,
                 {CONTENT_ENCODING: "deflate", CONTENT_TYPE: "application/json"},
@@ -712,7 +710,7 @@ class TestMultipartReader:
                     b"----:--",
                     b"",
                     b"passed",
-                    b"----:----" b"--:--",
+                    b"----:------:--",
                 ]
             )
         ) as stream:

--- a/tests/test_multipart_helpers.py
+++ b/tests/test_multipart_helpers.py
@@ -555,10 +555,10 @@ class TestParseContentDisposition:
 
     def test_attfncontenc(self) -> None:
         disptype, params = parse_content_disposition(
-            "attachment; filename*0*=UTF-8" 'foo-%c3%a4; filename*1=".html"'
+            "attachment; filename*0*=UTF-8" + 'foo-%c3%a4; filename*1=".html"'
         )
         assert "attachment" == disptype
-        assert {"filename*0*": "UTF-8" "foo-%c3%a4", "filename*1": ".html"} == params
+        assert {"filename*0*": "UTF-8foo-%c3%a4", "filename*1": ".html"} == params
 
     def test_attfncontlz(self) -> None:
         disptype, params = parse_content_disposition(
@@ -590,14 +590,14 @@ class TestParseContentDisposition:
 
     def test_attfnboth(self) -> None:
         disptype, params = parse_content_disposition(
-            'attachment; filename="foo-ae.html";' " filename*=UTF-8''foo-%c3%a4.html"
+            'attachment; filename="foo-ae.html";' + " filename*=UTF-8''foo-%c3%a4.html"
         )
         assert "attachment" == disptype
         assert {"filename": "foo-ae.html", "filename*": "foo-ä.html"} == params
 
     def test_attfnboth2(self) -> None:
         disptype, params = parse_content_disposition(
-            "attachment; filename*=UTF-8''foo-%c3%a4.html;" ' filename="foo-ae.html"'
+            "attachment; filename*=UTF-8''foo-%c3%a4.html;" + ' filename="foo-ae.html"'
         )
         assert "attachment" == disptype
         assert {"filename": "foo-ae.html", "filename*": "foo-ä.html"} == params

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -368,7 +368,7 @@ def test_add_static_append_version(router) -> None:
     resource = router.add_static("/st", pathlib.Path(__file__).parent, name="static")
     url = resource.url_for(filename="/data.unknown_mime_type", append_version=True)
     expect_url = (
-        "/st/data.unknown_mime_type?" "v=aUsn8CHEhhszc81d28QmlcBW0KQpfS2F4trgQKhOYd8%3D"
+        "/st/data.unknown_mime_type?v=aUsn8CHEhhszc81d28QmlcBW0KQpfS2F4trgQKhOYd8%3D"
     )
     assert expect_url == str(url)
 
@@ -379,7 +379,7 @@ def test_add_static_append_version_set_from_constructor(router) -> None:
     )
     url = resource.url_for(filename="/data.unknown_mime_type")
     expect_url = (
-        "/st/data.unknown_mime_type?" "v=aUsn8CHEhhszc81d28QmlcBW0KQpfS2F4trgQKhOYd8%3D"
+        "/st/data.unknown_mime_type?v=aUsn8CHEhhszc81d28QmlcBW0KQpfS2F4trgQKhOYd8%3D"
     )
     assert expect_url == str(url)
 
@@ -397,7 +397,7 @@ def test_add_static_append_version_filename_without_slash(router) -> None:
     resource = router.add_static("/st", pathlib.Path(__file__).parent, name="static")
     url = resource.url_for(filename="data.unknown_mime_type", append_version=True)
     expect_url = (
-        "/st/data.unknown_mime_type?" "v=aUsn8CHEhhszc81d28QmlcBW0KQpfS2F4trgQKhOYd8%3D"
+        "/st/data.unknown_mime_type?v=aUsn8CHEhhszc81d28QmlcBW0KQpfS2F4trgQKhOYd8%3D"
     )
     assert expect_url == str(url)
 

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -90,7 +90,7 @@ def test_path_when_unsupported(mocker, monkeypatch) -> None:
         web.main(argv)
 
     error.assert_called_with(
-        "file system paths not supported by your" " operating environment"
+        "file system paths not supported by your operating environment"
     )
 
 
@@ -107,7 +107,7 @@ def test_entry_func_call(mocker) -> None:
         web.main(argv)
 
     module.func.assert_called_with(
-        ("--extra-optional-eins --extra-optional-zwei extra positional " "args").split()
+        ("--extra-optional-eins --extra-optional-zwei extra positional args").split()
     )
 
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1651,9 +1651,7 @@ async def test_app_max_client_size(aiohttp_client) -> None:
         resp = await client.post("/", data=data)
     assert 413 == resp.status
     resp_text = await resp.text()
-    assert (
-        "Maximum request body size 1048576 exceeded, " "actual body size" in resp_text
-    )
+    assert "Maximum request body size 1048576 exceeded, actual body size" in resp_text
     # Maximum request body size X exceeded, actual body size X
     body_size = int(resp_text.split()[-1])
     assert body_size >= max_size
@@ -1685,9 +1683,7 @@ async def test_app_max_client_size_adjusted(aiohttp_client) -> None:
         resp = await client.post("/", data=too_large_data)
     assert 413 == resp.status
     resp_text = await resp.text()
-    assert (
-        "Maximum request body size 2097152 exceeded, " "actual body size" in resp_text
-    )
+    assert "Maximum request body size 2097152 exceeded, actual body size" in resp_text
     # Maximum request body size X exceeded, actual body size X
     body_size = int(resp_text.split()[-1])
     assert body_size >= custom_max_size

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -628,7 +628,7 @@ async def test_multipart_formdata(protocol) -> None:
         b"-----------------------------326931944431359--\r\n"
     )
     content_type = (
-        "multipart/form-data; boundary=" "---------------------------326931944431359"
+        "multipart/form-data; boundary=---------------------------326931944431359"
     )
     payload.feed_eof()
     req = make_mocked_request(
@@ -649,7 +649,7 @@ async def test_multipart_formdata_file(protocol) -> None:
         b"-----------------------------326931944431359--\r\n"
     )
     content_type = (
-        "multipart/form-data; boundary=" "---------------------------326931944431359"
+        "multipart/form-data; boundary=---------------------------326931944431359"
     )
     payload.feed_eof()
     req = make_mocked_request(

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -273,7 +273,7 @@ async def test_close_timeout(loop, aiohttp_client) -> None:
     await asyncio.sleep(0.08)
     assert await aborted
 
-    assert elapsed < 0.25, "close() should have returned before " "at most 2x timeout."
+    assert elapsed < 0.25, "close() should have returned before at most 2x timeout."
 
     await ws.close()
 

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -382,7 +382,7 @@ def test_continuation_with_close_empty(out, parser) -> None:
 websocket_mask_data = b"some very long data for masking by websocket"
 websocket_mask_mask = b"1234"
 websocket_mask_masked = (
-    b"B]^Q\x11DVFH\x12_[_U\x13PPFR\x14W]A\x14\\S@_X" b"\\T\x14SK\x13CTP@[RYV@"
+    b"B]^Q\x11DVFH\x12_[_U\x13PPFR\x14W]A\x14\\S@_X\\T\x14SK\x13CTP@[RYV@"
 )
 
 


### PR DESCRIPTION
(cherry picked from commit 1d170d37f476df705a9dcc3588e192e8ccb871c0)

<!-- Thank you for your contribution! -->

## What do these changes do?

Adds tests against implicitly concatenated strings. See original PR for more details https://github.com/aio-libs/aiohttp/pull/7731


## Are there changes in behavior for the user?

No

## Is it a substantial burden for the maintainers to support this?

It does raise the bar for code committed, but I believe in a way that prevents unintentional accidents.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
