### PR TITLE
Reduce overhead to check if a host is an IP Address

### DIFF
--- a/CHANGES/9095.misc.rst
+++ b/CHANGES/9095.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of checking if a host is an IP Address -- by :user:`bdraco`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -483,56 +483,51 @@ try:
 except ImportError:
     pass
 
-_ipv4_pattern = (
-    r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}"
-    r"(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
-)
-_ipv6_pattern = (
-    r"^(?:(?:(?:[A-F0-9]{1,4}:){6}|(?=(?:[A-F0-9]{0,4}:){0,6}"
-    r"(?:[0-9]{1,3}\.){3}[0-9]{1,3}$)(([0-9A-F]{1,4}:){0,5}|:)"
-    r"((:[0-9A-F]{1,4}){1,5}:|:)|::(?:[A-F0-9]{1,4}:){5})"
-    r"(?:(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])\.){3}"
-    r"(?:25[0-5]|2[0-4][0-9]|1[0-9][0-9]|[1-9]?[0-9])|(?:[A-F0-9]{1,4}:){7}"
-    r"[A-F0-9]{1,4}|(?=(?:[A-F0-9]{0,4}:){0,7}[A-F0-9]{0,4}$)"
-    r"(([0-9A-F]{1,4}:){1,7}|:)((:[0-9A-F]{1,4}){1,7}|:)|(?:[A-F0-9]{1,4}:){7}"
-    r":|:(:[A-F0-9]{1,4}){7})$"
-)
-_ipv4_regex = re.compile(_ipv4_pattern)
-_ipv6_regex = re.compile(_ipv6_pattern, flags=re.IGNORECASE)
-_ipv4_regexb = re.compile(_ipv4_pattern.encode("ascii"))
-_ipv6_regexb = re.compile(_ipv6_pattern.encode("ascii"), flags=re.IGNORECASE)
-
 
 def is_ipv4_address(host: Optional[Union[str, bytes]]) -> bool:
-    """Check if host is an valid IPv4 address."""
+    """Check if host looks like an IPv4 address.
+
+    This function does not validate that the format is correct, only that
+    the host is a str or bytes, and its all numeric.
+
+    This check is only meant as a heuristic to ensure that
+    a host is not a domain name.
+    """
     if not host:
         return False
+    # For a host to be an ipv4 address, it must be all numeric.
     if isinstance(host, str):
-        # The last character of the host must be a digit to be an IPv4 address.
-        # We check this first to avoid the overhead of the regex.
-        return host[-1].isdigit() and bool(_ipv4_regex.match(host))
+        return host.replace(".", "").isdigit()
     if isinstance(host, (bytes, bytearray, memoryview)):
-        return bool(_ipv4_regexb.match(host))
+        return host.decode("ascii").replace(".", "").isdigit()
     raise TypeError(f"{host} [{type(host)}] is not a str or bytes")
 
 
 def is_ipv6_address(host: Optional[Union[str, bytes]]) -> bool:
-    """Check if host is an valid IPv6 address."""
+    """Check if host looks like an IPv6 address.
+
+    This function does not validate that the format is correct, only that
+    the host contains a colon and that it is a str or bytes.
+
+    This check is only meant as a heuristic to ensure that
+    a host is not a domain name.
+    """
     if not host:
         return False
+    # The host must contain a colon to be an IPv6 address.
     if isinstance(host, str):
-        # The host must contain a colon to be an IPv6 address.
-        # We check this first to avoid the overhead of the regex.
-        return ":" in host and bool(_ipv6_regex.match(host))
+        return ":" in host
     if isinstance(host, (bytes, bytearray, memoryview)):
-        # The host must contain a colon to be an IPv6 address.
-        # We check this first to avoid the overhead of the regex.
-        return b":" in host and bool(_ipv6_regexb.match(host))
+        return b":" in host
     raise TypeError(f"{host} [{type(host)}] is not a str or bytes")
 
 
 def is_ip_address(host: Optional[Union[str, bytes, bytearray, memoryview]]) -> bool:
-    """Check if host is an valid IP address."""
+    """Check if host looks like an IP Address.
+
+    This check is only meant as a heuristic to ensure that
+    a host is not a domain name.
+    """
     return is_ipv4_address(host) or is_ipv6_address(host)
 
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -505,7 +505,7 @@ _ipv6_regexb = re.compile(_ipv6_pattern.encode("ascii"), flags=re.IGNORECASE)
 
 def is_ipv4_address(host: Optional[Union[str, bytes]]) -> bool:
     """Check if host is an valid IPv4 address."""
-    if host is None:
+    if not host:
         return False
     if isinstance(host, str):
         # The last character of the host must be a digit to be an IPv4 address.
@@ -518,7 +518,7 @@ def is_ipv4_address(host: Optional[Union[str, bytes]]) -> bool:
 
 def is_ipv6_address(host: Optional[Union[str, bytes]]) -> bool:
     """Check if host is an valid IPv6 address."""
-    if host is None:
+    if not host:
         return False
     if isinstance(host, str):
         # The host must contain a colon to be an IPv6 address.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -286,14 +286,6 @@ def test_is_ip_address() -> None:
     assert not helpers.is_ip_address("localhost")
     assert not helpers.is_ip_address("www.example.com")
 
-    # Out of range
-    assert not helpers.is_ip_address("999.999.999.999")
-    # Contain a port
-    assert not helpers.is_ip_address("127.0.0.1:80")
-    assert not helpers.is_ip_address("[2001:db8:0:1]:80")
-    # Too many "::"
-    assert not helpers.is_ip_address("1200::AB00:1234::2552:7777:1313")
-
 
 def test_is_ip_address_bytes() -> None:
     assert helpers.is_ip_address(b"127.0.0.1")
@@ -303,14 +295,6 @@ def test_is_ip_address_bytes() -> None:
     # Hostnames
     assert not helpers.is_ip_address(b"localhost")
     assert not helpers.is_ip_address(b"www.example.com")
-
-    # Out of range
-    assert not helpers.is_ip_address(b"999.999.999.999")
-    # Contain a port
-    assert not helpers.is_ip_address(b"127.0.0.1:80")
-    assert not helpers.is_ip_address(b"[2001:db8:0:1]:80")
-    # Too many "::"
-    assert not helpers.is_ip_address(b"1200::AB00:1234::2552:7777:1313")
 
 
 def test_ipv4_addresses() -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -344,6 +344,18 @@ def test_is_ip_address_invalid_type() -> None:
     with pytest.raises(TypeError):
         helpers.is_ip_address(object())  # type: ignore[arg-type]
 
+    with pytest.raises(TypeError):
+        helpers.is_ipv4_address(123)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError):
+        helpers.is_ipv4_address(object())  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError):
+        helpers.is_ipv6_address(123)  # type: ignore[arg-type]
+
+    with pytest.raises(TypeError):
+        helpers.is_ipv6_address(object())  # type: ignore[arg-type]
+
 
 # ----------------------------------- TimeoutHandle -------------------
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The IP Address regexes are a bit complex and take up ~35% of the time spent in `update_headers` https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client_reqrep.py#L361   

The checks for IP Addresses did not need to validate that the IP Address is valid, only that it was not a domain name https://github.com/aio-libs/aiohttp/pull/9095#issuecomment-2338631993 which means they can be much simpler.

Timings (more details below)
```
['ipv4 string - decode + isdigit', 0.05164358299225569]
['ipv4 string - regex', 0.24710870906710625]
['ipv4 binary - decode + isdigit', 0.07746362499892712]
['ipv4 binary - regex', 0.2532113748602569]
['ipv6 string - check for :', 0.00942283309996128]
['ipv6 string - regex', 1.4924992499873042]
['ipv6 binary - check for :', 0.11242458294145763]
['ipv6 binary - regex', 1.4484847909770906]
```

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no

before
![is_ip_address_before](https://github.com/user-attachments/assets/7a8bbe6c-2810-4f7f-9600-bdc71339426d)


after
![is_ipv4_address_after](https://github.com/user-attachments/assets/e0a44815-6e54-4755-a2e0-52fb01c6a061)
![is_ip_address_after](https://github.com/user-attachments/assets/6b025b66-afc5-4210-9839-173e21b2f296)
