### PR TITLE
Implement heapq for cookie expire times

### DIFF
--- a/CHANGES/9203.misc.rst
+++ b/CHANGES/9203.misc.rst
@@ -1,0 +1,3 @@
+Significantly improved performance of expiring cookies -- by :user:`bdraco`.
+
+Expiring cookies has been redesigned to use :mod:`heapq` instead of a linear search, to better scale.

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -159,7 +159,10 @@ class CookieJar(AbstractCookieJar):
         return sum(len(cookie.values()) for cookie in self._cookies.values())
 
     def _cleanup_expirations(self) -> None:
-        """Remove expired entries from the expiration heap."""
+        """Remove expired entries from the expiration heap.
+
+        This method is called when the expiration heap grows too large.
+        """
         self._expire_heap = [
             entry
             for entry in self._expire_heap

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -107,9 +107,8 @@ class CookieJar(AbstractCookieJar):
                     for url in treat_as_secure_origin
                 }
             )
-        self._expirations: Dict[Tuple[str, str, str], float] = {}
-        # heap of cookies by expiration time
         self._expire_heap: List[Tuple[float, str, str, str]] = []
+        self._expirations: Dict[Tuple[str, str, str], float] = {}
 
     def save(self, file_path: PathLike) -> None:
         file_path = pathlib.Path(file_path)
@@ -123,10 +122,10 @@ class CookieJar(AbstractCookieJar):
 
     def clear(self, predicate: Optional[ClearCookiePredicate] = None) -> None:
         if predicate is None:
+            self._expire_heap.clear()
             self._cookies.clear()
             self._host_only_cookies.clear()
             self._expirations.clear()
-            self._expire_heap.clear()
             return
 
         now = time.time()
@@ -193,8 +192,8 @@ class CookieJar(AbstractCookieJar):
             self._expirations.pop((domain, path, name), None)
 
     def _expire_cookie(self, when: float, domain: str, path: str, name: str) -> None:
-        self._expirations[(domain, path, name)] = when
         heapq.heappush(self._expire_heap, (when, domain, path, name))
+        self._expirations[(domain, path, name)] = when
 
     def update_cookies(self, cookies: LooseCookies, response_url: URL = URL()) -> None:
         """Update cookies."""

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -179,6 +179,8 @@ class CookieJar(AbstractCookieJar):
         ):
             # Remove any expired entries from the expiration heap
             # that do not match the expiration time in the expirations
+            # as it means the cookie has been re-added to the heap
+            # with a different expiration time.
             self._expire_heap = [
                 entry
                 for entry in self._expire_heap

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -41,6 +41,11 @@ CookieItem = Union[str, "Morsel[str]"]
 _FORMAT_PATH = "{}/{}".format
 _FORMAT_DOMAIN_REVERSED = "{1}.{0}".format
 
+# The minimum number of scheduled cookie expirations before we start cleaning up
+# the expiration heap. This is a performance optimization to avoid cleaning up the
+# heap too often when there are only a few scheduled expirations.
+_MIN_SCHEDULED_COOKIE_EXPIRATION = 100
+
 
 class CookieJar(AbstractCookieJar):
     """Implements cookie storage adhering to RFC 6265."""
@@ -176,7 +181,10 @@ class CookieJar(AbstractCookieJar):
         if not expire_heap_len:
             return
 
-        if expire_heap_len > 100 and expire_heap_len > len(self._expirations) * 2:
+        if (
+            expire_heap_len > _MIN_SCHEDULED_COOKIE_EXPIRATION
+            and expire_heap_len > len(self._expirations) * 2
+        ):
             self._cleanup_expirations()
 
         now = time.time()

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -181,6 +181,11 @@ class CookieJar(AbstractCookieJar):
         if not expire_heap_len:
             return
 
+        # If the expiration heap grows larger than the number expirations
+        # times two, we clean it up to avoid keeping expired entries in
+        # the heap and consuming memory. We guard this with a minimum
+        # threshold to avoid cleaning up the heap too often when there are
+        # only a few scheduled expirations.
         if (
             expire_heap_len > _MIN_SCHEDULED_COOKIE_EXPIRATION
             and expire_heap_len > len(self._expirations) * 2
@@ -189,6 +194,7 @@ class CookieJar(AbstractCookieJar):
 
         now = time.time()
         to_del: List[Tuple[str, str, str]] = []
+        # Find any expired cookies and add them to the to-delete list
         while self._expire_heap:
             when, cookie_key = self._expire_heap[0]
             if when > now:

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -168,17 +168,18 @@ class CookieJar(AbstractCookieJar):
 
         This method is called when the expiration heap grows too large.
         """
+        # Remove any expired entries from the expiration heap
+        # that do not match the expiration time in the expirations
         self._expire_heap = [
             entry
             for entry in self._expire_heap
-            if self._expirations.get(entry[1]) != entry[0]
+            if self._expirations.get(entry[1]) == entry[0]
         ]
         heapq.heapify(self._expire_heap)
 
     def _do_expiration(self) -> None:
         """Remove expired cookies."""
-        expire_heap_len = len(self._expire_heap)
-        if not expire_heap_len:
+        if not (expire_heap_len := len(self._expire_heap)):
             return
 
         # If the expiration heap grows larger than the number expirations

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -163,20 +163,6 @@ class CookieJar(AbstractCookieJar):
         """
         return sum(len(cookie.values()) for cookie in self._cookies.values())
 
-    def _cleanup_expirations(self) -> None:
-        """Remove expired entries from the expiration heap.
-
-        This method is called when the expiration heap grows too large.
-        """
-        # Remove any expired entries from the expiration heap
-        # that do not match the expiration time in the expirations
-        self._expire_heap = [
-            entry
-            for entry in self._expire_heap
-            if self._expirations.get(entry[1]) == entry[0]
-        ]
-        heapq.heapify(self._expire_heap)
-
     def _do_expiration(self) -> None:
         """Remove expired cookies."""
         if not (expire_heap_len := len(self._expire_heap)):
@@ -191,7 +177,13 @@ class CookieJar(AbstractCookieJar):
             expire_heap_len > _MIN_SCHEDULED_COOKIE_EXPIRATION
             and expire_heap_len > len(self._expirations) * 2
         ):
-            self._cleanup_expirations()
+            # Remove any expired entries from the expiration heap
+            # that do not match the expiration time in the expirations
+            self._expire_heap = [
+                entry
+                for entry in self._expire_heap
+                if self._expirations.get(entry[1]) == entry[0]
+            ]
 
         now = time.time()
         to_del: List[Tuple[str, str, str]] = []

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -186,6 +186,7 @@ class CookieJar(AbstractCookieJar):
                 for entry in self._expire_heap
                 if self._expirations.get(entry[1]) == entry[0]
             ]
+            heapq.heapify(self._expire_heap)
 
         now = time.time()
         to_del: List[Tuple[str, str, str]] = []

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -191,6 +191,9 @@ class CookieJar(AbstractCookieJar):
 
     def _expire_cookie(self, when: float, domain: str, path: str, name: str) -> None:
         cookie_key = (domain, path, name)
+        if self._expirations.get(cookie_key) == when:
+            # Avoid adding duplicates to the heap
+            return
         heapq.heappush(self._expire_heap, (when, cookie_key))
         self._expirations[cookie_key] = when
 

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -937,7 +937,7 @@ async def test_cookie_jar_expired_changes() -> None:
 
 
 async def test_cookie_jar_duplicates_with_expire_heap() -> None:
-    """Test that duplicate cookies to not grow the expires heap."""
+    """Test that duplicate cookies do not grow the expires heap."""
     jar = CookieJar()
 
     cookie_eleven_am = SimpleCookie()

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -876,9 +876,10 @@ async def test_cookie_jar_clear_expired() -> None:
     with freeze_time("1980-01-01"):
         sut.update_cookies(cookie)
 
-    sut.clear(lambda x: False)
-    with freeze_time("1980-01-01"):
-        assert len(sut) == 0
+    for _ in range(2):
+        sut.clear(lambda x: False)
+        with freeze_time("1980-01-01"):
+            assert len(sut) == 0
 
 
 async def test_cookie_jar_filter_cookies_expires() -> None:

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -5,6 +5,7 @@ import itertools
 import pickle
 import unittest
 from http.cookies import BaseCookie, Morsel, SimpleCookie
+from operator import not_
 from pathlib import Path
 from typing import List, Set, Tuple, Union
 from unittest import mock
@@ -878,7 +879,7 @@ async def test_cookie_jar_clear_expired() -> None:
         sut.update_cookies(cookie)
 
     for _ in range(2):
-        sut.clear(lambda x: False)
+        sut.clear(not_)
         with freeze_time("1980-01-01"):
             assert len(sut) == 0
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Implement heapq for cookie expire times

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?

heapq is a bit of a complex structure to maintain

## Related issue number
fixes #8575
fixes #7790

benchmark script (we care about the `filter_other_domain` case for expires and that still includes the filtering time so its actually even faster): https://github.com/aio-libs/aiohttp/issues/7790#issuecomment-1807262618

Before
filter_other_domain: 0.451234458014369

After
filter_other_domain: 0.0018771658651530743

note that profile is not exactly the same number of iterations since its using a real world use case of 60s and its hard to get it exactly the same (1644 before) / (1413 after) but its such a significant difference, its more than enough to show the performance improvement of ~96-97% less run time (adjusted ratio for the iterations):

before
![do_expiration_before](https://github.com/user-attachments/assets/224b5a56-227d-4682-931f-bca705aa67c3)


after
![do_expiration_after](https://github.com/user-attachments/assets/5964980e-324d-4f6e-850e-a9c31084c51f)
