### PR TITLE
Add tests for websocket close

### DIFF
--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -1152,9 +1152,30 @@ async def test_websocket_shutdown(aiohttp_client: AiohttpClient) -> None:
     assert websocket.closed is True
 
 
-@pytest.mark.xfail(reason="close never reaches client per issue #5180")
 async def test_ws_close_return_code(aiohttp_client: AiohttpClient) -> None:
     """Test that the close code is returned when the server closes the connection."""
+
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        await ws.receive()
+        await ws.close()
+        return ws
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+    resp = await client.ws_connect("/")
+    await resp.send_str("some data")
+    msg = await resp.receive()
+    assert msg.type is aiohttp.WSMsgType.CLOSE
+    assert resp.close_code == WSCloseCode.OK
+
+
+async def test_abnormal_closure_when_server_does_not_receive(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Test abnormal closure when the server closes and a message is pending."""
 
     async def handler(request: web.Request) -> web.WebSocketResponse:
         ws = web.WebSocketResponse()
@@ -1168,5 +1189,6 @@ async def test_ws_close_return_code(aiohttp_client: AiohttpClient) -> None:
     resp = await client.ws_connect("/")
     await resp.send_str("some data")
     await asyncio.sleep(0.1)
-    await resp.receive()
-    assert resp.close_code is WSCloseCode.OK
+    msg = await resp.receive()
+    assert msg.type is aiohttp.WSMsgType.CLOSE
+    assert resp.close_code == WSCloseCode.ABNORMAL_CLOSURE


### PR DESCRIPTION
This is a followup to add more coverage for #5180

It took me a while but I realized that this is behaving as expected because the client is sending a string `await ws.send_str('some data')` which is never received by the server (no `receive`), and the connection is closed while the message is still on the wire.

Everything is working as expected, and the test was wrong.

closes #5180