### PR TITLE
Avoid memory copy in the WebSocket reader for small payloads

### DIFF
--- a/CHANGES/9649.feature.rst
+++ b/CHANGES/9649.feature.rst
@@ -1,0 +1,1 @@
+9543.feature.rst

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -82,6 +82,7 @@ cdef class WebSocketReader:
         buf_length="unsigned int",
         first_byte="unsigned char",
         second_byte="unsigned char",
+        end_pos="unsigned int",
         has_mask=bint,
         fin=bint,
     )

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -50,7 +50,7 @@ cdef class WebSocketReader:
     cdef object _opcode
     cdef object _frame_fin
     cdef object _frame_opcode
-    cdef bytearray _frame_payload
+    cdef object _frame_payload
     cdef unsigned int _frame_payload_len
 
     cdef bytes _tail

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -51,6 +51,7 @@ cdef class WebSocketReader:
     cdef object _frame_fin
     cdef object _frame_opcode
     cdef bytearray _frame_payload
+    cdef unsigned int _frame_payload_len
 
     cdef bytes _tail
     cdef bint _has_mask
@@ -79,7 +80,6 @@ cdef class WebSocketReader:
         chunk_size="unsigned int",
         chunk_len="unsigned int",
         buf_length="unsigned int",
-        payload=bytearray,
         first_byte="unsigned char",
         second_byte="unsigned char",
         has_mask=bint,

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -346,6 +346,8 @@ class WebSocketReader:
                 if length >= chunk_len:
                     self._payload_length = length - chunk_len
                     if self._frame_payload_len:
+                        if type(payload) is not bytearray:
+                            payload = bytearray(payload)
                         payload += buf[start_pos:]
                     else:
                         payload = buf[start_pos:]
@@ -353,6 +355,8 @@ class WebSocketReader:
                 else:
                     self._payload_length = 0
                     if self._frame_payload_len:
+                        if type(payload) is not bytearray:
+                            payload = bytearray(payload)
                         payload += buf[start_pos : start_pos + length]
                     else:
                         payload = buf[start_pos : start_pos + length]

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -172,8 +172,10 @@ class WebSocketReader:
                                 self._max_msg_size + left, self._max_msg_size
                             ),
                         )
-                else:
+                elif type(assembled_payload) is not bytes:
                     payload_merged = bytes(assembled_payload)
+                else:
+                    payload_merged = assembled_payload
 
                 if opcode == OP_CODE_TEXT:
                     try:

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -350,6 +350,7 @@ class WebSocketReader:
                             payload = bytearray(payload)
                         payload += buf[start_pos:]
                     else:
+                        # Fast path for the first frame
                         payload = buf[start_pos:]
                     start_pos = buf_length
                 else:
@@ -359,6 +360,7 @@ class WebSocketReader:
                             payload = bytearray(payload)
                         payload += buf[start_pos : start_pos + length]
                     else:
+                        # Fast path for the first frame
                         payload = buf[start_pos : start_pos + length]
                     start_pos = start_pos + length
 

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -172,10 +172,10 @@ class WebSocketReader:
                                 self._max_msg_size + left, self._max_msg_size
                             ),
                         )
-                elif type(assembled_payload) is not bytes:
-                    payload_merged = bytes(assembled_payload)
-                else:
+                elif type(assembled_payload) is bytes:
                     payload_merged = assembled_payload
+                else:
+                    payload_merged = bytes(assembled_payload)
 
                 if opcode == OP_CODE_TEXT:
                     try:

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -377,7 +377,7 @@ class WebSocketReader:
                 frames.append(
                     (self._frame_fin, self._frame_opcode, payload, self._compressed)
                 )
-                self._frame_payload = bytearray()
+                self._frame_payload = b""
                 self._frame_payload_len = 0
                 self._state = READ_HEADER
 

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -60,7 +60,7 @@ class WebSocketReader:
         self._opcode: Optional[int] = None
         self._frame_fin = False
         self._frame_opcode: Optional[int] = None
-        self._frame_payload = bytearray()
+        self._frame_payload: Union[bytes, bytearray] = b""
         self._frame_payload_len = 0
 
         self._tail: bytes = b""

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -151,6 +151,20 @@ def test_parse_frame_length2_multi_byte(parser: WebSocketReader) -> None:
     assert (0, 1, expected_payload, False) == (fin, opcode, payload, not not compress)
 
 
+def test_parse_frame_length2_multi_byte_multi_packet(parser: WebSocketReader) -> None:
+    """Ensure a multi-byte length with multiple packets is parsed correctly."""
+    expected_payload = b"1" * 32768
+    assert parser.parse_frame(struct.pack("!BB", 0b00000001, 126)) == []
+    assert parser.parse_frame(struct.pack("!H", 32768)) == []
+    assert parser.parse_frame(b"1" * 8192) == []
+    assert parser.parse_frame(b"1" * 8192) == []
+    assert parser.parse_frame(b"1" * 8192) == []
+    res = parser.parse_frame(b"1" * 8192)
+    fin, opcode, payload, compress = res[0]
+    assert len(payload) == 32768
+    assert (0, 1, expected_payload, False) == (fin, opcode, payload, not not compress)
+
+
 def test_parse_frame_length4(parser: WebSocketReader) -> None:
     parser.parse_frame(struct.pack("!BB", 0b00000001, 127))
     parser.parse_frame(struct.pack("!Q", 4))


### PR DESCRIPTION
Only convert to `bytearray` when we know we are going to append messages or unmask.  If the message comes in without being fragmented, we can avoid many conversions from `bytes` to `bytearray` which is the common case for small messages