### PR TITLE
Refactor WebSocketWriter to remove high level protocol functions

### DIFF
--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -34,6 +34,14 @@ WEBSOCKET_MAX_SYNC_CHUNK_SIZE = 5 * 1024
 
 
 class WebSocketWriter:
+    """WebSocket writer.
+
+    The writer is responsible for sending messages to the client. It is
+    created by the protocol when a connection is established. The writer
+    should avoid implementing any application logic and should only be
+    concerned with the low-level details of the WebSocket protocol.
+    """
+
     def __init__(
         self,
         protocol: BaseProtocol,
@@ -45,6 +53,7 @@ class WebSocketWriter:
         compress: int = 0,
         notakeover: bool = False,
     ) -> None:
+        """Initialize a WebSocket writer."""
         self.protocol = protocol
         self.transport = transport
         self.use_mask = use_mask
@@ -154,14 +163,6 @@ class WebSocketWriter:
             wbits=-compress,
             max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
         )
-
-    async def pong(self, message: bytes = b"") -> None:
-        """Send pong message."""
-        await self.send_frame(message, WSMsgType.PONG)
-
-    async def ping(self, message: bytes = b"") -> None:
-        """Send ping message."""
-        await self.send_frame(message, WSMsgType.PING)
 
     async def close(self, code: int = 1000, message: Union[bytes, str] = b"") -> None:
         """Close the websocket, sending the specified code and message."""

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -141,13 +141,14 @@ class ClientWebSocketResponse:
         self._cancel_pong_response_cb()
         self._pong_response_cb = loop.call_at(when, self._pong_not_received)
 
+        coro = self._writer.send_frame(b"", WSMsgType.PING)
         if sys.version_info >= (3, 12):
             # Optimization for Python 3.12, try to send the ping
             # immediately to avoid having to schedule
             # the task on the event loop.
-            ping_task = asyncio.Task(self._writer.ping(), loop=loop, eager_start=True)
+            ping_task = asyncio.Task(coro, loop=loop, eager_start=True)
         else:
-            ping_task = loop.create_task(self._writer.ping())
+            ping_task = loop.create_task(coro)
 
         if not ping_task.done():
             self._ping_task = ping_task
@@ -225,10 +226,10 @@ class ClientWebSocketResponse:
         return self._exception
 
     async def ping(self, message: bytes = b"") -> None:
-        await self._writer.ping(message)
+        await self._writer.send_frame(message, WSMsgType.PING)
 
     async def pong(self, message: bytes = b"") -> None:
-        await self._writer.pong(message)
+        await self._writer.send_frame(message, WSMsgType.PONG)
 
     async def send_frame(
         self, message: bytes, opcode: WSMsgType, compress: Optional[int] = None

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -179,13 +179,14 @@ class WebSocketResponse(StreamResponse):
         self._cancel_pong_response_cb()
         self._pong_response_cb = loop.call_at(when, self._pong_not_received)
 
+        coro = self._writer.send_frame(b"", WSMsgType.PING)
         if sys.version_info >= (3, 12):
             # Optimization for Python 3.12, try to send the ping
             # immediately to avoid having to schedule
             # the task on the event loop.
-            ping_task = asyncio.Task(self._writer.ping(), loop=loop, eager_start=True)
+            ping_task = asyncio.Task(coro, loop=loop, eager_start=True)
         else:
-            ping_task = loop.create_task(self._writer.ping())
+            ping_task = loop.create_task(coro)
 
         if not ping_task.done():
             self._ping_task = ping_task
@@ -397,13 +398,13 @@ class WebSocketResponse(StreamResponse):
     async def ping(self, message: bytes = b"") -> None:
         if self._writer is None:
             raise RuntimeError("Call .prepare() first")
-        await self._writer.ping(message)
+        await self._writer.send_frame(message, WSMsgType.PING)
 
     async def pong(self, message: bytes = b"") -> None:
         # unsolicited pong
         if self._writer is None:
             raise RuntimeError("Call .prepare() first")
-        await self._writer.pong(message)
+        await self._writer.send_frame(message, WSMsgType.PONG)
 
     async def send_frame(
         self, message: bytes, opcode: WSMsgType, compress: Optional[int] = None

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -873,13 +873,11 @@ async def test_close_websocket_while_ping_inflight(
 
     cancelled = False
     ping_started = loop.create_future()
-    original_send_frame = resp._writer.send_frame
 
     async def delayed_send_frame(
         message: bytes, opcode: int, compress: Optional[int] = None
     ) -> None:
-        if opcode != WSMsgType.PING:
-            await original_send_frame(message, opcode, compress)
+        assert opcode == WSMsgType.PING
         nonlocal cancelled, ping_started
         ping_started.set_result(None)
         try:

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -879,7 +879,7 @@ async def test_close_websocket_while_ping_inflight(
         message: bytes, opcode: int, compress: Optional[int] = None
     ) -> None:
         if opcode != WSMsgType.PING:
-            return await original_send_frame(message, opcode, compress)
+            await original_send_frame(message, opcode, compress)
         nonlocal cancelled, ping_stated
         ping_stated = True
         try:

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -785,12 +785,14 @@ async def test_heartbeat_connection_closed(
         with mock.patch.object(
             ws_server._req.transport, "write", side_effect=ConnectionResetError
         ), mock.patch.object(
-            ws_server._writer, "ping", wraps=ws_server._writer.ping
-        ) as ping:
+            ws_server._writer, "send_frame", wraps=ws_server._writer.send_frame
+        ) as send_frame:
             try:
                 await ws_server.receive()
             finally:
-                ping_count = ping.call_count
+                ping_count = send_frame.call_args_list.count(
+                    mock.call(b"", WSMsgType.PING)
+                )
         assert False
 
     app = web.Application()

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -31,12 +31,12 @@ def writer(protocol: BaseProtocol, transport: asyncio.Transport) -> WebSocketWri
 
 
 async def test_pong(writer: WebSocketWriter) -> None:
-    await writer.pong()
+    await writer.send_frame(b"", WSMsgType.PONG)
     writer.transport.write.assert_called_with(b"\x8a\x00")  # type: ignore[attr-defined]
 
 
 async def test_ping(writer: WebSocketWriter) -> None:
-    await writer.ping()
+    await writer.send_frame(b"", WSMsgType.PING)
     writer.transport.write.assert_called_with(b"\x89\x00")  # type: ignore[attr-defined]
 
 


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

`ping` and `pong` are details that are implemented in ``ClientWebSocketResponse`` and ``WebSocketResponse``. Keep the writer clean by limiting it to sending frames and closing

closes #2837

## Are there changes in behavior for the user?

no, internal change only
