### PR TITLE
[3.11] Fix AsyncResolver query fallback swallowing the error message

### DIFF
--- a/CHANGES/9455.bugfix.rst
+++ b/CHANGES/9455.bugfix.rst
@@ -1,0 +1,1 @@
+9451.bugfix.rst

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -159,7 +159,7 @@ class AsyncResolver(AbstractResolver):
             resp = await self._resolver.query(host, qtype)
         except aiodns.error.DNSError as exc:
             msg = exc.args[1] if len(exc.args) >= 1 else "DNS lookup failed"
-            raise OSError(msg) from exc
+            raise OSError(None, msg) from exc
 
         hosts = []
         for rr in resp:
@@ -175,7 +175,7 @@ class AsyncResolver(AbstractResolver):
             )
 
         if not hosts:
-            raise OSError("DNS lookup failed")
+            raise OSError(None, "DNS lookup failed")
 
         return hosts
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -333,6 +333,36 @@ async def test_async_resolver_query_ipv6_positive_lookup(loop) -> None:
 
 
 @pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")
+async def test_async_resolver_query_fallback_error_messages_passed(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Ensure error messages are passed through from aiodns with query fallback."""
+    with patch("aiodns.DNSResolver", autospec=True, spec_set=True) as mock:
+        del mock().gethostbyname
+        mock().query.side_effect = aiodns.error.DNSError(1, "Test error message")
+        resolver = AsyncResolver()
+        with pytest.raises(OSError, match="Test error message") as excinfo:
+            await resolver.resolve("x.org")
+
+        assert excinfo.value.strerror == "Test error message"
+
+
+@pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")
+async def test_async_resolver_query_fallback_error_messages_passed_no_hosts(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Ensure error messages are passed through from aiodns with query fallback."""
+    with patch("aiodns.DNSResolver", autospec=True, spec_set=True) as mock:
+        del mock().gethostbyname
+        mock().query.return_value = fake_query_result([])
+        resolver = AsyncResolver()
+        with pytest.raises(OSError, match="DNS lookup failed") as excinfo:
+            await resolver.resolve("x.org")
+
+        assert excinfo.value.strerror == "DNS lookup failed"
+
+
+@pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")
 async def test_async_resolver_error_messages_passed(
     loop: asyncio.AbstractEventLoop,
 ) -> None:


### PR DESCRIPTION
Same change as #9451 but for the query fallback code for older versions of aiodns
