### PR TITLE
Fix all waiters being enumerated on connection release

### DIFF
--- a/CHANGES/9421.bugfix.rst
+++ b/CHANGES/9421.bugfix.rst
@@ -1,0 +1,1 @@
+Fix the connection limit so that the algorithm does not enumerate unrelated connections -- by user:`bdraco`.

--- a/CHANGES/9421.bugfix.rst
+++ b/CHANGES/9421.bugfix.rst
@@ -1,1 +1,1 @@
-Fix the connection limit so that the algorithm does not enumerate unrelated connections -- by user:`bdraco`.
+Fix the connection limit so that the algorithm does not enumerate unrelated connection waiters -- by user:`bdraco`.

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -464,7 +464,7 @@ async def test_release_waiter_no_limit(
     w = mock.Mock()
     w.done.return_value = False
     conn._waiters[key].append(w)
-    conn._release_waiter()
+    conn._release_waiter(key)
     assert len(conn._waiters[key]) == 0
     assert w.done.called
     await conn.close()
@@ -479,7 +479,7 @@ async def test_release_waiter_first_available(
     w2.done.return_value = False
     conn._waiters[key].append(w2)
     conn._waiters[key2].append(w1)
-    conn._release_waiter()
+    conn._release_waiter(key)
     assert (
         w1.set_result.called
         and not w2.set_result.called
@@ -497,7 +497,7 @@ async def test_release_waiter_release_first(
     w1.done.return_value = False
     w2.done.return_value = False
     conn._waiters[key] = deque([w1, w2])
-    conn._release_waiter()
+    conn._release_waiter(key)
     assert w1.set_result.called
     assert not w2.set_result.called
     await conn.close()
@@ -511,7 +511,7 @@ async def test_release_waiter_skip_done_waiter(
     w1.done.return_value = True
     w2.done.return_value = False
     conn._waiters[key] = deque([w1, w2])
-    conn._release_waiter()
+    conn._release_waiter(key)
     assert not w1.set_result.called
     assert w2.set_result.called
     await conn.close()
@@ -527,7 +527,7 @@ async def test_release_waiter_per_host(
     w2.done.return_value = False
     conn._waiters[key] = deque([w1])
     conn._waiters[key2] = deque([w2])
-    conn._release_waiter()
+    conn._release_waiter(key)
     assert (w1.set_result.called and not w2.set_result.called) or (
         not w1.set_result.called and w2.set_result.called
     )
@@ -545,7 +545,7 @@ async def test_release_waiter_no_available(
     with mock.patch.object(
         conn, "_available_connections", autospec=True, spec_set=True, return_value=0
     ):
-        conn._release_waiter()
+        conn._release_waiter(key)
         assert len(conn._waiters) == 1
         assert not w.done.called
         await conn.close()


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

#2964 changed the waiter implementation to enumerate all the waiters on release. This may be to handle a case where waiters are not properly released, however I could not find one where we should be releasing waiters for other keys when we already have the key

## Are there changes in behavior for the user?
no

## Is it a substantial burden for the maintainers to support this?
no