### PR TITLE
[PR #9032/c693a816 backport][3.10] Fix Link-Local IPv6 Flags in the Resolver

### DIFF
--- a/CHANGES/9032.bugfix.rst
+++ b/CHANGES/9032.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed the incorrect use of flags for ``getnameinfo()`` in the Resolver --by :user:`GitNMLee`
+
+Link-Local IPv6 addresses can now be handled by the Resolver correctly.

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -18,6 +18,7 @@ except ImportError:  # pragma: no cover
 
 
 _NUMERIC_SOCKET_FLAGS = socket.AI_NUMERICHOST | socket.AI_NUMERICSERV
+_NAME_SOCKET_FLAGS = socket.NI_NUMERICHOST | socket.NI_NUMERICSERV
 _SUPPORTS_SCOPE_ID = sys.version_info >= (3, 9, 0)
 
 
@@ -54,7 +55,7 @@ class ThreadedResolver(AbstractResolver):
                     # LL IPv6 is a VERY rare case. Strictly speaking, we should use
                     # getnameinfo() unconditionally, but performance makes sense.
                     resolved_host, _port = await self._loop.getnameinfo(
-                        address, _NUMERIC_SOCKET_FLAGS
+                        address, _NAME_SOCKET_FLAGS
                     )
                     port = int(_port)
                 else:
@@ -122,7 +123,7 @@ class AsyncResolver(AbstractResolver):
                     # getnameinfo() unconditionally, but performance makes sense.
                     result = await self._resolver.getnameinfo(
                         (address[0].decode("ascii"), *address[1:]),
-                        _NUMERIC_SOCKET_FLAGS,
+                        _NAME_SOCKET_FLAGS,
                     )
                     resolved_host = result.node
                 else:


### PR DESCRIPTION
Co-authored-by: Nathan Lee <nathan.lee@garmin.com>
Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
Co-authored-by: Sam Bull <git@sambull.org>
Co-authored-by: J. Nick Koston <nick@koston.org>
(cherry picked from commit c693a816ce84d46c445841c707f23e31f174cf28)
