### PR TITLE
Add test coverage for perserving the coded cookie value

### DIFF
--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -598,6 +598,14 @@ def test_gen_netloc_no_port(make_request: _RequestMaker) -> None:
     )
 
 
+def test_cookie_coded_value_preserved(loop: asyncio.AbstractEventLoop) -> None:
+    """Verify the coded value of a cookie is preserved."""
+    # https://github.com/aio-libs/aiohttp/pull/1453
+    req = ClientRequest("get", URL("http://python.org"), loop=loop)
+    req.update_cookies(cookies=SimpleCookie('ip-cookie="second"; Domain=127.0.0.1;'))
+    assert req.headers["COOKIE"] == 'ip-cookie="second"'
+
+
 async def test_connection_header(
     loop: asyncio.AbstractEventLoop, conn: mock.Mock
 ) -> None:


### PR DESCRIPTION
Adds missing test coverage for #1453

 I'm adding tests before I look at refactoring it.