### PR TITLE
Simplify ``close`` logic in client ``WebSocketResponse``

### DIFF
--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -268,10 +268,30 @@ class ClientWebSocketResponse:
             self._reader.feed_data(WS_CLOSING_MESSAGE)
             await self._close_wait
 
-        if not self._closed:
-            self._set_closed()
+        if self._closed:
+            return False
+
+        self._set_closed()
+        try:
+            await self._writer.close(code, message)
+        except asyncio.CancelledError:
+            self._close_code = WSCloseCode.ABNORMAL_CLOSURE
+            self._response.close()
+            raise
+        except Exception as exc:
+            self._close_code = WSCloseCode.ABNORMAL_CLOSURE
+            self._exception = exc
+            self._response.close()
+            return True
+
+        if self._close_code:
+            self._response.close()
+            return True
+
+        while True:
             try:
-                await self._writer.close(code, message)
+                async with async_timeout.timeout(self._timeout.ws_close):
+                    msg = await self._reader.read()
             except asyncio.CancelledError:
                 self._close_code = WSCloseCode.ABNORMAL_CLOSURE
                 self._response.close()
@@ -282,30 +302,10 @@ class ClientWebSocketResponse:
                 self._response.close()
                 return True
 
-            if self._close_code:
+            if msg.type is WSMsgType.CLOSE:
+                self._close_code = msg.data
                 self._response.close()
                 return True
-
-            while True:
-                try:
-                    async with async_timeout.timeout(self._timeout.ws_close):
-                        msg = await self._reader.read()
-                except asyncio.CancelledError:
-                    self._close_code = WSCloseCode.ABNORMAL_CLOSURE
-                    self._response.close()
-                    raise
-                except Exception as exc:
-                    self._close_code = WSCloseCode.ABNORMAL_CLOSURE
-                    self._exception = exc
-                    self._response.close()
-                    return True
-
-                if msg.type is WSMsgType.CLOSE:
-                    self._close_code = msg.data
-                    self._response.close()
-                    return True
-        else:
-            return False
 
     async def receive(self, timeout: Optional[float] = None) -> WSMessage:
         receive_timeout = timeout or self._timeout.ws_receive


### PR DESCRIPTION
Reverse the `self._closed` condition so `close` can return early like its counter-part `web.WebSocketResponse` does.

Not a functional change. Saves some indent ahead of future refactoring.