### PR TITLE
Small cleanup to should_close in client_proto

### DIFF
--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -54,15 +54,13 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
 
     @property
     def should_close(self) -> bool:
-        if self._payload is not None and not self._payload.is_eof():
-            return True
-
         return (
             self._should_close
+            or (self._payload is not None and not self._payload.is_eof())
             or self._upgraded
-            or self.exception() is not None
+            or self._exception is not None
             or self._payload_parser is not None
-            or len(self) > 0
+            or bool(self._buffer)
             or bool(self._tail)
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Cleanup `should_close` so its the same on `master` and `3.x`

It was starting to diverge a bit on 3.10 with `self._upgraded` checked twice

https://github.com/aio-libs/aiohttp/blob/00e06f038c99f1236af5f632b9d15ebf262aa679/aiohttp/client_proto.py#L53
https://github.com/aio-libs/aiohttp/blob/00e06f038c99f1236af5f632b9d15ebf262aa679/aiohttp/client_proto.py#L58

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no