### PR TITLE
Fix available connection calculation

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -475,6 +475,7 @@ class BaseConnector:
         available.
         """
         # check total available connections
+        # If there are no limits, this will always return 1
         total_remain = 1
 
         if self._limit and (total_remain := self._limit - len(self._acquired)) <= 0:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -475,9 +475,9 @@ class BaseConnector:
         available.
         """
         # check total available connections
-        available = 1
-        if self._limit and (available := self._limit - len(self._acquired)) <= 0:
-            return available
+        total_available = 1
+        if self._limit and (total_available := self._limit - len(self._acquired)) <= 0:
+            return total_available
 
         # check limit per host
         if self._limit_per_host:
@@ -486,10 +486,10 @@ class BaseConnector:
             else:
                 host_remain = self._limit_per_host
 
-            if available > host_remain:
+            if total_available > host_remain:
                 return host_remain
 
-        return available
+        return total_available
 
     async def connect(
         self, req: ClientRequest, traces: List["Trace"], timeout: "ClientTimeout"

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -476,6 +476,7 @@ class BaseConnector:
         """
         # check total available connections
         total_available = 1
+
         if self._limit and (total_available := self._limit - len(self._acquired)) <= 0:
             return total_available
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -481,11 +481,11 @@ class BaseConnector:
 
         # check limit per host
         if self._limit_per_host:
-            limit = (
-                self._limit_per_host - len(self._acquired_per_host[key])
-                if key in self._acquired_per_host
-                else self._limit_per_host
-            )
+            if key in self._acquired_per_host:
+                limit = self._limit_per_host - len(self._acquired_per_host[key])
+            else:
+                limit = self._limit_per_host
+
             if available > limit:
                 return limit
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -481,12 +481,9 @@ class BaseConnector:
             return total_remain
 
         # check limit per host
-        if self._limit_per_host:
-            if key in self._acquired_per_host:
-                host_remain = self._limit_per_host - len(self._acquired_per_host[key])
-            else:
-                host_remain = self._limit_per_host
-
+        if host_remain := self._limit_per_host:
+            if acquired := self._acquired_per_host.get(key):
+                host_remain -= len(acquired)
             if total_remain > host_remain:
                 return host_remain
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -482,12 +482,12 @@ class BaseConnector:
         # check limit per host
         if self._limit_per_host:
             if key in self._acquired_per_host:
-                limit = self._limit_per_host - len(self._acquired_per_host[key])
+                host_remain = self._limit_per_host - len(self._acquired_per_host[key])
             else:
-                limit = self._limit_per_host
+                host_remain = self._limit_per_host
 
-            if available > limit:
-                return limit
+            if available > host_remain:
+                return host_remain
 
         return available
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -475,10 +475,10 @@ class BaseConnector:
         available.
         """
         # check total available connections
-        total_available = 1
+        total_remain = 1
 
-        if self._limit and (total_available := self._limit - len(self._acquired)) <= 0:
-            return total_available
+        if self._limit and (total_remain := self._limit - len(self._acquired)) <= 0:
+            return total_remain
 
         # check limit per host
         if self._limit_per_host:
@@ -487,10 +487,10 @@ class BaseConnector:
             else:
                 host_remain = self._limit_per_host
 
-            if total_available > host_remain:
+            if total_remain > host_remain:
                 return host_remain
 
-        return total_available
+        return total_remain
 
     async def connect(
         self, req: ClientRequest, traces: List["Trace"], timeout: "ClientTimeout"

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -475,14 +475,21 @@ class BaseConnector:
         available.
         """
         # check total available connections
+        available = 1
         if self._limit and (available := self._limit - len(self._acquired)) <= 0:
             return available
 
         # check limit per host
-        if self._limit_per_host and key in self._acquired_per_host:
-            return self._limit_per_host - len(self._acquired_per_host[key])
+        if self._limit_per_host:
+            limit = (
+                self._limit_per_host - len(self._acquired_per_host[key])
+                if key in self._acquired_per_host
+                else self._limit_per_host
+            )
+            if available > limit:
+                return limit
 
-        return 1
+        return available
 
     async def connect(
         self, req: ClientRequest, traces: List["Trace"], timeout: "ClientTimeout"

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3398,7 +3398,7 @@ def test_default_ssl_context_creation_without_ssl() -> None:
         assert connector_module._make_ssl_context(True) is None
 
 
-async def test_available_connections(
+async def test_available_connections_with_limit_per_host(
     key: ConnectionKey, other_host_key2: ConnectionKey
 ) -> None:
     """Verify expected values based on active connections."""
@@ -3424,3 +3424,32 @@ async def test_available_connections(
     other_connection1.close()
     assert conn._available_connections(key) == 2
     assert conn._available_connections(other_host_key2) == 2
+
+
+@pytest.mark.parametrize("limit_per_host", [None, 10])
+async def test_available_connections_without_limit_per_host(
+    key: ConnectionKey, other_host_key2: ConnectionKey, limit_per_host: Optional[int]
+) -> None:
+    """Verify expected values based on active connections."""
+    conn = aiohttp.BaseConnector(limit=3, limit_per_host=limit_per_host)
+    assert conn._available_connections(key) == 3
+    assert conn._available_connections(other_host_key2) == 3
+    proto1 = create_mocked_conn()
+    connection1 = conn._acquired_connection(proto1, key)
+    assert conn._available_connections(key) == 2
+    assert conn._available_connections(other_host_key2) == 2
+    proto2 = create_mocked_conn()
+    connection2 = conn._acquired_connection(proto2, key)
+    assert conn._available_connections(key) == 1
+    assert conn._available_connections(other_host_key2) == 1
+    connection1.close()
+    assert conn._available_connections(key) == 2
+    assert conn._available_connections(other_host_key2) == 2
+    connection2.close()
+    other_proto1 = create_mocked_conn()
+    other_connection1 = conn._acquired_connection(other_proto1, other_host_key2)
+    assert conn._available_connections(key) == 2
+    assert conn._available_connections(other_host_key2) == 2
+    other_connection1.close()
+    assert conn._available_connections(key) == 3
+    assert conn._available_connections(other_host_key2) == 3

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3460,7 +3460,7 @@ async def test_available_connections_no_limits(
 ) -> None:
     """Verify expected values based on active connections with no limits."""
     # No limits is a special case where available connections should always be 1.
-    conn = aiohttp.BaseConnector(limit=None, limit_per_host=None)
+    conn = aiohttp.BaseConnector(limit=0, limit_per_host=0)
     assert conn._available_connections(key) == 1
     assert conn._available_connections(other_host_key2) == 1
     proto1 = create_mocked_conn()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3428,7 +3428,7 @@ async def test_available_connections_with_limit_per_host(
 
 @pytest.mark.parametrize("limit_per_host", [0, 10])
 async def test_available_connections_without_limit_per_host(
-    key: ConnectionKey, other_host_key2: ConnectionKey, limit_per_host: Optional[int]
+    key: ConnectionKey, other_host_key2: ConnectionKey, limit_per_host: int
 ) -> None:
     """Verify expected values based on active connections with higher host limit."""
     conn = aiohttp.BaseConnector(limit=3, limit_per_host=limit_per_host)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3459,6 +3459,7 @@ async def test_available_connections_no_limits(
     key: ConnectionKey, other_host_key2: ConnectionKey
 ) -> None:
     """Verify expected values based on active connections with no limits."""
+    # No limits is a special case where available connections should always be 1.
     conn = aiohttp.BaseConnector(limit=None, limit_per_host=None)
     assert conn._available_connections(key) == 1
     assert conn._available_connections(other_host_key2) == 1

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3426,7 +3426,7 @@ async def test_available_connections_with_limit_per_host(
     assert conn._available_connections(other_host_key2) == 2
 
 
-@pytest.mark.parametrize("limit_per_host", [None, 10])
+@pytest.mark.parametrize("limit_per_host", [0, 10])
 async def test_available_connections_without_limit_per_host(
     key: ConnectionKey, other_host_key2: ConnectionKey, limit_per_host: Optional[int]
 ) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The available connection calculation is only ever used to check if its above 0 (it could be a `bool` return) and the actual available number of connections was not always correct if the total available was less than the available per host. However, this was unlikely to have any actual impact on production since all the consumers of the function only cared if it was > 0 and that case was correct. As such this is not labeled as a bugfix and is an internal cleanup.

I refactored this logic to be a bit simplier in #9610 but it still was not correct.

Add some tests to make sure it works as expected as it was not directly tested.


## Are there changes in behavior for the user?
no

## Is it a substantial burden for the maintainers to support this?
no