### PR TITLE
Avoid passing client writer to response when already finished

### DIFF
--- a/CHANGES/9485.misc.rst
+++ b/CHANGES/9485.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of sending client requests when the writer can finish synchronously -- by :user:`bdraco`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -284,17 +284,11 @@ class ClientRequest:
         return self.__writer
 
     @_writer.setter
-    def _writer(self, writer: Optional["asyncio.Task[None]"]) -> None:
+    def _writer(self, writer: "asyncio.Task[None]") -> None:
         if self.__writer is not None:
             self.__writer.remove_done_callback(self.__reset_writer)
         self.__writer = writer
-        if writer is None:
-            return
-        if writer.done():
-            # The writer is already done, so we can clear it immediately.
-            self.__writer = None
-        else:
-            writer.add_done_callback(self.__reset_writer)
+        writer.add_done_callback(self.__reset_writer)
 
     def is_ssl(self) -> bool:
         return self.url.scheme in _SSL_SCHEMES

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -713,7 +713,7 @@ class ClientRequest:
         if task.done():
             task = None
         else:
-            self.__writer = task
+            self._writer = task
 
         response_class = self.response_class
         assert response_class is not None

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -701,6 +701,7 @@ class ClientRequest:
         await writer.write_headers(status_line, self.headers)
         coro = self.write_bytes(writer, conn)
 
+        task: Optional["asyncio.Task[None]"]
         if sys.version_info >= (3, 12):
             # Optimization for Python 3.12, try to write
             # bytes immediately to avoid having to schedule

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1344,7 +1344,7 @@ async def test_custom_req_rep(
             resp = self.response_class(
                 self.method,
                 self.url,
-                writer=self._writer,  # type: ignore[arg-type]
+                writer=self._writer,
                 continue100=self._continue,
                 timer=self._timer,
                 request_info=self.request_info,

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -300,7 +300,7 @@ async def test_response_eof(
         "get",
         URL("http://def-cl-resp.org"),
         request_info=mock.Mock(),
-        writer=None,  # type: ignore[arg-type]
+        writer=None,
         continue100=None,
         timer=TimerNoop(),
         traces=[],
@@ -346,7 +346,7 @@ async def test_response_eof_after_connection_detach(
         "get",
         URL("http://def-cl-resp.org"),
         request_info=mock.Mock(),
-        writer=None,  # type: ignore[arg-type]
+        writer=None,
         continue100=None,
         timer=TimerNoop(),
         traces=[],

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -268,7 +268,7 @@ class TestProxy(unittest.TestCase):
             "get",
             URL("http://proxy.example.com"),
             request_info=mock.Mock(),
-            writer=None,  # type: ignore[arg-type]
+            writer=None,
             continue100=None,
             timer=TimerNoop(),
             traces=[],
@@ -351,7 +351,7 @@ class TestProxy(unittest.TestCase):
             "get",
             URL("http://proxy.example.com"),
             request_info=mock.Mock(),
-            writer=None,  # type: ignore[arg-type]
+            writer=None,
             continue100=None,
             timer=TimerNoop(),
             traces=[],
@@ -533,7 +533,7 @@ class TestProxy(unittest.TestCase):
             "get",
             URL("http://proxy.example.com"),
             request_info=mock.Mock(),
-            writer=None,  # type: ignore[arg-type]
+            writer=None,
             continue100=None,
             timer=TimerNoop(),
             traces=[],
@@ -615,7 +615,7 @@ class TestProxy(unittest.TestCase):
             "get",
             URL("http://proxy.example.com"),
             request_info=mock.Mock(),
-            writer=None,  # type: ignore[arg-type]
+            writer=None,
             continue100=None,
             timer=TimerNoop(),
             traces=[],
@@ -692,7 +692,7 @@ class TestProxy(unittest.TestCase):
             "get",
             URL("http://proxy.example.com"),
             request_info=mock.Mock(),
-            writer=None,  # type: ignore[arg-type]
+            writer=None,
             continue100=None,
             timer=TimerNoop(),
             traces=[],
@@ -767,7 +767,7 @@ class TestProxy(unittest.TestCase):
             "get",
             URL("http://proxy.example.com"),
             request_info=mock.Mock(),
-            writer=None,  # type: ignore[arg-type]
+            writer=None,
             continue100=None,
             timer=TimerNoop(),
             traces=[],
@@ -843,7 +843,7 @@ class TestProxy(unittest.TestCase):
             "get",
             URL("http://proxy.example.com"),
             request_info=mock.Mock(),
-            writer=None,  # type: ignore[arg-type]
+            writer=None,
             continue100=None,
             timer=TimerNoop(),
             traces=[],
@@ -979,7 +979,7 @@ class TestProxy(unittest.TestCase):
             "get",
             URL("http://proxy.example.com"),
             request_info=mock.Mock(),
-            writer=None,  # type: ignore[arg-type]
+            writer=None,
             continue100=None,
             timer=TimerNoop(),
             traces=[],
@@ -1072,7 +1072,7 @@ class TestProxy(unittest.TestCase):
             "get",
             URL("http://proxy.example.com"),
             request_info=mock.Mock(),
-            writer=None,  # type: ignore[arg-type]
+            writer=None,
             continue100=None,
             timer=TimerNoop(),
             traces=[],


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

With Python 3.12+ its likely that the writer can finish synchronously (on a production HA instance, it always did for all samples in a 60s period). In this case avoid passing it to the response since it will get unset right away needlessly

## Are there changes in behavior for the user?

no

