### PR TITLE
Widen `trace_request_ctx` type

### DIFF
--- a/CHANGES/9397.bugfix.rst
+++ b/CHANGES/9397.bugfix.rst
@@ -1,0 +1,2 @@
+Widened the type of the trace_request_ctx parameter of ClientSession.request and friends
+-- by :user:`layday`.

--- a/CHANGES/9397.bugfix.rst
+++ b/CHANGES/9397.bugfix.rst
@@ -1,2 +1,2 @@
-Widened the type of the trace_request_ctx parameter of ClientSession.request and friends
+Widened the type of the ``trace_request_ctx`` parameter of ``ClientSession.request`` and friends
 -- by :user:`layday`.

--- a/CHANGES/9397.bugfix.rst
+++ b/CHANGES/9397.bugfix.rst
@@ -1,2 +1,3 @@
-Widened the type of the ``trace_request_ctx`` parameter of ``ClientSession.request`` and friends
+Widened the type of the ``trace_request_ctx`` parameter of
+:meth:`ClientSession.request() <aiohttp.ClientSession.request>` and friends
 -- by :user:`layday`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -184,7 +184,7 @@ class _RequestOptions(TypedDict, total=False):
     ssl: Union[SSLContext, bool, Fingerprint]
     server_hostname: Union[str, None]
     proxy_headers: Union[LooseHeaders, None]
-    trace_request_ctx: Union[Mapping[str, str], None]
+    trace_request_ctx: Union[Mapping[str, Any], None]
     read_bufsize: Union[int, None]
     auto_decompress: Union[bool, None]
     max_line_size: Union[int, None]
@@ -438,7 +438,7 @@ class ClientSession:
         ssl: Union[SSLContext, bool, Fingerprint] = True,
         server_hostname: Optional[str] = None,
         proxy_headers: Optional[LooseHeaders] = None,
-        trace_request_ctx: Optional[Mapping[str, str]] = None,
+        trace_request_ctx: Optional[Mapping[str, Any]] = None,
         read_bufsize: Optional[int] = None,
         auto_decompress: Optional[bool] = None,
         max_line_size: Optional[int] = None,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Widen the type of the `trace_request_ctx` parameter of `ClientSession.request` and friends.

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Fixes #9397.

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
