### PR TITLE
Remove unnecessary call to `.keys()` in `BaseConnector._release_waiter`

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -631,7 +631,7 @@ class BaseConnector:
 
         # Having the dict keys ordered this avoids to iterate
         # at the same order at each call.
-        queues = list(self._waiters.keys())
+        queues = list(self._waiters)
         random.shuffle(queues)
 
         for key in queues:


### PR DESCRIPTION
`.keys()` is the default, and not needed here
