### PR TITLE
Small performance improvement to handling redirects

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -742,8 +742,8 @@ class ClientSession:
                             ) from origin_val_err
 
                         if (
-                            url.origin() != redirect_origin
-                            and not is_same_host_https_redirect
+                            not is_same_host_https_redirect
+                            and url.origin() != redirect_origin
                         ):
                             auth = None
                             headers.pop(hdrs.AUTHORIZATION, None)


### PR DESCRIPTION
Reverse the conditional so the origin is only checked if not is_same_host_https_redirect

> Calling `.origin()` is a bit expensive https://github.com/aio-libs/aiohttp/issues/7583#issuecomment-1806828707

