### PR TITLE
Only create the connection closed exception once

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -751,6 +751,9 @@ class ClientRequest:
             await trace.send_request_headers(method, url, headers)
 
 
+_CONNECTION_CLOSED_EXCEPTION = ClientConnectionError("Connection closed")
+
+
 class ClientResponse(HeadersMixin):
     # Some of these attributes are None when created,
     # but will be set by the start() method.
@@ -1106,7 +1109,7 @@ class ClientResponse(HeadersMixin):
         content = self.content
         # content can be None here, but the types are cheated elsewhere.
         if content and content.exception() is None:  # type: ignore[truthy-bool]
-            set_exception(content, ClientConnectionError("Connection closed"))
+            set_exception(content, _CONNECTION_CLOSED_EXCEPTION)
         self._released = True
 
     async def wait_for_close(self) -> None:


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?
Every connection will end with the connection closed exception. Only create it once since its always the same.

related issue https://github.com/aio-libs/aiohttp/issues/4618#issuecomment-2391880153

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no