### PR TITLE
Release 3.10.8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,24 @@
 
 .. towncrier release notes start
 
+3.10.8 (2024-09-28)
+===================
+
+Bug fixes
+---------
+
+- Fixed cancellation leaking upwards on timeout -- by :user:`bdraco`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`9326`.
+
+
+
+
+----
+
+
 3.10.7 (2024-09-27)
 ===================
 

--- a/CHANGES/9326.bugfix.rst
+++ b/CHANGES/9326.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed cancellation leaking upwards on timeout -- by :user:`bdraco`.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.10.8.dev0"
+__version__ = "3.10.8"
 
 from typing import TYPE_CHECKING, Tuple
 


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/actions/runs/11086670160
<img width="585" alt="Screenshot 2024-09-28 at 2 50 15 PM" src="https://github.com/user-attachments/assets/20720102-6a57-401c-86b3-63a178a78fec">
