### PR TITLE
Fix building the URL in BaseRequest when the host contains a port or IPv6 address

### DIFF
--- a/CHANGES/9309.bugfix.rst
+++ b/CHANGES/9309.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed assembling the :class:`~yarl.URL` for web requests when the host contains a non-default port or IPv6 address -- by :user:`bdraco`.

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -449,12 +449,9 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
     @reify
     def url(self) -> URL:
         """The full URL of the request."""
-        host, has_port, port = self.host.partition(":")
-        if has_port:
-            url = URL.build(scheme=self.scheme, host=host, port=port)
-        else:
-            url = URL.build(scheme=self.scheme, host=host)
-        return url.join(self._rel_url)
+        # authority is used here because it may include the port number
+        # and we want yarl to parse it correctly
+        return URL.build(scheme=self.scheme, authority=self.host).join(self._rel_url)
 
     @reify
     def path(self) -> str:

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -421,6 +421,10 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         - overridden value by .clone(host=new_host) call.
         - HOST HTTP header
         - socket.getfqdn() value
+
+        For example, 'example.com' or 'localhost:8080'.
+
+        For historical reasons, the port number may be included.
         """
         host = self._message.headers.get(hdrs.HOST)
         if host is not None:
@@ -444,7 +448,12 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
 
     @reify
     def url(self) -> URL:
-        url = URL.build(scheme=self.scheme, host=self.host)
+        """The full URL of the request."""
+        host, has_port, port = self.host.partition(":")
+        if has_port:
+            url = URL.build(scheme=self.scheme, host=host, port=port)
+        else:
+            url = URL.build(scheme=self.scheme, host=host)
         return url.join(self._rel_url)
 
     @reify

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -451,7 +451,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         """The full URL of the request."""
         host, has_port, port = self.host.partition(":")
         if has_port:
-            url = URL.build(scheme=self.scheme, host=host, port=port)
+            url = URL.build(scheme=self.scheme, host=host, port=int(port))
         else:
             url = URL.build(scheme=self.scheme, host=host)
         return url.join(self._rel_url)

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -507,6 +507,16 @@ def test_url_url() -> None:
     assert URL("http://example.com/path") == req.url
 
 
+def test_url_non_default_port() -> None:
+    req = make_mocked_request("GET", "/path", headers={"HOST": "example.com:8123"})
+    assert req.url == URL("http://example.com:8123/path")
+
+
+def test_url_ipv6() -> None:
+    req = make_mocked_request("GET", "/path", headers={"HOST": "[::1]:8123"})
+    assert req.url == URL("http://[::1]:8123/path")
+
+
 def test_clone() -> None:
     req = make_mocked_request("GET", "/path")
     req2 = req.clone()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The port was incorrectly being passed in the `host` field to `URL.build` when the `Host` header included the `port` 

## Are there changes in behavior for the user?

Calling `BaseRequest.url` will not fail with yarl 1.13.0+ when the `host` header has a port

## Is it a substantial burden for the maintainers to support this?

no
## Related issue number
fixes #9307
