### PR TITLE
Fix handling of redirects with authentication

### DIFF
--- a/CHANGES/9436.bugfix.rst
+++ b/CHANGES/9436.bugfix.rst
@@ -1,0 +1,1 @@
+Authentication provided by a redirect now takes precedence over provided ``auth`` when making requests with the client -- by :user:`PLPeeters`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -569,7 +569,9 @@ class ClientSession:
                             "credentials encoded in URL"
                         )
 
-                    if auth is None:
+                    # Override the auth with the one from the URL only if we
+                    # have no auth, or if we got an auth from a redirect URL
+                    if auth is None or (history and auth_from_url is not None):
                         auth = auth_from_url
 
                     if (

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -472,7 +472,7 @@ class ClientSession:
             data = payload.JsonPayload(json, dumps=self._json_serialize)
 
         redirects = 0
-        history = []
+        history: List[ClientResponse] = []
         version = self._version
         params = params or {}
 
@@ -560,7 +560,10 @@ class ClientSession:
                             else InvalidUrlClientError
                         )
                         raise err_exc_cls(url)
-                    if auth and auth_from_url:
+                    # If `auth` was passed for an already authenticated URL,
+                    # disallow only if this is the initial URL; this is to avoid issues
+                    # with sketchy redirects that are not the caller's responsibility
+                    if not history and (auth and auth_from_url):
                         raise ValueError(
                             "Cannot combine AUTH argument with "
                             "credentials encoded in URL"

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -67,6 +67,13 @@ argument. An instance of :class:`BasicAuth` can be passed in like this::
     async with ClientSession(auth=auth) as session:
         ...
 
+Note that if the request is redirected and the redirect URL contains
+credentials, those credentials will supersede any previously set credentials.
+In other words, if ``http://user@example.com`` redirects to
+``http://other_user@example.com``, the second request will be authenticated
+as ``other_user``. Providing both the ``auth`` parameter and authentication in
+the *initial* URL will result in a :exc:`ValueError`.
+
 For other authentication flows, the ``Authorization`` header can be set
 directly::
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2930,6 +2930,7 @@ async def test_creds_in_auth_and_url() -> None:
 async def test_creds_in_auth_and_redirect_url(
     create_server_for_url_and_handler: Callable[[URL, Handler], Awaitable[TestServer]],
 ) -> None:
+    """Verify that credentials in redirect URLs can and do override any previous credentials."""
     url_from = URL("http://example.com")
     url_to = URL("http://user@example.com")
     redirected = False
@@ -2983,6 +2984,9 @@ async def test_creds_in_auth_and_redirect_url(
         assert len(resp.history) == 1
         assert str(resp.url) == "http://example.com"
         assert resp.status == 200
+        assert (
+            resp.request_info.headers.get("authorization") == "Basic dXNlcjo="
+        ), "Expected redirect credentials to take precedence over provided auth"
 
 
 @pytest.fixture


### PR DESCRIPTION
## What do these changes do?

They make the client ignore auth clashes that are solely due to redirects, in addition to having redirect authentication take precedence over previously set authentication.

## Are there changes in behavior for the user?

Users will no longer get a `ValueError` if a website suddenly includes multiple authenticated URLs in its redirect chain (see #9436 for an example).

While writing the test, I also wondered what should happen if we already have authentication set and get new authentication in a redirect URL. Mimicking what Chrome seems to be doing in this case, I opted to supersede the auth with that of the redirect. We can of course discuss this and tweak it if needed. I'm also on the fence on whether this warrants a separate PR, so I bundled it for now.

## Is it a substantial burden for the maintainers to support this?

Probably not.

## Related issue number

Fixes #9436

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
