### PR TITLE
Increase minimum yarl requirement to 1.13.0

### DIFF
--- a/CHANGES/9305.breaking.rst
+++ b/CHANGES/9305.breaking.rst
@@ -1,0 +1,1 @@
+Increased minimum yarl version to 1.12.0 -- by :user:`bdraco`.

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -8,4 +8,4 @@ Brotli; platform_python_implementation == 'CPython'
 brotlicffi; platform_python_implementation != 'CPython'
 frozenlist >= 1.1.1
 multidict >=4.5, < 7.0
-yarl >= 1.12.0, < 2.0
+yarl >= 1.13.0, < 2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ install_requires =
   async-timeout >= 4.0, < 5.0 ; python_version < "3.11"
   frozenlist >= 1.1.1
   multidict >=4.5, < 7.0
-  yarl >= 1.12.0, < 2.0
+  yarl >= 1.13.0, < 2.0
 
 [options.exclude_package_data]
 * =


### PR DESCRIPTION
Increased minimum yarl version to 1.12.0 -- by :user:`bdraco`.

Will remove the compat checks in master and 3.11 after https://github.com/aio-libs/aiohttp/pull/9301 merges