### PR TITLE
Add benchmark for roundtrip of 100 large WebSocket messages

### DIFF
--- a/tests/test_benchmarks_client_ws.py
+++ b/tests/test_benchmarks_client_ws.py
@@ -5,6 +5,7 @@ import asyncio
 from pytest_codspeed import BenchmarkFixture
 
 from aiohttp import web
+from aiohttp._websocket.helpers import MSG_SIZE
 from aiohttp.pytest_plugin import AiohttpClient
 
 
@@ -21,6 +22,38 @@ def test_one_thousand_round_trip_websocket_text_messages(
         await ws.prepare(request)
         for _ in range(message_count):
             await ws.send_str("answer")
+        await ws.close()
+        return ws
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+
+    async def run_websocket_benchmark() -> None:
+        client = await aiohttp_client(app)
+        resp = await client.ws_connect("/")
+        for _ in range(message_count):
+            await resp.receive()
+        await resp.close()
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_websocket_benchmark())
+
+
+def test_one_thousand_large_round_trip_websocket_text_messages(
+    loop: asyncio.AbstractEventLoop,
+    aiohttp_client: AiohttpClient,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark round trip of 100 large WebSocket text messages."""
+    message_count = 100
+    raw_message = b"x" * MSG_SIZE * 4
+
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        for _ in range(message_count):
+            await ws.send_str(raw_message)
         await ws.close()
         return ws
 

--- a/tests/test_benchmarks_client_ws.py
+++ b/tests/test_benchmarks_client_ws.py
@@ -47,7 +47,7 @@ def test_one_thousand_large_round_trip_websocket_text_messages(
 ) -> None:
     """Benchmark round trip of 100 large WebSocket text messages."""
     message_count = 100
-    raw_message = b"x" * MSG_SIZE * 4
+    raw_message = "x" * MSG_SIZE * 4
 
     async def handler(request: web.Request) -> web.WebSocketResponse:
         ws = web.WebSocketResponse()


### PR DESCRIPTION
SSIA

For testing if https://github.com/aio-libs/aiohttp/pull/9634 is viable

Looks like almost all the overhead is `memcpy`