### PR TITLE
Add __slots__ to DataQueue

### DIFF
--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -603,6 +603,15 @@ EMPTY_PAYLOAD: Final[StreamReader] = EmptyStreamReader()
 class DataQueue(Generic[_SizedT]):
     """DataQueue is a general-purpose blocking queue with one reader."""
 
+    __slots__ = (
+        "_loop",
+        "_eof",
+        "_waiter",
+        "_exception",
+        "_size",
+        "_buffer",
+    )
+
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
         self._loop = loop
         self._eof = False
@@ -682,6 +691,8 @@ class FlowControlDataQueue(DataQueue[_SizedT]):
 
     It is a destination for parsed data.
     """
+
+    __slots__ = ("_protocol", "_limit")
 
     def __init__(
         self, protocol: BaseProtocol, limit: int, *, loop: asyncio.AbstractEventLoop


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

The `StreamReader` has `__slots__` but `DataQueue` does not.

We have one in memory for every connection so it will save a tiny bit of RAM.

## Are there changes in behavior for the user?

no
## Is it a substantial burden for the maintainers to support this?
no