### PR TITLE
Fix AsyncResolver swallowing the error message

### DIFF
--- a/CHANGES/9451.bugfix.rst
+++ b/CHANGES/9451.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed error messages from :py:class:`~aiohttp.resolver.AsyncResolver` being swallowed -- by :user:`bdraco`.

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -100,7 +100,7 @@ class AsyncResolver(AbstractResolver):
             )
         except aiodns.error.DNSError as exc:
             msg = exc.args[1] if len(exc.args) >= 1 else "DNS lookup failed"
-            raise OSError(msg) from exc
+            raise OSError(None, msg) from exc
         hosts: List[ResolveResult] = []
         for node in resp.nodes:
             address: Union[Tuple[bytes, int], Tuple[bytes, int, int, int]] = node.addr
@@ -134,7 +134,7 @@ class AsyncResolver(AbstractResolver):
             )
 
         if not hosts:
-            raise OSError("DNS lookup failed")
+            raise OSError(None, "DNS lookup failed")
 
         return hosts
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -329,6 +329,20 @@ async def test_async_resolver_error_messages_passed(
         assert excinfo.value.strerror == "Test error message"
 
 
+@pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")
+async def test_async_resolver_error_messages_passed_no_hosts(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Ensure error messages are passed through from aiodns."""
+    with patch("aiodns.DNSResolver", autospec=True, spec_set=True) as mock:
+        mock().getaddrinfo.return_value = fake_aiodns_getaddrinfo_ipv6_result([])
+        resolver = AsyncResolver()
+        with pytest.raises(OSError, match="DNS lookup failed") as excinfo:
+            await resolver.resolve("x.org")
+
+        assert excinfo.value.strerror == "DNS lookup failed"
+
+
 async def test_async_resolver_aiodns_not_present(loop: Any, monkeypatch: Any) -> None:
     monkeypatch.setattr("aiohttp.resolver.aiodns", None)
     with pytest.raises(RuntimeError):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -315,6 +315,18 @@ async def test_async_resolver_ipv6_positive_lookup(loop: Any) -> None:
         )
 
 
+@pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")
+async def test_async_resolver_error_messages_passed(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Ensure error messages are passed through from aiodns."""
+    with patch("aiodns.DNSResolver", autospec=True, spec_set=True) as mock:
+        mock().getaddrinfo.side_effect = aiodns.error.DNSError(1, "Test error message")
+        resolver = AsyncResolver()
+        with pytest.raises(OSError, match="Test error message"):
+            await resolver.resolve("x.org")
+
+
 async def test_async_resolver_aiodns_not_present(loop: Any, monkeypatch: Any) -> None:
     monkeypatch.setattr("aiohttp.resolver.aiodns", None)
     with pytest.raises(RuntimeError):

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -323,8 +323,10 @@ async def test_async_resolver_error_messages_passed(
     with patch("aiodns.DNSResolver", autospec=True, spec_set=True) as mock:
         mock().getaddrinfo.side_effect = aiodns.error.DNSError(1, "Test error message")
         resolver = AsyncResolver()
-        with pytest.raises(OSError, match="Test error message"):
+        with pytest.raises(OSError, match="Test error message") as excinfo:
             await resolver.resolve("x.org")
+
+        assert excinfo.value.strerror == "Test error message"
 
 
 async def test_async_resolver_aiodns_not_present(loop: Any, monkeypatch: Any) -> None:


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

We would incorrectly create the `OSError` exception by passing the string as the first argument. The first argument of `OSError` is the errno. This meant that the message would end up in the wrong place.

https://docs.python.org/3/library/exceptions.html#OSError

## Are there changes in behavior for the user?

proper errors

## Is it a substantial burden for the maintainers to support this?
no

## Related issue number
#9447