### PR TITLE
Release 3.10.6rc1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,24 @@
 
 .. towncrier release notes start
 
+3.10.6rc1 (2024-09-22)
+======================
+
+Removals and backward incompatible breaking changes
+---------------------------------------------------
+
+- Increased minimum yarl version to 1.12.0 -- by :user:`bdraco`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`9267`.
+
+
+
+
+----
+
+
 3.10.6rc0 (2024-09-22)
 ======================
 

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.10.6rc0"
+__version__ = "3.10.6rc1"
 
 from typing import TYPE_CHECKING, Tuple
 


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/actions/runs/11003276126

rc1 to fix https://github.com/aio-libs/aiohttp/pull/9267 requires yarl 1.12.0+

<img width="734" alt="Screenshot 2024-09-23 at 5 15 15 PM" src="https://github.com/user-attachments/assets/f0ff20d4-cc86-41ea-ba1d-0d43595931f0">
