### PR TITLE
Avoid tracing overhead in http_writer when there are no traces

### DIFF
--- a/CHANGES/9031.misc.rst
+++ b/CHANGES/9031.misc.rst
@@ -1,0 +1,1 @@
+Tracing overhead is avoided in the http writer when there are no active traces -- by user:`bdraco`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -629,11 +629,15 @@ class ClientRequest:
         writer = StreamWriter(
             protocol,
             self.loop,
-            on_chunk_sent=functools.partial(
-                self._on_chunk_request_sent, self.method, self.url
+            on_chunk_sent=(
+                functools.partial(self._on_chunk_request_sent, self.method, self.url)
+                if self._traces
+                else None
             ),
-            on_headers_sent=functools.partial(
-                self._on_headers_request_sent, self.method, self.url
+            on_headers_sent=(
+                functools.partial(self._on_headers_request_sent, self.method, self.url)
+                if self._traces
+                else None
             ),
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

If there are not traces set for the request, we would still create partial functions in ClientRequest and call them in http_writer

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no

before
![write_headers_before](https://github.com/user-attachments/assets/40d49fbc-430c-4cbf-bd21-3f3c7a12cda3)

after
![write_headers_after](https://github.com/user-attachments/assets/7136fb33-98c4-4c0c-b50b-93e79d08922a)

