### PR TITLE
Simplify branching in the connector

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -615,6 +615,7 @@ class BaseConnector:
                     del self._conns[key]
                 return proto
 
+            # Connection cannot be reused, close it
             transport = proto.transport
             proto.close()
             # only for SSL transports

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -599,6 +599,7 @@ class BaseConnector:
                 await trace.send_connection_queued_end()
 
     def _get(self, key: "ConnectionKey") -> Optional[ResponseHandler]:
+        """Get next reusable connection for the key or None."""
         try:
             conns = self._conns[key]
         except KeyError:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -346,11 +346,11 @@ class BaseConnector:
                 for proto, use_time in conns:
                     if proto.is_connected() and use_time - deadline >= 0:
                         alive.append((proto, use_time))
-                    else:
-                        transport = proto.transport
-                        proto.close()
-                        if not self._cleanup_closed_disabled and key.is_ssl:
-                            self._cleanup_closed_transports.append(transport)
+                        continue
+                    transport = proto.transport
+                    proto.close()
+                    if not self._cleanup_closed_disabled and key.is_ssl:
+                        self._cleanup_closed_transports.append(transport)
 
                 if alive:
                     connections[key] = alive

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -344,14 +344,8 @@ class BaseConnector:
             for key, conns in self._conns.items():
                 alive = []
                 for proto, use_time in conns:
-                    if proto.is_connected():
-                        if use_time - deadline < 0:
-                            transport = proto.transport
-                            proto.close()
-                            if not self._cleanup_closed_disabled and key.is_ssl:
-                                self._cleanup_closed_transports.append(transport)
-                        else:
-                            alive.append((proto, use_time))
+                    if proto.is_connected() and use_time - deadline >= 0:
+                        alive.append((proto, use_time))
                     else:
                         transport = proto.transport
                         proto.close()

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -342,7 +342,7 @@ class BaseConnector:
             connections = {}
             deadline = now - timeout
             for key, conns in self._conns.items():
-                alive = []
+                alive: List[Tuple[ResponseHandler, float]] = []
                 for proto, use_time in conns:
                     if proto.is_connected() and use_time - deadline >= 0:
                         alive.append((proto, use_time))


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
`_get` and `_cleanup` branching had two branches that did the exact same thing.

Instead, return or continue as we have a reusable connection since the other
case can execute the exact same code.

The cleanup close check order is reversed since `key.is_ssl`
is slower to access than `self._cleanup_closed_disabled`

This will also take care of some missing coverage

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no, less duplicate code