### PR TITLE
Disabling retry_persistent_connection in Tests

### DIFF
--- a/CHANGES/9141.misc.rst
+++ b/CHANGES/9141.misc.rst
@@ -1,3 +1,3 @@
-Modified the `ClientSession` class by adding a private attribute `_test` of type `bool`, with a default value of `False` to the class.
-Modified the default value of `retry_persistent_connection` in `ClientSession` to `False` if `_test` was `True`.
-Also, `TestClient` initialized `ClientSession` with `test=True`. -- by :user:`ShubhAgarwal-dev`.
+Modified the `ClientSession` class by adding a private attribute `_retry_connection` of type `bool`, with a default value of `True` to the class.
+`retry_persistent_connection` in `ClientSession` is set to `False` if `_retry_connection` was `False`.
+In the session of `TestClient`, `ClientSession` attribute `_retry_connection` is changed to `False` -- by :user:`ShubhAgarwal-dev`.

--- a/CHANGES/9141.misc.rst
+++ b/CHANGES/9141.misc.rst
@@ -1,3 +1,3 @@
-- Modified the `ClientSession` class by adding a private attribute `_test` of type `bool`, with a default value of `False` to the class.
-- Modified the default value of `retry_persistent_connection` in `ClientSession` to `False` if `_test` was `True`.
-- Also, `TestClient` initialized `ClientSession` with `test=True`.
+Modified the `ClientSession` class by adding a private attribute `_test` of type `bool`, with a default value of `False` to the class.
+Modified the default value of `retry_persistent_connection` in `ClientSession` to `False` if `_test` was `True`.
+Also, `TestClient` initialized `ClientSession` with `test=True`. -- by :user:`ShubhAgarwal-dev`.

--- a/CHANGES/9141.misc.rst
+++ b/CHANGES/9141.misc.rst
@@ -1,3 +1,3 @@
-Modified the `ClientSession` class by adding a private attribute `_retry_connection` of type `bool`, with a default value of `True` to the class.
-`retry_persistent_connection` in `ClientSession` is set to `False` if `_retry_connection` was `False`.
-In the session of `TestClient`, `ClientSession` attribute `_retry_connection` is changed to `False` -- by :user:`ShubhAgarwal-dev`.
+Modified the :class:`aiohttp.ClientSession` class by adding a private attribute ``_retry_connection`` of type :class:`bool`, with a default value of :data:`True` to the class.
+``retry_persistent_connection`` in :class:`aiohttp.ClientSession` is set to :data:`False` if `_retry_connection` was :data:`False`.
+In the session of :class:`aiohttp.test_utils.TestClient`, :class:`aiohttp.ClientSession` attribute ``_retry_connection`` is changed to :data:`False` -- by :user:`ShubhAgarwal-dev`.

--- a/CHANGES/9141.misc.rst
+++ b/CHANGES/9141.misc.rst
@@ -1,3 +1,2 @@
-Modified the :class:`aiohttp.ClientSession` class by adding a private attribute ``_retry_connection`` of type :class:`bool`, with a default value of :data:`True` to the class.
-``retry_persistent_connection`` in :class:`aiohttp.ClientSession` is set to :data:`False` if `_retry_connection` was :data:`False`.
-In the session of :class:`aiohttp.test_utils.TestClient`, :class:`aiohttp.ClientSession` attribute ``_retry_connection`` is changed to :data:`False` -- by :user:`ShubhAgarwal-dev`.
+Disabled automatic retries of failed requests in :class:`aiohttp.test_utils.TestClient`'s client session
+(which could potentially hide errors in tests) -- by :user:`ShubhAgarwal-dev`.

--- a/CHANGES/9141.misc.rst
+++ b/CHANGES/9141.misc.rst
@@ -1,0 +1,3 @@
+- Modified the `ClientSession` class by adding a private attribute `_test` of type `bool`, with a default value of `False` to the class.
+- Modified the default value of `retry_persistent_connection` in `ClientSession` to `False` if `_test` was `True`.
+- Also, `TestClient` initialized `ClientSession` with `test=True`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -308,6 +308,7 @@ Sergey Skripnick
 Serhii Charykov
 Serhii Kostel
 Serhiy Storchaka
+Shubh Agarwal
 Simon Kennedy
 Sin-Woo Bang
 Stanislas Plum

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -254,7 +254,7 @@ class ClientSession:
         "_resolve_charset",
         "_default_proxy",
         "_default_proxy_auth",
-        "_test",
+        "_retry_connection",
     )
 
     def __init__(
@@ -287,7 +287,6 @@ class ClientSession:
         max_line_size: int = 8190,
         max_field_size: int = 8190,
         fallback_charset_resolver: _CharsetResolver = lambda r, b: "utf-8",
-        test: bool = False,
     ) -> None:
         # We initialise _connector to None immediately, as it's referenced in __del__()
         # and could cause issues if an exception occurs during initialisation.
@@ -369,7 +368,7 @@ class ClientSession:
 
         self._default_proxy = proxy
         self._default_proxy_auth = proxy_auth
-        self._test = test
+        self._retry_connection: bool = True
 
     def __init_subclass__(cls: Type["ClientSession"]) -> None:
         raise TypeError(
@@ -543,7 +542,7 @@ class ClientSession:
             with timer:
                 # https://www.rfc-editor.org/rfc/rfc9112.html#name-retrying-requests
                 retry_persistent_connection = (
-                    False if self._test else method in IDEMPOTENT_METHODS
+                    self._retry_connection and method in IDEMPOTENT_METHODS
                 )
                 while True:
                     url, auth_from_url = strip_auth_from_url(url)

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -286,6 +286,7 @@ class ClientSession:
         max_line_size: int = 8190,
         max_field_size: int = 8190,
         fallback_charset_resolver: _CharsetResolver = lambda r, b: "utf-8",
+        test: bool = False,
     ) -> None:
         # We initialise _connector to None immediately, as it's referenced in __del__()
         # and could cause issues if an exception occurs during initialisation.
@@ -367,6 +368,7 @@ class ClientSession:
 
         self._default_proxy = proxy
         self._default_proxy_auth = proxy_auth
+        self._test = test
 
     def __init_subclass__(cls: Type["ClientSession"]) -> None:
         raise TypeError(
@@ -539,7 +541,9 @@ class ClientSession:
         try:
             with timer:
                 # https://www.rfc-editor.org/rfc/rfc9112.html#name-retrying-requests
-                retry_persistent_connection = method in IDEMPOTENT_METHODS
+                retry_persistent_connection = (
+                    False if self._test else method in IDEMPOTENT_METHODS
+                )
                 while True:
                     url, auth_from_url = strip_auth_from_url(url)
                     if not url.raw_host:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -254,6 +254,7 @@ class ClientSession:
         "_resolve_charset",
         "_default_proxy",
         "_default_proxy_auth",
+        "_test",
     )
 
     def __init__(

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -293,7 +293,7 @@ class TestClient(Generic[_Request, _ApplicationNone]):
         self._server = server
         if cookie_jar is None:
             cookie_jar = aiohttp.CookieJar(unsafe=True)
-        self._session = ClientSession(cookie_jar=cookie_jar, **kwargs)
+        self._session = ClientSession(cookie_jar=cookie_jar, test=True, **kwargs)
         self._closed = False
         self._responses: List[ClientResponse] = []
         self._websockets: List[ClientWebSocketResponse] = []

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -293,7 +293,8 @@ class TestClient(Generic[_Request, _ApplicationNone]):
         self._server = server
         if cookie_jar is None:
             cookie_jar = aiohttp.CookieJar(unsafe=True)
-        self._session = ClientSession(cookie_jar=cookie_jar, test=True, **kwargs)
+        self._session = ClientSession(cookie_jar=cookie_jar, **kwargs)
+        self._session._retry_connection = False
         self._closed = False
         self._responses: List[ClientResponse] = []
         self._websockets: List[ClientWebSocketResponse] = []

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -10,7 +10,7 @@ from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 import aiohttp
-from aiohttp import web, ServerDisconnectedError
+from aiohttp import ServerDisconnectedError, web
 from aiohttp.pytest_plugin import AiohttpClient
 from aiohttp.test_utils import (
     AioHTTPTestCase,

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -10,7 +10,7 @@ from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 import aiohttp
-from aiohttp import ServerDisconnectedError, web
+from aiohttp import web
 from aiohttp.pytest_plugin import AiohttpClient
 from aiohttp.test_utils import (
     AioHTTPTestCase,

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -317,10 +317,12 @@ def test_testcase_no_app(
     result.stdout.fnmatch_lines(["*TypeError*"])
 
 
-async def test_disable_retry_persistent_connection(aiohttp_client: AiohttpClient):
+async def test_disable_retry_persistent_connection(
+    aiohttp_client: AiohttpClient,
+) -> None:
     async def handler(request: web.Request) -> web.Response:
         request.close()
-        return web.Response(200)
+        return web.Response()
 
     app = web.Application()
     app.router.add_get("/", handler)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

It disables retry logic by default in tests.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No
<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

No
<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

#9141 

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Add a new news fragment into the `CHANGES/` folder
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
