### PR TITLE
Speed up handling auth in urls

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -332,9 +332,8 @@ class ClientRequest:
             raise InvalidURL(url)
 
         # basic auth info
-        username, password = url.user, url.password
-        if username or password:
-            self.auth = helpers.BasicAuth(username or "", password or "")
+        if url.raw_user is not None or url.raw_password is not None:
+            self.auth = helpers.BasicAuth(url.user or "", url.password or "")
 
     def update_version(self, version: Union[http.HttpVersion, str]) -> None:
         """Convert request version to two elements tuple.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -332,7 +332,7 @@ class ClientRequest:
             raise InvalidURL(url)
 
         # basic auth info
-        if url.raw_user is not None or url.raw_password is not None:
+        if url.raw_user or url.raw_password:
             self.auth = helpers.BasicAuth(url.user or "", url.password or "")
 
     def update_version(self, version: Union[http.HttpVersion, str]) -> None:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -161,6 +161,8 @@ class BasicAuth(namedtuple("BasicAuth", ["login", "password", "encoding"])):
         """Create BasicAuth from url."""
         if not isinstance(url, URL):
             raise TypeError("url should be yarl.URL instance")
+        # Check raw_user and raw_password first as yarl is likely
+        # to already have these values parsed from the netloc in the cache.
         if url.raw_user is None and url.raw_password is None:
             return None
         return cls(url.user or "", url.password or "", encoding=encoding)
@@ -172,6 +174,9 @@ class BasicAuth(namedtuple("BasicAuth", ["login", "password", "encoding"])):
 
 
 def strip_auth_from_url(url: URL) -> Tuple[URL, Optional[BasicAuth]]:
+    """Remove user and password from URL if present and return BasicAuth object."""
+    # Check raw_user and raw_password first as yarl is likely
+    # to already have these values parsed from the netloc in the cache.
     if url.raw_user is None and url.raw_password is None:
         return url, None
     return url.with_user(None), BasicAuth(url.user or "", url.password or "")

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -161,7 +161,7 @@ class BasicAuth(namedtuple("BasicAuth", ["login", "password", "encoding"])):
         """Create BasicAuth from url."""
         if not isinstance(url, URL):
             raise TypeError("url should be yarl.URL instance")
-        if url.user is None and url.password is None:
+        if url.raw_user is None and url.raw_password is None:
             return None
         return cls(url.user or "", url.password or "", encoding=encoding)
 
@@ -172,11 +172,9 @@ class BasicAuth(namedtuple("BasicAuth", ["login", "password", "encoding"])):
 
 
 def strip_auth_from_url(url: URL) -> Tuple[URL, Optional[BasicAuth]]:
-    auth = BasicAuth.from_url(url)
-    if auth is None:
+    if url.raw_user is None and url.raw_password is None:
         return url, None
-    else:
-        return url.with_user(None), auth
+    return url.with_user(None), BasicAuth(url.user or "", url.password or "")
 
 
 def netrc_from_env() -> Optional[netrc.netrc]:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -216,6 +216,12 @@ def test_basic_auth_no_user_from_url() -> None:
     assert auth.password == "pass"
 
 
+def test_basic_auth_no_auth_from_url() -> None:
+    url = URL("http://example.com")
+    auth = helpers.BasicAuth.from_url(url)
+    assert auth is None
+
+
 def test_basic_auth_from_not_url() -> None:
     with pytest.raises(TypeError):
         helpers.BasicAuth.from_url("http://user:pass@example.com")  # type: ignore[arg-type]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Avoids calling the .user and .password methods if the raw versions are not set as auth in urls is going to be the rare case.

The cache of `raw_password` and `raw_user` is guaranteed to be set in yarl once the netloc is parsed

## Are there changes in behavior for the user?

no
## Is it a substantial burden for the maintainers to support this?
no


before

<img width="823" alt="Screenshot 2024-10-01 at 4 50 34 AM" src="https://github.com/user-attachments/assets/c9dd0768-5911-475c-a533-97044c9c9c1b">

after
<img width="241" alt="Screenshot 2024-10-01 at 4 49 06 AM" src="https://github.com/user-attachments/assets/8fca8a30-f8fa-4472-9de4-7bc85b7d22ff">
