### PR TITLE
Optimize WebSocketReader for 2 byte length case

### DIFF
--- a/CHANGES/9554.feature.rst
+++ b/CHANGES/9554.feature.rst
@@ -1,0 +1,1 @@
+9543.feature.rst

--- a/aiohttp/_websocket/helpers.py
+++ b/aiohttp/_websocket/helpers.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Final, List, Optional, Pattern, Tuple
 from ..helpers import NO_EXTENSIONS
 from .models import WSHandshakeError
 
-UNPACK_LEN2 = Struct("!H").unpack_from
 UNPACK_LEN3 = Struct("!Q").unpack_from
 UNPACK_CLOSE_CODE = Struct("!H").unpack
 PACK_LEN1 = Struct("!BB").pack

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -15,7 +15,6 @@ cdef unsigned int OP_CODE_CLOSE
 cdef unsigned int OP_CODE_PING
 cdef unsigned int OP_CODE_PONG
 
-cdef object UNPACK_LEN2
 cdef object UNPACK_LEN3
 cdef object UNPACK_CLOSE_CODE
 cdef object TUPLE_NEW

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -5,7 +5,7 @@ from typing import Final, List, Optional, Set, Tuple, Union
 from ..compression_utils import ZLibDecompressor
 from ..helpers import set_exception
 from ..streams import DataQueue
-from .helpers import UNPACK_CLOSE_CODE, UNPACK_LEN2, UNPACK_LEN3, websocket_mask
+from .helpers import UNPACK_CLOSE_CODE, UNPACK_LEN3, websocket_mask
 from .models import (
     WS_DEFLATE_TRAILING,
     WebSocketError,
@@ -313,9 +313,10 @@ class WebSocketReader:
                 if length_flag == 126:
                     if buf_length - start_pos < 2:
                         break
-                    data = buf[start_pos : start_pos + 2]
+                    first_byte = buf[start_pos]
+                    second_byte = buf[start_pos + 1]
                     start_pos += 2
-                    self._payload_length = UNPACK_LEN2(data)[0]
+                    self._payload_length = first_byte << 8 | second_byte
                 elif length_flag > 126:
                     if buf_length - start_pos < 8:
                         break


### PR DESCRIPTION
Optimize WebSocketReader for 2 byte length case. The simple 2 byte length unpack can be implemented almost entirely in native code.

The profile showed a lot of time in `unpack_from` so this should have speed this up a bit more