### PR TITLE
Increase default keepalive_timeout server-side.

### DIFF
--- a/CHANGES/9285.misc.rst
+++ b/CHANGES/9285.misc.rst
@@ -1,0 +1,1 @@
+Changed web ``keepalive_timeout`` default to around an hour in order to reduce race conditions on reverse proxies -- by :user:`Dreamsorcerer`.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -189,7 +189,8 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         manager: "Server[_Request]",
         *,
         loop: asyncio.AbstractEventLoop,
-        keepalive_timeout: float = 75.0,  # NGINX default is 75 secs
+        # Default should be high enough that it's likely longer than a reverse proxy.
+        keepalive_timeout: float = 3630,
         tcp_keepalive: bool = True,
         logger: Logger = server_logger,
         access_log_class: _AnyAbstractAccessLogger = AccessLogger,

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2609,7 +2609,9 @@ application on specific TCP or Unix socket, e.g.::
 
    :param bool tcp_keepalive: Enable TCP Keep-Alive. Default: ``True``.
    :param int keepalive_timeout: Number of seconds before closing Keep-Alive
-        connection. Default: ``75`` seconds (NGINX's default value).
+        connection. Default: ``3630`` seconds (when deployed behind a reverse proxy
+        it's important for this value to be higher than the proxy's timeout. To avoid
+        race conditions we always want the proxy to close the connection).
    :param logger: Custom logger object. Default:
         :data:`aiohttp.log.server_logger`.
    :param access_log: Custom logging object. Default:
@@ -2844,7 +2846,7 @@ Utilities
 
 .. function:: run_app(app, *, debug=False, host=None, port=None, \
                       path=None, sock=None, shutdown_timeout=60.0, \
-                      keepalive_timeout=75.0, ssl_context=None, \
+                      keepalive_timeout=3630, ssl_context=None, \
                       print=print, backlog=128, \
                       access_log_class=aiohttp.helpers.AccessLogger, \
                       access_log_format=aiohttp.helpers.AccessLogger.LOG_FORMAT, \
@@ -2912,6 +2914,12 @@ Utilities
    :param float keepalive_timeout: a delay before a TCP connection is
                                    closed after a HTTP request. The delay
                                    allows for reuse of a TCP connection.
+
+                                   When deployed behind a reverse proxy
+                                   it's important for this value to be
+                                   higher than the proxy's timeout. To avoid
+                                   race conditions, we always want the proxy
+                                   to handle connection closing.
 
       .. versionadded:: 3.8
 


### PR DESCRIPTION
As we strongly recommend deploying apps behind a reverse proxy it makes sense to optimise the defaults for this use case.

When using a reverse proxy it's important to have a longer timeout than the proxy's timeout, otherwise we likely hit race conditions with the proxy trying to forward another request as we close the connection.

For proxies, it'd probably make the most sense to actually remove the timeout entirely, but for users without proxies the defaults should still be safe, therefore I'm proposing to just make it substantially longer by default.

I expect the vast majority of proxies to have a keepalive of 1 hour or less, so have chosen a value just over the 1 hour mark (for reference, nginx defaults to 75 seconds, ALB to 1 hour).

See #9138