### PR TITLE
[3.11] Cache construction of middleware handlers

### DIFF
--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import warnings
-from functools import partial, update_wrapper
+from functools import cache, partial, update_wrapper
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -230,6 +230,9 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
     def __iter__(self) -> Iterator[Union[str, AppKey[Any]]]:
         return iter(self._state)
 
+    def __hash__(self) -> int:
+        return id(self)
+
     @overload  # type: ignore[override]
     def get(self, key: AppKey[_T], default: None = ...) -> Optional[_T]: ...
 
@@ -286,6 +289,9 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
         self._on_shutdown.freeze()
         self._on_cleanup.freeze()
         self._middlewares_handlers = tuple(self._prepare_middleware())
+        self._has_legacy_middlewares = any(
+            not new_style for _, new_style in self._middlewares_handlers
+        )
 
         # If current app and any subapp do not have middlewares avoid run all
         # of the code footprint that it implies, which have a middleware
@@ -527,37 +533,45 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
             handler = match_info.handler
 
             if self._run_middlewares:
-                handler = await self._apply_middlewares(handler, match_info.apps[::-1])
+                if self._has_legacy_middlewares:
+                    # Slow path for legacy handlers
+                    handler = await self._apply_middlewares(
+                        handler, match_info.apps[::-1]
+                    )
+                else:
+                    handler = Application._build_middlewares(
+                        handler, match_info.apps[::-1]
+                    )
 
             resp = await handler(request)
 
         return resp
 
     async def _apply_middlewares(
-        self,
-        handler: Handler,
-        apps: Tuple["Application", ...],
+        self, handler: Handler, apps: Tuple["Application", ...]
     ) -> Callable[[Request], Awaitable[StreamResponse]]:
-        """Apply middlewares to handler."""
-        cache_key = (handler, tuple(id(app) for app in apps))
-
-        if cache_key in self._middlewares_cache:
-            return self._middlewares_cache[cache_key]
-
-        can_cache: bool = True
+        """Apply middlewares to handler with support for legacy handlers."""
         for app in apps:
-            for m, new_style in app._middlewares_handlers:  # type: ignore[union-attr]
+            for m, new_style in app._middlewares_handlers:
                 if new_style:
                     handler = update_wrapper(
                         partial(m, handler=handler), handler  # type: ignore[misc]
                     )
                 else:
-                    handler = await m(app, handler)  # type: ignore[arg-type,assignment]
-                    can_cache = False
+                    handler = await m(app, handler)
 
-        if can_cache:
-            self._middlewares_cache[cache_key] = handler
+        return handler
 
+    @staticmethod
+    @cache
+    def _build_middlewares(
+        handler: Handler,
+        apps: Tuple["Application", ...],
+    ) -> Callable[[Request], Awaitable[StreamResponse]]:
+        """Apply middlewares to handler."""
+        for app in apps:
+            for m, _ in app._middlewares_handlers:  # type: ignore[union-attr]
+                handler = update_wrapper(partial(m, handler=handler), handler)  # type: ignore[misc]
         return handler
 
     def __call__(self) -> "Application":

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -89,7 +89,7 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
             "_handler_args",
             "_middlewares",
             "_middlewares_handlers",
-            "_middlewares_cache",
+            "_has_legacy_middlewares",
             "_run_middlewares",
             "_state",
             "_frozen",
@@ -144,7 +144,7 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
         self._middlewares_handlers: _MiddlewaresHandlers = None
         # initialized on freezing
         self._run_middlewares: Optional[bool] = None
-        self._middlewares_cache: Dict[Tuple[Handler, Tuple[int, ...]], Handler] = {}
+        self._has_legacy_middlewares: bool = True
 
         self._state: Dict[Union[AppKey[Any], str], object] = {}
         self._frozen = False

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -38,7 +38,7 @@ from .helpers import DEBUG, AppKey
 from .http_parser import RawRequestMessage
 from .log import web_logger
 from .streams import StreamReader
-from .typedefs import Middleware
+from .typedefs import Handler, Middleware
 from .web_exceptions import NotAppKeyWarning
 from .web_log import AccessLogger
 from .web_middlewares import _fix_request_current_app
@@ -89,6 +89,7 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
             "_handler_args",
             "_middlewares",
             "_middlewares_handlers",
+            "_middlewares_cache",
             "_run_middlewares",
             "_state",
             "_frozen",
@@ -143,6 +144,7 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
         self._middlewares_handlers: _MiddlewaresHandlers = None
         # initialized on freezing
         self._run_middlewares: Optional[bool] = None
+        self._middlewares_cache: Dict[Tuple[Handler, Tuple[int, ...]], Handler] = {}
 
         self._state: Dict[Union[AppKey[Any], str], object] = {}
         self._frozen = False
@@ -525,18 +527,38 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
             handler = match_info.handler
 
             if self._run_middlewares:
-                for app in match_info.apps[::-1]:
-                    for m, new_style in app._middlewares_handlers:  # type: ignore[union-attr]
-                        if new_style:
-                            handler = update_wrapper(
-                                partial(m, handler=handler), handler  # type: ignore[misc]
-                            )
-                        else:
-                            handler = await m(app, handler)  # type: ignore[arg-type,assignment]
+                handler = await self._apply_middlewares(handler, match_info.apps[::-1])
 
             resp = await handler(request)
 
         return resp
+
+    async def _apply_middlewares(
+        self,
+        handler: Handler,
+        apps: Tuple["Application", ...],
+    ) -> Callable[[Request], Awaitable[StreamResponse]]:
+        """Apply middlewares to handler."""
+        cache_key = (handler, tuple(id(app) for app in apps))
+
+        if cache_key in self._middlewares_cache:
+            return self._middlewares_cache[cache_key]
+
+        can_cache: bool = True
+        for app in apps:
+            for m, new_style in app._middlewares_handlers:  # type: ignore[union-attr]
+                if new_style:
+                    handler = update_wrapper(
+                        partial(m, handler=handler), handler  # type: ignore[misc]
+                    )
+                else:
+                    handler = await m(app, handler)  # type: ignore[arg-type,assignment]
+                    can_cache = False
+
+        if can_cache:
+            self._middlewares_cache[cache_key] = handler
+
+        return handler
 
     def __call__(self) -> "Application":
         """gunicorn compatibility"""

--- a/tests/test_web_middleware.py
+++ b/tests/test_web_middleware.py
@@ -24,10 +24,13 @@ async def test_middleware_modifies_response(loop, aiohttp_client) -> None:
     app.middlewares.append(middleware)
     app.router.add_route("GET", "/", handler)
     client = await aiohttp_client(app)
-    resp = await client.get("/")
-    assert 201 == resp.status
-    txt = await resp.text()
-    assert "OK[MIDDLEWARE]" == txt
+
+    # Call twice to verify cache works
+    for _ in range(2):
+        resp = await client.get("/")
+        assert 201 == resp.status
+        txt = await resp.text()
+        assert "OK[MIDDLEWARE]" == txt
 
 
 async def test_middleware_handles_exception(loop, aiohttp_client) -> None:
@@ -44,10 +47,13 @@ async def test_middleware_handles_exception(loop, aiohttp_client) -> None:
     app.middlewares.append(middleware)
     app.router.add_route("GET", "/", handler)
     client = await aiohttp_client(app)
-    resp = await client.get("/")
-    assert 501 == resp.status
-    txt = await resp.text()
-    assert "Error text[MIDDLEWARE]" == txt
+
+    # Call twice to verify cache works
+    for _ in range(2):
+        resp = await client.get("/")
+        assert 501 == resp.status
+        txt = await resp.text()
+        assert "Error text[MIDDLEWARE]" == txt
 
 
 async def test_middleware_chain(loop, aiohttp_client) -> None:


### PR DESCRIPTION
Will do a PR to master once I'm happy with this, but since I'm traveling, I want to test live for now.  master will be much simpler since we don't have to deal with legacy middleware.
master version is https://github.com/aio-libs/aiohttp/pull/9158


## What do these changes do?

Cache construction of middleware.  Calling `update_wrapper` many times for each request with middleware is a more expensive than running all the middlewares 

## Are there changes in behavior for the user?

No

## Is it a substantial burden for the maintainers to support this?
no

Before
```
bdraco@MacBook-Pro-5 ~ % wrk -t 10 http://localhost:8123
Running 10s test @ http://localhost:8123
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     6.83ms   33.14ms 348.84ms   96.25%
    Req/Sec     1.89k   799.64     2.41k    80.83%
  181206 requests in 10.01s, 0.95GB read
Requests/sec:  18100.19
Transfer/sec:     97.39MB
```



After
```
bdraco@MacBook-Pro-5 ~ % wrk -t 10 http://localhost:8123
Running 10s test @ http://localhost:8123
  10 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   386.34us  124.22us   5.11ms   98.73%
    Req/Sec     2.63k   156.95     2.77k    96.04%
  264316 requests in 10.10s, 1.39GB read
Requests/sec:  26169.50
Transfer/sec:    140.81MB
```

![middleware](https://github.com/user-attachments/assets/dd49750d-48b4-49eb-bfe9-39a3561934ff)
