### PR TITLE
Implement binding to IPv6 addresses in the pytest server fixture

### DIFF
--- a/CHANGES/4650.bugfix
+++ b/CHANGES/4650.bugfix
@@ -1,0 +1,1 @@
+Implement binding to IPv6 addresses in the pytest server fixture.

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -119,10 +119,13 @@ class BaseTestServer(ABC):
         await self.runner.setup()
         if not self.port:
             self.port = 0
+        absolute_host = self.host
         try:
             version = ipaddress.ip_address(self.host).version
         except ValueError:
             version = 4
+        if version == 6:
+            absolute_host = f"[{self.host}]"
         family = socket.AF_INET6 if version == 6 else socket.AF_INET
         _sock = self.socket_factory(self.host, self.port, family)
         self.host, self.port = _sock.getsockname()[:2]
@@ -135,7 +138,7 @@ class BaseTestServer(ABC):
         self.port = sockets[0].getsockname()[1]
         if not self.scheme:
             self.scheme = "https" if self._ssl else "http"
-        self._root = URL(f"{self.scheme}://{self.host}:{self.port}")
+        self._root = URL(f"{self.scheme}://{absolute_host}:{self.port}")
 
     @abstractmethod  # pragma: no cover
     async def _make_runner(self, **kwargs: Any) -> BaseRunner:

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -371,3 +371,14 @@ async def test_base_test_server_socket_factory(
         pass
 
     assert factory_called
+
+@pytest.mark.parametrize(("hostname", "expected_host"),
+                         [("127.0.0.1", "127.0.0.1"),
+                          ("localhost", "127.0.0.1"),
+                          ("::1", "::1")])
+async def test_test_server_hostnames(hostname, expected_host, loop) -> None:
+    app = _create_example_app()
+    server = _TestServer(app, host=hostname, loop=loop)
+    async with server:
+        pass
+    assert server.host == expected_host

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -372,10 +372,11 @@ async def test_base_test_server_socket_factory(
 
     assert factory_called
 
-@pytest.mark.parametrize(("hostname", "expected_host"),
-                         [("127.0.0.1", "127.0.0.1"),
-                          ("localhost", "127.0.0.1"),
-                          ("::1", "::1")])
+
+@pytest.mark.parametrize(
+    ("hostname", "expected_host"),
+    [("127.0.0.1", "127.0.0.1"), ("localhost", "127.0.0.1"), ("::1", "::1")],
+)
 async def test_test_server_hostnames(hostname, expected_host, loop) -> None:
     app = _create_example_app()
     server = _TestServer(app, host=hostname, loop=loop)


### PR DESCRIPTION
PR #4650 by @tan01

This change allows TestServer to be instantiated with IPv6 hostnames. Previously, the TestServer would open an IPv4 family socket regardless of hostname, causing an error to be raised upon starting the server. The BaseTestServer now parses the hostname and create an IPv4 or IPv6 socket based on the hostname.

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
