### PR TITLE
Avoid calling response prepare hook if its empty

### DIFF
--- a/CHANGES/9173.misc.rst
+++ b/CHANGES/9173.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of starting web requests when there is no response prepare hook -- by :user:`bdraco`.

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -902,4 +902,5 @@ class Request(BaseRequest):
         if match_info is None:
             return
         for app in match_info._apps:
-            await app.on_response_prepare.send(self, response)
+            if on_response_prepare := app.on_response_prepare:
+                await on_response_prepare.send(self, response)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Avoid calling response prepare hook if its empty as its likely to be empty in most cases

## Are there changes in behavior for the user?

no
## Is it a substantial burden for the maintainers to support this?
no


related issue #2779

before
![prepare_hook_before](https://github.com/user-attachments/assets/3f4fc176-fd18-4b90-ad9d-44002272c417)


after
![prepare_hook_after](https://github.com/user-attachments/assets/21e86b38-bf41-4a72-90ad-8e07644ed1e0)
