### PR TITLE
Improve performance of default auth

### DIFF
--- a/CHANGES/9466.feature.rst
+++ b/CHANGES/9466.feature.rst
@@ -1,0 +1,1 @@
+8966.feature.rst


### PR DESCRIPTION
followup to [#8966](https://github.com/aio-libs/aiohttp/pull/8966#discussion_r1796348152)

> Calling `.origin()` is a bit expensive https://github.com/aio-libs/aiohttp/issues/7583#issuecomment-1806828707

> We should probably cache `self._base_url.origin()` as self._base_url_origin` so we don't have to build it every time

> Probably could guard this with self._default_auth being set as well
