### PR TITLE
Replace code that can now be handled by yarl

### DIFF
--- a/CHANGES/9301.misc.rst
+++ b/CHANGES/9301.misc.rst
@@ -1,0 +1,1 @@
+Replaced code that can now be handled by ``yarl`` -- by :user:`bdraco`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -93,7 +93,7 @@ if TYPE_CHECKING:
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 _YARL_SUPPORTS_HOST_SUBCOMPONENT = tuple(map(int, yarl_version.split(".")[:2])) >= (
     1,
-    11,
+    13,
 )
 
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -27,7 +27,7 @@ from typing import (
 )
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
-from yarl import URL
+from yarl import URL, __version__ as yarl_version
 
 from . import hdrs, helpers, http, multipart, payload
 from .abc import AbstractStreamWriter
@@ -91,6 +91,10 @@ if TYPE_CHECKING:
 
 
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
+_YARL_SUPPORTS_HOST_SUBCOMPONENT = tuple(map(int, yarl_version.split(".")[:2])) >= (
+    1,
+    11,
+)
 
 
 def _gen_default_accept_encoding() -> str:
@@ -356,9 +360,13 @@ class ClientRequest:
         self.headers: CIMultiDict[str] = CIMultiDict()
 
         # add host
-        netloc = cast(str, self.url.raw_host)
-        if helpers.is_ipv6_address(netloc):
-            netloc = f"[{netloc}]"
+        if _YARL_SUPPORTS_HOST_SUBCOMPONENT:
+            netloc = self.url.host_subcomponent
+            assert netloc is not None
+        else:
+            netloc = cast(str, self.url.raw_host)
+            if helpers.is_ipv6_address(netloc):
+                netloc = f"[{netloc}]"
         # See https://github.com/aio-libs/aiohttp/issues/3636.
         netloc = netloc.rstrip(".")
         if self.url.port is not None and not self.url.is_default_port():
@@ -606,17 +614,19 @@ class ClientRequest:
         # - not CONNECT proxy must send absolute form URI
         # - most common is origin form URI
         if self.method == hdrs.METH_CONNECT:
-            connect_host = self.url.raw_host
-            assert connect_host is not None
-            if helpers.is_ipv6_address(connect_host):
-                connect_host = f"[{connect_host}]"
+            if _YARL_SUPPORTS_HOST_SUBCOMPONENT:
+                connect_host = self.url.host_subcomponent
+                assert connect_host is not None
+            else:
+                connect_host = self.url.raw_host
+                assert connect_host is not None
+                if helpers.is_ipv6_address(connect_host):
+                    connect_host = f"[{connect_host}]"
             path = f"{connect_host}:{self.url.port}"
         elif self.proxy and not self.is_ssl():
             path = str(self.url)
         else:
-            path = self.url.raw_path
-            if self.url.raw_query_string:
-                path += "?" + self.url.raw_query_string
+            path = self.url.raw_path_qs
 
         protocol = conn.protocol
         assert protocol is not None

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -286,13 +286,13 @@ def test_host_header_ipv4(make_request: _RequestMaker) -> None:
 def test_host_header_ipv6(
     make_request: _RequestMaker, yarl_supports_host_subcomponent: bool
 ) -> None:
-    req = make_request("get", "http://[::2]")
     # Ensure the old path is tested for old yarl versions
     with mock.patch.object(
         client_reqrep,
         "_YARL_SUPPORTS_HOST_SUBCOMPONENT",
         yarl_supports_host_subcomponent,
     ):
+        req = make_request("get", "http://[::2]")
         assert req.headers["HOST"] == "[::2]"
 
 


### PR DESCRIPTION
Needs yarl bumped to 1.13.0+

<!-- Thank you for your contribution! -->

## What do these changes do?

- The manual join of the query string in ClientRequest.send can be replaced with url.raw_path_qs

- All the IPv6 bracket checks can be replaced with url.host_subcomponent with yarl 1.13.0+

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no