### PR TITLE
Add support for adjusting the server WebSocket writer limit

### DIFF
--- a/CHANGES/9572.feature.rst
+++ b/CHANGES/9572.feature.rst
@@ -1,0 +1,1 @@
+Added ``writer_limit`` to the :py:class:`~aiohttp.web.WebSocketResponse` to be able to adjust the limit before the writer forces the buffer to be drained -- by :user:`bdraco`.

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -10,6 +10,7 @@ from typing import Any, Final, Iterable, Optional, Tuple
 from multidict import CIMultiDict
 
 from . import hdrs
+from ._websocket.writer import DEFAULT_LIMIT
 from .abc import AbstractStreamWriter
 from .helpers import calculate_timeout_when, set_exception, set_result
 from .http import (
@@ -57,6 +58,7 @@ class WebSocketReady:
 
 
 class WebSocketResponse(StreamResponse):
+
     __slots__ = (
         "_protocols",
         "_ws_protocol",
@@ -82,6 +84,7 @@ class WebSocketResponse(StreamResponse):
         "_compress",
         "_max_msg_size",
         "_ping_task",
+        "_writer_limit",
     )
 
     def __init__(
@@ -95,6 +98,7 @@ class WebSocketResponse(StreamResponse):
         protocols: Iterable[str] = (),
         compress: bool = True,
         max_msg_size: int = 4 * 1024 * 1024,
+        writer_limit: int = DEFAULT_LIMIT,
     ) -> None:
         super().__init__(status=101)
         self._length_check = False
@@ -123,6 +127,7 @@ class WebSocketResponse(StreamResponse):
         self._compress = compress
         self._max_msg_size = max_msg_size
         self._ping_task: Optional[asyncio.Task[None]] = None
+        self._writer_limit = writer_limit
 
     def _cancel_heartbeat(self) -> None:
         self._cancel_pong_response_cb()
@@ -331,7 +336,11 @@ class WebSocketResponse(StreamResponse):
         transport = request._protocol.transport
         assert transport is not None
         writer = WebSocketWriter(
-            request._protocol, transport, compress=compress, notakeover=notakeover
+            request._protocol,
+            transport,
+            compress=compress,
+            notakeover=notakeover,
+            limit=self._writer_limit,
         )
 
         return protocol, writer

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -58,7 +58,6 @@ class WebSocketReady:
 
 
 class WebSocketResponse(StreamResponse):
-
     __slots__ = (
         "_protocols",
         "_ws_protocol",

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -968,7 +968,7 @@ and :ref:`aiohttp-web-signals` handlers::
                             Once the buffer is full, the websocket will pause
                             to drain the buffer.
 
-      .. versionadded:: 3.3
+      .. versionadded:: 3.11
 
    :param bool autoclose: Close connection when the client sends
                            a :const:`~aiohttp.WSMsgType.CLOSE` message,
@@ -977,6 +977,8 @@ and :ref:`aiohttp-web-signals` handlers::
                            caller is responsible for calling
                            ``request.transport.close()`` to avoid
                            leaking resources.
+
+      .. versionadded:: 3.3
 
 
    The class supports ``async for`` statement for iterating over

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -922,7 +922,8 @@ and :ref:`aiohttp-web-signals` handlers::
 
 .. class:: WebSocketResponse(*, timeout=10.0, receive_timeout=None, \
                              autoclose=True, autoping=True, heartbeat=None, \
-                             protocols=(), compress=True, max_msg_size=4194304)
+                             protocols=(), compress=True, max_msg_size=4194304, \
+                             writer_limit=65536)
 
    Class for handling server-side websockets, inherited from
    :class:`StreamResponse`.
@@ -962,6 +963,10 @@ and :ref:`aiohttp-web-signals` handlers::
 
    :param int max_msg_size: maximum size of read websocket message, 4
                             MB by default. To disable the size limit use ``0``.
+
+   :param int writer_limit: maximum size of write buffer, 64 KB by default.
+                            Once the buffer is full, the websocket will pause
+                            to drain the buffer.
 
       .. versionadded:: 3.3
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -966,12 +966,6 @@ and :ref:`aiohttp-web-signals` handlers::
 
       .. versionadded:: 3.3
 
-   :param int writer_limit: maximum size of write buffer, 64 KB by default.
-                            Once the buffer is full, the websocket will pause
-                            to drain the buffer.
-
-      .. versionadded:: 3.11
-
    :param bool autoclose: Close connection when the client sends
                            a :const:`~aiohttp.WSMsgType.CLOSE` message,
                            ``True`` by default. If set to ``False``,
@@ -980,6 +974,11 @@ and :ref:`aiohttp-web-signals` handlers::
                            ``request.transport.close()`` to avoid
                            leaking resources.
 
+   :param int writer_limit: maximum size of write buffer, 64 KB by default.
+                            Once the buffer is full, the websocket will pause
+                            to drain the buffer.
+
+      .. versionadded:: 3.11
 
    The class supports ``async for`` statement for iterating over
    incoming messages::

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -964,6 +964,8 @@ and :ref:`aiohttp-web-signals` handlers::
    :param int max_msg_size: maximum size of read websocket message, 4
                             MB by default. To disable the size limit use ``0``.
 
+      .. versionadded:: 3.3
+
    :param int writer_limit: maximum size of write buffer, 64 KB by default.
                             Once the buffer is full, the websocket will pause
                             to drain the buffer.
@@ -977,8 +979,6 @@ and :ref:`aiohttp-web-signals` handlers::
                            caller is responsible for calling
                            ``request.transport.close()`` to avoid
                            leaking resources.
-
-      .. versionadded:: 3.3
 
 
    The class supports ``async for`` statement for iterating over

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -237,6 +237,18 @@ def test_closed_after_ctor() -> None:
     assert ws.close_code is None
 
 
+async def test_raise_writer_limit(make_request: _RequestMaker) -> None:
+    """Test the writer limit can be adjusted."""
+    req = make_request("GET", "/")
+    ws = web.WebSocketResponse(writer_limit=1234567)
+    await ws.prepare(req)
+    assert ws._reader is not None
+    assert ws._writer is not None
+    assert ws._writer._limit == 1234567
+    ws._reader.feed_data(WS_CLOSED_MESSAGE)
+    await ws.close()
+
+
 async def test_send_str_closed(make_request: _RequestMaker) -> None:
     req = make_request("GET", "/")
     ws = web.WebSocketResponse()


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Downstream is currently manually patching to increase the limit because the WebSocket has too much back pressure on reconnect as significant number of large messages get sent right after the connection is established. These sometimes take a while to get delivered because of latency, and too much back pressure causes downstream application to hit a timeout and disconnect prematurely.

https://github.com/aio-libs/aiohttp/issues/1367 added the limit but there has never been a way to adjust it in the public API.

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no