### PR TITLE
[PR #9530/f3a3f60 backport][3.11] Allow URLs with paths that end with / as base_url in ClientSession

### DIFF
--- a/CHANGES/9530.feature.rst
+++ b/CHANGES/9530.feature.rst
@@ -1,0 +1,2 @@
+Updated :py:class:`~aiohttp.ClientSession` to support paths in ``base_url`` parameter.
+``base_url`` paths must end with a ``/``  -- by :user:`Cycloctane`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -314,9 +314,9 @@ class ClientSession:
         else:
             self._base_url = URL(base_url)
             self._base_url_origin = self._base_url.origin()
-            assert (
-                self._base_url_origin == self._base_url
-            ), "Only absolute URLs without path part are supported"
+            assert self._base_url.absolute, "Only absolute URLs are supported"
+        if self._base_url is not None and not self._base_url.path.endswith("/"):
+            raise ValueError("base_url must have a trailing '/'")
 
         if timeout is sentinel or timeout is None:
             self._timeout = DEFAULT_TIMEOUT
@@ -463,7 +463,7 @@ class ClientSession:
         if self._base_url is None:
             return url
         else:
-            assert not url.absolute and url.path.startswith("/")
+            assert not url.absolute
             return self._base_url.join(url)
 
     async def _request(

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -62,9 +62,20 @@ The client session supports the context manager protocol for self closing.
 
 
    :param base_url: Base part of the URL (optional)
-      If set, it allows to skip the base part (https://docs.aiohttp.org) in
-      request calls. It must not include a path (as in
-      https://docs.aiohttp.org/en/stable).
+      If set, allows to join a base part to relative URLs in request calls.
+      If the URL has a path it must have a trailing ``/`` (as in
+      https://docs.aiohttp.org/en/stable/).
+
+      Note that URL joining follows :rfc:`3986`. This means, in the most
+      common case the request URLs should have no leading slash, e.g.::
+
+        session = ClientSession(base_url="http://example.com/foo/")
+
+        await session.request("GET", "bar")
+        # request for http://example.com/foo/bar
+
+        await session.request("GET", "/bar")
+        # request for http://example.com/bar
 
       .. versionadded:: 3.8
 

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -1068,6 +1068,24 @@ async def test_requote_redirect_setter() -> None:
             URL("http://example.com/test"),
             id="base_url=URL('http://example.com') url='/test'",
         ),
+        pytest.param(
+            URL("http://example.com/test1/"),
+            "test2",
+            URL("http://example.com/test1/test2"),
+            id="base_url=URL('http://example.com/test1/') url='test2'",
+        ),
+        pytest.param(
+            URL("http://example.com/test1/"),
+            "/test2",
+            URL("http://example.com/test2"),
+            id="base_url=URL('http://example.com/test1/') url='/test2'",
+        ),
+        pytest.param(
+            URL("http://example.com/test1/"),
+            "test2?q=foo#bar",
+            URL("http://example.com/test1/test2?q=foo#bar"),
+            id="base_url=URL('http://example.com/test1/') url='test2?q=foo#bar'",
+        ),
     ],
 )
 async def test_build_url_returns_expected_url(
@@ -1075,6 +1093,11 @@ async def test_build_url_returns_expected_url(
 ) -> None:
     session = await create_session(base_url)
     assert session._build_url(url) == expected_url
+
+
+async def test_base_url_without_trailing_slash() -> None:
+    with pytest.raises(ValueError, match="base_url must have a trailing '/'"):
+        ClientSession(base_url="http://example.com/test")
 
 
 async def test_instantiation_with_invalid_timeout_value(loop):


### PR DESCRIPTION
Backport from PR #9530 (commit https://github.com/aio-libs/aiohttp/commit/f3a3f60b7a4b181272472b188e67d3b5f4ad3306)
