### PR TITLE
[PR #9083/a6dd415 backport][3.10] Remove unused backwards compatibility code for old yarl versions

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -27,7 +27,7 @@ from typing import (
 
 import attr
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
-from yarl import URL, __version__ as yarl_version
+from yarl import URL
 
 from . import hdrs, helpers, http, multipart, payload
 from .abc import AbstractStreamWriter
@@ -89,7 +89,6 @@ if TYPE_CHECKING:
 
 
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
-_YARL_SUPPORTS_EXTEND_QUERY = tuple(map(int, yarl_version.split(".")[:2])) >= (1, 11)
 json_re = re.compile(r"^application/(?:[\w.+-]+?\+)?json")
 
 
@@ -303,13 +302,7 @@ class ClientRequest:
         # assert session is not None
         self._session = cast("ClientSession", session)
         if params:
-            if _YARL_SUPPORTS_EXTEND_QUERY:
-                url = url.extend_query(params)
-            else:
-                q = MultiDict(url.query)
-                url2 = url.with_query(params)
-                q.extend(url2.query)
-                url = url.with_query(q)
+            url = url.extend_query(params)
         self.original_url = url
         self.url = url.with_fragment(None)
         self.method = method.upper()

--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -8,23 +8,12 @@ from typing import (
     Iterable,
     Mapping,
     Protocol,
-    Sequence,
     Tuple,
     Union,
 )
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy, istr
-from yarl import URL
-
-try:
-    # Available in yarl>=1.10.0
-    from yarl import Query as _Query
-except ImportError:  # pragma: no cover
-    SimpleQuery = Union[str, int, float]  # pragma: no cover
-    QueryVariable = Union[SimpleQuery, "Sequence[SimpleQuery]"]  # pragma: no cover
-    _Query = Union[  # type: ignore[misc]  # pragma: no cover
-        None, str, "Mapping[str, QueryVariable]", "Sequence[Tuple[str, QueryVariable]]"
-    ]
+from yarl import URL, Query as _Query
 
 Query = _Query
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -20,7 +20,7 @@ from multidict import MultiDict
 from yarl import URL
 
 import aiohttp
-from aiohttp import Fingerprint, ServerFingerprintMismatch, client_reqrep, hdrs, web
+from aiohttp import Fingerprint, ServerFingerprintMismatch, hdrs, web
 from aiohttp.abc import AbstractResolver
 from aiohttp.client_exceptions import (
     ClientResponseError,
@@ -676,10 +676,7 @@ async def test_str_params(aiohttp_client) -> None:
         assert 200 == resp.status
 
 
-@pytest.mark.parametrize("yarl_supports_extend_query", [True, False])
-async def test_params_and_query_string(
-    aiohttp_client: AiohttpClient, yarl_supports_extend_query: bool
-) -> None:
+async def test_params_and_query_string(aiohttp_client: AiohttpClient) -> None:
     """Test combining params with an existing query_string."""
 
     async def handler(request: web.Request) -> web.Response:
@@ -690,18 +687,13 @@ async def test_params_and_query_string(
     app.router.add_route("GET", "/", handler)
     client = await aiohttp_client(app)
 
-    # Ensure the old path is tested for old yarl versions
-    with mock.patch.object(
-        client_reqrep, "_YARL_SUPPORTS_EXTEND_QUERY", yarl_supports_extend_query
-    ):
-        async with client.get("/?q=abc", params="q=test&d=dog") as resp:
-            assert resp.status == 200
+    async with client.get("/?q=abc", params="q=test&d=dog") as resp:
+        assert resp.status == 200
 
 
 @pytest.mark.parametrize("params", [None, "", {}, MultiDict()])
-@pytest.mark.parametrize("yarl_supports_extend_query", [True, False])
 async def test_empty_params_and_query_string(
-    aiohttp_client: AiohttpClient, params: Any, yarl_supports_extend_query: bool
+    aiohttp_client: AiohttpClient, params: Any
 ) -> None:
     """Test combining empty params with an existing query_string."""
 
@@ -713,12 +705,8 @@ async def test_empty_params_and_query_string(
     app.router.add_route("GET", "/", handler)
     client = await aiohttp_client(app)
 
-    # Ensure the old path is tested for old yarl versions
-    with mock.patch.object(
-        client_reqrep, "_YARL_SUPPORTS_EXTEND_QUERY", yarl_supports_extend_query
-    ):
-        async with client.get("/?q=abc", params=params) as resp:
-            assert resp.status == 200
+    async with client.get("/?q=abc", params=params) as resp:
+        assert resp.status == 200
 
 
 async def test_drop_params_on_redirect(aiohttp_client: AiohttpClient) -> None:


### PR DESCRIPTION
(cherry picked from commit a6dd415a1401c82722aed12b86ab878e9afb017f)

We ended up bumping yarl to 1.12.0+ for `path_safe` so we can remove these compat shims