### PR TITLE
Small speed up to checking connection in ClientResponse

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1018,7 +1018,7 @@ class ClientResponse(HeadersMixin):
             return
 
         # protocol could be None because connection could be detached
-        protocol = self._connection and self._connection.protocol
+        protocol = self._connection is not None and self._connection.protocol
         if protocol is not None and protocol.upgraded:
             return
 
@@ -1140,7 +1140,7 @@ class ClientResponse(HeadersMixin):
         elif self._released:  # Response explicitly released
             raise ClientConnectionError("Connection closed")
 
-        protocol = self._connection and self._connection.protocol
+        protocol = self._connection is not None and self._connection.protocol
         if protocol is None or not protocol.upgraded:
             await self._wait_released()  # Underlying connection released
         return self._body


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The check should have been `is not None` here to avoid the` __bool__` call which is always `True`


## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no