### PR TITLE
Avoid locking to compress when it can happen synchronously

### DIFF
--- a/CHANGES/9295.misc.rst
+++ b/CHANGES/9295.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of compressing small amount of data -- by :user:`bdraco`.

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -85,7 +85,7 @@ class ZLibCompressor(ZlibBaseHandler):
             # there are multiple writers, we need to lock
             # the compressor so that only one writer can
             # compress at a time.
-            return await asyncio.get_event_loop().run_in_executor(
+            return await asyncio.get_running_loop().run_in_executor(
                 self._executor, self.compress_sync, data
             )
 

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -632,14 +632,12 @@ class WebSocketWriter:
                     self._compressobj = self._make_compress_obj(self.compress)
                 compressobj = self._compressobj
 
-            message = await compressobj.compress(message)
+            flush_mode = zlib.Z_FULL_FLUSH if self.notakeover else zlib.Z_SYNC_FLUSH
+            message = await compressobj.compress(message, flush_mode)
             # Its critical that we do not return control to the event
             # loop until we have finished sending all the compressed
             # data. Otherwise we could end up mixing compressed frames
             # if there are multiple coroutines compressing data.
-            message += compressobj.flush(
-                zlib.Z_FULL_FLUSH if self.notakeover else zlib.Z_SYNC_FLUSH
-            )
             if message.endswith(_WS_DEFLATE_TRAILING):
                 message = message[:-4]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Avoid locking to compress when it can happen synchronously

If we are not going to await, there is no need to lock.  This is the most common case for WebSocket frames.



## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no

The locking was a non-trivial amount of the time
<img width="961" alt="Screenshot 2024-09-25 at 2 01 54 PM" src="https://github.com/user-attachments/assets/1fbc1a64-9d07-4163-b120-6d719b4dd1ad">
