### PR TITLE
DNM: Benchmark overhead of checking WebSocket msg type on receive

### DIFF
--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -360,18 +360,19 @@ class ClientWebSocketResponse:
                 await self.close()
                 return WSMessageError(data=exc)
 
-            if msg.type is WSMsgType.CLOSE:
+            msg_type = msg.type  # Call type property only once
+            if msg_type is WSMsgType.CLOSE:
                 self._set_closing()
                 self._close_code = msg.data
                 # Could be closed elsewhere while awaiting reader
                 if not self._closed and self._autoclose:  # type: ignore[redundant-expr]
                     await self.close()
-            elif msg.type is WSMsgType.CLOSING:
+            elif msg_type is WSMsgType.CLOSING:
                 self._set_closing()
-            elif msg.type is WSMsgType.PING and self._autoping:
+            elif msg_type is WSMsgType.PING and self._autoping:
                 await self.pong(msg.data)
                 continue
-            elif msg.type is WSMsgType.PONG and self._autoping:
+            elif msg_type is WSMsgType.PONG and self._autoping:
                 continue
 
             return msg

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -580,7 +580,8 @@ class WebSocketResponse(StreamResponse):
                 await self.close()
                 return WSMessageError(data=exc)
 
-            if msg.type is WSMsgType.CLOSE:
+            msg_type = msg.type  # Call type property only once
+            if msg_type is WSMsgType.CLOSE:
                 self._set_closing(msg.data)
                 # Could be closed while awaiting reader.
                 if not self._closed and self._autoclose:  # type: ignore[redundant-expr]
@@ -589,12 +590,12 @@ class WebSocketResponse(StreamResponse):
                     # want to drain any pending writes as it will
                     # likely result writing to a broken pipe.
                     await self.close(drain=False)
-            elif msg.type is WSMsgType.CLOSING:
+            elif msg_type is WSMsgType.CLOSING:
                 self._set_closing(WSCloseCode.OK)
-            elif msg.type is WSMsgType.PING and self._autoping:
+            elif msg_type is WSMsgType.PING and self._autoping:
                 await self.pong(msg.data)
                 continue
-            elif msg.type is WSMsgType.PONG and self._autoping:
+            elif msg_type is WSMsgType.PONG and self._autoping:
                 continue
 
             return msg


### PR DESCRIPTION
receive has a bit more overhead than expected:
<img width="614" alt="Screenshot 2024-11-03 at 1 26 06 AM" src="https://github.com/user-attachments/assets/d6846fe2-6ad3-4b91-9f0a-e26c0ba6777e">

It seem like it has to be the `property` call overhead of the `NamedTuple`, but now sure so running the benchmark