### PR TITLE
Refactor `FlowControlDataQueue` to improve performances

### DIFF
--- a/CHANGES/9659.misc.rst
+++ b/CHANGES/9659.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of the internal ``DataQueue`` -- by :user:`bdraco`.

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -630,14 +630,12 @@ class DataQueue(Generic[_SizedT]):
         self._eof = True
         self._exception = exc
 
-        waiter = self._waiter
-        if waiter is not None:
+        if (waiter := self._waiter) is not None:
             self._waiter = None
             set_exception(waiter, exc, exc_cause)
 
     def _release_waiter(self) -> None:
-        waiter = self._waiter
-        if waiter is not None:
+        if (waiter := self._waiter) is not None:
             self._waiter = None
             set_result(waiter, None)
 

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -629,7 +629,6 @@ class DataQueue(Generic[_SizedT]):
     ) -> None:
         self._eof = True
         self._exception = exc
-
         if (waiter := self._waiter) is not None:
             self._waiter = None
             set_exception(waiter, exc, exc_cause)

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -698,12 +698,10 @@ class FlowControlDataQueue(DataQueue[_SizedT]):
     async def read(self) -> _SizedT:
         if not self._buffer and not self._eof:
             await self._wait_for_data()
-
         if self._buffer:
             data = self._buffer.popleft()
             self._size -= len(data)
             if self._size < self._limit and self._protocol._reading_paused:
                 self._protocol.resume_reading()
             return data
-
         self._raise_exception_or_eof()

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -658,7 +658,7 @@ class DataQueue(Generic[_SizedT]):
             raise self._exception
         raise EofStream
 
-    async def _wait_for_data(self) -> _SizedT:
+    async def _wait_for_data(self) -> None:
         assert not self._waiter
         self._waiter = self._loop.create_future()
         try:


### PR DESCRIPTION
The `DataQueue` base class tracks `size` but it never uses it. Move all the `size` tracking into the `FlowControlDataQueue` 