### PR TITLE
Release 3.10.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,46 @@
 
 .. towncrier release notes start
 
+3.10.7 (2024-09-27)
+===================
+
+Bug fixes
+---------
+
+- Fixed assembling the :class:`~yarl.URL` for web requests when the host contains a non-default port or IPv6 address -- by :user:`bdraco`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`9309`.
+
+
+
+
+Miscellaneous internal changes
+------------------------------
+
+- Improved performance of determining if a URL is absolute -- by :user:`bdraco`.
+
+  The property :attr:`~yarl.URL.absolute` is more performant than the method ``URL.is_absolute()`` and preferred when newer versions of yarl are used.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`9171`.
+
+
+
+- Replaced code that can now be handled by ``yarl`` -- by :user:`bdraco`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`9301`.
+
+
+
+
+----
+
+
 3.10.6 (2024-09-24)
 ===================
 

--- a/CHANGES/9171.misc.rst
+++ b/CHANGES/9171.misc.rst
@@ -1,3 +1,0 @@
-Improved performance of determining if a URL is absolute -- by :user:`bdraco`.
-
-The property :attr:`~yarl.URL.absolute` is more performant than the method ``URL.is_absolute()`` and preferred when newer versions of yarl are used.

--- a/CHANGES/9301.misc.rst
+++ b/CHANGES/9301.misc.rst
@@ -1,1 +1,0 @@
-Replaced code that can now be handled by ``yarl`` -- by :user:`bdraco`.

--- a/CHANGES/9309.bugfix.rst
+++ b/CHANGES/9309.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed assembling the :class:`~yarl.URL` for web requests when the host contains a non-default port or IPv6 address -- by :user:`bdraco`.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.10.6.dev0"
+__version__ = "3.10.7"
 
 from typing import TYPE_CHECKING, Tuple
 


### PR DESCRIPTION

Releasing 3.10.7 to handle https://github.com/aio-libs/aiohttp/issues/9307

https://github.com/aio-libs/aiohttp/actions/runs/11076823037
<img width="548" alt="Screenshot 2024-09-27 at 2 20 19 PM" src="https://github.com/user-attachments/assets/5c133c2b-4391-47a6-8813-b1771a9d513d">
