### PR TITLE
DNM: Benchmark overhead of checking WebSocket str and bytes types

### DIFF
--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -238,14 +238,16 @@ class ClientWebSocketResponse:
         await self._writer.send_frame(message, opcode, compress)
 
     async def send_str(self, data: str, compress: Optional[int] = None) -> None:
-        if not isinstance(data, str):
+        if type(data) is not str and not isinstance(data, str):
             raise TypeError("data argument must be str (%r)" % type(data))
         await self._writer.send_frame(
             data.encode("utf-8"), WSMsgType.TEXT, compress=compress
         )
 
     async def send_bytes(self, data: bytes, compress: Optional[int] = None) -> None:
-        if not isinstance(data, (bytes, bytearray, memoryview)):
+        if type(data) is not bytes and not isinstance(
+            data, (bytes, bytearray, memoryview)
+        ):
             raise TypeError("data argument must be byte-ish (%r)" % type(data))
         await self._writer.send_frame(data, WSMsgType.BINARY, compress=compress)
 

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -422,7 +422,7 @@ class WebSocketResponse(StreamResponse):
     async def send_str(self, data: str, compress: Optional[int] = None) -> None:
         if self._writer is None:
             raise RuntimeError("Call .prepare() first")
-        if not isinstance(data, str):
+        if type(data) is not str and not isinstance(data, str):
             raise TypeError("data argument must be str (%r)" % type(data))
         await self._writer.send_frame(
             data.encode("utf-8"), WSMsgType.TEXT, compress=compress
@@ -431,7 +431,9 @@ class WebSocketResponse(StreamResponse):
     async def send_bytes(self, data: bytes, compress: Optional[int] = None) -> None:
         if self._writer is None:
             raise RuntimeError("Call .prepare() first")
-        if not isinstance(data, (bytes, bytearray, memoryview)):
+        if type(data) is not bytes and not isinstance(
+            data, (bytes, bytearray, memoryview)
+        ):
             raise TypeError("data argument must be byte-ish (%r)" % type(data))
         await self._writer.send_frame(data, WSMsgType.BINARY, compress=compress)
 


### PR DESCRIPTION
send_str has a bit more overhead than expected:
<img width="626" alt="Screenshot 2024-11-03 at 1 25 37 AM" src="https://github.com/user-attachments/assets/c975e5a7-3489-430f-b5d1-941658b4cdc9">

It seems like it has to be the `isinstance` check but the benchmark will tell for sure
