### PR TITLE
Add authentication using netrc file

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1280,11 +1280,8 @@ def get_auth_from_netrc(url):
     if netrc_obj:
         auth_from_netrc = netrc_obj.authenticators(url.host)
         if auth_from_netrc is not None:
-            # auth_from_netrc is a (`user`, `account`, `password`) tuple,
-            # `user` and `account` both can be username,
-            # if `user` is None, use `account`
-            *logins, password = auth_from_netrc
-            auth = BasicAuth(logins[0] if logins[0] else logins[-1], password)
+            user, account, password = auth_from_netrc
+            auth = BasicAuth(user if user else account, password)
 
     return auth
 

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -251,6 +251,7 @@ class ClientSession:
         "_max_line_size",
         "_max_field_size",
         "_resolve_charset",
+        "_netrc_obj"
     )
 
     def __init__(
@@ -778,7 +779,7 @@ class ClientSession:
                 )
             raise
 
-    def get_auth_from_netrc(self, url):
+    def get_auth_from_netrc(self, url: URL) -> Optional[BasicAuth]:
         """Get authentication through netrc."""
         auth = None
         if self._netrc_obj:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -782,6 +782,8 @@ class ClientSession:
 
     def get_auth_from_netrc(self, url: URL) -> Optional[BasicAuth]:
         """Get authentication through netrc."""
+        if not url.host:
+            return None
         try:
             return basicauth_from_netrc(self._netrc_obj, url.host)
         except LookupError:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -251,7 +251,7 @@ class ClientSession:
         "_max_line_size",
         "_max_field_size",
         "_resolve_charset",
-        "_netrc_obj"
+        "_netrc_obj",
     )
 
     def __init__(

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -362,7 +362,6 @@ class ClientSession:
 
         self._netrc_obj = netrc_from_env()
 
-
     def __init_subclass__(cls: Type["ClientSession"]) -> None:
         raise TypeError(
             "Inheritance class {} from ClientSession "

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1284,10 +1284,10 @@ def get_auth_from_netrc(url):
             # `user` and `account` both can be username,
             # if `user` is None, use `account`
             *logins, password = auth_from_netrc
-            auth = BasicAuth(logins[0] if logins[0] else logins[-1],
-                                password)
+            auth = BasicAuth(logins[0] if logins[0] else logins[-1], password)
 
     return auth
+
 
 class _BaseRequestContextManager(Coroutine[Any, Any, _RetType], Generic[_RetType]):
     __slots__ = ("_coro", "_resp")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR allows fetching the authentication to a server from netrc if nothing else is provided.

## Are there changes in behavior for the user?
In the case where there is an item in netrc for the host pointed to by the url requested, the login and password will be used to authenticate.

## Is it a substantial burden for the maintainers to support this?
I think this is a pretty lightweight change, I don't see any significant complication in maintaining.
<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number
I don't know of any related issue.
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
