### PR TITLE
Fix refactoring error from moving WebSocket mask

### DIFF
--- a/CHANGES/9558.feature.rst
+++ b/CHANGES/9558.feature.rst
@@ -1,0 +1,1 @@
+9554.feature.rst

--- a/aiohttp/_websocket/helpers.py
+++ b/aiohttp/_websocket/helpers.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING or NO_EXTENSIONS:  # pragma: no cover
     websocket_mask = _websocket_mask_python
 else:
     try:
-        from ._websocket import _websocket_mask_cython  # type: ignore[import-not-found]
+        from .mask import _websocket_mask_cython  # type: ignore[import-not-found]
 
         websocket_mask = _websocket_mask_cython
     except ImportError:  # pragma: no cover

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -494,6 +494,9 @@ def test_websocket_mask_cython() -> None:
     message = bytearray(websocket_mask_data)
     _websocket_helpers._websocket_mask_cython(websocket_mask_mask, message)  # type: ignore[attr-defined]
     assert message == websocket_mask_masked
+    assert (
+        _websocket_helpers.websocket_mask is _websocket_helpers._websocket_mask_cython
+    )
 
 
 def test_websocket_mask_python_empty() -> None:

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -495,7 +495,7 @@ def test_websocket_mask_cython() -> None:
     _websocket_helpers._websocket_mask_cython(websocket_mask_mask, message)  # type: ignore[attr-defined]
     assert message == websocket_mask_masked
     assert (
-        _websocket_helpers.websocket_mask is _websocket_helpers._websocket_mask_cython
+        _websocket_helpers.websocket_mask is _websocket_helpers._websocket_mask_cython  # type: ignore[attr-defined]
     )
 
 


### PR DESCRIPTION
#9543 missed changing the import when the code was relocated.  Fix the import and adjust the test to confirm the import works.  This only affected the writer since the reader now `cimport`s the mask code.

Performance tests did not catch it because the benchmarks do not use masking. A new benchmark will be added in https://github.com/aio-libs/aiohttp/pull/9559
