### PR TITLE
Adjust URL type checks to checks to explictly check for URL

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -294,7 +294,7 @@ class ClientSession:
         # We initialise _connector to None immediately, as it's referenced in __del__()
         # and could cause issues if an exception occurs during initialisation.
         self._connector: Optional[BaseConnector] = None
-        if base_url is None or isinstance(base_url, URL):
+        if base_url is None or type(base_url) is URL:
             self._base_url: Optional[URL] = base_url
             self._base_url_origin = None if base_url is None else base_url.origin()
         else:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -234,8 +234,9 @@ class ClientRequest:
                 f"Method cannot contain non-token characters {method!r} "
                 f"(found at least {match.group()!r})"
             )
-        assert isinstance(url, URL), url
-        assert isinstance(proxy, (URL, type(None))), proxy
+        assert type(url) is URL, url
+        if proxy is not None:
+            assert type(proxy) is URL, proxy
         # FIXME: session is None in tests only, need to fix tests
         # assert session is not None
         self._session = cast("ClientSession", session)
@@ -795,7 +796,7 @@ class ClientResponse(HeadersMixin):
         loop: asyncio.AbstractEventLoop,
         session: "ClientSession",
     ) -> None:
-        assert isinstance(url, URL)
+        assert type(url) is URL
         super().__init__()
 
         self.method = method

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -102,7 +102,7 @@ class CookieJar(AbstractCookieJar):
         self._quote_cookie = quote_cookie
         if treat_as_secure_origin is None:
             self._treat_as_secure_origin: FrozenSet[URL] = frozenset()
-        elif isinstance(treat_as_secure_origin, URL):
+        elif type(treat_as_secure_origin) is URL:
             self._treat_as_secure_origin = frozenset({treat_as_secure_origin.origin()})
         elif isinstance(treat_as_secure_origin, str):
             self._treat_as_secure_origin = frozenset(
@@ -301,7 +301,7 @@ class CookieJar(AbstractCookieJar):
 
     def filter_cookies(self, request_url: URL) -> "BaseCookie[str]":
         """Returns this jar's cookies filtered by their attributes."""
-        if not isinstance(request_url, URL):
+        if type(request_url) is not URL:
             warnings.warn(
                 "The method accepts yarl.URL instances only, got {}".format(
                     type(request_url)

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -160,7 +160,7 @@ class BasicAuth(namedtuple("BasicAuth", ["login", "password", "encoding"])):
     @classmethod
     def from_url(cls, url: URL, *, encoding: str = "latin1") -> Optional["BasicAuth"]:
         """Create BasicAuth from url."""
-        if not isinstance(url, URL):
+        if type(url) is not URL:
             raise TypeError("url should be yarl.URL instance")
         # Check raw_user and raw_password first as yarl is likely
         # to already have these values parsed from the netloc in the cache.


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

We do not need to check for subclassed URL as subclassing is forbidden in yarl:
https://github.com/aio-libs/yarl/blob/03e634eaa7837209dc60065ece85bb3e54b8770b/yarl/_url.py#L438

The `type` check is a bit faster than an `isinstance` check

## Are there changes in behavior for the user?
no