### PR TITLE
Cache construction of middleware handlers

### DIFF
--- a/CHANGES/9158.misc.rst
+++ b/CHANGES/9158.misc.rst
@@ -1,0 +1,3 @@
+Significantly improved performance of middlewares -- by :user:`bdraco`.
+
+The construction of the middleware wrappers is now cached and is built once per handler instead of on every request.

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -383,13 +383,13 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
             handler = match_info.handler
 
             if self._run_middlewares:
-                handler = await self._apply_middlewares(handler, match_info.apps[::-1])
+                handler = self._apply_middlewares(handler, match_info.apps[::-1])
 
             resp = await handler(request)
 
         return resp
 
-    async def _apply_middlewares(
+    def _apply_middlewares(
         self,
         handler: Handler,
         apps: Tuple["Application", ...],

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -73,8 +73,7 @@ _Resource = TypeVar("_Resource", bound=AbstractResource)
 @staticmethod
 @cache
 def _build_middlewares(
-    handler: Handler,
-    apps: Tuple["Application", ...],
+    handler: Handler, apps: Tuple["Application", ...]
 ) -> Callable[[Request], Awaitable[StreamResponse]]:
     """Apply middlewares to handler."""
     for app in apps:

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -70,7 +70,6 @@ _U = TypeVar("_U")
 _Resource = TypeVar("_Resource", bound=AbstractResource)
 
 
-@staticmethod
 @cache
 def _build_middlewares(
     handler: Handler, apps: Tuple["Application", ...]

--- a/tests/test_web_middleware.py
+++ b/tests/test_web_middleware.py
@@ -23,10 +23,13 @@ async def test_middleware_modifies_response(loop: Any, aiohttp_client: Any) -> N
     app.middlewares.append(middleware)
     app.router.add_route("GET", "/", handler)
     client = await aiohttp_client(app)
-    resp = await client.get("/")
-    assert 201 == resp.status
-    txt = await resp.text()
-    assert "OK[MIDDLEWARE]" == txt
+
+    # Call twice to verify cache works
+    for _ in range(2):
+        resp = await client.get("/")
+        assert 201 == resp.status
+        txt = await resp.text()
+        assert "OK[MIDDLEWARE]" == txt
 
 
 async def test_middleware_handles_exception(loop: Any, aiohttp_client: Any) -> None:
@@ -42,10 +45,13 @@ async def test_middleware_handles_exception(loop: Any, aiohttp_client: Any) -> N
     app.middlewares.append(middleware)
     app.router.add_route("GET", "/", handler)
     client = await aiohttp_client(app)
-    resp = await client.get("/")
-    assert 501 == resp.status
-    txt = await resp.text()
-    assert "Error text[MIDDLEWARE]" == txt
+
+    # Call twice to verify cache works
+    for _ in range(2):
+        resp = await client.get("/")
+        assert 501 == resp.status
+        txt = await resp.text()
+        assert "Error text[MIDDLEWARE]" == txt
 
 
 async def test_middleware_chain(loop: Any, aiohttp_client: Any) -> None:


### PR DESCRIPTION
## What do these changes do?

Cache construction of middleware.  Calling `update_wrapper` many times for each request with middleware is more expensive than running all the middlewares 

The `update_wrapper` call was introduced in https://github.com/aio-libs/aiohttp/pull/4195 which is what made middleware much slower.

## Are there changes in behavior for the user?

No

## Is it a substantial burden for the maintainers to support this?
no

Before
```
bdraco@MacBook-Pro-5 ~ % wrk -t 10 http://localhost:8123
Running 10s test @ http://localhost:8123
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     6.83ms   33.14ms 348.84ms   96.25%
    Req/Sec     1.89k   799.64     2.41k    80.83%
  181206 requests in 10.01s, 0.95GB read
Requests/sec:  18100.19
Transfer/sec:     97.39MB
```



After
```
bdraco@MacBook-Pro-5 ~ % wrk -t 10 http://localhost:8123
Running 10s test @ http://localhost:8123
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   386.34us  124.22us   5.11ms   98.73%
    Req/Sec     2.63k   156.95     2.77k    96.04%
  264316 requests in 10.10s, 1.39GB read
Requests/sec:  26169.50
Transfer/sec:    140.81MB
```

![middleware](https://github.com/user-attachments/assets/dd49750d-48b4-49eb-bfe9-39a3561934ff)
