### PR TITLE
DNM: Test run of cancel fix and aiohappyeyeballs 2.4.2

### DIFF
--- a/CHANGES/9326.bugfix.rst
+++ b/CHANGES/9326.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed cancellation leaking upwards on timeout -- by :user:`bdraco`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -733,7 +733,7 @@ class TimerContext(BaseTimerContext):
         if self._tasks:
             enter_task = self._tasks.pop()
 
-        if self._cancelled and exc_type is asyncio.CancelledError:
+        if exc_type is asyncio.CancelledError and self._cancelled:
             assert enter_task is not None
             # The timeout was hit, and the task was cancelled
             # so we need to uncancel the last task that entered the context manager

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -699,6 +699,7 @@ class TimerContext(BaseTimerContext):
         self._loop = loop
         self._tasks: List[asyncio.Task[Any]] = []
         self._cancelled = False
+        self._cancelling = 0
 
     def assert_timeout(self) -> None:
         """Raise TimeoutError if timer has already been cancelled."""
@@ -707,9 +708,14 @@ class TimerContext(BaseTimerContext):
 
     def __enter__(self) -> BaseTimerContext:
         task = asyncio.current_task(loop=self._loop)
-
         if task is None:
             raise RuntimeError("Timeout context manager should be used inside a task")
+
+        if sys.version_info >= (3, 11):
+            # Remember if the task was already cancelling
+            # so when we __exit__ we can decide if we should
+            # raise asyncio.TimeoutError or let the cancellation propagate
+            self._cancelling = task.cancelling()
 
         if self._cancelled:
             raise asyncio.TimeoutError from None
@@ -727,14 +733,18 @@ class TimerContext(BaseTimerContext):
         if self._tasks:
             enter_task = self._tasks.pop()
 
-        if exc_type is asyncio.CancelledError and self._cancelled:
+        if self._cancelled and exc_type is asyncio.CancelledError:
             assert enter_task is not None
             # The timeout was hit, and the task was cancelled
             # so we need to uncancel the last task that entered the context manager
             # since the cancellation should not leak out of the context manager
             if sys.version_info >= (3, 11):
-                enter_task.uncancel()
-            raise asyncio.TimeoutError from None
+                # If the task was already cancelling don't raise
+                # asyncio.TimeoutError and instead return None
+                # to allow the cancellation to propagate
+                if enter_task.uncancel() > self._cancelling:
+                    return None
+            raise asyncio.TimeoutError from exc_val
         return None
 
     def timeout(self) -> None:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -692,17 +692,6 @@ class TimerNoop(BaseTimerContext):
         return
 
 
-if sys.version_info >= (3, 11):
-
-    def _uncancel_task(task: "asyncio.Task[object]") -> None:
-        task.uncancel()
-
-else:
-
-    def _uncancel_task(task: "asyncio.Task[object]") -> None:
-        pass
-
-
 class TimerContext(BaseTimerContext):
     """Low resolution timeout context manager"""
 
@@ -743,7 +732,8 @@ class TimerContext(BaseTimerContext):
             # The timeout was hit, and the task was cancelled
             # so we need to uncancel the last task that entered the context manager
             # since the cancellation should not leak out of the context manager
-            _uncancel_task(enter_task)
+            if sys.version_info >= (3, 11):
+                enter_task.uncancel()
             raise asyncio.TimeoutError from None
         return None
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@
 #
 aiodns==3.2.0 ; sys_platform == "linux" or sys_platform == "darwin"
     # via -r requirements/runtime-deps.in
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.2
     # via -r requirements/runtime-deps.in
 aiosignal==1.3.1
     # via -r requirements/runtime-deps.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -8,7 +8,7 @@ aiodns==3.2.0 ; sys_platform == "linux" or sys_platform == "darwin"
     # via
     #   -r requirements/lint.in
     #   -r requirements/runtime-deps.in
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.2
     # via -r requirements/runtime-deps.in
 aiohttp-theme==0.1.7
     # via -r requirements/doc.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,7 +8,7 @@ aiodns==3.2.0 ; sys_platform == "linux" or sys_platform == "darwin"
     # via
     #   -r requirements/lint.in
     #   -r requirements/runtime-deps.in
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.2
     # via -r requirements/runtime-deps.in
 aiohttp-theme==0.1.7
     # via -r requirements/doc.in

--- a/requirements/runtime-deps.txt
+++ b/requirements/runtime-deps.txt
@@ -6,7 +6,7 @@
 #
 aiodns==3.2.0 ; sys_platform == "linux" or sys_platform == "darwin"
     # via -r requirements/runtime-deps.in
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.2
     # via -r requirements/runtime-deps.in
 aiosignal==1.3.1
     # via -r requirements/runtime-deps.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@
 #
 aiodns==3.2.0 ; sys_platform == "linux" or sys_platform == "darwin"
     # via -r requirements/runtime-deps.in
-aiohappyeyeballs==2.4.0
+aiohappyeyeballs==2.4.2
     # via -r requirements/runtime-deps.in
 aiosignal==1.3.1
     # via -r requirements/runtime-deps.in

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -451,6 +451,7 @@ async def test_timer_context_timeout_does_swallow_cancellation() -> None:
     """Verify that the TimerContext does not swallow cancellation."""
     loop = asyncio.get_running_loop()
     current_task = asyncio.current_task()
+    assert current_task is not None
     ctx = helpers.TimerContext(loop)
 
     async def task_with_timeout() -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -444,6 +444,40 @@ async def test_timer_context_timeout_does_not_leak_upward() -> None:
     assert current_task.cancelling() == 0
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="Python 3.11+ is required for .cancelling()"
+)
+async def test_timer_context_timeout_does_swallow_cancellation() -> None:
+    """Verify that the TimerContext does not swallow cancellation."""
+    loop = asyncio.get_running_loop()
+    current_task = asyncio.current_task()
+    ctx = helpers.TimerContext(loop)
+
+    async def task_with_timeout():
+        nonlocal ctx
+        current_task = asyncio.current_task()
+        assert current_task is not None
+        with pytest.raises(asyncio.TimeoutError):
+            with ctx:
+                assert current_task.cancelling() == 0
+                await asyncio.sleep(1)
+
+    task = asyncio.create_task(task_with_timeout())
+    await asyncio.sleep(0)
+    task.cancel()
+    assert task.cancelling() == 1
+    ctx.timeout()
+
+    # Cancellation should not leak into the current task
+    assert current_task.cancelling() == 0
+    # Cancellation should not be swallowed if the task is cancelled
+    # and it also times out
+    await asyncio.sleep(0)
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelling() == 1
+
+
 def test_timer_context_no_task(loop: asyncio.AbstractEventLoop) -> None:
     with pytest.raises(RuntimeError):
         with helpers.TimerContext(loop):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -433,6 +433,7 @@ async def test_timer_context_timeout_does_not_leak_upward() -> None:
     loop = asyncio.get_running_loop()
     ctx = helpers.TimerContext(loop)
     current_task = asyncio.current_task()
+    assert current_task is not None
     with pytest.raises(asyncio.TimeoutError):
         with ctx:
             assert current_task.cancelling() == 0

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -453,13 +453,13 @@ async def test_timer_context_timeout_does_swallow_cancellation() -> None:
     current_task = asyncio.current_task()
     ctx = helpers.TimerContext(loop)
 
-    async def task_with_timeout():
+    async def task_with_timeout() -> None:
         nonlocal ctx
-        current_task = asyncio.current_task()
-        assert current_task is not None
+        new_task = asyncio.current_task()
+        assert new_task is not None
         with pytest.raises(asyncio.TimeoutError):
             with ctx:
-                assert current_task.cancelling() == 0
+                assert new_task.cancelling() == 0
                 await asyncio.sleep(1)
 
     task = asyncio.create_task(task_with_timeout())


### PR DESCRIPTION
test run of https://github.com/aio-libs/aiohttp/pull/9326 with aiohappyeyeballs bumped to 2.4.2