### PR TITLE
DNM: Avoid constructing traces during client request if there are none

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1287,7 +1287,7 @@ class ClientSession:
     @property
     def trace_configs(self) -> List[TraceConfig[Any]]:
         """A list of TraceConfig instances used for client tracing"""
-        return self._trace_configs
+        return self._trace_configs or []
 
     def detach(self) -> None:
         """Detach connector from session without closing the former.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -364,9 +364,10 @@ class ClientSession:
         self._response_class = response_class
         self._ws_response_class = ws_response_class
 
-        self._trace_configs = trace_configs or []
-        for trace_config in self._trace_configs:
-            trace_config.freeze()
+        self._trace_configs = trace_configs
+        if trace_configs:
+            for trace_config in trace_configs:
+                trace_config.freeze()
 
         self._resolve_charset = fallback_charset_resolver
 
@@ -529,17 +530,23 @@ class ClientSession:
         if max_field_size is None:
             max_field_size = self._max_field_size
 
-        traces = [
-            Trace(
-                self,
-                trace_config,
-                trace_config.trace_config_ctx(trace_request_ctx=trace_request_ctx),
-            )
-            for trace_config in self._trace_configs
-        ]
+        traces: Optional[List[Trace]]
+        if self._trace_configs:
+            traces = [
+                Trace(
+                    self,
+                    trace_config,
+                    trace_config.trace_config_ctx(trace_request_ctx=trace_request_ctx),
+                )
+                for trace_config in self._trace_configs
+            ]
 
-        for trace in traces:
-            await trace.send_request_start(method, url.update_query(params), headers)
+            for trace in traces:
+                await trace.send_request_start(
+                    method, url.update_query(params), headers
+                )
+        else:
+            traces = None
 
         timer = tm.timer()
         try:
@@ -684,10 +691,11 @@ class ClientSession:
 
                     # redirects
                     if resp.status in (301, 302, 303, 307, 308) and allow_redirects:
-                        for trace in traces:
-                            await trace.send_request_redirect(
-                                method, url.update_query(params), headers, resp
-                            )
+                        if traces:
+                            for trace in traces:
+                                await trace.send_request_redirect(
+                                    method, url.update_query(params), headers, resp
+                                )
 
                         redirects += 1
                         history.append(resp)
@@ -783,10 +791,11 @@ class ClientSession:
 
             resp._history = tuple(history)
 
-            for trace in traces:
-                await trace.send_request_end(
-                    method, url.update_query(params), headers, resp
-                )
+            if traces:
+                for trace in traces:
+                    await trace.send_request_end(
+                        method, url.update_query(params), headers, resp
+                    )
             return resp
 
         except BaseException as e:
@@ -796,10 +805,11 @@ class ClientSession:
                 handle.cancel()
                 handle = None
 
-            for trace in traces:
-                await trace.send_request_exception(
-                    method, url.update_query(params), headers, e
-                )
+            if traces:
+                for trace in traces:
+                    await trace.send_request_exception(
+                        method, url.update_query(params), headers, e
+                    )
             raise
 
     def ws_connect(

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -741,7 +741,7 @@ class ClientRequest:
     async def _on_headers_request_sent(
         self, method: str, url: URL, headers: "CIMultiDict[str]", traces: List[Trace]
     ) -> None:
-        for trace in self.traces:
+        for trace in traces:
             await trace.send_request_headers(method, url, headers)
 
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -733,13 +733,13 @@ class ClientRequest:
             self.__writer = None
 
     async def _on_chunk_request_sent(
-        self, method: str, url: URL, chunk: bytes, traces: List[Trace]
+        self, method: str, url: URL, chunk: bytes, traces: List["Trace"]
     ) -> None:
         for trace in traces:
             await trace.send_request_chunk_sent(method, url, chunk)
 
     async def _on_headers_request_sent(
-        self, method: str, url: URL, headers: "CIMultiDict[str]", traces: List[Trace]
+        self, method: str, url: URL, headers: "CIMultiDict[str]", traces: List["Trace"]
     ) -> None:
         for trace in traces:
             await trace.send_request_headers(method, url, headers)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1458,7 +1458,10 @@ class UnixConnector(BaseConnector):
         return self._path
 
     async def _create_connection(
-        self, req: ClientRequest, traces: List["Trace"], timeout: "ClientTimeout"
+        self,
+        req: ClientRequest,
+        traces: Optional[List["Trace"]],
+        timeout: "ClientTimeout",
     ) -> ResponseHandler:
         try:
             async with ceil_timeout(
@@ -1520,7 +1523,10 @@ class NamedPipeConnector(BaseConnector):
         return self._path
 
     async def _create_connection(
-        self, req: ClientRequest, traces: List["Trace"], timeout: "ClientTimeout"
+        self,
+        req: ClientRequest,
+        traces: Optional[List["Trace"]],
+        timeout: "ClientTimeout",
     ) -> ResponseHandler:
         try:
             async with ceil_timeout(

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -707,7 +707,10 @@ class BaseConnector:
             )
 
     async def _create_connection(
-        self, req: ClientRequest, traces: List["Trace"], timeout: "ClientTimeout"
+        self,
+        req: ClientRequest,
+        traces: Optional[List["Trace"]],
+        timeout: "ClientTimeout",
     ) -> ResponseHandler:
         raise NotImplementedError()
 
@@ -1024,7 +1027,10 @@ class TCPConnector(BaseConnector):
         return self._cached_hosts.next_addrs(key)
 
     async def _create_connection(
-        self, req: ClientRequest, traces: List["Trace"], timeout: "ClientTimeout"
+        self,
+        req: ClientRequest,
+        traces: Optional[List["Trace"]],
+        timeout: "ClientTimeout",
     ) -> ResponseHandler:
         """Create connection.
 
@@ -1242,7 +1248,7 @@ class TCPConnector(BaseConnector):
     async def _create_direct_connection(
         self,
         req: ClientRequest,
-        traces: List["Trace"],
+        traces: Optional[List["Trace"]],
         timeout: "ClientTimeout",
         *,
         client_error: Type[Exception] = ClientConnectorError,
@@ -1314,7 +1320,10 @@ class TCPConnector(BaseConnector):
         raise last_exc
 
     async def _create_proxy_connection(
-        self, req: ClientRequest, traces: List["Trace"], timeout: "ClientTimeout"
+        self,
+        req: ClientRequest,
+        traces: Optional[List["Trace"]],
+        timeout: "ClientTimeout",
     ) -> Tuple[asyncio.BaseTransport, ResponseHandler]:
         headers: Dict[str, str] = {}
         if req.proxy_headers is not None:
@@ -1334,7 +1343,7 @@ class TCPConnector(BaseConnector):
 
         # create connection to proxy server
         transport, proto = await self._create_direct_connection(
-            proxy_req, [], timeout, client_error=ClientProxyConnectionError
+            proxy_req, None, timeout, client_error=ClientProxyConnectionError
         )
 
         auth = proxy_req.headers.pop(hdrs.AUTHORIZATION, None)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -485,7 +485,10 @@ class BaseConnector:
         return total_remain
 
     async def connect(
-        self, req: ClientRequest, traces: List["Trace"], timeout: "ClientTimeout"
+        self,
+        req: ClientRequest,
+        traces: Optional[List["Trace"]],
+        timeout: "ClientTimeout",
     ) -> Connection:
         """Get from pool or create new connection."""
         key = req.connection_key


### PR DESCRIPTION
Most of the downstream objects already made them optional

Maybe long term it would be nicer to put all the traces in a manager object and let it do all the dispatches so we can check to see if the object is None and do nothing

TODO: need to write a benchmark that would cover this path since it turned out to be a bit larger than I expected, and it may not be worth it.  EDIT: rough profile shows 23% less time spent in `def _request` in `client.py`, but we should still get a benchmark written to validate this is worth it.