### PR TITLE
Offload file operations to prevent the event loop from being blocked by synchronous file operations

### DIFF
--- a/CHANGES/9430.misc.rst
+++ b/CHANGES/9430.misc.rst
@@ -1,0 +1,4 @@
+Changes to prevent the event loop from being blocked by synchronous file operations -- by :user:`jleinenbach` and :user:`danielbrunt57`.
+- Offload file operations in the save and load methods to separate threads using run_in_executor.
+- Use threading.Event to wait for the completion of loading and saving operations.
+- Ensure synchronization, so methods accessing self._cookies wait until the cookies are fully loaded.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -86,6 +86,7 @@ Cong Xu
 Damien Nadé
 Dan King
 Dan Xu
+Daniel Brunt
 Daniel García
 Daniel Golding
 Daniel Grossmann-Kavanagh

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -120,6 +120,10 @@ class CookieJar(AbstractCookieJar):
             )
         self._expire_heap: List[Tuple[float, Tuple[str, str, str]]] = []
         self._expirations: Dict[Tuple[str, str, str], float] = {}
+        self._cookies_loaded = threading.Event()
+        self._cookies_saved = threading.Event()
+        self._cookies_loaded.set()  # Initialized as set when no cookies need to be loaded
+
 
     def save(self, file_path: PathLike) -> None:
         self._cookies_saved.clear()

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -8,6 +8,7 @@ import os  # noqa
 import pathlib
 import pickle
 import re
+import threading
 import time
 import warnings
 from collections import defaultdict

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -125,7 +125,6 @@ class CookieJar(AbstractCookieJar):
         self._cookies_saved = threading.Event()
         self._cookies_loaded.set()  # Initialized as set when no cookies need to be loaded
 
-
     def save(self, file_path: PathLike) -> None:
         self._cookies_saved.clear()
         loop = asyncio.get_event_loop()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

- Offload file operations in the save and load methods to separate threads using run_in_executor.
- Use threading.Event to wait for the completion of loading and saving operations.
- Ensure synchronization, so methods accessing self._cookies wait until the cookies are fully loaded.

## Are there changes in behavior for the user?

No notable behaviour change for end users.

## Is it a substantial burden for the maintainers to support this?

Minimal to no burden is expected for maintainers to support these changes but will eliminate these warnings in Home Assistant:
> Detected blocking call to open with args (PosixPath('/config/.storage/alexa_media.YOUR_EMAIL@gmail.com.pickle'),) in /usr/local/lib/python3.12/site-packages/aiohttp/cookiejar.py, line 113: with file_path.open(mode="wb") as f: inside the event loop; This is causing stability issues. Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#open

> Detected blocking call to open with args (PosixPath('/config/.storage/alexa_media.YOUR_EMAIL@gmail.com.pickle'),) inside the event loop by custom integration 'alexa_media' at custom_components/alexa_media/__init__.py, line 251: cookies = await login.load_cookie() (offender: /usr/local/lib/python3.12/site-packages/aiohttp/cookiejar.py, line 118: with file_path.open(mode="rb") as f:), please create a bug report at https://github.com/alandtse/alexa_media_player/issues For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#open

## Related issue number

Fixes [github.com/alandtse/alexa_media_player Issue #2520](https://github.com/alandtse/alexa_media_player/issues/2520)
<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [X] Add a new news fragment into the `CHANGES/` folder
