### PR TITLE
Bump yarl requirement to >=1.11.0

### DIFF
--- a/CHANGES/9079.misc.rst
+++ b/CHANGES/9079.misc.rst
@@ -1,0 +1,1 @@
+Increase minimum yarl version to 1.11.0 -- by :user:`bdraco`.

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -8,4 +8,4 @@ Brotli; platform_python_implementation == 'CPython'
 brotlicffi; platform_python_implementation != 'CPython'
 frozenlist >= 1.1.1
 multidict >=4.5, < 7.0
-yarl >= 1.6, < 2.0
+yarl >= 1.11.0, < 2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ install_requires =
   async-timeout >= 4.0, < 5.0 ; python_version < "3.11"
   frozenlist >= 1.1.1
   multidict >=4.5, < 7.0
-  yarl >= 1.6, < 2.0
+  yarl >= 1.11.0, < 2.0
 
 [options.exclude_package_data]
 * =


### PR DESCRIPTION
This will allow us to remove some conditional logic to support old yarl versions. https://github.com/aio-libs/aiohttp/pull/9068#issuecomment-2336844811

Should not backport to 3.10, master/3.11 only
