### PR TITLE
Avoid multiple slice calls in the WebSocket reader

### DIFF
--- a/CHANGES/9636.feature.rst
+++ b/CHANGES/9636.feature.rst
@@ -1,0 +1,1 @@
+9543.feature.rst

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -79,7 +79,6 @@ cdef class WebSocketReader:
         chunk_size="unsigned int",
         chunk_len="unsigned int",
         buf_length="unsigned int",
-        data=bytes,
         payload=bytearray,
         first_byte="unsigned char",
         second_byte="unsigned char",

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -246,9 +246,9 @@ class WebSocketReader:
             if self._state == READ_HEADER:
                 if buf_length - start_pos < 2:
                     break
-                start_pos += 2
                 first_byte = buf[start_pos]
                 second_byte = buf[start_pos + 1]
+                start_pos += 2
 
                 fin = (first_byte >> 7) & 1
                 rsv1 = (first_byte >> 6) & 1

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -363,6 +363,6 @@ class WebSocketReader:
                 self._frame_payload = bytearray()
                 self._state = READ_HEADER
 
-        self._tail = buf[start_pos:]
+        self._tail = buf[start_pos:] if start_pos < buf_length else b""
 
         return frames

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -246,10 +246,9 @@ class WebSocketReader:
             if self._state == READ_HEADER:
                 if buf_length - start_pos < 2:
                     break
-                data = buf[start_pos : start_pos + 2]
                 start_pos += 2
-                first_byte = data[0]
-                second_byte = data[1]
+                first_byte = buf[start_pos]
+                second_byte = buf[start_pos + 1]
 
                 fin = (first_byte >> 7) & 1
                 rsv1 = (first_byte >> 6) & 1


### PR DESCRIPTION
Avoids `PySequence_GetSlice(__pyx_v_buf, __pyx_v_start_pos, PY_SSIZE_T_MAX);` in most cases when there is no tail

Avoids `PySequence_GetSlice(__pyx_v_buf, __pyx_v_start_pos, (__pyx_v_start_pos + 2));` to copy `buf` to `data` since `data` is only used to unpack 2 bytes, and we already know where they are in `buf`