### PR TITLE
Fix SSLContext creation in the TCPConnector with multiple loops

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -984,7 +984,7 @@ class TCPConnector(BaseConnector):
 
         return proto
 
-    async def _get_ssl_context(self, req: ClientRequest) -> Optional[SSLContext]:
+    def _get_ssl_context(self, req: ClientRequest) -> Optional[SSLContext]:
         """Logic to get the correct SSL context
 
         0. if req.ssl is false, return None
@@ -1108,7 +1108,7 @@ class TCPConnector(BaseConnector):
         # `req.is_ssl()` evaluates to `False` which is never gonna happen
         # in this code path. Of course, it's rather fragile
         # maintainability-wise but this is to be solved separately.
-        sslcontext = cast(ssl.SSLContext, await self._get_ssl_context(req))
+        sslcontext = cast(ssl.SSLContext, self._get_ssl_context(req))
 
         try:
             async with ceil_timeout(
@@ -1186,7 +1186,7 @@ class TCPConnector(BaseConnector):
         *,
         client_error: Type[Exception] = ClientConnectorError,
     ) -> Tuple[asyncio.Transport, ResponseHandler]:
-        sslcontext = await self._get_ssl_context(req)
+        sslcontext = self._get_ssl_context(req)
         fingerprint = self._get_fingerprint(req)
 
         host = req.url.raw_host

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -728,6 +728,9 @@ def _make_ssl_context(verified: bool) -> SSLContext:
     This method is not async-friendly and should be called from a thread
     because it will load certificates from disk and do other blocking I/O.
     """
+    if ssl is None:
+        # No ssl support
+        return None
     if verified:
         return ssl.create_default_context()
     sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -722,7 +722,7 @@ class _DNSCacheTable:
         return self._timestamps[key] + self._ttl < monotonic()
 
 
-def _make_ssl_context(verified: bool) -> "ssl.SSLContext":
+def _make_ssl_context(verified: bool) -> SSLContext:
     """Create SSL context.
 
     This method is not async-friendly and should be called from a thread
@@ -1103,6 +1103,10 @@ class TCPConnector(BaseConnector):
         """Wrap the raw TCP transport with TLS."""
         tls_proto = self._factory()  # Create a brand new proto for TLS
         sslcontext = self._get_ssl_context(req)
+        if TYPE_CHECKING:
+            # _start_tls_connection is unreachable in the current code path
+            # if sslcontext is None.
+            assert sslcontext is not None
 
         try:
             async with ceil_timeout(

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -743,8 +743,8 @@ def _make_ssl_context(verified: bool) -> SSLContext:
     return sslcontext
 
 
-# These are created at import time when since they
-# do blocking I/O to load certificates from disk,
+# The default SSLContext objects are created at import time
+# since they do blocking I/O to load certificates from disk,
 # and imports should always be done before the event loop starts
 # or in a thread.
 _SSL_CONTEXT_VERIFIED = _make_ssl_context(True)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -722,7 +722,7 @@ class _DNSCacheTable:
         return self._timestamps[key] + self._ttl < monotonic()
 
 
-def _make_ssl_context(verified: bool) -> SSLContext:
+def _make_ssl_context(verified: bool) -> "ssl.SSLContext":
     """Create SSL context.
 
     This method is not async-friendly and should be called from a thread
@@ -1102,13 +1102,7 @@ class TCPConnector(BaseConnector):
     ) -> Tuple[asyncio.BaseTransport, ResponseHandler]:
         """Wrap the raw TCP transport with TLS."""
         tls_proto = self._factory()  # Create a brand new proto for TLS
-
-        # Safety of the `cast()` call here is based on the fact that
-        # internally `_get_ssl_context()` only returns `None` when
-        # `req.is_ssl()` evaluates to `False` which is never gonna happen
-        # in this code path. Of course, it's rather fragile
-        # maintainability-wise but this is to be solved separately.
-        sslcontext = cast(ssl.SSLContext, self._get_ssl_context(req))
+        sslcontext = self._get_ssl_context(req)
 
         try:
             async with ceil_timeout(

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2987,15 +2987,16 @@ def test_connector_multiple_event_loop() -> None:
     async def async_connect():
         conn = aiohttp.TCPConnector()
         loop = asyncio.get_running_loop()
-        req = ClientRequest("GET", URL("https://127.0.0.1:443"), loop=loop)
-        with mock.patch.object(
-            conn._loop,
-            "create_connection",
-            autospec=True,
-            spec_set=True,
-            side_effect=ssl.CertificateError,
-        ):
-            await conn.connect(req, [], ClientTimeout())
+        req = ClientRequest("GET", URL("https://127.0.0.1"), loop=loop)
+        with suppress(aiohttp.ClientConnectorError):
+            with mock.patch.object(
+                conn._loop,
+                "create_connection",
+                autospec=True,
+                spec_set=True,
+                side_effect=ssl.CertificateError,
+            ):
+                await conn.connect(req, [], ClientTimeout())
         return True
 
     def test_connect():

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3001,7 +3001,11 @@ def test_connector_multiple_event_loop() -> None:
         return True
 
     def test_connect() -> Literal[True]:
-        return asyncio.new_event_loop().run_until_complete(async_connect())
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(async_connect())
+        finally:
+            loop.close()
 
     with ThreadPoolExecutor() as executor:
         res_list = [executor.submit(test_connect) for _ in range(2)]

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -8,7 +8,7 @@ import ssl
 import sys
 import uuid
 from collections import deque
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent import futures
 from contextlib import closing, suppress
 from typing import (
     Awaitable,
@@ -2972,8 +2972,8 @@ def test_connector_multiple_event_loop() -> None:
         finally:
             loop.close()
 
-    with ThreadPoolExecutor() as executor:
+    with futures.ThreadPoolExecutor() as executor:
         res_list = [executor.submit(test_connect) for _ in range(2)]
-        raw_response_list = [res.result() for res in as_completed(res_list)]
+        raw_response_list = [res.result() for res in futures.as_completed(res_list)]
 
     assert raw_response_list == [True, True]

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -30,7 +30,13 @@ from pytest_mock import MockerFixture
 from yarl import URL
 
 import aiohttp
-from aiohttp import ClientRequest, ClientSession, ClientTimeout, connector, web
+from aiohttp import (
+    ClientRequest,
+    ClientSession,
+    ClientTimeout,
+    connector as connector_module,
+    web,
+)
 from aiohttp.abc import ResolveResult
 from aiohttp.client_proto import ResponseHandler
 from aiohttp.client_reqrep import ConnectionKey
@@ -2981,6 +2987,6 @@ def test_connector_multiple_event_loop() -> None:
 
 def test_default_ssl_context_creation_without_ssl():
     """Verify _make_ssl_context does not raise when ssl is not available."""
-    with mock.patch.object(connector, "ssl", None):
-        assert connector._make_ssl_context(False) is None
-        assert connector._make_ssl_context(True) is None
+    with mock.patch.object(connector_module, "ssl", None):
+        assert connector_module._make_ssl_context(False) is None
+        assert connector_module._make_ssl_context(True) is None

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2981,7 +2981,6 @@ async def test_connector_does_not_remove_needed_waiters(
             await connector.close()
 
 
-@pytest.mark.xfail
 def test_connector_multiple_event_loop() -> None:
     """Test the connector with multiple event loops."""
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -17,6 +17,7 @@ from typing import (
     Dict,
     Iterator,
     List,
+    Literal,
     NoReturn,
     Optional,
     Sequence,
@@ -2984,7 +2985,7 @@ async def test_connector_does_not_remove_needed_waiters(
 def test_connector_multiple_event_loop() -> None:
     """Test the connector with multiple event loops."""
 
-    async def async_connect():
+    async def async_connect() -> Literal[True]:
         conn = aiohttp.TCPConnector()
         loop = asyncio.get_running_loop()
         req = ClientRequest("GET", URL("https://127.0.0.1"), loop=loop)
@@ -2999,10 +3000,8 @@ def test_connector_multiple_event_loop() -> None:
                 await conn.connect(req, [], ClientTimeout())
         return True
 
-    def test_connect():
-        loop = asyncio.new_event_loop()
-        results = loop.run_until_complete(async_connect())
-        return results
+    def test_connect() -> Literal[True]:
+        return asyncio.new_event_loop().run_until_complete(async_connect())
 
     with ThreadPoolExecutor() as executor:
         res_list = [executor.submit(test_connect) for _ in range(2)]

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2985,7 +2985,7 @@ def test_connector_multiple_event_loop() -> None:
     assert raw_response_list == [True, True]
 
 
-def test_default_ssl_context_creation_without_ssl():
+def test_default_ssl_context_creation_without_ssl() -> None:
     """Verify _make_ssl_context does not raise when ssl is not available."""
     with mock.patch.object(connector_module, "ssl", None):
         assert connector_module._make_ssl_context(False) is None

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -9,6 +9,7 @@ from yarl import URL
 
 import aiohttp
 from aiohttp.client_reqrep import ClientRequest, ClientResponse
+from aiohttp.connector import _SSL_CONTEXT_VERIFIED
 from aiohttp.helpers import TimerNoop
 from aiohttp.test_utils import make_mocked_coro
 
@@ -934,9 +935,7 @@ class TestProxy(unittest.TestCase):
                             tls_m.assert_called_with(
                                 mock.ANY,
                                 mock.ANY,
-                                self.loop.run_until_complete(
-                                    connector._make_or_get_ssl_context(True)
-                                ),
+                                _SSL_CONTEXT_VERIFIED,
                                 server_hostname="www.python.org",
                                 ssl_handshake_timeout=mock.ANY,
                             )


### PR DESCRIPTION
Creation of the SSLContexts did not account for multiple event loops in different threads.

Creation is now done at import time to ensure it does not block the event loop.

fixes #9020
