### PR TITLE
Release 3.10.6rc2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,15 @@
 
 .. towncrier release notes start
 
+3.10.6rc2 (2024-09-23)
+======================
+
+No significant changes.
+
+
+----
+
+
 3.10.6rc1 (2024-09-22)
 ======================
 

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.10.6rc1"
+__version__ = "3.10.6rc2"
 
 from typing import TYPE_CHECKING, Tuple
 


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/actions/runs/11005244436

3.10.6rc1 failed to fully upload as GitHub flaked out. This is a no change release.
