### PR TITLE
Enable unreachable in mypy

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -23,7 +23,7 @@ strict_equality = True
 warn_incomplete_stub = True
 warn_redundant_casts = True
 warn_return_any = True
-#warn_unreachable = True
+warn_unreachable = True
 warn_unused_ignores = True
 
 [mypy-brotli]

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -680,7 +680,7 @@ class ClientSession:
                     except ClientError:
                         raise
                     except OSError as exc:
-                        if exc.errno is None and isinstance(exc, asyncio.TimeoutError):
+                        if exc.errno is None and isinstance(exc, asyncio.TimeoutError):  # type: ignore[unreachable]
                             raise
                         raise ClientOSError(*exc.args) from exc
 
@@ -882,7 +882,7 @@ class ClientSession:
             if isinstance(timeout, ClientWSTimeout):
                 ws_timeout = timeout
             else:
-                warnings.warn(
+                warnings.warn(  # type: ignore[unreachable]
                     "parameter 'timeout' of type 'float' "
                     "is deprecated, please use "
                     "'timeout=ClientWSTimeout(ws_close=...)'",

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -331,7 +331,7 @@ if ssl is not None:
     ssl_errors = (ssl.SSLError,)
     ssl_error_bases = (ClientSSLError, ssl.SSLError)
 else:  # pragma: no cover
-    cert_errors = tuple()
+    cert_errors = tuple()  # type: ignore[unreachable]
     cert_errors_bases = (
         ClientSSLError,
         ValueError,

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -589,8 +589,11 @@ class ClientRequest:
         except OSError as underlying_exc:
             reraised_exc = underlying_exc
 
-            exc_is_not_timeout = underlying_exc.errno is not None or not isinstance(  # type: ignore[unreachable]
-                underlying_exc, asyncio.TimeoutError
+            exc_is_not_timeout = (
+                underlying_exc.errno is not None
+                or not isinstance(  # type: ignore[unreachable]
+                    underlying_exc, asyncio.TimeoutError
+                )
             )
             if exc_is_not_timeout:
                 reraised_exc = ClientOSError(

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -149,7 +149,7 @@ class Fingerprint:
 if ssl is not None:
     SSL_ALLOWED_TYPES = (ssl.SSLContext, bool, Fingerprint)
 else:  # pragma: no cover
-    SSL_ALLOWED_TYPES = (bool,)
+    SSL_ALLOWED_TYPES = (bool,)  # type: ignore[unreachable]
 
 
 _SSL_SCHEMES = frozenset(("https", "wss"))
@@ -193,7 +193,7 @@ class ClientRequest:
     auth = None
     response = None
 
-    __writer = None  # async task for streaming data
+    __writer: Optional["asyncio.Task[None]"] = None  # async task for streaming data
     _continue = None  # waiter future for '100 Continue' response
 
     # N.B.
@@ -589,7 +589,7 @@ class ClientRequest:
         except OSError as underlying_exc:
             reraised_exc = underlying_exc
 
-            exc_is_not_timeout = underlying_exc.errno is not None or not isinstance(
+            exc_is_not_timeout = underlying_exc.errno is not None or not isinstance(  # type: ignore[unreachable]
                 underlying_exc, asyncio.TimeoutError
             )
             if exc_is_not_timeout:
@@ -754,14 +754,14 @@ class ClientResponse(HeadersMixin):
     _headers: CIMultiDictProxy[str] = None  # type: ignore[assignment]
     _raw_headers: RawHeaders = None  # type: ignore[assignment]
 
-    _connection = None  # current connection
+    _connection: Optional["Connection"] = None  # current connection
     _source_traceback: Optional[traceback.StackSummary] = None
     # set up by ClientRequest after ClientResponse object creation
     # post-init stage allows to not change ctor signature
     _closed = True  # to allow __del__ for non-initialized properly response
     _released = False
     _in_context = False
-    __writer = None
+    __writer: Optional["asyncio.Task[None]"] = None
 
     def __init__(
         self,
@@ -801,7 +801,7 @@ class ClientResponse(HeadersMixin):
         # work after the response has finished reading the body.
         if session is None:
             # TODO: Fix session=None in tests (see ClientRequest.__init__).
-            self._resolve_charset: Callable[["ClientResponse", bytes], str] = (
+            self._resolve_charset: Callable[["ClientResponse", bytes], str] = (  # type: ignore[unreachable]
                 lambda *_: "utf-8"
             )
         else:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -736,7 +736,7 @@ def _make_ssl_context(verified: bool) -> SSLContext:
     """
     if ssl is None:
         # No ssl support
-        return None
+        return None  # type: ignore[unreachable]
     if verified:
         return ssl.create_default_context()
     sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
@@ -1082,7 +1082,7 @@ class TCPConnector(BaseConnector):
         except ssl_errors as exc:
             raise ClientConnectorSSLError(req.connection_key, exc) from exc
         except OSError as exc:
-            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):
+            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):  # type: ignore[unreachable]
                 raise
             raise client_error(req.connection_key, exc) from exc
 
@@ -1171,7 +1171,7 @@ class TCPConnector(BaseConnector):
         except ssl_errors as exc:
             raise ClientConnectorSSLError(req.connection_key, exc) from exc
         except OSError as exc:
-            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):
+            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):  # type: ignore[unreachable]
                 raise
             raise client_error(req.connection_key, exc) from exc
         except TypeError as type_err:
@@ -1242,7 +1242,7 @@ class TCPConnector(BaseConnector):
             #  across all connections.
             hosts = await self._resolve_host(host, port, traces=traces)
         except OSError as exc:
-            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):
+            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):  # type: ignore[unreachable]
                 raise
             # in case of proxy it is not ClientProxyConnectionError
             # it is problem of resolving proxy ip itself
@@ -1437,7 +1437,7 @@ class UnixConnector(BaseConnector):
                     self._factory, self._path
                 )
         except OSError as exc:
-            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):
+            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):  # type: ignore[unreachable]
                 raise
             raise UnixClientConnectorError(self.path, req.connection_key, exc) from exc
 
@@ -1506,7 +1506,7 @@ class NamedPipeConnector(BaseConnector):
                 # other option is to manually set transport like
                 # `proto.transport = trans`
         except OSError as exc:
-            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):
+            if exc.errno is None and isinstance(exc, asyncio.TimeoutError):  # type: ignore[unreachable]
                 raise
             raise ClientConnectorError(req.connection_key, exc) from exc
 

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -302,7 +302,7 @@ class CookieJar(AbstractCookieJar):
     def filter_cookies(self, request_url: URL) -> "BaseCookie[str]":
         """Returns this jar's cookies filtered by their attributes."""
         if not isinstance(request_url, URL):
-            warnings.warn(
+            warnings.warn(  # type: ignore[unreachable]
                 "The method accepts yarl.URL instances only, got {}".format(
                     type(request_url)
                 ),
@@ -466,7 +466,7 @@ class DummyCookieJar(AbstractCookieJar):
 
     def __iter__(self) -> "Iterator[Morsel[str]]":
         while False:
-            yield None
+            yield None  # type: ignore[unreachable]
 
     def __len__(self) -> int:
         return 0

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -258,7 +258,7 @@ def basicauth_from_netrc(netrc_obj: Optional[netrc.netrc], host: str) -> BasicAu
     # TODO(PY311): Remove this, as password will be empty string
     # if not specified
     if password is None:
-        password = ""
+        password = ""  # type: ignore[unreachable]
 
     return BasicAuth(username, password)
 
@@ -800,6 +800,7 @@ class AppKey(Generic[_T]):
     # like Iterable, which can't be passed as the second parameter to __init__.
     __orig_class__: Type[object]
 
+    # TODO(PY314): Change Type to TypeForm (this should resolve unreachable below).
     def __init__(self, name: str, t: Optional[Type[_T]] = None):
         # Prefix with module name to help deduplicate key names.
         frame = inspect.currentframe()
@@ -835,7 +836,7 @@ class AppKey(Generic[_T]):
             else:
                 t_repr = f"{t.__module__}.{t.__qualname__}"
         else:
-            t_repr = repr(t)
+            t_repr = repr(t)  # type: ignore[unreachable]
         return f"<AppKey({self._name}, type={t_repr})>"
 
 

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -314,7 +314,8 @@ class BodyPartReader:
         data = bytearray()
         while not self._at_eof:
             data.extend(await self.read_chunk(self.chunk_size))
-        if decode:
+        # https://github.com/python/mypy/issues/17537
+        if decode:  # type: ignore[unreachable]
             return self.decode(data)
         return data
 
@@ -655,7 +656,8 @@ class MultipartReader:
         else:
             await self._read_boundary()
         if self._at_eof:  # we just read the last boundary, nothing to do there
-            return None
+            # https://github.com/python/mypy/issues/17537
+            return None  # type: ignore[unreachable]
 
         part = await self.fetch_next_part()
         # https://datatracker.ietf.org/doc/html/rfc7578#section-4.6

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -147,8 +147,6 @@ class StreamReader(AsyncStreamReaderMixin):
         self._protocol = protocol
         self._low_water = limit
         self._high_water = limit * 2
-        if loop is None:
-            loop = asyncio.get_event_loop()
         self._loop = loop
         self._size = 0
         self._cursor = 0

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -673,7 +673,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             prepare_meth = resp.prepare
         except AttributeError:
             if resp is None:
-                self.log_exception("Missing return statement on request handler")
+                self.log_exception("Missing return statement on request handler")  # type: ignore[unreachable]
             else:
                 self.log_exception(
                     "Web-handler should return a response instance, "

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -279,8 +279,6 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
 
     @property
     def transport(self) -> Optional[asyncio.Transport]:
-        if self._protocol is None:
-            return None
         return self._protocol.transport
 
     @property
@@ -800,11 +798,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
 
     def get_extra_info(self, name: str, default: Any = None) -> Any:
         """Extra info from protocol transport"""
-        protocol = self._protocol
-        if protocol is None:
-            return default
-
-        transport = protocol.transport
+        transport = self._protocol.transport
         if transport is None:
             return default
 

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -395,10 +395,7 @@ class WebSocketResponse(StreamResponse):
         writer = self._writer
         if writer is None:
             return default
-        transport = writer.transport
-        if transport is None:
-            return default
-        return transport.get_extra_info(name, default)
+        return writer.transport.get_extra_info(name, default)
 
     def exception(self) -> Optional[BaseException]:
         return self._exception

--- a/tests/test_base_protocol.py
+++ b/tests/test_base_protocol.py
@@ -118,7 +118,7 @@ async def test_connection_lost_waiter_done() -> None:
     pr._drain_waiter = waiter
     pr.connection_lost(None)
     assert pr._drain_waiter is None
-    assert waiter.mock_calls == [mock.call.done()]
+    assert waiter.mock_calls == [mock.call.done()]  # type: ignore[unreachable]
 
 
 async def test_drain_lost() -> None:

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1032,7 +1032,7 @@ async def test_data_stream(
     assert asyncio.isfuture(req._writer)
     await resp.wait_for_close()
     assert req._writer is None
-    assert (
+    assert (  # type: ignore[unreachable]
         buf.split(b"\r\n\r\n", 1)[1] == b"b\r\nbinary data\r\n7\r\n result\r\n0\r\n\r\n"
     )
     await req.close()
@@ -1057,7 +1057,7 @@ async def test_data_file(
         await resp.wait_for_close()
 
         assert req._writer is None
-        assert buf.split(b"\r\n\r\n", 1)[1] == b"2\r\n" + b"*" * 2 + b"\r\n0\r\n\r\n"
+        assert buf.split(b"\r\n\r\n", 1)[1] == b"2\r\n" + b"*" * 2 + b"\r\n0\r\n\r\n"  # type: ignore[unreachable]
         await req.close()
 
 
@@ -1098,7 +1098,7 @@ async def test_data_stream_exc_chain(
     async def gen() -> AsyncIterator[None]:
         await fut
         assert False
-        yield  # pragma: no cover
+        yield  # type: ignore[unreachable]  # pragma: no cover
 
     req = ClientRequest("POST", URL("http://python.org/"), data=gen(), loop=loop)
 

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -391,7 +391,7 @@ async def test_close(
                 res = await resp.close()
                 writer.close.assert_called_with(1000, b"")
                 assert resp.closed
-                assert res
+                assert res  # type: ignore[unreachable]
                 assert resp.exception() is None
 
                 # idempotent
@@ -432,7 +432,7 @@ async def test_close_eofstream(
                 writer.close.assert_called_with(1000, b"")
                 assert resp.closed
 
-                await session.close()
+                await session.close()  # type: ignore[unreachable]
 
 
 async def test_close_connection_lost(
@@ -465,7 +465,7 @@ async def test_close_connection_lost(
         assert msg.type is aiohttp.WSMsgType.CLOSED
         assert resp.closed
 
-        await session.close()
+        await session.close()  # type: ignore[unreachable]
 
 
 async def test_close_exc(
@@ -498,7 +498,7 @@ async def test_close_exc(
 
                 await resp.close()
                 assert resp.closed
-                assert resp.exception() is exc
+                assert resp.exception() is exc  # type: ignore[unreachable]
 
                 await session.close()
 
@@ -530,7 +530,7 @@ async def test_close_exc2(
 
                 await resp.close()
                 assert resp.closed
-                assert resp.exception() is exc
+                assert resp.exception() is exc  # type: ignore[unreachable]
 
                 resp._closed = False
                 writer.close.side_effect = asyncio.CancelledError()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2324,7 +2324,7 @@ async def test_connect_with_limit(
         connection1.release()
         await asyncio.sleep(0)
         assert acquired
-        await task
+        await task  # type: ignore[unreachable]
         await conn.close()
 
 
@@ -2438,7 +2438,7 @@ async def test_connect_with_limit_and_limit_per_host(
         connection1.release()
         await asyncio.sleep(0)
         assert acquired
-        await task
+        await task  # type: ignore[unreachable]
         await conn.close()
 
 
@@ -2471,7 +2471,7 @@ async def test_connect_with_no_limit_and_limit_per_host(
         connection1.release()
         await asyncio.sleep(0)
         assert acquired
-        await task
+        await task  # type: ignore[unreachable]
         await conn.close()
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1151,7 +1151,7 @@ def test_http_response_parser_lenient_headers(response: HttpResponseParser) -> N
 def test_http_response_parser_strict_headers(response: HttpResponseParser) -> None:
     if isinstance(response, HttpResponseParserPy):
         pytest.xfail("Py parser is lenient. May update py-parser later.")
-    with pytest.raises(http_exceptions.BadHttpMessage):
+    with pytest.raises(http_exceptions.BadHttpMessage):  # type: ignore[unreachable]
         response.feed_data(b"HTTP/1.1 200 test\r\nFoo: abc\x01def\r\n\r\n")
 
 

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -262,7 +262,7 @@ async def test_write_drain(
 
         await msg.write(b"1", drain=True)
         assert m.called
-        assert msg.buffer_size == 0
+        assert msg.buffer_size == 0  # type: ignore[unreachable]
 
 
 async def test_write_calls_callback(

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -103,7 +103,7 @@ def test_string_io_payload() -> None:
 def test_async_iterable_payload_default_content_type() -> None:
     async def gen() -> AsyncIterator[bytes]:
         return
-        yield b"abc"
+        yield b"abc"  # type: ignore[unreachable]
 
     p = payload.AsyncIterablePayload(gen())
     assert p.content_type == "application/octet-stream"
@@ -112,7 +112,7 @@ def test_async_iterable_payload_default_content_type() -> None:
 def test_async_iterable_payload_explicit_content_type() -> None:
     async def gen() -> AsyncIterator[bytes]:
         return
-        yield b"abc"
+        yield b"abc"  # type: ignore[unreachable]
 
     p = payload.AsyncIterablePayload(gen(), content_type="application/custom")
     assert p.content_type == "application/custom"

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -103,7 +103,7 @@ def test_string_io_payload() -> None:
 def test_async_iterable_payload_default_content_type() -> None:
     async def gen() -> AsyncIterator[bytes]:
         return
-        yield b"abc"  # type: ignore[unreachable]
+        yield b"abc"  # type: ignore[unreachable]  # pragma: no cover
 
     p = payload.AsyncIterablePayload(gen())
     assert p.content_type == "application/octet-stream"
@@ -112,7 +112,7 @@ def test_async_iterable_payload_default_content_type() -> None:
 def test_async_iterable_payload_explicit_content_type() -> None:
     async def gen() -> AsyncIterator[bytes]:
         return
-        yield b"abc"  # type: ignore[unreachable]
+        yield b"abc"  # type: ignore[unreachable]  # pragma: no cover
 
     p = payload.AsyncIterablePayload(gen(), content_type="application/custom")
     assert p.content_type == "application/custom"

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -982,7 +982,7 @@ def test_run_app_context_vars(patched_loop: asyncio.AbstractEventLoop) -> None:
 def test_run_app_raises_exception(patched_loop: asyncio.AbstractEventLoop) -> None:
     async def context(app: web.Application) -> AsyncIterator[None]:
         raise RuntimeError("foo")
-        yield  # pragma: no cover
+        yield  # type: ignore[unreachable]  # pragma: no cover
 
     app = web.Application()
     app.cleanup_ctx.append(context)

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1285,7 +1285,7 @@ async def test_feed_data_waiters(protocol: BaseProtocol) -> None:
     assert waiter.done()
     assert not eof_waiter.done()
     assert reader._waiter is None
-    assert reader._eof_waiter is eof_waiter
+    assert reader._eof_waiter is eof_waiter  # type: ignore[unreachable]
 
 
 async def test_feed_data_completed_waiters(protocol: BaseProtocol) -> None:
@@ -1311,7 +1311,7 @@ async def test_feed_eof_waiters(protocol: BaseProtocol) -> None:
     assert waiter.done()
     assert eof_waiter.done()
     assert reader._waiter is None
-    assert reader._eof_waiter is None
+    assert reader._eof_waiter is None  # type: ignore[unreachable]
 
 
 async def test_feed_eof_cancelled(protocol: BaseProtocol) -> None:
@@ -1328,7 +1328,7 @@ async def test_feed_eof_cancelled(protocol: BaseProtocol) -> None:
     assert waiter.done()
     assert eof_waiter.done()
     assert reader._waiter is None
-    assert reader._eof_waiter is None
+    assert reader._eof_waiter is None  # type: ignore[unreachable]
 
 
 async def test_on_eof(protocol: BaseProtocol) -> None:
@@ -1363,7 +1363,7 @@ async def test_on_eof_exc_in_callback(protocol: BaseProtocol) -> None:
     assert not on_eof.called
     reader.feed_eof()
     assert on_eof.called
-    assert not reader._eof_callbacks
+    assert not reader._eof_callbacks  # type: ignore[unreachable]
 
 
 async def test_on_eof_exc_in_callback_empty_stream_reader() -> None:
@@ -1412,7 +1412,7 @@ async def test_set_exception(protocol: BaseProtocol) -> None:
     assert waiter.exception() is exc
     assert eof_waiter.exception() is exc
     assert reader._waiter is None
-    assert reader._eof_waiter is None
+    assert reader._eof_waiter is None  # type: ignore[unreachable]
 
 
 async def test_set_exception_cancelled(protocol: BaseProtocol) -> None:
@@ -1430,7 +1430,7 @@ async def test_set_exception_cancelled(protocol: BaseProtocol) -> None:
     assert waiter.exception() is None
     assert eof_waiter.exception() is None
     assert reader._waiter is None
-    assert reader._eof_waiter is None
+    assert reader._eof_waiter is None  # type: ignore[unreachable]
 
 
 async def test_set_exception_eof_callbacks(protocol: BaseProtocol) -> None:

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1011,7 +1011,6 @@ def test_static_route_user_home(router: web.UrlDispatcher) -> None:
         static_dir = pathlib.Path("~") / here.relative_to(pathlib.Path.home())
     except ValueError:
         pytest.skip("aiohttp folder is not placed in user's HOME")
-        return  # TODO: Remove and fix type error
     route = router.add_static("/st", str(static_dir))
     assert here == route.get_info()["directory"]
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -321,7 +321,7 @@ async def test_cleanup_ctx_cleanup_after_exception() -> None:
 
     async def fail_ctx(app: web.Application) -> AsyncIterator[NoReturn]:
         raise Exception()
-        yield  # type: ignore[unreachable]
+        yield  # type: ignore[unreachable]  # pragma: no cover
 
     app.cleanup_ctx.append(success_ctx)
     app.cleanup_ctx.append(fail_ctx)

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -321,7 +321,7 @@ async def test_cleanup_ctx_cleanup_after_exception() -> None:
 
     async def fail_ctx(app: web.Application) -> AsyncIterator[NoReturn]:
         raise Exception()
-        yield
+        yield  # type: ignore[unreachable]
 
     app.cleanup_ctx.append(success_ctx)
     app.cleanup_ctx.append(fail_ctx)
@@ -516,7 +516,7 @@ async def test_subapp_on_startup(aiohttp_client: AiohttpClient) -> None:
     client = await aiohttp_client(app)
 
     assert startup_called
-    assert ctx_pre_called
+    assert ctx_pre_called  # type: ignore[unreachable]
     assert not ctx_post_called
     assert not shutdown_called
     assert not cleanup_called

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1973,7 +1973,7 @@ async def test_context_manager_close_on_release(
             assert resp.status == 200
             assert resp.connection is not None
         assert resp.connection is None
-        assert proto.close.called
+        assert proto.close.called  # type: ignore[unreachable]
 
         resp.release()  # Trigger handler completion
 
@@ -2272,7 +2272,7 @@ async def test_no_body_for_1xx_204_304_responses(
 
 
 async def test_keepalive_race_condition(aiohttp_client: AiohttpClient) -> None:
-    protocol = None
+    protocol: Optional[RequestHandler[web.Request]] = None
     orig_data_received = RequestHandler.data_received
 
     def delay_received(self: RequestHandler[web.Request], data: bytes) -> None:

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -777,10 +777,6 @@ async def test_get_extra_info() -> None:
     extra_info = req.get_extra_info(valid_key, default_value)
     assert extra_info == default_value
 
-    req._protocol = None  # type: ignore[assignment]
-    extra_info = req.get_extra_info(valid_key, default_value)
-    assert extra_info == default_value
-
 
 def test_eq() -> None:
     req1 = make_mocked_request("GET", "/path/to?a=1&b=2")

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -345,7 +345,7 @@ async def test_start() -> None:
 
     assert resp.keep_alive
 
-    req2 = make_request("GET", "/")
+    req2 = make_request("GET", "/")  # type: ignore[unreachable]
     # with pytest.raises(RuntimeError):
     msg3 = await resp.prepare(req2)
     assert msg is msg3
@@ -359,7 +359,7 @@ async def test_chunked_encoding() -> None:
     resp.enable_chunked_encoding()
     assert resp.chunked
 
-    msg = await resp.prepare(req)
+    msg = await resp.prepare(req)  # type: ignore[unreachable]
     assert msg.chunked
 
 
@@ -390,7 +390,7 @@ async def test_compression_no_accept() -> None:
     resp.enable_compression()
     assert resp.compression
 
-    msg = await resp.prepare(req)
+    msg = await resp.prepare(req)  # type: ignore[unreachable]
     assert not msg.enable_compression.called
 
 
@@ -405,7 +405,7 @@ async def test_compression_default_coding() -> None:
     resp.enable_compression()
     assert resp.compression
 
-    msg = await resp.prepare(req)
+    msg = await resp.prepare(req)  # type: ignore[unreachable]
 
     msg.enable_compression.assert_called_with("deflate", zlib.Z_DEFAULT_STRATEGY)
     assert "deflate" == resp.headers.get(hdrs.CONTENT_ENCODING)
@@ -708,7 +708,7 @@ async def test_content_length_on_chunked() -> None:
     assert resp.content_length == 6
     resp.enable_chunked_encoding()
     assert resp.content_length is None
-    await resp.prepare(req)
+    await resp.prepare(req)  # type: ignore[unreachable]
 
 
 async def test_write_non_byteish() -> None:

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -502,7 +502,7 @@ async def test_close_after_closing(
 
     await ws.close()
     assert ws.closed
-    assert len(req.transport.close.mock_calls) == 1
+    assert len(req.transport.close.mock_calls) == 1  # type: ignore[unreachable]
 
 
 async def test_receive_timeouterror(
@@ -629,7 +629,6 @@ async def test_no_transfer_encoding_header(
             "existent",
         ),
         (None, "default"),
-        (mock.MagicMock(transport=None), "default"),
     ],
 )
 async def test_get_extra_info(

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -618,7 +618,7 @@ async def test_client_close_handshake(
         assert not ws.closed
         await ws.close()
         assert ws.closed
-        assert ws.close_code == WSCloseCode.INVALID_TEXT
+        assert ws.close_code == WSCloseCode.INVALID_TEXT  # type: ignore[unreachable]
 
         msg = await ws.receive()
         assert msg.type == WSMsgType.CLOSED
@@ -978,7 +978,7 @@ async def test_websocket_disable_keepalive(
         assert request.protocol._keepalive
         await ws.prepare(request)
         assert not request.protocol._keepalive
-        assert not request.protocol._keepalive_handle
+        assert not request.protocol._keepalive_handle  # type: ignore[unreachable]
 
         await ws.send_str("OK")
         await ws.close()

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -89,8 +89,6 @@ def build_close_frame(
     code: int = 1000, message: bytes = b"", noheader: bool = False
 ) -> bytes:
     # Close the websocket, sending the specified code and message.
-    if isinstance(message, str):  # pragma: no cover
-        message = message.encode("utf-8")
     return build_frame(
         PACK_CLOSE_CODE(code) + message, opcode=WSMsgType.CLOSE, noheader=noheader
     )

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -156,7 +156,7 @@ def test__notify_waiter_done(worker: base_worker.GunicornWebWorker) -> None:
     worker._notify_waiter_done()
 
     assert worker._notify_waiter is None
-    waiter.set_result.assert_called_with(True)
+    waiter.set_result.assert_called_with(True)  # type: ignore[unreachable]
 
 
 def test__notify_waiter_done_explicit_waiter(


### PR DESCRIPTION
Pretty much all the ignores in the test files are due to overzealous type narrowing by mypy. A future release might resolve these some day.