### PR TITLE
DNM: Attempt to improve WebSocket receive performance

### DIFF
--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -326,26 +326,22 @@ class ClientWebSocketResponse:
 
             try:
                 self._waiting = True
-                try:
-                    if receive_timeout:
-                        # Entering the context manager and creating
-                        # Timeout() object can take almost 50% of the
-                        # run time in this loop so we avoid it if
-                        # there is no read timeout.
-                        async with async_timeout.timeout(receive_timeout):
-                            msg = await self._reader.read()
-                    else:
+                if receive_timeout:
+                    # Entering the context manager and creating
+                    # Timeout() object can take almost 50% of the
+                    # run time in this loop so we avoid it if
+                    # there is no read timeout.
+                    async with async_timeout.timeout(receive_timeout):
                         msg = await self._reader.read()
-                    self._reset_heartbeat()
-                finally:
-                    self._waiting = False
-                    if self._close_wait:
-                        set_result(self._close_wait, None)
+                else:
+                    msg = await self._reader.read()
+                self._reset_heartbeat()
             except (asyncio.CancelledError, asyncio.TimeoutError):
                 self._close_code = WSCloseCode.ABNORMAL_CLOSURE
                 raise
             except EofStream:
                 self._close_code = WSCloseCode.OK
+                self._waiting = False
                 await self.close()
                 return WS_CLOSED_MESSAGE
             except ClientError:
@@ -355,14 +351,20 @@ class ClientWebSocketResponse:
                 return WS_CLOSED_MESSAGE
             except WebSocketError as exc:
                 self._close_code = exc.code
+                self._waiting = False
                 await self.close(code=exc.code)
                 return WSMessageError(data=exc)
             except Exception as exc:
                 self._exception = exc
                 self._set_closing()
                 self._close_code = WSCloseCode.ABNORMAL_CLOSURE
+                self._waiting = False
                 await self.close()
                 return WSMessageError(data=exc)
+            finally:
+                self._waiting = False
+                if self._close_wait:
+                    set_result(self._close_wait, None)
 
             if msg.type not in _INTERNAL_RECEIVE_TYPES:
                 return msg

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -312,6 +312,13 @@ class ClientWebSocketResponse:
             return False
 
     async def _close_from_receive(self, code: int) -> None:
+        """Close the connection from the receive coroutine.
+
+        Called when an error occurs while receiving a message.
+
+        Always sets self._waiting to False before returning
+        to ensure close does not wait.
+        """
         self._waiting = False
         await self.close(code=code)
 

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -380,6 +380,7 @@ class ClientWebSocketResponse:
                 continue
             elif msg.type is WSMsgType.PONG and self._autoping:
                 continue
+
             return msg
 
     async def receive_str(self, *, timeout: Optional[float] = None) -> str:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -604,6 +604,7 @@ class WebSocketResponse(StreamResponse):
                 continue
             elif msg.type is WSMsgType.PONG and self._autoping:
                 continue
+
             return msg
 
     async def receive_str(self, *, timeout: Optional[float] = None) -> str:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -585,24 +585,25 @@ class WebSocketResponse(StreamResponse):
                 await self.close()
                 return WSMessageError(data=exc)
 
-            if msg.type in _INTERNAL_RECEIVE_TYPES:
-                if msg.type is WSMsgType.CLOSE:
-                    self._set_closing(msg.data)
-                    # Could be closed while awaiting reader.
-                    if not self._closed and self._autoclose:  # type: ignore[redundant-expr]
-                        # The client is likely going to close the
-                        # connection out from under us so we do not
-                        # want to drain any pending writes as it will
-                        # likely result writing to a broken pipe.
-                        await self.close(drain=False)
-                elif msg.type is WSMsgType.CLOSING:
-                    self._set_closing(WSCloseCode.OK)
-                elif msg.type is WSMsgType.PING and self._autoping:
-                    await self.pong(msg.data)
-                    continue
-                elif msg.type is WSMsgType.PONG and self._autoping:
-                    continue
+            if msg.type not in _INTERNAL_RECEIVE_TYPES:
+                return msg
 
+            if msg.type is WSMsgType.CLOSE:
+                self._set_closing(msg.data)
+                # Could be closed while awaiting reader.
+                if not self._closed and self._autoclose:  # type: ignore[redundant-expr]
+                    # The client is likely going to close the
+                    # connection out from under us so we do not
+                    # want to drain any pending writes as it will
+                    # likely result writing to a broken pipe.
+                    await self.close(drain=False)
+            elif msg.type is WSMsgType.CLOSING:
+                self._set_closing(WSCloseCode.OK)
+            elif msg.type is WSMsgType.PING and self._autoping:
+                await self.pong(msg.data)
+                continue
+            elif msg.type is WSMsgType.PONG and self._autoping:
+                continue
             return msg
 
     async def receive_str(self, *, timeout: Optional[float] = None) -> str:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -534,6 +534,13 @@ class WebSocketResponse(StreamResponse):
             self._req.transport.close()
 
     async def _close_from_receive(self, code: int) -> None:
+        """Close the connection from the receive coroutine.
+
+        Called when an error occurs while receiving a message.
+
+        Always sets self._waiting to False before returning
+        to ensure close does not wait.
+        """
         self._waiting = False
         await self.close(code=code)
 

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -548,8 +548,6 @@ class WebSocketResponse(StreamResponse):
         if self._reader is None:
             raise RuntimeError("Call .prepare() first")
 
-        loop = self._loop
-        assert loop is not None
         receive_timeout = timeout or self._receive_timeout
         while True:
             if self._waiting:


### PR DESCRIPTION
- Collapse the nested `try` into a single `try`
- We have a lot of checks at the end of receive that are rarely hit. Return early if we do not need to do any additional processing.
- Remove dead code in the web side (loop is unused)