### PR TITLE
[PR #9556/df0c461 backport][3.11] Fix Cython `WebSocketReader` byte signedness

### DIFF
--- a/CHANGES/9556.feature.rst
+++ b/CHANGES/9556.feature.rst
@@ -1,0 +1,1 @@
+9543.feature.rst

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -76,8 +76,8 @@ cdef class WebSocketReader:
         buf_length="unsigned int",
         data=bytes,
         payload=bytearray,
-        first_byte=char,
-        second_byte=char,
+        first_byte="unsigned char",
+        second_byte="unsigned char",
         has_mask=bint,
         fin=bint,
     )

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -128,7 +128,18 @@ def test_parse_frame_length2(parser) -> None:
     assert (0, 1, b"1234", False) == (fin, opcode, payload, not not compress)
 
 
-def test_parse_frame_length4(parser) -> None:
+def test_parse_frame_length2_multi_byte(parser: WebSocketReader) -> None:
+    """Ensure a multi-byte length is parsed correctly."""
+    expected_payload = b"1" * 32768
+    parser.parse_frame(struct.pack("!BB", 0b00000001, 126))
+    parser.parse_frame(struct.pack("!H", 32768))
+    res = parser.parse_frame(b"1" * 32768)
+    fin, opcode, payload, compress = res[0]
+
+    assert (0, 1, expected_payload, False) == (fin, opcode, payload, not not compress)
+
+
+def test_parse_frame_length4(parser: WebSocketReader) -> None:
     parser.parse_frame(struct.pack("!BB", 0b00000001, 127))
     parser.parse_frame(struct.pack("!Q", 4))
     fin, opcode, payload, compress = parser.parse_frame(b"1234")[0]


### PR DESCRIPTION
(cherry picked from commit df0c46190c4d858ce2b0990320b941c22109d6b8)
