### PR TITLE
Merge FlowControlDataQueue into DataQueue

### DIFF
--- a/tests/test_benchmarks_http_websocket.py
+++ b/tests/test_benchmarks_http_websocket.py
@@ -5,7 +5,7 @@ from typing import Union
 
 from pytest_codspeed import BenchmarkFixture
 
-from aiohttp import DataQueue
+from aiohttp import FlowControlDataQueue
 from aiohttp._websocket.helpers import MSG_SIZE
 from aiohttp.base_protocol import BaseProtocol
 from aiohttp.http_websocket import (
@@ -20,7 +20,7 @@ def test_read_one_hundred_websocket_text_messages(
     loop: asyncio.AbstractEventLoop, benchmark: BenchmarkFixture
 ) -> None:
     """Benchmark reading 100 WebSocket text messages."""
-    queue: DataQueue[WSMessage] = DataQueue(loop=loop)
+    queue: FlowControlDataQueue[WSMessage] = FlowControlDataQueue(loop=loop)
     reader = WebSocketReader(queue, max_msg_size=2**16)
     raw_message = (
         b'\x81~\x01!{"id":1,"src":"shellyplugus-c049ef8c30e4","dst":"aios-1453812500'

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -47,7 +47,7 @@ async def test_http_processing_error(session: ClientSession) -> None:
     loop.get_debug.return_value = True
 
     connection = mock.Mock()
-    connection.protocol = aiohttp.DataQueue(loop)
+    connection.protocol = aiohttp.FlowControlDataQueue(loop)
     connection.protocol.set_exception(http.HttpProcessingError())
 
     with pytest.raises(aiohttp.ClientResponseError) as info:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`DataQueue` was only used in tests and the `super()` calls for all the `read` and `feed_data` added overhead.

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?

no, less code to maintain
