### PR TITLE
Remove yarl back-compat shims for yarl older than 1.13.0 (#9316)

### DIFF
--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -14,7 +14,7 @@ from multidict import CIMultiDict, CIMultiDictProxy, istr
 from yarl import URL
 
 import aiohttp
-from aiohttp import BaseConnector, client_reqrep, hdrs, helpers, payload
+from aiohttp import BaseConnector, hdrs, helpers, payload
 from aiohttp.client_exceptions import ClientConnectionError
 from aiohttp.client_reqrep import (
     ClientRequest,
@@ -280,16 +280,9 @@ def test_host_header_ipv4(make_request) -> None:
     assert req.headers["HOST"] == "127.0.0.2"
 
 
-@pytest.mark.parametrize("yarl_supports_host_subcomponent", [True, False])
-def test_host_header_ipv6(make_request, yarl_supports_host_subcomponent: bool) -> None:
-    # Ensure the old path is tested for old yarl versions
-    with mock.patch.object(
-        client_reqrep,
-        "_YARL_SUPPORTS_HOST_SUBCOMPONENT",
-        yarl_supports_host_subcomponent,
-    ):
-        req = make_request("get", "http://[::2]")
-        assert req.headers["HOST"] == "[::2]"
+def test_host_header_ipv6(make_request) -> None:
+    req = make_request("get", "http://[::2]")
+    assert req.headers["HOST"] == "[::2]"
 
 
 def test_host_header_ipv4_with_port(make_request) -> None:

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -12,7 +12,7 @@ import pytest
 from yarl import URL
 
 import aiohttp
-from aiohttp import client_reqrep, web
+from aiohttp import web
 from aiohttp.client_exceptions import ClientConnectionError
 from aiohttp.helpers import IS_MACOS, IS_WINDOWS
 
@@ -95,7 +95,6 @@ async def web_server_endpoint_url(
     reason="asyncio on this python does not support TLS in TLS",
 )
 @pytest.mark.parametrize("web_server_endpoint_type", ("http", "https"))
-@pytest.mark.parametrize("yarl_supports_host_subcomponent", [True, False])
 @pytest.mark.filterwarnings(r"ignore:.*ssl.OP_NO_SSL*")
 # Filter out the warning from
 # https://github.com/abhinavsingh/proxy.py/blob/30574fd0414005dfa8792a6e797023e862bdcf43/proxy/common/utils.py#L226
@@ -105,25 +104,18 @@ async def test_secure_https_proxy_absolute_path(
     secure_proxy_url: URL,
     web_server_endpoint_url: str,
     web_server_endpoint_payload: str,
-    yarl_supports_host_subcomponent: bool,
 ) -> None:
     """Ensure HTTP(S) sites are accessible through a secure proxy."""
     conn = aiohttp.TCPConnector()
     sess = aiohttp.ClientSession(connector=conn)
 
-    # Ensure the old path is tested for old yarl versions
-    with mock.patch.object(
-        client_reqrep,
-        "_YARL_SUPPORTS_HOST_SUBCOMPONENT",
-        yarl_supports_host_subcomponent,
-    ):
-        async with sess.get(
-            web_server_endpoint_url,
-            proxy=secure_proxy_url,
-            ssl=client_ssl_ctx,  # used for both proxy and endpoint connections
-        ) as response:
-            assert response.status == 200
-            assert await response.text() == web_server_endpoint_payload
+    async with sess.get(
+        web_server_endpoint_url,
+        proxy=secure_proxy_url,
+        ssl=client_ssl_ctx,  # used for both proxy and endpoint connections
+    ) as response:
+        assert response.status == 200
+        assert await response.text() == web_server_endpoint_payload
 
     await sess.close()
     await conn.close()


### PR DESCRIPTION
(cherry picked from commit c2eb67e6956795d8513c577ef90746c6e629f202)
