### PR TITLE
Fix badly encoded charset crashing instead of falling back to detector

### DIFF
--- a/CHANGES/9160.bugfix
+++ b/CHANGES/9160.bugfix
@@ -1,0 +1,1 @@
+Fixed badly encoded charset crashing when getting response text instead of falling back to charset detector.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -280,6 +280,7 @@ Pawel Kowalski
 Pawel Miech
 Pepe Osca
 Philipp A.
+Pierre-Louis Peeters
 Pieter van Beek
 Qiao Han
 Rafael Viotti

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1090,7 +1090,7 @@ class ClientResponse(HeadersMixin):
 
         encoding = mimetype.parameters.get("charset")
         if encoding:
-            with contextlib.suppress(LookupError):
+            with contextlib.suppress(LookupError, ValueError):
                 return codecs.lookup(encoding).name
 
         if mimetype.type == "application" and (


### PR DESCRIPTION
## What do these changes do?

They fix a crash that occurs when processing a `Content-Type` header that is itself badly encoded.

Example I saw in the wild was:

```
HTTP/1.1 200 OK
Date: Tue, 17 Sep 2024 08:02:39 GMT
Server: Apache
Vary: Accept-Encoding
Connection: close
Content-Type: text/html; charset=�gUTF-8��
```

where I got:

```
  File "/usr/local/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 1179, in text
    encoding = self.get_encoding()
               ^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/aiohttp/client_reqrep.py", line 1157, in get_encoding
    return codecs.lookup(encoding).name
           ^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'utf-8' codec can't encode character '\udc81' in position 0: surrogates not allowed
```

Yet to me, this falls under the "not understood by Python" case of the documentation:

> Retrieve content encoding using ``charset`` info in ``Content-Type`` HTTP header.
      If no charset is present **or the charset is not understood by Python**, the
      ``fallback_charset_resolver`` function associated with the ``ClientSession`` is called.

## Are there changes in behavior for the user?

Such websites no longer cause a `UnicodeEncodeError` that crashes `ClientResponse.get_encoding()` (and ultimately `ClientResponse.text()`) and will instead fallback as if it was a `LookupError` on the encoding. This is the behaviour I expected to see, hence the PR.

## Is it a substantial burden for the maintainers to support this?

I don't think so, it might even lead to issues not being raised when they would have.

## Related issue number

Sort of related to #207 and #3279.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
