### PR TITLE
Avoid calling update_cookies when there are no cookies

### DIFF
--- a/CHANGES/9470.misc.rst
+++ b/CHANGES/9470.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of the client request lifecycle when there are no cookies -- by :user:`bdraco`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -335,7 +335,7 @@ class ClientSession:
             cookie_jar = CookieJar()
         self._cookie_jar = cookie_jar
 
-        if cookies is not None:
+        if cookies:
             self._cookie_jar.update_cookies(cookies)
 
         self._connector_owner = connector_owner
@@ -679,7 +679,8 @@ class ClientSession:
                             raise
                         raise ClientOSError(*exc.args) from exc
 
-                    self._cookie_jar.update_cookies(resp.cookies, resp.url)
+                    if cookies := resp.cookies:
+                        self._cookie_jar.update_cookies(cookies, resp.url)
 
                     # redirects
                     if resp.status in (301, 302, 303, 307, 308) and allow_redirects:


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Calling update_cookies is ~4% of the client lifecycle time and we call it even with an empty dict of cookies

## Are there changes in behavior for the user?

no
## Is it a substantial burden for the maintainers to support this?
no