### PR TITLE
[PR #9079/7404afc backport][3.11] Bump yarl requirement to >=1.11.0

### DIFF
--- a/CHANGES/9079.misc.rst
+++ b/CHANGES/9079.misc.rst
@@ -1,0 +1,1 @@
+Increase minimum yarl version to 1.11.0 -- by :user:`bdraco`.

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -9,4 +9,4 @@ Brotli; platform_python_implementation == 'CPython'
 brotlicffi; platform_python_implementation != 'CPython'
 frozenlist >= 1.1.1
 multidict >=4.5, < 7.0
-yarl >= 1.0, < 2.0
+yarl >= 1.11.0, < 2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
   attrs >= 17.3.0
   frozenlist >= 1.1.1
   multidict >=4.5, < 7.0
-  yarl >= 1.0, < 2.0
+  yarl >= 1.11.0, < 2.0
 
 [options.exclude_package_data]
 * =


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/pull/9068#issuecomment-2336844811

(cherry picked from commit 7404afcf9f6303eb288d3254b5fdd89a656c5ded)
