### PR TITLE
Remove unused ip address helpers

### DIFF
--- a/CHANGES/9344.breaking.rst
+++ b/CHANGES/9344.breaking.rst
@@ -1,0 +1,1 @@
+Removed the ``is_ipv6_address`` and ``is_ip4_address`` helpers are they are no longer used -- by :user:`bdraco`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -484,7 +484,7 @@ except ImportError:
     pass
 
 
-def is_ip_address(host: Optional[Union[str, bytes, bytearray, memoryview]]) -> bool:
+def is_ip_address(host: Optional[str]) -> bool:
     """Check if host looks like an IP Address.
 
     This check is only meant as a heuristic to ensure that
@@ -494,13 +494,7 @@ def is_ip_address(host: Optional[Union[str, bytes, bytearray, memoryview]]) -> b
         return False
     # For a host to be an ipv4 address, it must be all numeric.
     # The host must contain a colon to be an IPv6 address.
-    if isinstance(host, str):
-        return ":" in host or host.replace(".", "").isdigit()
-    if isinstance(host, (bytes, bytearray)):
-        return b":" in host or host.decode("ascii").replace(".", "").isdigit()
-    if isinstance(host, memoryview):
-        return b":" in host or bytes(host).decode("ascii").replace(".", "").isdigit()
-    raise TypeError(f"{host} [{type(host)}] is not a str or bytes")
+    return ":" in host or host.replace(".", "").isdigit()
 
 
 _cached_current_datetime: Optional[int] = None

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -496,8 +496,10 @@ def is_ip_address(host: Optional[Union[str, bytes, bytearray, memoryview]]) -> b
     # The host must contain a colon to be an IPv6 address.
     if isinstance(host, str):
         return ":" in host or host.replace(".", "").isdigit()
-    if isinstance(host, (bytes, bytearray, memoryview)):
+    if isinstance(host, (bytes, bytearray)):
         return b":" in host or host.decode("ascii").replace(".", "").isdigit()
+    if isinstance(host, memoryview):
+        return b":" in host or bytes(host).decode("ascii").replace(".", "").isdigit()
     raise TypeError(f"{host} [{type(host)}] is not a str or bytes")
 
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -484,11 +484,8 @@ except ImportError:
     pass
 
 
-def is_ipv4_address(host: Optional[Union[str, bytes]]) -> bool:
-    """Check if host looks like an IPv4 address.
-
-    This function does not validate that the format is correct, only that
-    the host is a str or bytes, and its all numeric.
+def is_ip_address(host: Optional[Union[str, bytes, bytearray, memoryview]]) -> bool:
+    """Check if host looks like an IP Address.
 
     This check is only meant as a heuristic to ensure that
     a host is not a domain name.
@@ -496,39 +493,12 @@ def is_ipv4_address(host: Optional[Union[str, bytes]]) -> bool:
     if not host:
         return False
     # For a host to be an ipv4 address, it must be all numeric.
-    if isinstance(host, str):
-        return host.replace(".", "").isdigit()
-    if isinstance(host, (bytes, bytearray, memoryview)):
-        return host.decode("ascii").replace(".", "").isdigit()
-    raise TypeError(f"{host} [{type(host)}] is not a str or bytes")
-
-
-def is_ipv6_address(host: Optional[Union[str, bytes]]) -> bool:
-    """Check if host looks like an IPv6 address.
-
-    This function does not validate that the format is correct, only that
-    the host contains a colon and that it is a str or bytes.
-
-    This check is only meant as a heuristic to ensure that
-    a host is not a domain name.
-    """
-    if not host:
-        return False
     # The host must contain a colon to be an IPv6 address.
     if isinstance(host, str):
-        return ":" in host
+        return ":" in host or host.replace(".", "").isdigit()
     if isinstance(host, (bytes, bytearray, memoryview)):
-        return b":" in host
+        return b":" in host or host.decode("ascii").replace(".", "").isdigit()
     raise TypeError(f"{host} [{type(host)}] is not a str or bytes")
-
-
-def is_ip_address(host: Optional[Union[str, bytes, bytearray, memoryview]]) -> bool:
-    """Check if host looks like an IP Address.
-
-    This check is only meant as a heuristic to ensure that
-    a host is not a domain name.
-    """
-    return is_ipv4_address(host) or is_ipv6_address(host)
 
 
 _cached_current_datetime: Optional[int] = None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -304,8 +304,6 @@ def test_ipv4_addresses() -> None:
         "255.255.255.255",
     ]
     for address in ip_addresses:
-        assert helpers.is_ipv4_address(address)
-        assert not helpers.is_ipv6_address(address)
         assert helpers.is_ip_address(address)
 
 
@@ -321,8 +319,6 @@ def test_ipv6_addresses() -> None:
         "1::1",
     ]
     for address in ip_addresses:
-        assert not helpers.is_ipv4_address(address)
-        assert helpers.is_ipv6_address(address)
         assert helpers.is_ip_address(address)
 
 
@@ -343,18 +339,6 @@ def test_is_ip_address_invalid_type() -> None:
 
     with pytest.raises(TypeError):
         helpers.is_ip_address(object())  # type: ignore[arg-type]
-
-    with pytest.raises(TypeError):
-        helpers.is_ipv4_address(123)  # type: ignore[arg-type]
-
-    with pytest.raises(TypeError):
-        helpers.is_ipv4_address(object())  # type: ignore[arg-type]
-
-    with pytest.raises(TypeError):
-        helpers.is_ipv6_address(123)  # type: ignore[arg-type]
-
-    with pytest.raises(TypeError):
-        helpers.is_ipv6_address(object())  # type: ignore[arg-type]
 
 
 # ----------------------------------- TimeoutHandle -------------------

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -287,25 +287,6 @@ def test_is_ip_address() -> None:
     assert not helpers.is_ip_address("www.example.com")
 
 
-def test_is_ip_address_bytes() -> None:
-    assert helpers.is_ip_address(b"127.0.0.1")
-    assert helpers.is_ip_address(b"::1")
-    assert helpers.is_ip_address(b"FE80:0000:0000:0000:0202:B3FF:FE1E:8329")
-
-    # Hostnames
-    assert not helpers.is_ip_address(b"localhost")
-    assert not helpers.is_ip_address(b"www.example.com")
-
-
-def test_is_ip_address_memoryview() -> None:
-    assert helpers.is_ip_address(memoryview(b"127.0.0.1"))
-    assert helpers.is_ip_address(memoryview(b"::1"))
-
-    # Hostnames
-    assert not helpers.is_ip_address(memoryview(b"localhost"))
-    assert not helpers.is_ip_address(memoryview(b"www.example.com"))
-
-
 def test_ipv4_addresses() -> None:
     ip_addresses = [
         "0.0.0.0",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -297,6 +297,15 @@ def test_is_ip_address_bytes() -> None:
     assert not helpers.is_ip_address(b"www.example.com")
 
 
+def test_is_ip_address_memoryview() -> None:
+    assert helpers.is_ip_address(memoryview(b"127.0.0.1"))
+    assert helpers.is_ip_address(memoryview(b"::1"))
+
+    # Hostnames
+    assert not helpers.is_ip_address(memoryview(b"localhost"))
+    assert not helpers.is_ip_address(memoryview(b"www.example.com"))
+
+
 def test_ipv4_addresses() -> None:
     ip_addresses = [
         "0.0.0.0",


### PR DESCRIPTION
## What do these changes do?

Remove `is_ipv6_address` and `is_ipv4_address` helpers as they are not used in the codebase anymore.  Not back-ported to 3.10 since there is still back-compat code that uses them.

Remove support for `bytes`/`bytesarray`/`memoryview` from `is_ip_address` as its never used.  Also passing a `memoryview` did not work so there was no chance it was being used.

## Are there changes in behavior for the user?

The helpers have been removed. They are not expected to be called externally, however in case someone was using them, this was marked as a breaking change.

## Is it a substantial burden for the maintainers to support this?
no