### PR TITLE
Remove extra ``MultiDictProxy`` wrapper from ``BaseRequest.query``

### DIFF
--- a/CHANGES/9098.misc.rst
+++ b/CHANGES/9098.misc.rst
@@ -1,0 +1,3 @@
+Remove extra ``MultiDictProxy`` wrapper from ``BaseRequest.query`` -- by :user:`bdraco`.
+
+The underlying object returned from ``yarl`` is already a ``MultiDictProxy``.

--- a/CHANGES/9098.misc.rst
+++ b/CHANGES/9098.misc.rst
@@ -1,3 +1,0 @@
-Remove extra ``MultiDictProxy`` wrapper from ``BaseRequest.query`` -- by :user:`bdraco`.
-
-The underlying object returned from ``yarl`` is already a ``MultiDictProxy``.

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -476,7 +476,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
     @reify
     def query(self) -> MultiDictProxy[str]:
         """A multidict with all the variables in the query string."""
-        return MultiDictProxy(self._rel_url.query)
+        return self._rel_url.query
 
     @reify
     def query_string(self) -> str:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Remove extra ``MultiDictProxy`` wrapper from ``BaseRequest.query``
query is already a MultiDictProxy even as far back as yarl 1.0.0 https://github.com/aio-libs/yarl/blob/829f6568916f9f3219a940720bee65103ca591c2/yarl/__init__.py#L472


## Are there changes in behavior for the user?

no
## Is it a substantial burden for the maintainers to support this?
no