### PR TITLE
Improve middleware performance

### DIFF
--- a/CHANGES/9200.breaking.rst
+++ b/CHANGES/9200.breaking.rst
@@ -1,0 +1,3 @@
+Improved middleware performance -- by :user:`bdraco`.
+
+The ``set_current_app`` method was removed from :class:`UrlMappingMatchInfo` because it is no longer used, and it was unlikely external caller would ever use it.

--- a/CHANGES/9200.breaking.rst
+++ b/CHANGES/9200.breaking.rst
@@ -1,3 +1,3 @@
 Improved middleware performance -- by :user:`bdraco`.
 
-The ``set_current_app`` method was removed from :class:`UrlMappingMatchInfo` because it is no longer used, and it was unlikely external caller would ever use it.
+The ``set_current_app`` method was removed from ``UrlMappingMatchInfo`` because it is no longer used, and it was unlikely external caller would ever use it.

--- a/aiohttp/web_middlewares.py
+++ b/aiohttp/web_middlewares.py
@@ -115,7 +115,12 @@ def normalize_path_middleware(
 
 def _fix_request_current_app(app: "Application") -> Middleware:
     async def impl(request: Request, handler: Handler) -> StreamResponse:
-        with request.match_info.set_current_app(app):
+        match_info = request.match_info
+        prev = match_info.current_app
+        match_info.current_app = app
+        try:
             return await handler(request)
+        finally:
+            match_info.current_app = prev
 
     return impl

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -8,7 +8,6 @@ import keyword
 import os
 import re
 import sys
-from contextlib import contextmanager
 from pathlib import Path
 from types import MappingProxyType
 from typing import (
@@ -271,8 +270,8 @@ class UrlMappingMatchInfo(BaseDict, AbstractMatchInfo):
         assert app is not None
         return app
 
-    @contextmanager
-    def set_current_app(self, app: "Application") -> Generator[None, None, None]:
+    @current_app.setter
+    def current_app(self, app: "Application") -> None:
         if DEBUG:  # pragma: no cover
             if app not in self._apps:
                 raise RuntimeError(
@@ -280,12 +279,7 @@ class UrlMappingMatchInfo(BaseDict, AbstractMatchInfo):
                         self._apps, app
                     )
                 )
-        prev = self._current_app
         self._current_app = app
-        try:
-            yield
-        finally:
-            self._current_app = prev
 
     def freeze(self) -> None:
         self._frozen = True


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
The contextmanager in cff60ebb65e35a28b481969a8e91b72e95a9f649 [added quite a bit of overhead](https://github.com/aio-libs/aiohttp/issues/9196#issuecomment-2360799101) and was only used for fixing the current app when using middleware. I did a github code search and did not find usage of `set_current_app` outside of aiohttp so I think its safe to remove as its unlikely to be used outside of aiohttp.

closes #9196

## Are there changes in behavior for the user?

The `set_current_app` function has been removed.

## Is it a substantial burden for the maintainers to support this?
no