### PR TITLE
Add note to WebSocket docs that the async iterator swallows close messages

### DIFF
--- a/CHANGES/9461.doc.rst
+++ b/CHANGES/9461.doc.rst
@@ -1,1 +1,1 @@
-Added a warning to the documentation about the WebSocket async iterators swallowing close messages -- by :user:`bdraco`.
+Added a note to the documentation about the WebSocket async iterators swallowing close messages -- by :user:`bdraco`.

--- a/CHANGES/9461.doc.rst
+++ b/CHANGES/9461.doc.rst
@@ -1,0 +1,1 @@
+Added a warning to the documentation about the WebSocket async iterators swallowing close messages -- by :user:`bdraco`.

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -404,7 +404,7 @@ multiple writer tasks which can only send data asynchronously (by
     When using ``async for msg in ws:``, messages of type
     :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
     and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
-    handle these messages, you should use the
+    handle these messages, use the
     :meth:`~aiohttp.ClientWebSocketResponse.receive` method instead.
 
 .. _aiohttp-client-timeouts:

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -399,7 +399,7 @@ ws.receive()`` or ``async for msg in ws:``) and writing but may have
 multiple writer tasks which can only send data asynchronously (by
 ``await ws.send_str('data')`` for example).
 
-.. warning::
+.. note::
 
     When using ``async for msg in ws:``, messages of type
     :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -384,13 +384,13 @@ methods::
 
    async with session.ws_connect('http://example.org/ws') as ws:
        async for msg in ws:
-           if msg.type == aiohttp.WSMsgType.TEXT:
+           if msg.type is aiohttp.WSMsgType.TEXT:
                if msg.data == 'close cmd':
                    await ws.close()
                    break
                else:
                    await ws.send_str(msg.data + '/answer')
-           elif msg.type == aiohttp.WSMsgType.ERROR:
+           elif msg.type is aiohttp.WSMsgType.ERROR:
                break
 
 
@@ -399,6 +399,13 @@ ws.receive()`` or ``async for msg in ws:``) and writing but may have
 multiple writer tasks which can only send data asynchronously (by
 ``await ws.send_str('data')`` for example).
 
+.. warning::
+
+    When using the ``async for msg in ws:``, messages of type
+    :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
+    and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
+    handle these messages, you should use the
+    :meth:`~aiohttp.ClientWebSocketResponse.receive` method instead.
 
 .. _aiohttp-client-timeouts:
 

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -401,7 +401,7 @@ multiple writer tasks which can only send data asynchronously (by
 
 .. warning::
 
-    When using the ``async for msg in ws:``, messages of type
+    When using ``async for msg in ws:``, messages of type
     :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
     and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
     handle these messages, you should use the

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -384,13 +384,13 @@ methods::
 
    async with session.ws_connect('http://example.org/ws') as ws:
        async for msg in ws:
-           if msg.type is aiohttp.WSMsgType.TEXT:
+           if msg.type == aiohttp.WSMsgType.TEXT:
                if msg.data == 'close cmd':
                    await ws.close()
                    break
                else:
                    await ws.send_str(msg.data + '/answer')
-           elif msg.type is aiohttp.WSMsgType.ERROR:
+           elif msg.type == aiohttp.WSMsgType.ERROR:
                break
 
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1703,7 +1703,7 @@ manually.
         :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
         and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
         handle these messages, you should use the
-        :meth:`~aiohttp.web.WebSocketResponse.receive` method instead.
+        :meth:`~aiohttp.ClientWebSocketResponse.receive` method instead.
 
 
 Utilities

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1510,7 +1510,7 @@ manually.
       async for msg in ws:
         print(msg.data)
 
-   .. warning::
+   .. note::
 
        When using ``async for msg in ws:``, messages of type
        :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1504,6 +1504,21 @@ manually.
       :param default: Default value to be used when no value for ``name`` is
                       found (default is ``None``).
 
+   The class supports ``async for`` statement for iterating over
+   incoming messages::
+
+      async for msg in ws:
+        print(msg.data)
+
+   .. warning::
+
+       When using ``async for msg in ws:``, messages of type
+       :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
+       and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
+       handle these messages, you should use the
+       :meth:`~aiohttp.ClientWebSocketResponse.receive` method instead.
+
+
    .. method:: exception()
 
       Returns exception if any occurs or returns None.
@@ -1690,20 +1705,6 @@ manually.
 
       :raise TypeError: if message is :const:`~aiohttp.WSMsgType.BINARY`.
       :raise ValueError: if message is not valid JSON.
-
-   The class supports ``async for`` statement for iterating over
-   incoming messages::
-
-      async for msg in ws:
-        print(msg.data)
-
-   .. warning::
-
-       When using ``async for msg in ws:``, messages of type
-       :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
-       and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
-       handle these messages, you should use the
-       :meth:`~aiohttp.ClientWebSocketResponse.receive` method instead.
 
 
 Utilities

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1515,7 +1515,7 @@ manually.
        When using ``async for msg in ws:``, messages of type
        :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
        and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
-       handle these messages, you should use the
+       handle these messages, use the
        :meth:`~aiohttp.ClientWebSocketResponse.receive` method instead.
 
    .. method:: exception()

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1518,7 +1518,6 @@ manually.
        handle these messages, you should use the
        :meth:`~aiohttp.ClientWebSocketResponse.receive` method instead.
 
-
    .. method:: exception()
 
       Returns exception if any occurs or returns None.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1691,6 +1691,20 @@ manually.
       :raise TypeError: if message is :const:`~aiohttp.WSMsgType.BINARY`.
       :raise ValueError: if message is not valid JSON.
 
+   The class supports ``async for`` statement for iterating over
+   incoming messages::
+
+      async for msg in ws:
+        print(msg.data)
+
+    .. warning::
+
+        When using the ``async for msg in ws:``, messages of type
+        :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
+        and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
+        handle these messages, you should use the
+        :meth:`~aiohttp.web.WebSocketResponse.receive` method instead.
+
 
 Utilities
 ---------

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1699,7 +1699,7 @@ manually.
 
     .. warning::
 
-        When using the ``async for msg in ws:``, messages of type
+        When using ``async for msg in ws:``, messages of type
         :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
         and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
         handle these messages, you should use the

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1697,13 +1697,13 @@ manually.
       async for msg in ws:
         print(msg.data)
 
-    .. warning::
+   .. warning::
 
-        When using ``async for msg in ws:``, messages of type
-        :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
-        and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
-        handle these messages, you should use the
-        :meth:`~aiohttp.ClientWebSocketResponse.receive` method instead.
+       When using ``async for msg in ws:``, messages of type
+       :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
+       and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
+       handle these messages, you should use the
+       :meth:`~aiohttp.ClientWebSocketResponse.receive` method instead.
 
 
 Utilities

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -640,7 +640,7 @@ The handler should be registered as HTTP GET processor::
     When using ``async for msg in ws:``, messages of type
     :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
     and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
-    handle these messages, you should use the
+    handle these messages, use the
     :meth:`~aiohttp.web.WebSocketResponse.receive` method instead.
 
 .. _aiohttp-web-redirects:

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -618,12 +618,12 @@ with the peer::
         async for msg in ws:
             # ws.__next__() automatically terminates the loop
             # after ws.close() or ws.exception() is called
-            if msg.type == aiohttp.WSMsgType.TEXT:
+            if msg.type is aiohttp.WSMsgType.TEXT:
                 if msg.data == 'close':
                     await ws.close()
                 else:
                     await ws.send_str(msg.data + '/answer')
-            elif msg.type == aiohttp.WSMsgType.ERROR:
+            elif msg.type is aiohttp.WSMsgType.ERROR:
                 print('ws connection closed with exception %s' %
                       ws.exception())
 
@@ -634,6 +634,14 @@ with the peer::
 The handler should be registered as HTTP GET processor::
 
     app.add_routes([web.get('/ws', websocket_handler)])
+
+.. warning::
+
+    When using the ``async for msg in ws:``, messages of type
+    :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
+    and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
+    handle these messages, you should use the
+    :meth:`~aiohttp.web.WebSocketResponse.receive` method instead.
 
 .. _aiohttp-web-redirects:
 

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -637,7 +637,7 @@ The handler should be registered as HTTP GET processor::
 
 .. warning::
 
-    When using the ``async for msg in ws:``, messages of type
+    When using ``async for msg in ws:``, messages of type
     :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
     and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
     handle these messages, you should use the

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -635,7 +635,7 @@ The handler should be registered as HTTP GET processor::
 
     app.add_routes([web.get('/ws', websocket_handler)])
 
-.. warning::
+.. note::
 
     When using ``async for msg in ws:``, messages of type
     :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -618,12 +618,12 @@ with the peer::
         async for msg in ws:
             # ws.__next__() automatically terminates the loop
             # after ws.close() or ws.exception() is called
-            if msg.type is aiohttp.WSMsgType.TEXT:
+            if msg.type == aiohttp.WSMsgType.TEXT:
                 if msg.data == 'close':
                     await ws.close()
                 else:
                     await ws.send_str(msg.data + '/answer')
-            elif msg.type is aiohttp.WSMsgType.ERROR:
+            elif msg.type == aiohttp.WSMsgType.ERROR:
                 print('ws connection closed with exception %s' %
                       ws.exception())
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -983,13 +983,13 @@ and :ref:`aiohttp-web-signals` handlers::
           async for msg in ws:
               print(msg.data)
 
-    .. warning::
+   .. warning::
 
-        When using ``async for msg in ws:``, messages of type
-        :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
-        and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
-        handle these messages, you should use the
-        :meth:`~aiohttp.web.WebSocketResponse.receive` method instead.
+       When using ``async for msg in ws:``, messages of type
+       :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
+       and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
+       handle these messages, you should use the
+       :meth:`~aiohttp.web.WebSocketResponse.receive` method instead.
 
    .. method:: prepare(request)
       :async:

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -983,6 +983,13 @@ and :ref:`aiohttp-web-signals` handlers::
           async for msg in ws:
               print(msg.data)
 
+    .. warning::
+
+        When using the ``async for msg in ws:``, messages of type
+        :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
+        and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
+        handle these messages, you should use the
+        :meth:`~aiohttp.web.WebSocketResponse.receive` method instead.
 
    .. method:: prepare(request)
       :async:

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -985,7 +985,7 @@ and :ref:`aiohttp-web-signals` handlers::
 
     .. warning::
 
-        When using the ``async for msg in ws:``, messages of type
+        When using ``async for msg in ws:``, messages of type
         :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
         and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
         handle these messages, you should use the

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -983,7 +983,7 @@ and :ref:`aiohttp-web-signals` handlers::
           async for msg in ws:
               print(msg.data)
 
-   .. warning::
+   .. note::
 
        When using ``async for msg in ws:``, messages of type
        :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -988,7 +988,7 @@ and :ref:`aiohttp-web-signals` handlers::
        When using ``async for msg in ws:``, messages of type
        :attr:`~aiohttp.WSMsgType.CLOSE`, :attr:`~aiohttp.WSMsgType.CLOSED`,
        and :attr:`~aiohttp.WSMsgType.CLOSING` are swallowed. If you need to
-       handle these messages, you should use the
+       handle these messages, use the
        :meth:`~aiohttp.web.WebSocketResponse.receive` method instead.
 
    .. method:: prepare(request)

--- a/docs/websocket_utilities.rst
+++ b/docs/websocket_utilities.rst
@@ -122,7 +122,12 @@ WebSocket utilities
 
       Close frame.
 
-   .. attribute:: CLOSED FRAME
+   .. attribute:: CLOSING
+
+      Actually not frame but a flag indicating that websocket is
+      closing.
+
+   .. attribute:: CLOSED
 
       Actually not frame but a flag indicating that websocket was
       closed.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add warnings to WebSocket docs that the async iterator swallows close messages.
https://github.com/aio-libs/aiohttp/blob/b09d7cc07607d01badf8051f5b8feb2a2ed070c8/aiohttp/web_ws.py#L625
https://github.com/aio-libs/aiohttp/blob/b09d7cc07607d01badf8051f5b8feb2a2ed070c8/aiohttp/client_ws.py#L404

Additionally, I found that `CLOSED` was improperly documented, and `CLOSING` was missing from the docs. Since the new warning references these messages, they have been fixed.

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no

related issue #7682