### PR TITLE
Add __slots__ to stream classes

### DIFF
--- a/CHANGES/9407.misc.rst
+++ b/CHANGES/9407.misc.rst
@@ -1,0 +1,1 @@
+Reduced memory required for stream objects created during the client request lifecycle -- by :user:`bdraco`.

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -129,7 +129,6 @@ class StreamReader(AsyncStreamReaderMixin):
         "_exception",
         "_timer",
         "_eof_callbacks",
-        "total_bytes",
     )
 
     total_bytes = 0
@@ -601,15 +600,6 @@ EMPTY_PAYLOAD: Final[StreamReader] = EmptyStreamReader()
 class DataQueue(Generic[_SizedT]):
     """DataQueue is a general-purpose blocking queue with one reader."""
 
-    __slots__ = (
-        "_loop",
-        "_eof",
-        "_waiter",
-        "_exception",
-        "_size",
-        "_buffer",
-    )
-
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
         self._loop = loop
         self._eof = False
@@ -689,8 +679,6 @@ class FlowControlDataQueue(DataQueue[_SizedT]):
 
     It is a destination for parsed data.
     """
-
-    __slots__ = ("_protocol", "_limit")
 
     def __init__(
         self, protocol: BaseProtocol, limit: int, *, loop: asyncio.AbstractEventLoop

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -42,6 +42,9 @@ class EofStream(Exception):
 
 
 class AsyncStreamIterator(Generic[_T]):
+
+    __slots__ = ("read_func",)
+
     def __init__(self, read_func: Callable[[], Awaitable[_T]]) -> None:
         self.read_func = read_func
 
@@ -59,6 +62,9 @@ class AsyncStreamIterator(Generic[_T]):
 
 
 class ChunkTupleAsyncStreamIterator:
+
+    __slots__ = ("_stream",)
+
     def __init__(self, stream: "StreamReader") -> None:
         self._stream = stream
 
@@ -106,6 +112,25 @@ class StreamReader(AsyncStreamReaderMixin):
             ...
 
     """
+
+    __slots__ = (
+        "_protocol",
+        "_low_water",
+        "_high_water",
+        "_loop",
+        "_size",
+        "_cursor",
+        "_http_chunk_splits",
+        "_buffer",
+        "_buffer_offset",
+        "_eof",
+        "_waiter",
+        "_eof_waiter",
+        "_exception",
+        "_timer",
+        "_eof_callbacks",
+        "total_bytes",
+    )
 
     total_bytes = 0
 
@@ -505,6 +530,9 @@ class StreamReader(AsyncStreamReaderMixin):
 
 
 class EmptyStreamReader(StreamReader):  # lgtm [py/missing-call-to-init]
+
+    __slots__ = ("_read_eof_chunk",)
+
     def __init__(self) -> None:
         self._read_eof_chunk = False
 
@@ -572,6 +600,15 @@ EMPTY_PAYLOAD: Final[StreamReader] = EmptyStreamReader()
 
 class DataQueue(Generic[_SizedT]):
     """DataQueue is a general-purpose blocking queue with one reader."""
+
+    __slots__ = (
+        "_loop",
+        "_eof",
+        "_waiter",
+        "_exception",
+        "_size",
+        "_buffer",
+    )
 
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
         self._loop = loop
@@ -652,6 +689,8 @@ class FlowControlDataQueue(DataQueue[_SizedT]):
 
     It is a destination for parsed data.
     """
+
+    __slots__ = ("_protocol", "_limit")
 
     def __init__(
         self, protocol: BaseProtocol, limit: int, *, loop: asyncio.AbstractEventLoop

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -132,6 +132,7 @@ class StreamReader(AsyncStreamReaderMixin):
         "_exception",
         "_timer",
         "_eof_callbacks",
+        "_eof_counter",
         "total_bytes",
     )
 
@@ -160,6 +161,7 @@ class StreamReader(AsyncStreamReaderMixin):
         self._exception: Optional[Union[Type[BaseException], BaseException]] = None
         self._timer = TimerNoop() if timer is None else timer
         self._eof_callbacks: List[Callable[[], None]] = []
+        self._eof_counter = 0
         self.total_bytes = 0
 
     def __repr__(self) -> str:

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -79,6 +79,9 @@ class ChunkTupleAsyncStreamIterator:
 
 
 class AsyncStreamReaderMixin:
+
+    __slots__ = ()
+
     def __aiter__(self) -> AsyncStreamIterator[bytes]:
         return AsyncStreamIterator(self.readline)  # type: ignore[attr-defined]
 

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -132,9 +132,8 @@ class StreamReader(AsyncStreamReaderMixin):
         "_exception",
         "_timer",
         "_eof_callbacks",
+        "total_bytes",
     )
-
-    total_bytes = 0
 
     def __init__(
         self,
@@ -161,6 +160,7 @@ class StreamReader(AsyncStreamReaderMixin):
         self._exception: Optional[Union[Type[BaseException], BaseException]] = None
         self._timer = TimerNoop() if timer is None else timer
         self._eof_callbacks: List[Callable[[], None]] = []
+        self.total_bytes = 0
 
     def __repr__(self) -> str:
         info = [self.__class__.__name__]


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

We use `__slots__` almost everywhere else in the codebase, however `__slots__` were not implemented in stream

related issue https://github.com/aio-libs/aiohttp/issues/4618#issuecomment-2391880153

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no