### PR TITLE
Switch to using `URL.host_port_subcomponent` in `yarl` for the client host header

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -362,30 +362,11 @@ class ClientRequest:
         self.headers: CIMultiDict[str] = CIMultiDict()
 
         # Build the host header
-        host = self.url.host_subcomponent
+        host = self.url.host_port_subcomponent
 
-        # host_subcomponent is None when the URL is a relative URL.
+        # host_port_subcomponent is None when the URL is a relative URL.
         # but we know we do not have a relative URL here.
         assert host is not None
-
-        if host[-1] == ".":
-            # Remove all trailing dots from the netloc as while
-            # they are valid FQDNs in DNS, TLS validation fails.
-            # See https://github.com/aio-libs/aiohttp/issues/3636.
-            # To avoid string manipulation we only call rstrip if
-            # the last character is a dot.
-            host = host.rstrip(".")
-
-        # If explicit port is not None, it means that the port was
-        # explicitly specified in the URL. In this case we check
-        # if its not the default port for the scheme and add it to
-        # the host header. We check explicit_port first because
-        # yarl caches explicit_port and its likely to already be
-        # in the cache and non-default port URLs are far less common.
-        explicit_port = self.url.explicit_port
-        if explicit_port is not None and not self.url.is_default_port():
-            host = f"{host}:{explicit_port}"
-
         self.headers[hdrs.HOST] = host
 
         if not headers:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

We can use `URL.host_port_subcomponent` for the host header instead of constructing it ourselves. Additionally, this means the value is cached if the url already accessed it.

The documented semantics are the same.

This is an internal change only

## Are there changes in behavior for the user?

no
