### PR TITLE
Speed up matching the host header when updating client headers

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -4,6 +4,7 @@ import contextlib
 import dataclasses
 import functools
 import io
+import itertools
 import re
 import sys
 import traceback
@@ -178,6 +179,9 @@ class ClientRequest:
     }
     POST_METHODS = {hdrs.METH_PATCH, hdrs.METH_POST, hdrs.METH_PUT}
     ALL_METHODS = GET_METHODS.union(POST_METHODS).union({hdrs.METH_DELETE})
+    _HOST_STRINGS = frozenset(
+        map("".join, itertools.product(*zip("host".upper(), "host".lower())))
+    )
 
     DEFAULT_HEADERS = {
         hdrs.ACCEPT: "*/*",
@@ -395,7 +399,7 @@ class ClientRequest:
 
         for key, value in headers:  # type: ignore[misc]
             # A special case for Host header
-            if key.lower() == "host":
+            if key in self._HOST_STRINGS:
                 self.headers[key] = value
             else:
                 self.headers.add(key, value)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`update_headers` is one of the most expensive areas of the client request when headers are being added.  While its gotten a lot better lately, we can still do a bit better.

Avoid calling `.lower()` on every header key for the special case.

I got the idea from https://github.com/aio-libs/multidict/pull/683

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no