### PR TITLE
Add benchmark for sending binary WebSocket messages

### DIFF
--- a/tests/test_benchmarks_client_ws.py
+++ b/tests/test_benchmarks_client_ws.py
@@ -40,6 +40,37 @@ def test_one_thousand_round_trip_websocket_text_messages(
         loop.run_until_complete(run_websocket_benchmark())
 
 
+def test_one_thousand_round_trip_websocket_binary_messages(
+    loop: asyncio.AbstractEventLoop,
+    aiohttp_client: AiohttpClient,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark round trip of 1000 WebSocket binary messages."""
+    message_count = 1000
+
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        for _ in range(message_count):
+            await ws.send_bytes(b"answer")
+        await ws.close()
+        return ws
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+
+    async def run_websocket_benchmark() -> None:
+        client = await aiohttp_client(app)
+        resp = await client.ws_connect("/")
+        for _ in range(message_count):
+            await resp.receive()
+        await resp.close()
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_websocket_benchmark())
+
+
 def test_one_thousand_large_round_trip_websocket_text_messages(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,


### PR DESCRIPTION
Binary should be a bit faster since it does not have to convert them to binary before sending. It would be nice to get a better handle on the overhead of encoding to bytes so we can better look for places where there are still performance bottlenecks
