### PR TITLE
Create dns resolution task eagerly on python 3.12+

### DIFF
--- a/CHANGES/9342.misc.rst
+++ b/CHANGES/9342.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of resolving hosts with Python 3.12+ -- by :user:`bdraco`.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -911,11 +911,18 @@ class TCPConnector(BaseConnector):
         # the underlying lookup or else the cancel event will get broadcast to
         # all the waiters across all connections.
         #
-        resolved_host_task = asyncio.create_task(
-            self._resolve_host_with_throttle(key, host, port, traces)
-        )
-        self._resolve_host_tasks.add(resolved_host_task)
-        resolved_host_task.add_done_callback(self._resolve_host_tasks.discard)
+        coro = self._resolve_host_with_throttle(key, host, port, traces)
+        loop = asyncio.get_running_loop()
+        if sys.version_info >= (3, 12):
+            # Optimization for Python 3.12, try to send immediately
+            resolved_host_task = asyncio.Task(coro, loop=loop, eager_start=True)
+        else:
+            resolved_host_task = loop.create_task(coro)
+
+        if not resolved_host_task.done():
+            self._resolve_host_tasks.add(resolved_host_task)
+            resolved_host_task.add_done_callback(self._resolve_host_tasks.discard)
+
         try:
             return await asyncio.shield(resolved_host_task)
         except asyncio.CancelledError:


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

DNS resolution may be able to happen synchronously if the host is already known. Effectively the same change as #8661

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no