### PR TITLE
Add a cache to must_be_empty_body

### DIFF
--- a/CHANGES/9174.misc.rst
+++ b/CHANGES/9174.misc.rst
@@ -1,1 +1,1 @@
-Improved performance of preparing web requests -- by :user:`bdraco`.
+Improved performance of web requests -- by :user:`bdraco`.

--- a/CHANGES/9174.misc.rst
+++ b/CHANGES/9174.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of preparing web requests -- by :user:`bdraco`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -1099,6 +1099,7 @@ def parse_http_date(date_str: Optional[str]) -> Optional[datetime.datetime]:
     return None
 
 
+@functools.lru_cache
 def must_be_empty_body(method: str, code: int) -> bool:
     """Check if a request must return an empty body."""
     return (


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Nearly all the calls are going to be the same so we can cache the logic

I couldn't figure out how to avoid this call in most cases like https://github.com/aio-libs/aiohttp/pull/9172 so a cache made more sense.


## Are there changes in behavior for the user?

no
## Is it a substantial burden for the maintainers to support this?
no


related issue #2779

before
![must_be_empty_body_before](https://github.com/user-attachments/assets/0ccf92d8-4adf-4cff-97b2-4d31fd7e8da1)


after
![must_be_empty_body_after](https://github.com/user-attachments/assets/01f2bccf-452b-4994-ae4c-1942963af646)
