### PR TITLE
Fix Cython `WebSocketReader` byte signedness

### DIFF
--- a/CHANGES/9556.feature.rst
+++ b/CHANGES/9556.feature.rst
@@ -1,0 +1,1 @@
+9543.feature.rst

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -82,8 +82,8 @@ cdef class WebSocketReader:
         buf_length="unsigned int",
         data=bytes,
         payload=bytearray,
-        first_byte=char,
-        second_byte=char,
+        first_byte="unsigned char",
+        second_byte="unsigned char",
         has_mask=bint,
         fin=bint,
     )

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -142,6 +142,17 @@ def test_parse_frame_length2(parser: WebSocketReader) -> None:
     assert (0, 1, b"1234", False) == (fin, opcode, payload, not not compress)
 
 
+def test_parse_frame_length2_multi_byte(parser: WebSocketReader) -> None:
+    """Ensure a multi-byte length is parsed correctly."""
+    expected_payload = b"1" * 32768
+    parser.parse_frame(struct.pack("!BB", 0b00000001, 126))
+    parser.parse_frame(struct.pack("!H", 32768))
+    res = parser.parse_frame(b"1" * 32768)
+    fin, opcode, payload, compress = res[0]
+
+    assert (0, 1, expected_payload, False) == (fin, opcode, payload, not not compress)
+
+
 def test_parse_frame_length4(parser: WebSocketReader) -> None:
     parser.parse_frame(struct.pack("!BB", 0b00000001, 127))
     parser.parse_frame(struct.pack("!Q", 4))


### PR DESCRIPTION
The `first_byte` and `second_byte` are `unsigned`. This would occasionally cause the length to be wrong for the new `WebSocketReader` added in #9543 and #9554

We didn't have coverage for a longer multi-byte payload. Add coverage for this case.
