### PR TITLE
Only prepare proxy headers for a request if a proxy is set

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -492,7 +492,7 @@ class ClientSession:
             proxy_auth = self._default_proxy_auth
 
         if proxy is None:
-            proxy_headers: Optional[CIMultiDict[str]] = None
+            proxy_headers = None
         else:
             proxy_headers = self._prepare_headers(proxy_headers)
             try:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -471,7 +471,6 @@ class ClientSession:
 
         # Merge with default headers and transform to CIMultiDict
         headers = self._prepare_headers(headers)
-        proxy_headers = self._prepare_headers(proxy_headers)
 
         try:
             url = self._build_url(str_or_url)
@@ -492,7 +491,10 @@ class ClientSession:
         if proxy_auth is None:
             proxy_auth = self._default_proxy_auth
 
-        if proxy is not None:
+        if proxy is None:
+            proxy_headers: Optional[CIMultiDict[str]] = None
+        else:
+            proxy_headers = self._prepare_headers(proxy_headers)
             try:
                 proxy = URL(proxy)
             except ValueError as e:


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Since proxy headers also include default headers we would prepare them even when no proxy was in use


## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no