### PR TITLE
Improve performance of creating the ConnectionKey

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -304,14 +304,17 @@ class ClientRequest:
         else:
             h = None
         url = self.url
-        return ConnectionKey(
-            url.raw_host or "",
-            url.port,
-            url.scheme in _SSL_SCHEMES,
-            self._ssl,
-            self.proxy,
-            self.proxy_auth,
-            h,
+        return tuple.__new__(
+            ConnectionKey,
+            (
+                url.raw_host or "",
+                url.port,
+                url.scheme in _SSL_SCHEMES,
+                self._ssl,
+                self.proxy,
+                self.proxy_auth,
+                h,
+            ),
         )
 
     @property


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Improve performance of the client by reducing the overhead to create the `ConnectionKey` objects.

Reuses the same idea as https://github.com/aio-libs/yarl/pull/1316 and https://github.com/aio-libs/yarl/pull/1322

Calling `tuple.__new__` is much faster because it avoids the extra runtime lambda having to be run and arguments unpacked for every message https://github.com/python/cpython/blob/d83fcf8371f2f33c7797bc8f5423a8bca8c46e5c/Lib/collections/__init__.py#L441

This only works if the object being created is a `NamedTuple` so this speed up is only recommended internally and should not be used outside of `aiohttp` since we do not guarantee that ConnectionKey will remain a `NamedTuple` in the future.


## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no