### PR TITLE
Improve performance of fetching the content-length for web responses

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -747,9 +747,7 @@ class HeadersMixin:
     def content_length(self) -> Optional[int]:
         """The value of Content-Length HTTP header."""
         content_length = self._headers.get(hdrs.CONTENT_LENGTH)
-        if content_length is None:
-            return None
-        return int(content_length)
+        return None if content_length is None else int(content_length)
 
 
 def set_result(fut: "asyncio.Future[_T]", result: _T) -> None:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -746,12 +746,10 @@ class HeadersMixin:
     @property
     def content_length(self) -> Optional[int]:
         """The value of Content-Length HTTP header."""
-        content_length = self._headers.get(hdrs.CONTENT_LENGTH)
-
+        content_length = self._headers[hdrs.CONTENT_LENGTH]
         if content_length is not None:
             return int(content_length)
-        else:
-            return None
+        return None
 
 
 def set_result(fut: "asyncio.Future[_T]", result: _T) -> None:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -746,7 +746,7 @@ class HeadersMixin:
     @property
     def content_length(self) -> Optional[int]:
         """The value of Content-Length HTTP header."""
-        content_length = self._headers[hdrs.CONTENT_LENGTH]
+        content_length = self._headers.get(hdrs.CONTENT_LENGTH)
         if content_length is None:
             return None
         return int(content_length)

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -747,9 +747,9 @@ class HeadersMixin:
     def content_length(self) -> Optional[int]:
         """The value of Content-Length HTTP header."""
         content_length = self._headers[hdrs.CONTENT_LENGTH]
-        if content_length is not None:
-            return int(content_length)
-        return None
+        if content_length is None:
+            return None
+        return int(content_length)
 
 
 def set_result(fut: "asyncio.Future[_T]", result: _T) -> None:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -647,9 +647,9 @@ class Response(StreamResponse):
 
         if hdrs.CONTENT_LENGTH in self._headers:
             content_length = self._headers[hdrs.CONTENT_LENGTH]
-            if content_length is not None:
-                return int(content_length)
-            return None
+            if content_length is None:
+                return None
+            return int(content_length)
 
         if self._compressed_body is not None:
             # Return length of the compressed body

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -646,7 +646,10 @@ class Response(StreamResponse):
             return None
 
         if hdrs.CONTENT_LENGTH in self._headers:
-            return super().content_length
+            content_length = self._headers[hdrs.CONTENT_LENGTH]
+            if content_length is not None:
+                return int(content_length)
+            return None
 
         if self._compressed_body is not None:
             # Return length of the compressed body

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -646,10 +646,7 @@ class Response(StreamResponse):
             return None
 
         if hdrs.CONTENT_LENGTH in self._headers:
-            content_length = self._headers[hdrs.CONTENT_LENGTH]
-            if content_length is None:
-                return None
-            return int(content_length)
+            return int(self._headers[hdrs.CONTENT_LENGTH])
 
         if self._compressed_body is not None:
             # Return length of the compressed body


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Small performance improvement for web responses ~1.8% speed up from avoiding all the multiple super calls

ref #2779 https://github.com/aio-libs/aiohttp/issues/2779#issuecomment-2400156629

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no