### PR TITLE
Use URL.extend_query to add params in `ClientRequest`

### DIFF
--- a/CHANGES/9068.misc.rst
+++ b/CHANGES/9068.misc.rst
@@ -1,0 +1,3 @@
+Use :meth:`URL.extend_query() <yarl.URL.extend_query>` to extend query params (requires yarl 1.11.0+) -- by :user:`bdraco`.
+
+If yarl is older than 1.11.0, the previous slower hand rolled version will be used.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -90,7 +90,7 @@ if TYPE_CHECKING:
 
 
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
-_YARL_SUPPORTS_EXTEND_QUERY = tuple(map(int, yarl_version.split(".")[:2])) > (1, 10)
+_YARL_SUPPORTS_EXTEND_QUERY = tuple(map(int, yarl_version.split(".")[:2])) >= (1, 11)
 
 
 def _gen_default_accept_encoding() -> str:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -33,7 +33,7 @@ from pytest_mock import MockerFixture
 from yarl import URL
 
 import aiohttp
-from aiohttp import Fingerprint, ServerFingerprintMismatch, hdrs, web
+from aiohttp import Fingerprint, ServerFingerprintMismatch, client_reqrep, hdrs, web
 from aiohttp.abc import AbstractResolver, ResolveResult
 from aiohttp.client_exceptions import (
     InvalidURL,
@@ -702,7 +702,10 @@ async def test_str_params(aiohttp_client: AiohttpClient) -> None:
         assert 200 == resp.status
 
 
-async def test_params_and_query_string(aiohttp_client: AiohttpClient) -> None:
+@pytest.mark.parametrize("yarl_supports_extend_query", [True, False])
+async def test_params_and_query_string(
+    aiohttp_client: AiohttpClient, yarl_supports_extend_query: bool
+) -> None:
     """Test combining params with an existing query_string."""
 
     async def handler(request: web.Request) -> web.Response:
@@ -713,13 +716,18 @@ async def test_params_and_query_string(aiohttp_client: AiohttpClient) -> None:
     app.router.add_route("GET", "/", handler)
     client = await aiohttp_client(app)
 
-    async with client.get("/?q=abc", params="q=test&d=dog") as resp:
-        assert resp.status == 200
+    # Ensure the old path is tested for old yarl versions
+    with mock.patch.object(
+        client_reqrep, "_YARL_SUPPORTS_EXTEND_QUERY", yarl_supports_extend_query
+    ):
+        async with client.get("/?q=abc", params="q=test&d=dog") as resp:
+            assert resp.status == 200
 
 
 @pytest.mark.parametrize("params", [None, "", {}, MultiDict()])
+@pytest.mark.parametrize("yarl_supports_extend_query", [True, False])
 async def test_empty_params_and_query_string(
-    aiohttp_client: AiohttpClient, params: Any
+    aiohttp_client: AiohttpClient, params: Any, yarl_supports_extend_query: bool
 ) -> None:
     """Test combining empty params with an existing query_string."""
 
@@ -731,8 +739,12 @@ async def test_empty_params_and_query_string(
     app.router.add_route("GET", "/", handler)
     client = await aiohttp_client(app)
 
-    async with client.get("/?q=abc", params=params) as resp:
-        assert resp.status == 200
+    # Ensure the old path is tested for old yarl versions
+    with mock.patch.object(
+        client_reqrep, "_YARL_SUPPORTS_EXTEND_QUERY", yarl_supports_extend_query
+    ):
+        async with client.get("/?q=abc", params=params) as resp:
+            assert resp.status == 200
 
 
 async def test_drop_params_on_redirect(aiohttp_client: AiohttpClient) -> None:


### PR DESCRIPTION
- [x] needs yarl bumped before this can merge so we test both paths https://github.com/aio-libs/aiohttp/pull/9072

<!-- Thank you for your contribution! -->

## What do these changes do?

Use `URL.extend_query` to add `params` in `ClientRequest`



## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no