### PR TITLE
Avoid using the proxy headers in the ConnectionKey if no proxy is in use

### DIFF
--- a/CHANGES/9368.bugfix.rst
+++ b/CHANGES/9368.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed proxy headers being used in the ``ConnectionKey`` hash when proxy was being used -- by :user:`bdraco`.
+
+If default headers are used, they are also used for proxy headers. This could have led to creating connections that were not needed when one was already available.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -526,10 +526,16 @@ class ClientRequest:
         proxy_auth: Optional[BasicAuth],
         proxy_headers: Optional[LooseHeaders],
     ) -> None:
+        self.proxy = proxy
+        if proxy is None:
+            self.proxy_auth = None
+            self.proxy_headers = None
+            return
+
         if proxy_auth and not isinstance(proxy_auth, helpers.BasicAuth):
             raise ValueError("proxy_auth must be None or BasicAuth() tuple")
-        self.proxy = proxy
         self.proxy_auth = proxy_auth
+
         if proxy_headers is not None and not isinstance(
             proxy_headers, (MultiDict, MultiDictProxy)
         ):

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1474,3 +1474,23 @@ def test_basicauth_from_empty_netrc(
     """Test that no Authorization header is sent when netrc is empty"""
     req = make_request("get", "http://example.com", trust_env=True)
     assert hdrs.AUTHORIZATION not in req.headers
+
+
+async def test_connection_key_with_proxy() -> None:
+    """Verify the proxy headers are included in the ConnectionKey when a proxy is used."""
+    proxy = URL("http://proxy.example.com")
+    req = ClientRequest(
+        "GET", URL("http://example.com"), proxy=proxy, proxy_headers={"X-Proxy": "true"}
+    )
+    assert req.connection_key.proxy_headers_hash is not None
+    await req.close()
+
+
+async def test_connection_key_without_proxy() -> None:
+    """Verify the proxy headers are not included in the ConnectionKey when a proxy is used."""
+    # If proxy is unspecified, proxy_headers should be ignored
+    req = ClientRequest(
+        "GET", URL("http://example.com"), proxy_headers={"X-Proxy": "true"}
+    )
+    assert req.connection_key.proxy_headers_hash is None
+    await req.close()

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1480,7 +1480,11 @@ async def test_connection_key_with_proxy() -> None:
     """Verify the proxy headers are included in the ConnectionKey when a proxy is used."""
     proxy = URL("http://proxy.example.com")
     req = ClientRequest(
-        "GET", URL("http://example.com"), proxy=proxy, proxy_headers={"X-Proxy": "true"}
+        "GET",
+        URL("http://example.com"),
+        proxy=proxy,
+        proxy_headers={"X-Proxy": "true"},
+        loop=asyncio.get_running_loop(),
     )
     assert req.connection_key.proxy_headers_hash is not None
     await req.close()
@@ -1490,7 +1494,10 @@ async def test_connection_key_without_proxy() -> None:
     """Verify the proxy headers are not included in the ConnectionKey when a proxy is used."""
     # If proxy is unspecified, proxy_headers should be ignored
     req = ClientRequest(
-        "GET", URL("http://example.com"), proxy_headers={"X-Proxy": "true"}
+        "GET",
+        URL("http://example.com"),
+        proxy_headers={"X-Proxy": "true"},
+        loop=asyncio.get_running_loop(),
     )
     assert req.connection_key.proxy_headers_hash is None
     await req.close()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Default proxy headers may be passed to the connector to be included in the event a proxy is being used. If no proxy is being used, we should not include the proxy auth and proxy headers in the `ConnectionKey` since it means we could end up creating a connection when one was already available for reuse

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no