### PR TITLE
DNM: Test why update_query was not used

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -229,10 +229,7 @@ class ClientRequest:
         # assert session is not None
         self._session = cast("ClientSession", session)
         if params:
-            q = MultiDict(url.query)
-            url2 = url.with_query(params)
-            q.extend(url2.query)
-            url = url.with_query(q)
+            url = url.update_query(params)
         self.original_url = url
         self.url = url.with_fragment(None)
         self.method = method.upper()

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -702,6 +702,21 @@ async def test_str_params(aiohttp_client: AiohttpClient) -> None:
         assert 200 == resp.status
 
 
+async def test_params_and_query_string(aiohttp_client: AiohttpClient) -> None:
+    """Test combining params with an existing query_string."""
+
+    async def handler(request: web.Request) -> web.Response:
+        assert request.rel_url.query_string == "q=abc&q=test&d=dog"
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+
+    async with client.get("/?q=abc", params="q=test&d=dog") as resp:
+        assert 200 == resp.status
+
+
 async def test_drop_params_on_redirect(aiohttp_client: AiohttpClient) -> None:
     async def handler_redirect(request: web.Request) -> web.Response:
         return web.Response(status=301, headers={"Location": "/ok?a=redirect"})

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -714,7 +714,25 @@ async def test_params_and_query_string(aiohttp_client: AiohttpClient) -> None:
     client = await aiohttp_client(app)
 
     async with client.get("/?q=abc", params="q=test&d=dog") as resp:
-        assert 200 == resp.status
+        assert resp.status == 200
+
+
+@pytest.mark.parametrize("params", [None, "", {}, MultiDict()])
+async def test_empty_params_and_query_string(
+    aiohttp_client: AiohttpClient, params: Any
+) -> None:
+    """Test combining empty params with an existing query_string."""
+
+    async def handler(request: web.Request) -> web.Response:
+        assert request.rel_url.query_string == "q=abc"
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+
+    async with client.get("/?q=abc", params=params) as resp:
+        assert resp.status == 200
 
 
 async def test_drop_params_on_redirect(aiohttp_client: AiohttpClient) -> None:


### PR DESCRIPTION
DO NOT MERGE

Exploring if we need an `extend_query`, we are missing test coverage, or `update_query` can be used here.

related issue: https://github.com/aio-libs/yarl/issues/1127