### PR TITLE
Add coverage for combining an existing query string with params

### DIFF
--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -702,6 +702,21 @@ async def test_str_params(aiohttp_client: AiohttpClient) -> None:
         assert 200 == resp.status
 
 
+async def test_params_and_query_string(aiohttp_client: AiohttpClient) -> None:
+    """Test combining params with an existing query_string."""
+
+    async def handler(request: web.Request) -> web.Response:
+        assert request.rel_url.query_string == "q=abc&q=test&d=dog"
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+
+    async with client.get("/?q=abc", params="q=test&d=dog") as resp:
+        assert 200 == resp.status
+
+
 async def test_drop_params_on_redirect(aiohttp_client: AiohttpClient) -> None:
     async def handler_redirect(request: web.Request) -> web.Response:
         return web.Response(status=301, headers={"Location": "/ok?a=redirect"})

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -714,7 +714,25 @@ async def test_params_and_query_string(aiohttp_client: AiohttpClient) -> None:
     client = await aiohttp_client(app)
 
     async with client.get("/?q=abc", params="q=test&d=dog") as resp:
-        assert 200 == resp.status
+        assert resp.status == 200
+
+
+@pytest.mark.parametrize("params", [None, "", {}, MultiDict()])
+async def test_empty_params_and_query_string(
+    aiohttp_client: AiohttpClient, params: Any
+) -> None:
+    """Test combining empty params with an existing query_string."""
+
+    async def handler(request: web.Request) -> web.Response:
+        assert request.rel_url.query_string == "q=abc"
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+
+    async with client.get("/?q=abc", params=params) as resp:
+        assert resp.status == 200
 
 
 async def test_drop_params_on_redirect(aiohttp_client: AiohttpClient) -> None:


### PR DESCRIPTION
Add coverage for combining an existing query string with params. 

I expected the change in https://github.com/aio-libs/aiohttp/pull/9062 would have failed the CI, and turns out the complex query string construction there is needed, but there is no coverage for it.

When we have multiple query strings, we don't want to overwrite keys, since some applications will want multiple values for the same key.  Ie `name=X&name=Y&name=Z` is used to indicate there are 3 payloads, etc.

The complex logic we have to combine query strings should be handled in `yarl`.  Currently we only have a way to update the query string but that overwrites values.  We need a way to extend the query string and take advantage of `multidict`'s ability to have the same key.


```python
            q = MultiDict(url.query)
            url2 = url.with_query(params)
            q.extend(url2.query)
            url = url.with_query(q)
```