### PR TITLE
Remove duplicate checks in the StreamWriter

### DIFF
--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -71,8 +71,8 @@ class StreamWriter(AbstractStreamWriter):
         size = len(chunk)
         self.buffer_size += size
         self.output_size += size
-        transport = self.transport
-        if not self._protocol.connected or transport is None or transport.is_closing():
+        transport = self._protocol.transport
+        if transport is None or transport.is_closing():
             raise ClientConnectionResetError("Cannot write to closing transport")
         transport.write(chunk)
 


### PR DESCRIPTION
Calling [self._protocol.connected is a check to see if self._protocol.transport is not None](https://github.com/aio-libs/aiohttp/blob/3c1ca45515b766ceb8bbbd8d710096c03106dd38/aiohttp/base_protocol.py#L28). Since we already check that, only do it once
