### PR TITLE
Add missing docs for timeout parameter in WebSocketResponse.__init__()

### DIFF
--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -960,7 +960,7 @@ and :ref:`aiohttp-web-signals` handlers::
                          operation)
 
    :param float receive_timeout: Timeout value for `receive`
-                                 operations.  Default value is ``None``
+                                 operations.  Default value is :data:`None`
                                  (no timeout for receive operation)
 
    :param bool compress: Enable per-message deflate extension support.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -964,7 +964,7 @@ and :ref:`aiohttp-web-signals` handlers::
                                  (no timeout for receive operation)
 
    :param bool compress: Enable per-message deflate extension support.
-                          False for disabled, default value is ``True``.
+                          :data:`False` for disabled, default value is :data:`True`.
 
    :param int max_msg_size: maximum size of read websocket message, 4
                             MB by default. To disable the size limit use ``0``.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -955,7 +955,7 @@ and :ref:`aiohttp-web-signals` handlers::
 
    :param float timeout: Timeout value for the `close`
                          operation. After sending the close websocket message,
-                         `close` waits for ``timeout`` seconds for a response.
+                         ``close`` waits for ``timeout`` seconds for a response.
                          Default value is ``10.0`` (10 seconds for ``close``
                          operation)
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -953,7 +953,7 @@ and :ref:`aiohttp-web-signals` handlers::
                            connection if `pong` response is not
                            received. The timer is reset on any data reception.
 
-   :param float timeout: Timeout value for the `close`
+   :param float timeout: Timeout value for the ``close``
                          operation. After sending the close websocket message,
                          ``close`` waits for ``timeout`` seconds for a response.
                          Default value is ``10.0`` (10 seconds for ``close``

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -953,12 +953,18 @@ and :ref:`aiohttp-web-signals` handlers::
                            connection if `pong` response is not
                            received. The timer is reset on any data reception.
 
+   :param float timeout: Timeout value for the `close`
+                         operation. After sending the close websocket message,
+                         `close` waits for ``timeout`` seconds for a response.
+                         Default value is ``10.0`` (10 seconds for `close`
+                         operation)
+
    :param float receive_timeout: Timeout value for `receive`
-                                 operations.  Default value is None
+                                 operations.  Default value is ``None``
                                  (no timeout for receive operation)
 
    :param bool compress: Enable per-message deflate extension support.
-                          False for disabled, default value is True.
+                          False for disabled, default value is ``True``.
 
    :param int max_msg_size: maximum size of read websocket message, 4
                             MB by default. To disable the size limit use ``0``.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -956,7 +956,7 @@ and :ref:`aiohttp-web-signals` handlers::
    :param float timeout: Timeout value for the `close`
                          operation. After sending the close websocket message,
                          `close` waits for ``timeout`` seconds for a response.
-                         Default value is ``10.0`` (10 seconds for `close`
+                         Default value is ``10.0`` (10 seconds for ``close``
                          operation)
 
    :param float receive_timeout: Timeout value for `receive`


### PR DESCRIPTION
## What do these changes do?

Adds missing documentation.

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

No

## Related issue number

This was easier than opening an issue.

## Checklist

- [x] I think the code is well written
- [ ] ~~Unit tests for the changes exist~~
- [x] Documentation reflects the changes
- [ ] ~~If you provide code modification, please add yourself to `CONTRIBUTORS.txt`~~
- [ ] Add a new news fragment into the `CHANGES/` folder
