### PR TITLE
Improve performance of _serialize_headers

### DIFF
--- a/CHANGES/9603.misc.rst
+++ b/CHANGES/9603.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of serializing HTTP headers -- by :user:`bdraco`.

--- a/aiohttp/_http_writer.pyx
+++ b/aiohttp/_http_writer.pyx
@@ -127,10 +127,6 @@ def _serialize_headers(str status_line, headers):
 
     _init_writer(&writer)
 
-    for key, val in headers.items():
-        _safe_header(to_str(key))
-        _safe_header(to_str(val))
-
     try:
         if _write_str(&writer, status_line) < 0:
             raise
@@ -140,6 +136,9 @@ def _serialize_headers(str status_line, headers):
             raise
 
         for key, val in headers.items():
+            _safe_header(to_str(key))
+            _safe_header(to_str(val))
+
             if _write_str(&writer, to_str(key)) < 0:
                 raise
             if _write_byte(&writer, b':') < 0:


### PR DESCRIPTION
Improve performance of `_serialize_headers` by ~23%

- [x] benchmark https://github.com/aio-libs/aiohttp/pull/9604
- [x] verify noexcept is safe -- seems like it should be -- removed, it was the dict iter loop that was slow anyways

