### PR TITLE
Avoid starting connection timeout when a connection is already available

### DIFF
--- a/CHANGES/9600.breaking.rst
+++ b/CHANGES/9600.breaking.rst
@@ -1,3 +1,3 @@
 Improved performance of the connector when a connection can be reused -- by :user:`bdraco`.
 
-If ``BaseConnector.connect`` has sub-classed and replaced with custom logic, the ``ceil_timeout`` must be added.
+If ``BaseConnector.connect`` has been subclassed and replaced with custom logic, the ``ceil_timeout`` must be added.

--- a/CHANGES/9600.breaking.rst
+++ b/CHANGES/9600.breaking.rst
@@ -1,0 +1,3 @@
+Improved performance of the connector when a connection can be reused -- by :user:`bdraco`.
+
+If ``BaseConnector.connect`` has sub-classed and replaced with custom logic, the ``ceil_timeout`` must be added.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -94,7 +94,6 @@ from .helpers import (
     _SENTINEL,
     BasicAuth,
     TimeoutHandle,
-    ceil_timeout,
     get_env_proxy_for_url,
     method_must_be_empty_body,
     sentinel,
@@ -634,13 +633,9 @@ class ClientSession:
 
                     # connection timeout
                     try:
-                        async with ceil_timeout(
-                            real_timeout.connect,
-                            ceil_threshold=real_timeout.ceil_threshold,
-                        ):
-                            conn = await self._connector.connect(
-                                req, traces=traces, timeout=real_timeout
-                            )
+                        conn = await self._connector.connect(
+                            req, traces=traces, timeout=real_timeout
+                        )
                     except asyncio.TimeoutError as exc:
                         raise ConnectionTimeoutError(
                             f"Connection timeout to host {url}"

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -494,7 +494,7 @@ class BaseConnector:
         key = req.connection_key
         available = self._available_connections(key)
         wait_for_conn = available <= 0 or key in self._waiters
-        if not wait_for_conn and (proto := self._get(key)):
+        if not wait_for_conn and (proto := self._get(key)) is not None:
             # If we do not have to wait and we can get a connection from the pool
             # we can avoid the timeout ceil logic and directly return the connection
             if traces:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -572,10 +572,9 @@ class BaseConnector:
             if key in self._waiters:
                 # remove a waiter even if it was cancelled, normally it's
                 #  removed when it's notified
-                try:
+                with suppress(ValueError):
+                    # fut may no longer be in list
                     self._waiters[key].remove(fut)
-                except ValueError:  # fut may no longer be in list
-                    pass
 
             raise e
         finally:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -587,7 +587,7 @@ class BaseConnector:
                 await trace.send_connection_queued_end()
 
     async def _send_connect_reuseconn(
-        self, key: ConnectionKey, traces: List["Trace"]
+        self, key: "ConnectionKey", traces: List["Trace"]
     ) -> None:
         """Send tracing events for reusing a connection."""
         # Acquire the connection to prevent race conditions with limits

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -539,9 +539,8 @@ class BaseConnector:
                 if traces:
                     for trace in traces:
                         await trace.send_connection_create_end()
-            else:
-                if traces:
-                    await self._send_connect_reuseconn(key, traces)
+            elif traces:
+                await self._send_connect_reuseconn(key, traces)
 
         return self._acquired_connection(proto, key)
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -493,82 +493,111 @@ class BaseConnector:
         """Get from pool or create new connection."""
         key = req.connection_key
         available = self._available_connections(key)
-
-        # Wait if there are no available connections or if there are/were
-        # waiters (i.e. don't steal connection from a waiter about to wake up)
-        if available <= 0 or key in self._waiters:
-            fut: asyncio.Future[None] = self._loop.create_future()
-
-            # This connection will now count towards the limit.
-            self._waiters[key].append(fut)
-
+        wait_for_conn = available <= 0 or key in self._waiters
+        if not wait_for_conn and (proto := self._get(key)):
+            # If we do not have to wait and we can get a connection from the pool
+            # we can avoid the timeout ceil logic and directly return the connection
             if traces:
-                for trace in traces:
-                    await trace.send_connection_queued_start()
+                await self._send_connect_reuseconn(key, traces)
+            return self._acquired_connection(proto, key)
 
-            try:
-                await fut
-            except BaseException as e:
-                if key in self._waiters:
-                    # remove a waiter even if it was cancelled, normally it's
-                    #  removed when it's notified
-                    try:
-                        self._waiters[key].remove(fut)
-                    except ValueError:  # fut may no longer be in list
-                        pass
+        async with ceil_timeout(
+            timeout.connect,
+            ceil_threshold=timeout.ceil_threshold,
+        ):
+            # Wait if there are no available connections or if there are/were
+            # waiters (i.e. don't steal connection from a waiter about to wake up)
+            if wait_for_conn:
+                await self._wait_for_available_connection(key, traces)
+                proto = self._get(key)
 
-                raise e
-            finally:
-                if key in self._waiters and not self._waiters[key]:
-                    del self._waiters[key]
-
-            if traces:
-                for trace in traces:
-                    await trace.send_connection_queued_end()
-
-        proto = self._get(key)
-        if proto is None:
-            placeholder = cast(ResponseHandler, _TransportPlaceholder(self._loop))
-            self._acquired.add(placeholder)
-            self._acquired_per_host[key].add(placeholder)
-
-            if traces:
-                for trace in traces:
-                    await trace.send_connection_create_start()
-
-            try:
-                proto = await self._create_connection(req, traces, timeout)
-                if self._closed:
-                    proto.close()
-                    raise ClientConnectionError("Connector is closed.")
-            except BaseException:
-                if not self._closed:
-                    self._acquired.remove(placeholder)
-                    self._drop_acquired_per_host(key, placeholder)
-                    self._release_waiter()
-                raise
-            else:
-                if not self._closed:
-                    self._acquired.remove(placeholder)
-                    self._drop_acquired_per_host(key, placeholder)
-
-            if traces:
-                for trace in traces:
-                    await trace.send_connection_create_end()
-        else:
-            if traces:
-                # Acquire the connection to prevent race conditions with limits
+            if proto is None:
                 placeholder = cast(ResponseHandler, _TransportPlaceholder(self._loop))
                 self._acquired.add(placeholder)
                 self._acquired_per_host[key].add(placeholder)
-                for trace in traces:
-                    await trace.send_connection_reuseconn()
-                self._acquired.remove(placeholder)
-                self._drop_acquired_per_host(key, placeholder)
 
+                if traces:
+                    for trace in traces:
+                        await trace.send_connection_create_start()
+
+                try:
+                    proto = await self._create_connection(req, traces, timeout)
+                    if self._closed:
+                        proto.close()
+                        raise ClientConnectionError("Connector is closed.")
+                except BaseException:
+                    if not self._closed:
+                        self._acquired.remove(placeholder)
+                        self._drop_acquired_per_host(key, placeholder)
+                        self._release_waiter()
+                    raise
+                else:
+                    if not self._closed:
+                        self._acquired.remove(placeholder)
+                        self._drop_acquired_per_host(key, placeholder)
+
+                if traces:
+                    for trace in traces:
+                        await trace.send_connection_create_end()
+            else:
+                if traces:
+                    await self._send_connect_reuseconn(key, traces)
+
+        return self._acquired_connection(proto, key)
+
+    def _acquired_connection(
+        self, proto: ResponseHandler, key: "ConnectionKey"
+    ) -> Connection:
+        """Mark proto as acquired and wrap it in a Connection object."""
         self._acquired.add(proto)
         self._acquired_per_host[key].add(proto)
         return Connection(self, key, proto, self._loop)
+
+    async def _wait_for_available_connection(
+        self, key: "ConnectionKey", traces: List["Trace"]
+    ) -> None:
+        """Wait until there is an available connection."""
+        fut: asyncio.Future[None] = self._loop.create_future()
+
+        # This connection will now count towards the limit.
+        self._waiters[key].append(fut)
+
+        if traces:
+            for trace in traces:
+                await trace.send_connection_queued_start()
+
+        try:
+            await fut
+        except BaseException as e:
+            if key in self._waiters:
+                # remove a waiter even if it was cancelled, normally it's
+                #  removed when it's notified
+                try:
+                    self._waiters[key].remove(fut)
+                except ValueError:  # fut may no longer be in list
+                    pass
+
+            raise e
+        finally:
+            if key in self._waiters and not self._waiters[key]:
+                del self._waiters[key]
+
+        if traces:
+            for trace in traces:
+                await trace.send_connection_queued_end()
+
+    async def _send_connect_reuseconn(
+        self, key: ConnectionKey, traces: List["Trace"]
+    ) -> None:
+        """Send tracing events for reusing a connection."""
+        # Acquire the connection to prevent race conditions with limits
+        placeholder = cast(ResponseHandler, _TransportPlaceholder(self._loop))
+        self._acquired.add(placeholder)
+        self._acquired_per_host[key].add(placeholder)
+        for trace in traces:
+            await trace.send_connection_reuseconn()
+        self._acquired.remove(placeholder)
+        self._drop_acquired_per_host(key, placeholder)
 
     def _get(self, key: "ConnectionKey") -> Optional[ResponseHandler]:
         try:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -499,10 +499,7 @@ class BaseConnector:
             # we can avoid the timeout ceil logic and directly return the connection
             return await self._reused_connection(key, proto, traces)
 
-        async with ceil_timeout(
-            timeout.connect,
-            ceil_threshold=timeout.ceil_threshold,
-        ):
+        async with ceil_timeout(timeout.connect, timeout.ceil_threshold):
             # Wait if there are no available connections or if there are/were
             # waiters (i.e. don't steal connection from a waiter about to wake up)
             if wait_for_conn:

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -295,6 +295,7 @@ ssl
 SSLContext
 startup
 subapplication
+subclassed
 subclasses
 subdirectory
 submodules


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Since connection re-use is common, we can avoid starting the `ceil_timeout` when we have a connection immediately available. Previously when a connection is already available for reuse, `ceil_timeout` had to create a `TimerHandle`, schedule it on the event loop, and then immediately cancel it, leaving the loop to have to remove it from the heap. See https://github.com/aio-libs/aiohttp/pull/8608#discussion_r1704175784 and https://github.com/aio-libs/aiohttp/issues/8613 for more history on the overhead of this set of operations.

If the server supports keep-alive, the hit rate on avoiding the timeout is over 80% in testing. https://github.com/aio-libs/aiohttp/pull/9601/commits/31b9637410d5cbf50e4ed1868b8203f3894807b7

closes #9598

## Are there changes in behavior for the user?

If `BaseConnector.connect` was replaced with a custom connect function, the timeout must now be handled in this function. [The only abstract method the docs specify to be overwritten is `_create_connection`](https://docs.aiohttp.org/en/v3.8.4/client_reference.html#baseconnector). While it seems extremely unlikely that someone would write out a custom `connect` function since it would likely break all the protected calls back into the connector from `Connection`, I think this change is likely safe to backport. ~~To be on the safe side I only tagged it for 3.11 (tested in https://github.com/aio-libs/aiohttp/pull/9601) in case someone is doing that.~~ This was originally planned not to backport to 3.10, but its needed to fix https://github.com/aio-libs/aiohttp/pull/9670
```
aiohttp/connector.py:            self._connector._release(self._key, self._protocol, should_close=True)
aiohttp/connector.py:            self._connector._release(self._key, self._protocol, should_close=True)
aiohttp/connector.py:            self._connector._release(
```

## Is it a substantial burden for the maintainers to support this?

no

Benchmarks
See script in https://github.com/aio-libs/aiohttp/issues/9598

aiohttp 3.10.0, yarl 1.9.5
![aiohttp_3_10_0_yarl_1_9_5](https://github.com/user-attachments/assets/539f32f1-ef98-45c3-9d89-48dd0f1304ff)

aiohttp 3.11.0b0 yarl 1.17.0
![aiohttp_3_11_0b0_yarl_1_17_0](https://github.com/user-attachments/assets/b29a5735-eb17-42bb-9745-2bd723745137)

aiohttp 3.11.0b0+ this change yarl 1.17.0
![aiohttp 3 11 0b0+change yarl 1 17 0](https://github.com/user-attachments/assets/36cb7b00-af3e-4cc4-9a88-b80d8539bf61)

aiohttp 3.11.0b0+ this change yarl 1.17.1 
![aiohttp 3 11 0b0+change yarl 1 17 1](https://github.com/user-attachments/assets/35b68bff-cfa2-47f5-8ac6-7168db21640a)


