### PR TITLE
Fix 'I/O operation on closed file' and 'Form data has been processed already' upon redirect on multipart data

### DIFF
--- a/CHANGES/9201.bugfix.rst
+++ b/CHANGES/9201.bugfix.rst
@@ -1,0 +1,1 @@
+Fix `I/O operation on closed file` and `Form data has been processed already` upon redirect on multipart data -- by :user:`GLGDLY`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -134,6 +134,7 @@ Franek Magiera
 Frederik Gladhorn
 Frederik Peter Aalund
 Gabriel Tremblay
+Gary Leung
 Gary Wilson Jr.
 Gennady Andreyev
 Georges Dubus

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -75,6 +75,7 @@ from .client_reqrep import (
     ClientResponse,
     Fingerprint,
     RequestInfo,
+    process_data_to_payload,
 )
 from .client_ws import (
     DEFAULT_WS_CLIENT_TIMEOUT,
@@ -520,6 +521,9 @@ class ClientSession:
 
         for trace in traces:
             await trace.send_request_start(method, url.update_query(params), headers)
+
+        # preprocess the data so we can reuse the Payload object when redirect is needed
+        data = process_data_to_payload(data)
 
         timer = tm.timer()
         try:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -163,7 +163,7 @@ class ConnectionKey:
     proxy_headers_hash: Optional[int]  # hash(CIMultiDict)
 
 
-def process_data_to_payload(body):
+def process_data_to_payload(body: Any) -> Optional[payload.Payload]:
     # this function is used to convert data to payload before looping into redirects,
     # so payload with io objects can be keep alive and use the stored data for the next request
     if body is None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -163,6 +163,24 @@ class ConnectionKey:
     proxy_headers_hash: Optional[int]  # hash(CIMultiDict)
 
 
+def process_data_to_payload(body):
+    # this function is used to convert data to payload before looping into redirects,
+    # so payload with io objects can be keep alive and use the stored data for the next request
+    if body is None:
+        return None
+
+    # FormData
+    if isinstance(body, FormData):
+        body = body()
+
+    try:
+        body = payload.PAYLOAD_REGISTRY.get(body, disposition=None)
+    except payload.LookupError:
+        pass  # keep for ClientRequest to handle
+
+    return body
+
+
 class ClientRequest:
     GET_METHODS = {
         hdrs.METH_GET,

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -163,7 +163,7 @@ class ConnectionKey:
     proxy_headers_hash: Optional[int]  # hash(CIMultiDict)
 
 
-def process_data_to_payload(body: Any) -> Optional[payload.Payload]:
+def process_data_to_payload(body: Any) -> Any:
     # this function is used to convert data to payload before looping into redirects,
     # so payload with io objects can be keep alive and use the stored data for the next request
     if body is None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -169,14 +169,11 @@ def process_data_to_payload(body: Any) -> Any:
     if body is None:
         return None
 
-    # FormData
     if isinstance(body, FormData):
         body = body()
 
-    try:
+    with contextlib.suppress(payload.LookupError):
         body = payload.PAYLOAD_REGISTRY.get(body, disposition=None)
-    except payload.LookupError:
-        pass  # keep for ClientRequest to handle
 
     return body
 

--- a/aiohttp/formdata.py
+++ b/aiohttp/formdata.py
@@ -28,7 +28,6 @@ class FormData:
         self._writer = multipart.MultipartWriter("form-data", boundary=self._boundary)
         self._fields: List[Any] = []
         self._is_multipart = False
-        self._is_processed = False
         self._quote_fields = quote_fields
         self._charset = charset
 
@@ -117,8 +116,8 @@ class FormData:
 
     def _gen_form_data(self) -> multipart.MultipartWriter:
         """Encode a list of fields using the multipart/form-data MIME format"""
-        if self._is_processed:
-            raise RuntimeError("Form data has been processed already")
+        if not self._fields:
+            return self._writer
         for dispparams, headers, value in self._fields:
             try:
                 if hdrs.CONTENT_TYPE in headers:
@@ -149,7 +148,7 @@ class FormData:
 
             self._writer.append_payload(part)
 
-        self._is_processed = True
+        self._fields.clear()
         return self._writer
 
     def __call__(self) -> Payload:

--- a/aiohttp/formdata.py
+++ b/aiohttp/formdata.py
@@ -116,8 +116,6 @@ class FormData:
 
     def _gen_form_data(self) -> multipart.MultipartWriter:
         """Encode a list of fields using the multipart/form-data MIME format"""
-        if not self._fields:
-            return self._writer
         for dispparams, headers, value in self._fields:
             try:
                 if hdrs.CONTENT_TYPE in headers:

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -311,7 +311,7 @@ class IOBasePayload(Payload):
 
         try:
             self._seekable = self._value.seekable()
-        except (AttributeError, OSError):
+        except AttributeError:  # https://github.com/python/cpython/issues/124293
             self._seekable = False
 
         if self._seekable:

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -410,7 +410,7 @@ class BytesIOPayload(IOBasePayload):
     _value: io.BytesIO
 
     @property
-    def size(self) -> int:
+    def size(self) -> Optional[int]:
         if self._seekable:
             end = self._value.seek(0, os.SEEK_END)
             self._value.seek(self._stream_pos)

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -308,11 +308,20 @@ class IOBasePayload(Payload):
                 self.set_content_disposition(disposition, filename=self._filename)
 
         self._writable = True
+
+        # Below try-except code segment is a temporary workaround for the issue now:
+        # It is weird but some IO objects don't have `seekable()` method as io.IOBase,
+        # the workaround here is to directly check if `seek()` and `tell()` methods are available
+        # e.g. tarfile.TarFile._Stream
+        #
+        # TODO: version check should be added after those libs are updated to prevent the issue
+        # seealso: https://github.com/aio-libs/aiohttp/pull/9201
+
+        # if sys.version_info >= (3, xx)
+        #     self._seekable = self._value.seekable()
+        # else:
         self._seekable = True
         try:
-            # It is weird but some IO object dont have `seekable()` method as IOBase object,
-            # it seems better for us to direct try if the `seek()` and `tell()` is available
-            # e.g. tarfile.TarFile._Stream
             self._value.seek(self._value.tell())
         except (AttributeError, OSError):
             self._seekable = False

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -309,20 +309,8 @@ class IOBasePayload(Payload):
 
         self._writable = True
 
-        # Below try-except code segment is a temporary workaround for the issue now:
-        # It is weird but some IO objects don't have `seekable()` method as io.IOBase,
-        # the workaround here is to directly check if `seek()` and `tell()` methods are available
-        # e.g. tarfile.TarFile._Stream
-        #
-        # TODO: version check should be added after those libs are updated to prevent the issue
-        # seealso: https://github.com/aio-libs/aiohttp/pull/9201
-
-        # if sys.version_info >= (3, xx)
-        #     self._seekable = self._value.seekable()
-        # else:
-        self._seekable = True
         try:
-            self._value.seek(self._value.tell())
+            self._seekable = self._value.seekable()
         except (AttributeError, OSError):
             self._seekable = False
 

--- a/tests/test_formdata.py
+++ b/tests/test_formdata.py
@@ -114,7 +114,8 @@ async def test_formdata_on_redirect(aiohttp_client: AiohttpClient) -> None:
 
         async def handler_1(request: web.Request) -> web.Response:
             req_data = await request.post()
-            target_file: web.FileField = req_data["sample.txt"]
+            target_file = req_data["sample.txt"]
+            assert isinstance(tarfile, web.FileField)
             assert target_file.file.read() == content
             return web.Response()
 
@@ -141,13 +142,15 @@ async def test_formdata_on_redirect_after_recv(aiohttp_client: AiohttpClient) ->
 
         async def handler_0(request: web.Request) -> web.Response:
             req_data = await request.post()
-            target_file: web.FileField = req_data["sample.txt"]
+            target_file = req_data["sample.txt"]
+            assert isinstance(tarfile, web.FileField)
             assert target_file.file.read() == content
             raise web.HTTPPermanentRedirect("/1")
 
         async def handler_1(request: web.Request) -> web.Response:
             req_data = await request.post()
-            target_file: web.FileField = req_data["sample.txt"]
+            target_file = req_data["sample.txt"]
+            assert isinstance(tarfile, web.FileField)
             assert target_file.file.read() == content
             return web.Response()
 
@@ -196,7 +199,8 @@ async def test_streaming_tarfile_on_redirect(aiohttp_client: AiohttpClient) -> N
     for entry in tf:
         with pytest.raises(ClientConnectionError) as exc_info:
             await client.post("/0", data=tf.extractfile(entry))
-        raw_exc_info: tuple = exc_info._excinfo
+        raw_exc_info = exc_info._excinfo
+        assert isinstance(raw_exc_info, tuple)
         cause_exc = raw_exc_info[1].__cause__
         assert isinstance(cause_exc, RuntimeError)
         assert len(cause_exc.args) == 1

--- a/tests/test_formdata.py
+++ b/tests/test_formdata.py
@@ -1,7 +1,7 @@
 import io
-import pathlib
 import tarfile
 import tempfile
+from pathlib import Path
 from typing import NoReturn
 from unittest import mock
 
@@ -107,7 +107,7 @@ async def test_formdata_boundary_param() -> None:
 
 
 async def test_formdata_on_redirect(aiohttp_client: AiohttpClient) -> None:
-    with pathlib.Path(pathlib.Path(__file__).parent / "sample.txt").open("rb") as fobj:
+    with Path(__file__).with_name("sample.txt").open("rb") as fobj:
         content = fobj.read()
         fobj.seek(0)
 
@@ -139,7 +139,7 @@ async def test_formdata_on_redirect(aiohttp_client: AiohttpClient) -> None:
 
 
 async def test_formdata_on_redirect_after_recv(aiohttp_client: AiohttpClient) -> None:
-    with pathlib.Path(pathlib.Path(__file__).parent / "sample.txt").open("rb") as fobj:
+    with Path(__file__).with_name("sample.txt").open("rb") as fobj:
         content = fobj.read()
         fobj.seek(0)
 

--- a/tests/test_formdata.py
+++ b/tests/test_formdata.py
@@ -1,9 +1,12 @@
 import io
+import pathlib
+import tarfile
 from unittest import mock
 
 import pytest
 
 from aiohttp import FormData, web
+from aiohttp.client_exceptions import ClientConnectionError
 from aiohttp.http_writer import StreamWriter
 from aiohttp.pytest_plugin import AiohttpClient
 
@@ -95,28 +98,104 @@ async def test_formdata_field_name_is_not_quoted(
     assert b'name="email 1"' in buf
 
 
-async def test_mark_formdata_as_processed(aiohttp_client: AiohttpClient) -> None:
-    async def handler(request: web.Request) -> web.Response:
-        return web.Response()
-
-    app = web.Application()
-    app.add_routes([web.post("/", handler)])
-
-    client = await aiohttp_client(app)
-
-    data = FormData()
-    data.add_field("test", "test_value", content_type="application/json")
-
-    resp = await client.post("/", data=data)
-    assert len(data._writer._parts) == 1
-
-    with pytest.raises(RuntimeError):
-        await client.post("/", data=data)
-
-    resp.release()
-
-
 async def test_formdata_boundary_param() -> None:
     boundary = "some_boundary"
     form = FormData(boundary=boundary)
     assert form._writer.boundary == boundary
+
+
+async def test_formdata_on_redirect(aiohttp_client: AiohttpClient) -> None:
+    with pathlib.Path(pathlib.Path(__file__).parent / "sample.txt").open("rb") as fobj:
+        content = fobj.read()
+        fobj.seek(0)
+
+        async def handler_0(request: web.Request):
+            raise web.HTTPPermanentRedirect("/1")
+
+        async def handler_1(request: web.Request) -> web.Response:
+            req_data = await request.post()
+            assert req_data["sample.txt"].file.read() == content
+            return web.Response()
+
+        app = web.Application()
+        app.router.add_post("/0", handler_0)
+        app.router.add_post("/1", handler_1)
+
+        client = await aiohttp_client(app)
+
+        data = FormData()
+        data._gen_form_data = mock.Mock(wraps=data._gen_form_data)
+        data.add_field("sample.txt", fobj)
+
+        resp = await client.post("/0", data=data)
+        assert len(data._writer._parts) == 1
+        assert resp.status == 200
+
+        resp.release()
+
+
+async def test_formdata_on_redirect_after_recv(aiohttp_client: AiohttpClient) -> None:
+    with pathlib.Path(pathlib.Path(__file__).parent / "sample.txt").open("rb") as fobj:
+        content = fobj.read()
+        fobj.seek(0)
+
+        async def handler_0(request: web.Request):
+            req_data = await request.post()
+            assert req_data["sample.txt"].file.read() == content
+            raise web.HTTPPermanentRedirect("/1")
+
+        async def handler_1(request: web.Request) -> web.Response:
+            req_data = await request.post()
+            assert req_data["sample.txt"].file.read() == content
+            return web.Response()
+
+        app = web.Application()
+        app.router.add_post("/0", handler_0)
+        app.router.add_post("/1", handler_1)
+
+        client = await aiohttp_client(app)
+
+        data = FormData()
+        data._gen_form_data = mock.Mock(wraps=data._gen_form_data)
+        data.add_field("sample.txt", fobj)
+
+        resp = await client.post("/0", data=data)
+        assert len(data._writer._parts) == 1
+        assert resp.status == 200
+
+        resp.release()
+
+
+async def test_streaming_tarfile_on_redirect(aiohttp_client: AiohttpClient) -> None:
+    data = b"This is a tar file payload text file."
+
+    async def handler_0(request: web.Request):
+        await request.read()
+        raise web.HTTPPermanentRedirect("/1")
+
+    async def handler_1(request: web.Request) -> web.Response:
+        await request.read()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/0", handler_0)
+    app.router.add_post("/1", handler_1)
+
+    client = await aiohttp_client(app)
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        ti = tarfile.TarInfo(name="payload1.txt")
+        ti.size = len(data)
+        tf.addfile(tarinfo=ti, fileobj=io.BytesIO(data))
+
+    # Streaming tarfile.
+    buf.seek(0)
+    tf = tarfile.open(fileobj=buf, mode="r|")
+    for entry in tf:
+        with pytest.raises(ClientConnectionError) as exc_info:
+            await client.post("/0", data=tf.extractfile(entry))
+        cause_exc = exc_info._excinfo[1].__cause__
+        assert isinstance(cause_exc, RuntimeError)
+        assert len(cause_exc.args) == 1
+        assert cause_exc.args[0].startswith("Non-seekable IO payload")

--- a/tests/test_formdata.py
+++ b/tests/test_formdata.py
@@ -114,9 +114,10 @@ async def test_formdata_on_redirect(aiohttp_client: AiohttpClient) -> None:
 
         async def handler_1(request: web.Request) -> web.Response:
             req_data = await request.post()
-            target_file = req_data["sample.txt"]
-            assert isinstance(tarfile, web.FileField)
-            assert target_file.file.read() == content
+            assert ["sample.txt"] == list(req_data.keys())
+            file_field = req_data["sample.txt"]
+            assert isinstance(file_field, web.FileField)
+            assert content == file_field.file.read()
             return web.Response()
 
         app = web.Application()
@@ -142,16 +143,18 @@ async def test_formdata_on_redirect_after_recv(aiohttp_client: AiohttpClient) ->
 
         async def handler_0(request: web.Request) -> web.Response:
             req_data = await request.post()
-            target_file = req_data["sample.txt"]
-            assert isinstance(tarfile, web.FileField)
-            assert target_file.file.read() == content
+            assert ["sample.txt"] == list(req_data.keys())
+            file_field = req_data["sample.txt"]
+            assert isinstance(file_field, web.FileField)
+            assert content == file_field.file.read()
             raise web.HTTPPermanentRedirect("/1")
 
         async def handler_1(request: web.Request) -> web.Response:
             req_data = await request.post()
-            target_file = req_data["sample.txt"]
-            assert isinstance(tarfile, web.FileField)
-            assert target_file.file.read() == content
+            assert ["sample.txt"] == list(req_data.keys())
+            file_field = req_data["sample.txt"]
+            assert isinstance(file_field, web.FileField)
+            assert content == file_field.file.read()
             return web.Response()
 
         app = web.Application()

--- a/tests/test_formdata.py
+++ b/tests/test_formdata.py
@@ -231,7 +231,7 @@ async def test_nonseekable_text_io_on_redirect(aiohttp_client: AiohttpClient) ->
 
         f = getattr(temp_file, "_file")
         assert isinstance(f, io.TextIOBase)
-        with mock.patch.object(f, "seek", side_effect=OSError):
+        with mock.patch.object(f, "seekable", return_value=False):
             with pytest.raises(ClientConnectionError) as exc_info:
                 await client.post("/0", data=f)
             raw_exc_info = exc_info._excinfo

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1426,9 +1426,7 @@ class TestMultipartWriter:
         self, buf: bytearray, stream: Stream
     ) -> None:
         with aiohttp.MultipartWriter("form-data", boundary=":") as writer:
-            with pathlib.Path(pathlib.Path(__file__).parent / "sample.txt").open(
-                "rb"
-            ) as fobj:
+            with pathlib.Path(__file__).with_name("sample.txt").open("rb") as fobj:
                 content = fobj.read()
                 fobj.seek(0)
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1422,7 +1422,9 @@ class TestMultipartWriter:
             b' attachments; filename="bug.py"'
         )
 
-    async def test_multiple_write_on_io_payload(self, buf: bytearray, stream: Stream):
+    async def test_multiple_write_on_io_payload(
+        self, buf: bytearray, stream: Stream
+    ) -> None:
         with aiohttp.MultipartWriter("form-data", boundary=":") as writer:
             with pathlib.Path(pathlib.Path(__file__).parent / "sample.txt").open(
                 "rb"

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -153,10 +153,6 @@ def test_async_iterable_payload_not_async_iterable() -> None:
         payload.AsyncIterablePayload(object())  # type: ignore[arg-type]
 
 
-async def write_mock(*args, **kwargs) -> None:
-    pass
-
-
 async def test_string_io_payload_write() -> None:
     content = "ű" * 5000
 
@@ -165,7 +161,7 @@ async def test_string_io_payload_write() -> None:
 
     with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
         instance = mock_obj.return_value
-        instance.write = mock.Mock(write_mock)
+        instance.write = mock.AsyncMock()
 
         await p.write(instance)
         instance.write.assert_called_once_with(content.encode("utf-8"))
@@ -186,7 +182,7 @@ async def test_text_io_payload_write() -> None:
 
         with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
             instance = mock_obj.return_value
-            instance.write = mock.Mock(write_mock)
+            instance.write = mock.AsyncMock()
 
             await p.write(instance)
             instance.write.assert_called_once_with(content.encode("utf-8"))  # 1 chunk
@@ -207,7 +203,7 @@ async def test_bytes_io_payload_write() -> None:
 
             with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
                 instance = mock_obj.return_value
-                instance.write = mock.Mock(write_mock)
+                instance.write = mock.AsyncMock()
 
                 await p.write(instance)
                 instance.write.assert_called_once_with(content)  # 1 chunk
@@ -228,7 +224,7 @@ async def test_buffered_reader_payload_write() -> None:
 
         with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
             instance = mock_obj.return_value
-            instance.write = mock.Mock(write_mock)
+            instance.write = mock.AsyncMock()
 
             await p.write(instance)
             instance.write.assert_called_once_with(content)  # 1 chunk

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1,6 +1,8 @@
 import array
-from io import StringIO
+import io
+import pathlib
 from typing import Any, AsyncIterator, Iterator
+from unittest import mock
 
 import pytest
 
@@ -92,11 +94,40 @@ def test_string_payload() -> None:
 
 
 def test_string_io_payload() -> None:
-    s = StringIO("ű" * 5000)
+    s = io.StringIO("ű" * 5000)
     p = payload.StringIOPayload(s)
     assert p.encoding == "utf-8"
     assert p.content_type == "text/plain; charset=utf-8"
     assert p.size == 10000
+
+
+def test_text_io_payload() -> None:
+    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    filesize = filepath.stat().st_size
+    with filepath.open("r") as f:
+        p = payload.TextIOPayload(f)
+        assert p.encoding == "utf-8"
+        assert p.content_type == "text/plain; charset=utf-8"
+        assert p.size == filesize
+        assert not f.closed
+
+
+def test_bytes_io_payload() -> None:
+    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    filesize = filepath.stat().st_size
+    with filepath.open("rb") as f:
+        p = payload.BytesIOPayload(f)
+        assert p.size == filesize
+        assert not f.closed
+
+
+def test_buffered_reader_payload() -> None:
+    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    filesize = filepath.stat().st_size
+    with filepath.open("rb") as f:
+        p = payload.BufferedReaderPayload(f)
+        assert p.size == filesize
+        assert not f.closed
 
 
 def test_async_iterable_payload_default_content_type() -> None:
@@ -120,3 +151,89 @@ def test_async_iterable_payload_explicit_content_type() -> None:
 def test_async_iterable_payload_not_async_iterable() -> None:
     with pytest.raises(TypeError):
         payload.AsyncIterablePayload(object())  # type: ignore[arg-type]
+
+
+async def write_mock(*args, **kwargs):
+    pass
+
+
+async def test_string_io_payload_write() -> None:
+    content = "ű" * 5000
+
+    s = io.StringIO(content)
+    p = payload.StringIOPayload(s)
+
+    with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
+        instance = mock_obj.return_value
+        instance.write = mock.Mock(write_mock)
+
+        await p.write(instance)
+        instance.write.assert_called_once_with(content.encode("utf-8"))
+
+        instance.write.reset_mock()
+
+        await p.write(instance)
+        instance.write.assert_called_once_with(content.encode("utf-8"))
+
+
+async def test_text_io_payload_write() -> None:
+    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    with filepath.open("r") as f:
+        content = f.read()
+        f.seek(0)
+
+        p = payload.TextIOPayload(f)
+
+        with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
+            instance = mock_obj.return_value
+            instance.write = mock.Mock(write_mock)
+
+            await p.write(instance)
+            instance.write.assert_called_once_with(content.encode("utf-8"))  # 1 chunk
+
+            instance.write.reset_mock()
+
+            await p.write(instance)
+            instance.write.assert_called_once_with(content.encode("utf-8"))  # 1 chunk
+
+
+async def test_bytes_io_payload_write() -> None:
+    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    with filepath.open("rb") as f:
+        content = f.read()
+        with io.BytesIO(content) as bf:
+
+            p = payload.BytesIOPayload(bf)
+
+            with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
+                instance = mock_obj.return_value
+                instance.write = mock.Mock(write_mock)
+
+                await p.write(instance)
+                instance.write.assert_called_once_with(content)  # 1 chunk
+
+                instance.write.reset_mock()
+
+                await p.write(instance)
+                instance.write.assert_called_once_with(content)  # 1 chunk
+
+
+async def test_buffered_reader_payload_write() -> None:
+    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    with filepath.open("rb") as f:
+        content = f.read()
+        f.seek(0)
+
+        p = payload.BufferedReaderPayload(f)
+
+        with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
+            instance = mock_obj.return_value
+            instance.write = mock.Mock(write_mock)
+
+            await p.write(instance)
+            instance.write.assert_called_once_with(content)  # 1 chunk
+
+            instance.write.reset_mock()
+
+            await p.write(instance)
+            instance.write.assert_called_once_with(content)  # 1 chunk

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -188,6 +188,10 @@ async def test_io_base_payload_write() -> None:
 
             assert p.decode() == content.decode()
 
+            p._seekable = False
+            assert p.decode() == ""
+            p._seekable = True
+
             with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
                 instance = mock_obj.return_value
                 instance.write = mock.AsyncMock()
@@ -210,6 +214,10 @@ async def test_text_io_payload_write() -> None:
         p = payload.TextIOPayload(f)
 
         assert p.decode() == content
+
+        p._seekable = False
+        assert p.decode() == ""
+        p._seekable = True
 
         with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
             instance = mock_obj.return_value
@@ -234,6 +242,10 @@ async def test_bytes_io_payload_write() -> None:
 
             assert p.decode() == content.decode()
 
+            p._seekable = False
+            assert p.decode() == ""
+            p._seekable = True
+
             with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
                 instance = mock_obj.return_value
                 instance.write = mock.AsyncMock()
@@ -256,6 +268,10 @@ async def test_buffered_reader_payload_write() -> None:
         p = payload.BufferedReaderPayload(f)
 
         assert p.decode() == content.decode()
+
+        p._seekable = False
+        assert p.decode() == ""
+        p._seekable = True
 
         with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
             instance = mock_obj.return_value

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -118,6 +118,10 @@ def test_bytes_io_payload() -> None:
     with filepath.open("rb") as f:
         p = payload.BytesIOPayload(f)
         assert p.size == filesize
+
+        p._seekable = False
+        assert p.size is None
+
         assert not f.closed
 
 
@@ -159,6 +163,8 @@ async def test_string_io_payload_write() -> None:
     s = io.StringIO(content)
     p = payload.StringIOPayload(s)
 
+    assert p.decode() == content
+
     with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
         instance = mock_obj.return_value
         instance.write = mock.AsyncMock()
@@ -179,6 +185,8 @@ async def test_text_io_payload_write() -> None:
         f.seek(0)
 
         p = payload.TextIOPayload(f)
+
+        assert p.decode() == content
 
         with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
             instance = mock_obj.return_value
@@ -201,6 +209,8 @@ async def test_bytes_io_payload_write() -> None:
 
             p = payload.BytesIOPayload(bf)
 
+            assert p.decode() == content.decode()
+
             with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
                 instance = mock_obj.return_value
                 instance.write = mock.AsyncMock()
@@ -221,6 +231,8 @@ async def test_buffered_reader_payload_write() -> None:
         f.seek(0)
 
         p = payload.BufferedReaderPayload(f)
+
+        assert p.decode() == content.decode()
 
         with mock.patch("aiohttp.http_writer.StreamWriter") as mock_obj:
             instance = mock_obj.return_value

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -153,7 +153,7 @@ def test_async_iterable_payload_not_async_iterable() -> None:
         payload.AsyncIterablePayload(object())  # type: ignore[arg-type]
 
 
-async def write_mock(*args, **kwargs):
+async def write_mock(*args, **kwargs) -> None:
     pass
 
 

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1,6 +1,6 @@
 import array
 import io
-import pathlib
+from pathlib import Path
 from typing import Any, AsyncIterator, Iterator
 from unittest import mock
 
@@ -102,7 +102,7 @@ def test_string_io_payload() -> None:
 
 
 def test_text_io_payload() -> None:
-    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    filepath = Path(__file__).with_name("sample.txt")
     filesize = filepath.stat().st_size
     with filepath.open("r") as f:
         p = payload.TextIOPayload(f)
@@ -113,7 +113,7 @@ def test_text_io_payload() -> None:
 
 
 def test_bytes_io_payload() -> None:
-    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    filepath = Path(__file__).with_name("sample.txt")
     filesize = filepath.stat().st_size
     with filepath.open("rb") as f:
         p = payload.BytesIOPayload(f)
@@ -126,7 +126,7 @@ def test_bytes_io_payload() -> None:
 
 
 def test_buffered_reader_payload() -> None:
-    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    filepath = Path(__file__).with_name("sample.txt")
     filesize = filepath.stat().st_size
     with filepath.open("rb") as f:
         p = payload.BufferedReaderPayload(f)
@@ -179,7 +179,7 @@ async def test_string_io_payload_write() -> None:
 
 
 async def test_io_base_payload_write() -> None:
-    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    filepath = Path(__file__).with_name("sample.txt")
     with filepath.open("rb") as f:
         content = f.read()
         with io.BytesIO(content) as bf:
@@ -206,7 +206,7 @@ async def test_io_base_payload_write() -> None:
 
 
 async def test_text_io_payload_write() -> None:
-    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    filepath = Path(__file__).with_name("sample.txt")
     with filepath.open("r") as f:
         content = f.read()
         f.seek(0)
@@ -233,7 +233,7 @@ async def test_text_io_payload_write() -> None:
 
 
 async def test_bytes_io_payload_write() -> None:
-    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    filepath = Path(__file__).with_name("sample.txt")
     with filepath.open("rb") as f:
         content = f.read()
         with io.BytesIO(content) as bf:
@@ -260,7 +260,7 @@ async def test_bytes_io_payload_write() -> None:
 
 
 async def test_buffered_reader_payload_write() -> None:
-    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    filepath = Path(__file__).with_name("sample.txt")
     with filepath.open("rb") as f:
         content = f.read()
         f.seek(0)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fix 'I/O operation on closed file' and 'Form data has been processed already' upon redirect on multipart data, based on the discussion in #6853 .

This approach tries to pre-build Payload object for the data passing into the request, before the redirect `while True` loop starts, so we can reuse the same Payload object for the entire redirect chain. However, it is notable that I/O object is always an issue, so my thought here is to use the `seek` operation on the I/O object to allow chunk writing on redirect requests.

Yet, for non-seekable I/O objects, some possible solution are:

- sending expect 100 first
- local buffering
- raise error

I think more discussion might be needed for non-seekable objects, so I just raise error in this PR first.

Another thing I think worth discussion is that I removed the `close()` operation on the I/O object in this PR due to the following reasons:

- `StringIOPayload` do not `close` its I/O value in the original code,
- Closing of the I/O value will make the payload un-reusable, even if it is seekable
- We are not the one to create the I/O value, so maybe we should leave for user to close it.
- standard I/O object will be closed upon destructure, so it won't affect the user interface

But I do think more discussions might be needed here.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No.

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

Yes.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

Fixes #5577 
Fixes #5530

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
