### PR TITLE
Remove None as a compress value

### DIFF
--- a/CHANGES/9109.breaking.rst
+++ b/CHANGES/9109.breaking.rst
@@ -1,0 +1,1 @@
+Changed default value to ``compress`` from ``None`` to ``False`` (``None`` is no longer an expected value) -- by :user:`Dreamsorcerer`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -171,7 +171,7 @@ class _RequestOptions(TypedDict, total=False):
     auth: Union[BasicAuth, None]
     allow_redirects: bool
     max_redirects: int
-    compress: Union[str, bool, None]
+    compress: Union[str, bool]
     chunked: Union[bool, None]
     expect100: bool
     raise_for_status: Union[None, bool, Callable[[ClientResponse], Awaitable[None]]]
@@ -416,7 +416,7 @@ class ClientSession:
         auth: Optional[BasicAuth] = None,
         allow_redirects: bool = True,
         max_redirects: int = 10,
-        compress: Union[str, bool, None] = None,
+        compress: Union[str, bool] = False,
         chunked: Optional[bool] = None,
         expect100: bool = False,
         raise_for_status: Union[
@@ -1370,7 +1370,7 @@ def request(
     auth: Optional[BasicAuth] = None,
     allow_redirects: bool = True,
     max_redirects: int = 10,
-    compress: Optional[str] = None,
+    compress: Union[str, bool] = False,
     chunked: Optional[bool] = None,
     expect100: bool = False,
     raise_for_status: Optional[bool] = None,

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -423,9 +423,8 @@ class ClientRequest:
 
     def update_content_encoding(self, data: Any, compress: Union[bool, str]) -> None:
         """Set request content encoding."""
+        self.compress = None
         if not data:
-            # Don't compress an empty body.
-            self.compress = None
             return
 
         enc = self.headers.get(hdrs.CONTENT_ENCODING, "").lower()

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -958,7 +958,7 @@ async def test_precompressed_data_stays_intact(loop: asyncio.AbstractEventLoop) 
         URL("http://python.org/"),
         data=data,
         headers={"CONTENT-ENCODING": "deflate"},
-        compress=None,
+        compress=False,
         loop=loop,
     )
     assert not req.compress


### PR DESCRIPTION
Changed default value to ``compress`` from ``None`` to ``False`` (``None`` is no longer an expected value)