### PR TITLE
Simplify WebSocket writer

### DIFF
--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -105,7 +105,7 @@ class WebSocketWriter:
         if msg_length < 126:
             header = PACK_LEN1(first_byte, msg_length | mask_bit)
             header_len = 2
-        elif msg_length < (1 << 16):
+        elif msg_length < 65536:
             header = PACK_LEN2(first_byte, 126 | mask_bit, msg_length)
             header_len = 4
         else:

--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -127,16 +127,14 @@ class WebSocketWriter:
             message = bytearray(message)
             websocket_mask(mask, message)
             self.transport.write(header + mask + message)
-            self._output_size += header_len + MASK_LEN + msg_length
-
+            self._output_size += MASK_LEN
+        elif msg_length > MSG_SIZE:
+            self.transport.write(header)
+            self.transport.write(message)
         else:
-            if msg_length > MSG_SIZE:
-                self.transport.write(header)
-                self.transport.write(message)
-            else:
-                self.transport.write(header + message)
+            self.transport.write(header + message)
 
-            self._output_size += header_len + msg_length
+        self._output_size += header_len + msg_length
 
         # It is safe to return control to the event loop when using compression
         # after this point as we have already sent or buffered all the data.

--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -112,6 +112,9 @@ class WebSocketWriter:
             header = PACK_LEN3(first_byte, 127 | mask_bit, msg_length)
             header_len = 10
 
+        if self.transport.is_closing():
+            raise ClientConnectionResetError("Cannot write to closing transport")
+
         # https://datatracker.ietf.org/doc/html/rfc6455#section-5.3
         # If we are using a mask, we need to generate it randomly
         # and apply it to the message before sending it. A mask is
@@ -119,9 +122,6 @@ class WebSocketWriter:
         # bitwise XOR operation. It is used to prevent certain types
         # of attacks on the websocket protocol. The mask is only used
         # when aiohttp is acting as a client. Servers do not use a mask.
-        if self.transport.is_closing():
-            raise ClientConnectionResetError("Cannot write to closing transport")
-
         if use_mask:
             mask = PACK_RANDBITS(self.get_random_bits())
             message = bytearray(message)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The WebSocket writer checked if the transport was closing multiple times if there were multiple write calls. We only need to check once since all the writes are synchronous, and there is no way it suddenly be closing before control is returned to the event loop.

This won't make much difference for performance, but it does make the code a bit more concise

## Are there changes in behavior for the user?

no
