### PR TITLE
Improve performance of WebSocketReader

### DIFF
--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -124,8 +124,8 @@ class WSMessage(NamedTuple):
         return loads(self.data)
 
 
-WS_CLOSED_MESSAGE = WSMessage(WSMsgType.CLOSED, None, None)
-WS_CLOSING_MESSAGE = WSMessage(WSMsgType.CLOSING, None, None)
+WS_CLOSED_MESSAGE = tuple.__new__(WSMessage, (WSMsgType.CLOSED, None, None))
+WS_CLOSING_MESSAGE = tuple.__new__(WSMessage, (WSMsgType.CLOSING, None, None))
 
 
 class WebSocketError(Exception):
@@ -402,10 +402,12 @@ class WebSocketReader:
                             WSCloseCode.INVALID_TEXT, "Invalid UTF-8 text message"
                         ) from exc
 
-                    self.queue.feed_data(WSMessage(WSMsgType.TEXT, text, ""))
+                    msg = tuple.__new__(WSMessage, (WSMsgType.TEXT, text, ""))
+                    self.queue.feed_data(msg)
                     continue
 
-                self.queue.feed_data(WSMessage(WSMsgType.BINARY, payload_merged, ""))
+                msg = tuple.__new__(WSMessage, (WSMsgType.BINARY, payload_merged, ""))
+                self.queue.feed_data(msg)
             elif opcode == WSMsgType.CLOSE:
                 if len(payload) >= 2:
                     close_code = UNPACK_CLOSE_CODE(payload[:2])[0]
@@ -420,22 +422,26 @@ class WebSocketReader:
                         raise WebSocketError(
                             WSCloseCode.INVALID_TEXT, "Invalid UTF-8 text message"
                         ) from exc
-                    msg = WSMessage(WSMsgType.CLOSE, close_code, close_message)
+                    msg = tuple.__new__(
+                        WSMessage, (WSMsgType.CLOSE, close_code, close_message)
+                    )
                 elif payload:
                     raise WebSocketError(
                         WSCloseCode.PROTOCOL_ERROR,
                         f"Invalid close frame: {fin} {opcode} {payload!r}",
                     )
                 else:
-                    msg = WSMessage(WSMsgType.CLOSE, 0, "")
+                    msg = tuple.__new__(WSMessage, (WSMsgType.CLOSE, 0, ""))
 
                 self.queue.feed_data(msg)
 
             elif opcode == WSMsgType.PING:
-                self.queue.feed_data(WSMessage(WSMsgType.PING, payload, ""))
+                msg = tuple.__new__(WSMessage, (WSMsgType.PING, payload, ""))
+                self.queue.feed_data(msg)
 
             elif opcode == WSMsgType.PONG:
-                self.queue.feed_data(WSMessage(WSMsgType.PONG, payload, ""))
+                msg = tuple.__new__(WSMessage, (WSMsgType.PONG, payload, ""))
+                self.queue.feed_data(msg)
 
             else:
                 raise WebSocketError(

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -124,6 +124,10 @@ class WSMessage(NamedTuple):
         return loads(self.data)
 
 
+# Constructing the tuple directly to avoid the overhead of
+# the lambda and arg processing since NamedTuples are constructed
+# with a run time built lambda
+# https://github.com/python/cpython/blob/d83fcf8371f2f33c7797bc8f5423a8bca8c46e5c/Lib/collections/__init__.py#L441
 WS_CLOSED_MESSAGE = tuple.__new__(WSMessage, (WSMsgType.CLOSED, None, None))
 WS_CLOSING_MESSAGE = tuple.__new__(WSMessage, (WSMsgType.CLOSING, None, None))
 
@@ -402,10 +406,12 @@ class WebSocketReader:
                             WSCloseCode.INVALID_TEXT, "Invalid UTF-8 text message"
                         ) from exc
 
+                    # tuple.__new__ is used to avoid the overhead of the lambda
                     msg = tuple.__new__(WSMessage, (WSMsgType.TEXT, text, ""))
                     self.queue.feed_data(msg)
                     continue
 
+                # tuple.__new__ is used to avoid the overhead of the lambda
                 msg = tuple.__new__(WSMessage, (WSMsgType.BINARY, payload_merged, ""))
                 self.queue.feed_data(msg)
             elif opcode == WSMsgType.CLOSE:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Improve performance of WebSocketReader by reducing the overhead to create the `WSMessage` objects.

Reuses the same idea as https://github.com/aio-libs/yarl/pull/1316 and https://github.com/aio-libs/yarl/pull/1322

Calling `tuple.__new__` is much faster because it avoids the extra runtime lambda having to be run and arguments unpacked for every message
https://github.com/python/cpython/blob/d83fcf8371f2f33c7797bc8f5423a8bca8c46e5c/Lib/collections/__init__.py#L441

I limited the change to the `http_websocket.py` module since this is the only place where they are created at volume.  This only works if the object being created is a `NamedTuple` so this speed up is only recommended internally and should not be used outside of `aiohttp` since we do not guarantee that `WSMessage` will remain a `NamedTuple` in the future.


## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no