### PR TITLE
Switch to using `yarl.URL.absolute` over `yarl.URL.is_absolute()`

### DIFF
--- a/CHANGES/9171.misc.rst
+++ b/CHANGES/9171.misc.rst
@@ -1,0 +1,3 @@
+Improved performance of determining if a URL is absolute -- by :user:`bdraco`.
+
+The property :attr:`~yarl.URL.absolute` is more performant than the method ``URL.is_absolute()`` and preferred when newer versions of yarl are used.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -399,7 +399,7 @@ class ClientSession:
         if self._base_url is None:
             return url
         else:
-            assert not url.is_absolute() and url.path.startswith("/")
+            assert not url.absolute and url.path.startswith("/")
             return self._base_url.join(url)
 
     async def _request(

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -162,7 +162,7 @@ class BaseTestServer(ABC, Generic[_Request]):
         assert self._root is not None
         url = URL(path)
         if not self.skip_url_asserts:
-            assert not url.is_absolute()
+            assert not url.absolute
             return self._root.join(url)
         else:
             return URL(str(self._root) + str(path))

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -176,7 +176,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         self._version = message.version
         self._cache: Dict[str, Any] = {}
         url = message.url
-        if url.is_absolute():
+        if url.absolute:
             if scheme is not None:
                 url = url.with_scheme(scheme)
             if host is not None:


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

`.absolute` is directly cached and preferred

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no

related issue #2779