### PR TITLE
[PR #9160 backport][3.10] Fix badly encoded charset crashing instead of falling back to detector

### DIFF
--- a/CHANGES/9160.bugfix
+++ b/CHANGES/9160.bugfix
@@ -1,0 +1,1 @@
+Fixed badly encoded charset crashing when getting response text instead of falling back to charset detector.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -271,6 +271,7 @@ Pawel Kowalski
 Pawel Miech
 Pepe Osca
 Philipp A.
+Pierre-Louis Peeters
 Pieter van Beek
 Qiao Han
 Rafael Viotti

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1168,7 +1168,7 @@ class ClientResponse(HeadersMixin):
 
         encoding = mimetype.parameters.get("charset")
         if encoding:
-            with contextlib.suppress(LookupError):
+            with contextlib.suppress(LookupError, ValueError):
                 return codecs.lookup(encoding).name
 
         if mimetype.type == "application" and (

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -6,7 +6,7 @@ from typing import Callable
 from unittest import mock
 
 import pytest
-from multidict import CIMultiDict
+from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 import aiohttp
@@ -421,6 +421,36 @@ async def test_text_bad_encoding(loop, session) -> None:
     res = await response.text(errors="ignore")
     assert res == '{"key": "value"}'
     assert response._connection is None
+
+
+async def test_text_badly_encoded_encoding_header(loop, session) -> None:
+    session._resolve_charset = lambda *_: "utf-8"
+    response = ClientResponse(
+        "get",
+        URL("http://def-cl-resp.org"),
+        request_info=mock.Mock(),
+        writer=WriterMock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[],
+        loop=loop,
+        session=session,
+    )
+
+    def side_effect(*args: object, **kwargs: object):
+        fut = loop.create_future()
+        fut.set_result(b"foo")
+        return fut
+
+    h = {"Content-Type": "text/html; charset=\udc81gutf-8\udc81\udc8d"}
+    response._headers = CIMultiDictProxy(CIMultiDict(h))
+    content = response.content = mock.Mock()
+    content.read.side_effect = side_effect
+
+    await response.read()
+    encoding = response.get_encoding()
+
+    assert encoding == "utf-8"
 
 
 async def test_text_custom_encoding(loop, session) -> None:


### PR DESCRIPTION
Backport of #9160 to 3.10