### PR TITLE
[3.11] Fix merge conflict resolution error in `TimerContext.__enter__`

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -702,12 +702,6 @@ class TimerContext(BaseTimerContext):
             # raise asyncio.TimeoutError or let the cancellation propagate
             self._cancelling = task.cancelling()
 
-        if sys.version_info >= (3, 11):
-            # Remember if the task was already cancelling
-            # so when we __exit__ we can decide if we should
-            # raise asyncio.TimeoutError or let the cancellation propagate
-            self._cancelling = task.cancelling()
-
         if self._cancelled:
             raise asyncio.TimeoutError from None
 


### PR DESCRIPTION
self._cancelling was set twice in `TimerContext.__enter__` due to a mistake resolving the conflict.  The error only appear on 3.11

