### PR TITLE
Add __slots__ to timer helpers

### DIFF
--- a/CHANGES/9406.misc.rst
+++ b/CHANGES/9406.misc.rst
@@ -1,0 +1,1 @@
+Reduced memory required for timer objects created during the client request lifecycle -- by :user:`bdraco`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -596,6 +596,8 @@ def calculate_timeout_when(
 class TimeoutHandle:
     """Timeout handle"""
 
+    __slots__ = ("_timeout", "_loop", "_ceil_threshold", "_callbacks")
+
     def __init__(
         self,
         loop: asyncio.AbstractEventLoop,
@@ -644,11 +646,17 @@ class TimeoutHandle:
 
 
 class BaseTimerContext(ContextManager["BaseTimerContext"]):
+
+    __slots__ = ()
+
     def assert_timeout(self) -> None:
         """Raise TimeoutError if timeout has been exceeded."""
 
 
 class TimerNoop(BaseTimerContext):
+
+    __slots__ = ()
+
     def __enter__(self) -> BaseTimerContext:
         return self
 
@@ -663,6 +671,8 @@ class TimerNoop(BaseTimerContext):
 
 class TimerContext(BaseTimerContext):
     """Low resolution timeout context manager"""
+
+    __slots__ = ("_loop", "_tasks", "_cancelled", "_cancelling")
 
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
         self._loop = loop

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,6 @@ skip = '.git,*.pdf,*.svg,Makefile,CONTRIBUTORS.txt,venvs,_build'
 ignore-words-list = 'te,assertIn'
 
 [tool.slotscheck]
-# Remove aiohttp.helpers once https://github.com/python/cpython/pull/106771
+# TODO(3.13): Remove aiohttp.helpers once https://github.com/python/cpython/pull/106771
 # is available in all supported cpython versions
 exclude-modules = "(^aiohttp\\.helpers)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,3 +82,8 @@ skip = "pp*"
 [tool.codespell]
 skip = '.git,*.pdf,*.svg,Makefile,CONTRIBUTORS.txt,venvs,_build'
 ignore-words-list = 'te,assertIn'
+
+[tool.slotscheck]
+# Remove require-superclass = false once https://github.com/python/cpython/pull/106771
+# is available in all supported cpython versions
+require-superclass = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,6 @@ skip = '.git,*.pdf,*.svg,Makefile,CONTRIBUTORS.txt,venvs,_build'
 ignore-words-list = 'te,assertIn'
 
 [tool.slotscheck]
-# Remove aiohttp.helkpers once https://github.com/python/cpython/pull/106771
+# Remove aiohttp.helpers once https://github.com/python/cpython/pull/106771
 # is available in all supported cpython versions
 exclude-modules = "(^aiohttp\\.helpers)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,6 @@ skip = '.git,*.pdf,*.svg,Makefile,CONTRIBUTORS.txt,venvs,_build'
 ignore-words-list = 'te,assertIn'
 
 [tool.slotscheck]
-# Remove require-superclass = false once https://github.com/python/cpython/pull/106771
+# Remove aiohttp.helkpers once https://github.com/python/cpython/pull/106771
 # is available in all supported cpython versions
-require-superclass = false
+exclude-modules = "(^aiohttp\\.helpers)"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

We use `__slots__` almost everywhere else in the codebase, however `__slots__` was missing for these helpers

related issue https://github.com/aio-libs/aiohttp/issues/4618#issuecomment-2391880153

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no