### PR TITLE
DNM: Benchmark WebSocket sending without kwargs

### DIFF
--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -240,14 +240,12 @@ class ClientWebSocketResponse:
     async def send_str(self, data: str, compress: Optional[int] = None) -> None:
         if not isinstance(data, str):
             raise TypeError("data argument must be str (%r)" % type(data))
-        await self._writer.send_frame(
-            data.encode("utf-8"), WSMsgType.TEXT, compress=compress
-        )
+        await self._writer.send_frame(data.encode("utf-8"), WSMsgType.TEXT, compress)
 
     async def send_bytes(self, data: bytes, compress: Optional[int] = None) -> None:
         if not isinstance(data, (bytes, bytearray, memoryview)):
             raise TypeError("data argument must be byte-ish (%r)" % type(data))
-        await self._writer.send_frame(data, WSMsgType.BINARY, compress=compress)
+        await self._writer.send_frame(data, WSMsgType.BINARY, compress)
 
     async def send_json(
         self,

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -424,16 +424,14 @@ class WebSocketResponse(StreamResponse):
             raise RuntimeError("Call .prepare() first")
         if not isinstance(data, str):
             raise TypeError("data argument must be str (%r)" % type(data))
-        await self._writer.send_frame(
-            data.encode("utf-8"), WSMsgType.TEXT, compress=compress
-        )
+        await self._writer.send_frame(data.encode("utf-8"), WSMsgType.TEXT, compress)
 
     async def send_bytes(self, data: bytes, compress: Optional[int] = None) -> None:
         if self._writer is None:
             raise RuntimeError("Call .prepare() first")
         if not isinstance(data, (bytes, bytearray, memoryview)):
             raise TypeError("data argument must be byte-ish (%r)" % type(data))
-        await self._writer.send_frame(data, WSMsgType.BINARY, compress=compress)
+        await self._writer.send_frame(data, WSMsgType.BINARY, compress)
 
     async def send_json(
         self,
@@ -442,7 +440,7 @@ class WebSocketResponse(StreamResponse):
         *,
         dumps: JSONEncoder = json.dumps,
     ) -> None:
-        await self.send_str(dumps(data), compress=compress)
+        await self.send_str(dumps(data), compress)
 
     async def write_eof(self) -> None:  # type: ignore[override]
         if self._eof_sent:


### PR DESCRIPTION
`send_str` has a bit more overhead than expected:
<img width="626" alt="Screenshot 2024-11-03 at 1 25 37 AM" src="https://github.com/user-attachments/assets/c975e5a7-3489-430f-b5d1-941658b4cdc9">

Check if removing the kwargs makes a measurable difference... probably not, but worth checking
