### PR TITLE
Small speed up to update_headers

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -360,7 +360,7 @@ class ClientRequest:
         assert netloc is not None
         # See https://github.com/aio-libs/aiohttp/issues/3636.
         if netloc[-1] == ".":
-            netloc = netloc[:-1]
+            netloc = netloc.rstrip(".")
         explicit_port = self.url.explicit_port
         if explicit_port is not None and not self.url.is_default_port():
             netloc = f"{netloc}:{explicit_port}"

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -379,7 +379,7 @@ class ClientRequest:
 
         self.headers[hdrs.HOST] = host
 
-        if headers:
+        if not headers:
             return
 
         if isinstance(headers, (dict, MultiDictProxy, MultiDict)):

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -380,15 +380,17 @@ class ClientRequest:
         self.headers[hdrs.HOST] = host
 
         if headers:
-            if isinstance(headers, (dict, MultiDictProxy, MultiDict)):
-                headers = headers.items()
+            return
 
-            for key, value in headers:  # type: ignore[misc]
-                # A special case for Host header
-                if key.lower() == "host":
-                    self.headers[key] = value
-                else:
-                    self.headers.add(key, value)
+        if isinstance(headers, (dict, MultiDictProxy, MultiDict)):
+            headers = headers.items()
+
+        for key, value in headers:  # type: ignore[misc]
+            # A special case for Host header
+            if key.lower() == "host":
+                self.headers[key] = value
+            else:
+                self.headers.add(key, value)
 
     def update_auto_headers(self, skip_auto_headers: Optional[Iterable[str]]) -> None:
         if skip_auto_headers is not None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -359,9 +359,11 @@ class ClientRequest:
         netloc = self.url.host_subcomponent
         assert netloc is not None
         # See https://github.com/aio-libs/aiohttp/issues/3636.
-        netloc = netloc.rstrip(".")
-        if self.url.port is not None and not self.url.is_default_port():
-            netloc += ":" + str(self.url.port)
+        if netloc[-1] == ".":
+            netloc = netloc[:-1]
+        explicit_port = self.url.explicit_port
+        if explicit_port is not None and not self.url.is_default_port():
+            netloc = f"{netloc}:{explicit_port}"
         self.headers[hdrs.HOST] = netloc
 
         if headers:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -358,9 +358,21 @@ class ClientRequest:
         # add host
         netloc = self.url.host_subcomponent
         assert netloc is not None
-        # See https://github.com/aio-libs/aiohttp/issues/3636.
+
         if netloc[-1] == ".":
+            # Remove all trailing dots from the netloc as while
+            # they are valid FQDNs in DNS, TLS validation fails.
+            # See https://github.com/aio-libs/aiohttp/issues/3636.
+            # To avoid string manipulation we only call rstrip if
+            # the last character is a dot.
             netloc = netloc.rstrip(".")
+
+        # If explicit port is not None, it means that the port was
+        # explicitly specified in the URL. In this case we check
+        # if its not the default port for the scheme and add it to
+        # the host header. We check explicit_port first because
+        # yarl caches explicit_port and its likely to already be
+        # in the cache and non-default port URLs are far less common.
         explicit_port = self.url.explicit_port
         if explicit_port is not None and not self.url.is_default_port():
             netloc = f"{netloc}:{explicit_port}"

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -355,17 +355,17 @@ class ClientRequest:
         """Update request headers."""
         self.headers: CIMultiDict[str] = CIMultiDict()
 
-        # add host
-        netloc = self.url.host_subcomponent
-        assert netloc is not None
+        # Build the host header
+        host = self.url.host_subcomponent
+        assert host is not None
 
-        if netloc[-1] == ".":
+        if host[-1] == ".":
             # Remove all trailing dots from the netloc as while
             # they are valid FQDNs in DNS, TLS validation fails.
             # See https://github.com/aio-libs/aiohttp/issues/3636.
             # To avoid string manipulation we only call rstrip if
             # the last character is a dot.
-            netloc = netloc.rstrip(".")
+            host = host.rstrip(".")
 
         # If explicit port is not None, it means that the port was
         # explicitly specified in the URL. In this case we check
@@ -375,8 +375,9 @@ class ClientRequest:
         # in the cache and non-default port URLs are far less common.
         explicit_port = self.url.explicit_port
         if explicit_port is not None and not self.url.is_default_port():
-            netloc = f"{netloc}:{explicit_port}"
-        self.headers[hdrs.HOST] = netloc
+            host = f"{host}:{explicit_port}"
+
+        self.headers[hdrs.HOST] = host
 
         if headers:
             if isinstance(headers, (dict, MultiDictProxy, MultiDict)):

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -357,6 +357,9 @@ class ClientRequest:
 
         # Build the host header
         host = self.url.host_subcomponent
+
+        # host_subcomponent is None when the URL is a relative URL.
+        # but we know we do not have a relative URL here.
         assert host is not None
 
         if host[-1] == ".":


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

- Avoid checking to see if the port is default if no port is set: For most cases we can avoid the `is_default_port` check which has to work out the default port internally in yarl since if there is no explict port set, it must be the default port
- Avoid using strip for a single char check

Event if we have to call `is_default_port`, `explict_port` will already be cached
<img width="577" alt="Screenshot 2024-10-01 at 4 33 00 AM" src="https://github.com/user-attachments/assets/579a7a02-03b7-4a4b-968c-00675c3721bf">


## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no