### PR TITLE
[PR #9072/7fb1631 backport][3.10] Bump yarl to 1.11.0

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -39,7 +39,7 @@ from typing import (
     cast,
 )
 
-from yarl import URL, __version__ as yarl_version  # type: ignore[attr-defined]
+from yarl import URL, __version__ as yarl_version
 
 from . import hdrs
 from .abc import AbstractMatchInfo, AbstractRouter, AbstractView

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -38,5 +38,5 @@ pycparser==2.21
     # via cffi
 uvloop==0.19.0 ; platform_system != "Windows" and implementation_name == "cpython"
     # via -r requirements/base.in
-yarl==1.9.6
+yarl==1.11.0
     # via -r requirements/runtime-deps.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -274,7 +274,7 @@ webcolors==1.11.1
     # via blockdiag
 wheel==0.37.0
     # via pip-tools
-yarl==1.9.6
+yarl==1.11.0
     # via -r requirements/runtime-deps.in
 zipp==3.17.0
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -261,7 +261,7 @@ webcolors==1.13
     # via blockdiag
 wheel==0.41.0
     # via pip-tools
-yarl==1.9.6
+yarl==1.11.0
     # via -r requirements/runtime-deps.in
 zipp==3.17.0
     # via

--- a/requirements/runtime-deps.txt
+++ b/requirements/runtime-deps.txt
@@ -32,5 +32,5 @@ pycares==4.3.0
     # via aiodns
 pycparser==2.21
     # via cffi
-yarl==1.9.6
+yarl==1.11.0
     # via -r requirements/runtime-deps.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -125,5 +125,5 @@ uvloop==0.19.0 ; platform_system != "Windows" and implementation_name == "cpytho
     # via -r requirements/base.in
 wait-for-it==2.2.2
     # via -r requirements/test.in
-yarl==1.9.6
+yarl==1.11.0
     # via -r requirements/runtime-deps.in


### PR DESCRIPTION
(cherry picked from commit 7fb16311604d23ac5deb63c08a99629bd33aa6b6)
