### PR TITLE
[PR #9018/63813fe backport][3.11] Reject data after close message

### DIFF
--- a/CHANGES/9018.bugfix.rst
+++ b/CHANGES/9018.bugfix.rst
@@ -1,0 +1,1 @@
+Updated Python parser to reject messages after a close message, matching C parser behaviour -- by :user:`Dreamsorcerer`.

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -17,6 +17,7 @@ from aiohttp.http_parser import (
     NO_EXTENSIONS,
     DeflateBuffer,
     HttpPayloadParser,
+    HttpRequestParser,
     HttpRequestParserPy,
     HttpResponseParserPy,
     HttpVersion,
@@ -826,7 +827,15 @@ def test_http_request_bad_status_line_whitespace(parser: Any) -> None:
         parser.feed_data(text)
 
 
-def test_http_request_upgrade(parser: Any) -> None:
+def test_http_request_message_after_close(parser: HttpRequestParser) -> None:
+    text = b"GET / HTTP/1.1\r\nConnection: close\r\n\r\nInvalid\r\n\r\n"
+    with pytest.raises(
+        http_exceptions.BadHttpMessage, match="Data after `Connection: close`"
+    ):
+        parser.feed_data(text)
+
+
+def test_http_request_upgrade(parser: HttpRequestParser) -> None:
     text = (
         b"GET /test HTTP/1.1\r\n"
         b"connection: upgrade\r\n"


### PR DESCRIPTION
Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
(cherry picked from commit 63813fe5f6d115c98beb180ddefb8cdc1b201b74)
