### PR TITLE
Refactor connection waiters to be cancellation safe

### DIFF
--- a/CHANGES/9670.bugfix.rst
+++ b/CHANGES/9670.bugfix.rst
@@ -1,0 +1,1 @@
+9671.bugfix.rst

--- a/CHANGES/9671.bugfix.rst
+++ b/CHANGES/9671.bugfix.rst
@@ -1,3 +1,3 @@
-Fix a deadlock that could occur while attempting to get a new connection slot after a timeout -- by :user:`bdraco`.
+Fixed a deadlock that could occur while attempting to get a new connection slot after a timeout -- by :user:`bdraco`.
 
 The connector was not cancellation-safe.

--- a/CHANGES/9671.bugfix.rst
+++ b/CHANGES/9671.bugfix.rst
@@ -1,0 +1,3 @@
+Fix a deadlock that could occur while attempting to get a new connection slot after a timeout -- by :user:`bdraco`.
+
+The connector was not cancellation-safe.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -497,10 +497,11 @@ class BaseConnector:
         if (proto := self._get(key)) is not None:
             # If we do not have to wait and we can get a connection from the pool
             # we can avoid the timeout ceil logic and directly return the connection
+            conn = Connection(self, key, proto, self._loop)
             if traces:
                 for trace in traces:
                     await trace.send_connection_reuseconn()
-            return Connection(self, key, proto, self._loop)
+            return conn
 
         async with ceil_timeout(timeout.connect, timeout.ceil_threshold):
             #
@@ -545,10 +546,11 @@ class BaseConnector:
                         await trace.send_connection_queued_end()
 
                 if (proto := self._get(key)) is not None:
+                    conn = Connection(self, key, proto, self._loop)
                     if traces:
                         for trace in traces:
                             await trace.send_connection_reuseconn()
-                    return Connection(self, key, proto, self._loop)
+                    return conn
 
             placeholder = cast(
                 ResponseHandler, _TransportPlaceholder(self._placeholder_future)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -368,7 +368,13 @@ class BaseConnector:
                 timeout_ceil_threshold=self._timeout_ceil_threshold,
             )
 
+    def _mark_acquired(self, key: "ConnectionKey", proto: ResponseHandler) -> None:
+        """Mark connection acquired."""
+        self._acquired.add(proto)
+        self._acquired_per_host[key].add(proto)
+
     def _drop_acquired(self, key: "ConnectionKey", val: ResponseHandler) -> None:
+        """Drop acquired connection."""
         self._acquired.discard(val)
         if conns := self._acquired_per_host.get(key):
             conns.discard(val)
@@ -566,10 +572,6 @@ class BaseConnector:
                 await trace.send_connection_reuseconn()
         return Connection(self, key, proto, self._loop)
 
-    def _mark_acquired(self, key: "ConnectionKey", proto: ResponseHandler) -> None:
-        self._acquired.add(proto)
-        self._acquired_per_host[key].add(proto)
-
     def _get(self, key: "ConnectionKey") -> Optional[ResponseHandler]:
         """Get next reusable connection for the key or None.
 
@@ -628,6 +630,7 @@ class BaseConnector:
                     return
 
     def _release_acquired(self, key: "ConnectionKey", proto: ResponseHandler) -> None:
+        """Release acquired connection."""
         if self._closed:
             # acquired connection is already released on connector closing
             return

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -557,7 +557,8 @@ class BaseConnector:
                 for trace in traces:
                     await trace.send_connection_create_end()
 
-            return self._acquired_connection(proto, key)
+            self._mark_acquired(key, proto)
+            return Connection(self, key, proto, self._loop)
 
     async def _reused_connection(
         self, key: "ConnectionKey", proto: ResponseHandler, traces: List["Trace"]
@@ -571,13 +572,6 @@ class BaseConnector:
     def _mark_acquired(self, key: "ConnectionKey", proto: ResponseHandler) -> None:
         self._acquired.add(proto)
         self._acquired_per_host[key].add(proto)
-
-    def _acquired_connection(
-        self, proto: ResponseHandler, key: "ConnectionKey"
-    ) -> Connection:
-        """Mark proto as acquired and wrap it in a Connection object."""
-        self._mark_acquired(key, proto)
-        return Connection(self, key, proto, self._loop)
 
     def _get(self, key: "ConnectionKey") -> Optional[ResponseHandler]:
         """Get next reusable connection for the key or None."""

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -125,15 +125,7 @@ class Connection:
             if self._loop.is_closed():
                 return
 
-            # __del__ may be called in different thread. We have to use call_soon_threadsafe.
-            self._loop.call_soon_threadsafe(
-                functools.partial(
-                    self._connector._release,
-                    self._key,
-                    self._protocol,
-                    should_close=True,
-                )
-            )
+            self._connector._release(self._key, self._protocol, should_close=True)
 
             context = {"client_connection": self, "message": "Unclosed connection"}
             if self._source_traceback is not None:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -252,6 +252,8 @@ class BaseConnector:
         self._force_close = force_close
 
         # {host_key: FIFO list of waiters}
+        # The FIFO is implemented with a dict with None keys because
+        # python does not have an ordered set.
         self._waiters: DefaultDict[ConnectionKey, dict[asyncio.Future[None], None]] = (
             defaultdict(dict)
         )

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -558,9 +558,8 @@ class BaseConnector:
             placeholder = cast(
                 ResponseHandler, _TransportPlaceholder(self._placeholder_future)
             )
-            acquired_per_host = self._acquired_per_host[key]
             self._acquired.add(placeholder)
-            acquired_per_host.add(placeholder)
+            self._acquired_per_host[key].add(placeholder)
 
             try:
                 # Traces are done inside the try block to ensure that the
@@ -590,7 +589,7 @@ class BaseConnector:
         # and add the real connection to the acquired set. Nothing
         self._drop_acquired(key, placeholder)
         self._acquired.add(proto)
-        acquired_per_host.add(proto)
+        self._acquired_per_host[key].add(proto)
         return Connection(self, key, proto, self._loop)
 
     def _get(self, key: "ConnectionKey") -> Optional[ResponseHandler]:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -449,8 +449,7 @@ class BaseConnector:
             self._acquired.clear()
             for keyed_waiters in self._waiters.values():
                 for keyed_waiter in keyed_waiters:
-                    if not keyed_waiter.done():
-                        keyed_waiter.cancel()
+                    keyed_waiter.cancel()
             self._waiters.clear()
             self._cleanup_handle = None
             self._cleanup_closed_transports.clear()

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -535,7 +535,7 @@ class BaseConnector:
                     # pop the waiter from the queue if its still
                     # there and not already removed by _release_waiter
                     keyed_waiters.pop(fut, None)
-                    if not self._waiters.get(key):
+                    if not self._waiters.get(key, True):
                         del self._waiters[key]
 
                 if (conn := await self._get(key, traces)) is not None:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -565,7 +565,10 @@ class BaseConnector:
                     raise ClientConnectionError("Connector is closed.")
 
         # The connection was successfully created, drop the placeholder
-        # and add the real connection to the acquired set. Nothing
+        # and add the real connection to the acquired set. There should
+        # be no awaits after the proto is added to the acquired set
+        # to ensure that the connection is not left in the acquired set
+        # on cancellation.
         self._drop_acquired(key, placeholder)
         self._acquired.add(proto)
         self._acquired_per_host[key].add(proto)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -505,6 +505,15 @@ class BaseConnector:
             return await self._reused_connection(key, proto, traces)
 
         async with ceil_timeout(timeout.connect, timeout.ceil_threshold):
+            #
+            # Wait for the connection limit.
+            #
+            # we loop here because there is a race between
+            # the connection limit check and the connection
+            # being acquired. If the connection is acquired
+            # between the check and the await statement, we
+            # need to loop again to check if the connection
+            # slot is still available.
             while self._available_connections(key) <= 0:
                 # Be sure to fill the waiters dict before the next
                 # await statement to guarantee that the available

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -578,12 +578,12 @@ class BaseConnector:
                     proto.close()
                     raise ClientConnectionError("Connector is closed.")
 
-            # The connection was successfully created, drop the placeholder
-            # and add the real connection to the acquired set.
-            self._drop_acquired(key, placeholder)
-            self._acquired.add(proto)
-            acquired_per_host.add(proto)
-            return Connection(self, key, proto, self._loop)
+        # The connection was successfully created, drop the placeholder
+        # and add the real connection to the acquired set. Nothing
+        self._drop_acquired(key, placeholder)
+        self._acquired.add(proto)
+        acquired_per_host.add(proto)
+        return Connection(self, key, proto, self._loop)
 
     def _get(self, key: "ConnectionKey") -> Optional[ResponseHandler]:
         """Get next reusable connection for the key or None.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -502,8 +502,8 @@ class BaseConnector:
             # await statement to guarantee that the available
             # connections are correctly calculated.
             fut = self._loop.create_future()
-            # This connection will now count towards the limit.
             waiters = self._waiters[key]
+            # This connection will now count towards the limit.
             waiters.append(fut)
 
         elif (proto := self._get(key)) is not None:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -551,13 +551,12 @@ class BaseConnector:
         # between the check and the await statement, we
         # need to loop again to check if the connection
         # slot is still available.
-        wait_count = 0
+        attempts = 0
         while True:
-            wait_count += 1
             fut: asyncio.Future[None] = self._loop.create_future()
             keyed_waiters = self._waiters[key]
             keyed_waiters[fut] = None
-            if wait_count > 1:
+            if attempts:
                 # If we have waited before, we need to move the waiter
                 # to the front of the queue as otherwise we might get
                 # starved and hit the timeout.
@@ -582,6 +581,7 @@ class BaseConnector:
 
             if self._available_connections(key) > 0:
                 break
+            attempts += 1
 
     async def _get(
         self, key: "ConnectionKey", traces: List["Trace"]

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -447,10 +447,10 @@ class BaseConnector:
         finally:
             self._conns.clear()
             self._acquired.clear()
-            for waiters in self._waiters.values():
-                for waiter in waiters:
-                    if not waiter.done():
-                        waiter.cancel()
+            for keyed_waiters in self._waiters.values():
+                for keyed_waiter in keyed_waiters:
+                    if not keyed_waiter.done():
+                        keyed_waiter.cancel()
             self._waiters.clear()
             self._cleanup_handle = None
             self._cleanup_closed_transports.clear()

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -515,7 +515,8 @@ class BaseConnector:
             placeholder = cast(
                 ResponseHandler, _TransportPlaceholder(self._placeholder_future)
             )
-            self._add_acquired(key, proto)
+            self._acquired.add(placeholder)
+            self._acquired_per_host[key].add(placeholder)
 
         async with ceil_timeout(timeout.connect, timeout.ceil_threshold):
             # Wait if there are no available connections or if there are/were
@@ -529,10 +530,6 @@ class BaseConnector:
                 )
                 if (proto := self._get(key)) is not None:
                     return await self._reused_connection(key, proto, traces)
-                placeholder = cast(
-                    ResponseHandler, _TransportPlaceholder(self._placeholder_future)
-                )
-                self._add_acquired(key, proto)
 
             if traces:
                 for trace in traces:
@@ -566,7 +563,8 @@ class BaseConnector:
             placeholder = cast(
                 ResponseHandler, _TransportPlaceholder(self._placeholder_future)
             )
-            self._add_acquired(key, placeholder)
+            self._acquired.add(placeholder)
+            self._acquired_per_host[key].add(placeholder)
             for trace in traces:
                 await trace.send_connection_reuseconn()
             self._drop_acquired(key, placeholder)
@@ -576,12 +574,9 @@ class BaseConnector:
         self, proto: ResponseHandler, key: "ConnectionKey"
     ) -> Connection:
         """Mark proto as acquired and wrap it in a Connection object."""
-        self._add_acquired(key, proto)
-        return Connection(self, key, proto, self._loop)
-
-    def _add_acquired(self, key: "ConnectionKey", proto: ResponseHandler) -> None:
         self._acquired.add(proto)
         self._acquired_per_host[key].add(proto)
+        return Connection(self, key, proto, self._loop)
 
     async def _wait_for_available_connection(
         self,

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -578,8 +578,8 @@ class BaseConnector:
             # The connection was successfully created, drop the placeholder
             # We must never yield to the event loop after this point as
             # it is not cancellation safe once we have acquired the connection.
-            self._acquired.discard(placeholder)
-            self._acquired_per_host[key].discard(placeholder)
+            self._acquired.remove(placeholder)
+            self._acquired_per_host[key].remove(placeholder)
             self._acquired.add(proto)
             self._acquired_per_host[key].add(proto)
             return Connection(self, key, proto, self._loop)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -501,7 +501,7 @@ class BaseConnector:
             # Be sure to fill the waiters dict before the next
             # await statement to guarantee that the available
             # connections are correctly calculated.
-            fut: asyncio.Future[None] = self._loop.create_future()
+            fut = self._loop.create_future()
             # This connection will now count towards the limit.
             waiters = self._waiters[key]
             waiters.append(fut)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -511,13 +511,6 @@ class BaseConnector:
             # we can avoid the timeout ceil logic and directly return the connection
             return await self._reused_connection(key, proto, traces)
 
-        if available:
-            placeholder = cast(
-                ResponseHandler, _TransportPlaceholder(self._placeholder_future)
-            )
-            self._acquired.add(placeholder)
-            self._acquired_per_host[key].add(placeholder)
-
         async with ceil_timeout(timeout.connect, timeout.ceil_threshold):
             # Wait if there are no available connections or if there are/were
             # waiters (i.e. don't steal connection from a waiter about to wake up)
@@ -530,6 +523,12 @@ class BaseConnector:
                 )
                 if (proto := self._get(key)) is not None:
                     return await self._reused_connection(key, proto, traces)
+
+            placeholder = cast(
+                ResponseHandler, _TransportPlaceholder(self._placeholder_future)
+            )
+            self._acquired.add(placeholder)
+            self._acquired_per_host[key].add(placeholder)
 
             if traces:
                 for trace in traces:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -252,7 +252,7 @@ class BaseConnector:
         self._force_close = force_close
 
         # {host_key: FIFO list of waiters}
-        # The FIFO is implemented with a dict with None keys because
+        # The FIFO is implemented with an OrderedDict with None keys because
         # python does not have an ordered set.
         self._waiters: DefaultDict[
             ConnectionKey, OrderedDict[asyncio.Future[None], None]

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -125,7 +125,15 @@ class Connection:
             if self._loop.is_closed():
                 return
 
-            self._connector._release(self._key, self._protocol, should_close=True)
+            # __del__ may be called in different thread. We have to use call_soon_threadsafe.
+            self._loop.call_soon_threadsafe(
+                functools.partial(
+                    self._connector._release,
+                    self._key,
+                    self._protocol,
+                    should_close=True,
+                )
+            )
 
             context = {"client_connection": self, "message": "Unclosed connection"}
             if self._source_traceback is not None:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -592,8 +592,10 @@ class BaseConnector:
 
         try:
             await fut
-        finally:
+        except BaseException:
             waiters.remove(fut)
+            raise
+        finally:
             if not self._waiters.get(key):
                 del self._waiters[key]
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -523,7 +523,7 @@ class BaseConnector:
                 # Be sure to fill the waiters dict before the next
                 # await statement to guarantee that the available
                 # connections are correctly calculated.
-                fut = self._loop.create_future()
+                fut: asyncio.Future[None] = self._loop.create_future()
                 keyed_waiters = self._waiters[key]
                 # This connection will now count towards the limit.
                 keyed_waiters[fut] = None
@@ -563,7 +563,10 @@ class BaseConnector:
 
             try:
                 proto = await self._create_connection(req, traces, timeout)
-            except BaseException:
+            except BaseException as ex:
+                import pprint
+
+                pprint.pprint(["Got exception", ex, iter_count])
                 if not self._closed:
                     self._drop_acquired(key, placeholder)
                     self._release_waiter()

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -512,7 +512,13 @@ class BaseConnector:
             # between the check and the await statement, we
             # need to loop again to check if the connection
             # slot is still available.
+            # iter_count = 0
             while self._available_connections(key) <= 0:
+                # iter_count += 1
+                # import pprint
+                # if iter_count > 1:
+                #    pprint.pprint(['wait for', iter_count])
+
                 # Be sure to fill the waiters dict before the next
                 # await statement to guarantee that the available
                 # connections are correctly calculated.
@@ -635,7 +641,7 @@ class BaseConnector:
                 continue
 
             for waiter in self._waiters[key]:
-                if not waiter.done():  # and not waiter.cancelled():
+                if not waiter.done():
                     waiter.set_result(None)
                     return
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -512,12 +512,13 @@ class BaseConnector:
             # between the check and the await statement, we
             # need to loop again to check if the connection
             # slot is still available.
-            # iter_count = 0
+            iter_count = 0
             while self._available_connections(key) <= 0:
-                # iter_count += 1
-                # import pprint
-                # if iter_count > 1:
-                #    pprint.pprint(['wait for', iter_count])
+                iter_count += 1
+                import pprint
+
+                if iter_count > 1:
+                    pprint.pprint(["wait for", iter_count])
 
                 # Be sure to fill the waiters dict before the next
                 # await statement to guarantee that the available

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -597,7 +597,7 @@ class BaseConnector:
             await fut
         finally:
             del keyed_waiters[fut]
-            if not self._waiters.get(key):
+            if not keyed_waiters:
                 del self._waiters[key]
 
         if traces:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -592,10 +592,8 @@ class BaseConnector:
 
         try:
             await fut
-        except BaseException:
-            waiters.remove(fut)
-            raise
         finally:
+            waiters.remove(fut)
             if not self._waiters.get(key):
                 del self._waiters[key]
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -510,11 +510,7 @@ class BaseConnector:
                     try:
                         await trace.send_connection_reuseconn()
                     except BaseException:
-                        # If the send_connection_reuseconn() fails
-                        # we need to release the connection and re-raise
-                        if not self._closed:
-                            self._drop_acquired(key, proto)
-                            self._release_waiter()
+                        self._release_acquired(key, proto)
                         raise
             return Connection(self, key, proto, self._loop)
 
@@ -561,11 +557,7 @@ class BaseConnector:
                             for trace in traces:
                                 await trace.send_connection_reuseconn()
                         except BaseException:
-                            # If the send_connection_reuseconn() fails
-                            # we need to release the connection and re-raise
-                            if not self._closed:
-                                self._drop_acquired(key, proto)
-                                self._release_waiter()
+                            self._release_acquired(key, proto)
                             raise
                     return Connection(self, key, proto, self._loop)
 
@@ -587,9 +579,7 @@ class BaseConnector:
                     for trace in traces:
                         await trace.send_connection_create_end()
             except BaseException:
-                if not self._closed:
-                    self._drop_acquired(key, placeholder)
-                    self._release_waiter()
+                self._release_acquired(key, placeholder)
                 raise
             else:
                 if self._closed:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -502,9 +502,8 @@ class BaseConnector:
         async with ceil_timeout(timeout.connect, timeout.ceil_threshold):
             if self._available_connections(key) <= 0:
                 await self._wait_for_available_connection(key, traces)
-
-            if (conn := await self._get(key, traces)) is not None:
-                return conn
+                if (conn := await self._get(key, traces)) is not None:
+                    return conn
 
             placeholder = cast(
                 ResponseHandler, _TransportPlaceholder(self._placeholder_future)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -337,7 +337,7 @@ class BaseConnector:
             # recreate it ever!
             self._cleanup_handle = None
 
-        now = self._loop.time()
+        now = monotonic()
         timeout = self._keepalive_timeout
 
         if self._conns:
@@ -594,7 +594,7 @@ class BaseConnector:
         except KeyError:
             return None
 
-        t1 = self._loop.time()
+        t1 = monotonic()
         while conns:
             proto, t0 = conns.pop()
             # We will we reuse the connection if its connected and
@@ -690,7 +690,7 @@ class BaseConnector:
         conns = self._conns.get(key)
         if conns is None:
             conns = self._conns[key] = []
-        conns.append((protocol, self._loop.time()))
+        conns.append((protocol, monotonic()))
 
         if self._cleanup_handle is None:
             self._cleanup_handle = helpers.weakref_handle(

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -581,8 +581,7 @@ class BaseConnector:
                     await trace.send_connection_create_end()
 
             # The connection was successfully created, drop the placeholder
-            # We must never yield to the event loop after this point as
-            # it is not cancellation safe once we have acquired the connection.
+            # and add the real connection to the acquired set.
             self._drop_acquired(key, placeholder)
             self._acquired.add(proto)
             acquired_per_host.add(proto)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -597,8 +597,6 @@ class BaseConnector:
                     del self._conns[key]
                 self._acquired.add(proto)
                 self._acquired_per_host[key].add(proto)
-                # If we do not have to wait and we can get a connection from the pool
-                # we can avoid the timeout ceil logic and directly return the connection
                 if traces:
                     for trace in traces:
                         try:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -499,7 +499,7 @@ class BaseConnector:
             return await self._reused_connection(key, proto, traces)
 
         async with ceil_timeout(timeout.connect, timeout.ceil_threshold):
-            if self._available_connections(key) <= 0:
+            while self._available_connections(key) <= 0:
                 # Be sure to fill the waiters dict before the next
                 # await statement to guarantee that the available
                 # connections are correctly calculated.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -532,6 +532,10 @@ class BaseConnector:
                         for trace in traces:
                             await trace.send_connection_queued_end()
                 finally:
+                    # This is the only point that the waiters
+                    # are removed from the queue. This ensures that
+                    # the waiters are always cleaned up and there
+                    # is no race between other parts of the code
                     del keyed_waiters[fut]
                     if not self._waiters.get(key):
                         del self._waiters[key]
@@ -636,6 +640,10 @@ class BaseConnector:
             if self._available_connections(key) < 1:
                 continue
 
+            # Waiters are not removed from the queue here,
+            # and only one waiter is released at a time.
+            # They are only removed in a finally block
+            # in the connect method where they are added.
             for waiter in self._waiters[key]:
                 if not waiter.done():
                     waiter.set_result(None)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3340,7 +3340,7 @@ async def test_connector_does_not_remove_needed_waiters(
         "_available_connections",
         autospec=True,
         spec_set=True,
-        return_value=0,
+        side_effect=[0, 1, 1, 1],
     ):
         connector._conns[key] = [(proto, loop.time())]
         with mock.patch.object(

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -319,6 +319,7 @@ async def test_get(loop: asyncio.AbstractEventLoop, key: ConnectionKey) -> None:
     proto = create_mocked_conn(loop)
     conn._conns[key] = [(proto, loop.time())]
     connection = await conn._get(key, [])
+    assert connection is not None
     assert connection.protocol == proto
     connection.close()
     await conn.close()
@@ -332,6 +333,7 @@ async def test_get_unconnected_proto(loop: asyncio.AbstractEventLoop) -> None:
     proto = create_mocked_conn(loop)
     conn._conns[key] = [(proto, loop.time())]
     connection = await conn._get(key, [])
+    assert connection is not None
     assert connection.protocol == proto
     connection.close()
 
@@ -350,6 +352,7 @@ async def test_get_unconnected_proto_ssl(loop: asyncio.AbstractEventLoop) -> Non
     proto = create_mocked_conn(loop)
     conn._conns[key] = [(proto, loop.time())]
     connection = await conn._get(key, [])
+    assert connection is not None
     assert connection.protocol == proto
     connection.close()
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -480,7 +480,7 @@ async def test_release_waiter_no_limit(
     w.done.return_value = False
     conn._waiters[key][w] = None
     conn._release_waiter()
-    assert len(conn._waiters[key]) == 1
+    assert len(conn._waiters[key]) == 0
     assert w.done.called
     await conn.close()
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -7,7 +7,6 @@ import socket
 import ssl
 import sys
 import uuid
-from collections import deque
 from concurrent import futures
 from contextlib import closing, suppress
 from typing import (
@@ -502,7 +501,8 @@ async def test_release_waiter_release_first(
     w1, w2 = mock.Mock(), mock.Mock()
     w1.done.return_value = False
     w2.done.return_value = False
-    conn._waiters[key] = deque([w1, w2])
+    conn._waiters[key][w1] = None
+    conn._waiters[key][w2] = None
     conn._release_waiter()
     assert w1.set_result.called
     assert not w2.set_result.called
@@ -516,7 +516,8 @@ async def test_release_waiter_skip_done_waiter(
     w1, w2 = mock.Mock(), mock.Mock()
     w1.done.return_value = True
     w2.done.return_value = False
-    conn._waiters[key] = deque([w1, w2])
+    conn._waiters[key][w1] = None
+    conn._waiters[key][w2] = None
     conn._release_waiter()
     assert not w1.set_result.called
     assert w2.set_result.called
@@ -531,8 +532,8 @@ async def test_release_waiter_per_host(
     w1, w2 = mock.Mock(), mock.Mock()
     w1.done.return_value = False
     w2.done.return_value = False
-    conn._waiters[key] = deque([w1])
-    conn._waiters[key2] = deque([w2])
+    conn._waiters[key][w1] = None
+    conn._waiters[key2][w2] = None
     conn._release_waiter()
     assert (w1.set_result.called and not w2.set_result.called) or (
         not w1.set_result.called and w2.set_result.called

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3402,7 +3402,8 @@ def test_default_ssl_context_creation_without_ssl() -> None:
 def _acquired_connection(
     conn: aiohttp.BaseConnector, proto: ResponseHandler, key: ConnectionKey
 ) -> Connection:
-    conn._mark_acquired(key, proto)
+    conn._acquired.add(proto)
+    conn._acquired_per_host[key].add(proto)
     return Connection(conn, key, proto, conn._loop)
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -581,7 +581,7 @@ async def test__drop_acquire_per_host1(
     loop: asyncio.AbstractEventLoop, key: ConnectionKey
 ) -> None:
     conn = aiohttp.BaseConnector()
-    conn._drop_acquired_per_host(key, create_mocked_conn(loop))
+    conn._drop_acquired(key, create_mocked_conn(loop))
     assert len(conn._acquired_per_host) == 0
 
 
@@ -591,7 +591,7 @@ async def test__drop_acquire_per_host2(
     conn = aiohttp.BaseConnector()
     handler = create_mocked_conn(loop)
     conn._acquired_per_host[key].add(handler)
-    conn._drop_acquired_per_host(key, handler)
+    conn._drop_acquired(key, handler)
     assert len(conn._acquired_per_host) == 0
 
 
@@ -603,7 +603,7 @@ async def test__drop_acquire_per_host3(
     handler2 = create_mocked_conn(loop)
     conn._acquired_per_host[key].add(handler)
     conn._acquired_per_host[key].add(handler2)
-    conn._drop_acquired_per_host(key, handler)
+    conn._drop_acquired(key, handler)
     assert len(conn._acquired_per_host) == 1
     assert conn._acquired_per_host[key] == {handler2}
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -132,7 +132,7 @@ def create_mocked_conn(
     return proto
 
 
-def test_connection_del(loop: asyncio.AbstractEventLoop) -> None:
+async def test_connection_del(loop: asyncio.AbstractEventLoop) -> None:
     connector = mock.Mock()
     key = mock.Mock()
     protocol = mock.Mock()
@@ -145,6 +145,7 @@ def test_connection_del(loop: asyncio.AbstractEventLoop) -> None:
         del conn
         gc.collect()
 
+    await asyncio.sleep(0)
     connector._release.assert_called_with(key, protocol, should_close=True)
     msg = {
         "message": mock.ANY,

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -588,25 +588,25 @@ async def test_release_proto_closed_future(
     assert protocol.closed.result() is None
 
 
-async def test__drop_acquire_per_host1(
+async def test__release_acquired_per_host1(
     loop: asyncio.AbstractEventLoop, key: ConnectionKey
 ) -> None:
     conn = aiohttp.BaseConnector()
-    conn._drop_acquired(key, create_mocked_conn(loop))
+    conn._release_acquired(key, create_mocked_conn(loop))
     assert len(conn._acquired_per_host) == 0
 
 
-async def test__drop_acquire_per_host2(
+async def test__release_acquired_per_host2(
     loop: asyncio.AbstractEventLoop, key: ConnectionKey
 ) -> None:
     conn = aiohttp.BaseConnector()
     handler = create_mocked_conn(loop)
     conn._acquired_per_host[key].add(handler)
-    conn._drop_acquired(key, handler)
+    conn._release_acquired(key, handler)
     assert len(conn._acquired_per_host) == 0
 
 
-async def test__drop_acquire_per_host3(
+async def test__release_acquired_per_host3(
     loop: asyncio.AbstractEventLoop, key: ConnectionKey
 ) -> None:
     conn = aiohttp.BaseConnector()
@@ -614,7 +614,7 @@ async def test__drop_acquire_per_host3(
     handler2 = create_mocked_conn(loop)
     conn._acquired_per_host[key].add(handler)
     conn._acquired_per_host[key].add(handler2)
-    conn._drop_acquired(key, handler)
+    conn._release_acquired(key, handler)
     assert len(conn._acquired_per_host) == 1
     assert conn._acquired_per_host[key] == {handler2}
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1726,7 +1726,7 @@ async def test_exception_during_connection_reuse_tracing(
         assert key not in conn._acquired_per_host
         assert key in conn._conns
 
-        resp = await conn.connect(req, traces, ClientTimeout())
+        await conn.connect(req, traces, ClientTimeout())
 
     assert not conn._acquired
     assert key not in conn._acquired_per_host
@@ -1740,9 +1740,6 @@ async def test_cancellation_during_waiting_for_free_connection(
     waiter_wait_stated_future = loop.create_future()
 
     async def on_connection_queued_start(*args: object, **kwargs: object) -> None:
-        import pprint
-
-        pprint.pprint(["_waiters", conn._waiters])
         waiter_wait_stated_future.set_result(None)
 
     trace_config = aiohttp.TraceConfig(
@@ -1769,9 +1766,6 @@ async def test_cancellation_during_waiting_for_free_connection(
         # 2nd connect request will be queued
         task = asyncio.create_task(conn.connect(req, traces, ClientTimeout()))
         await waiter_wait_stated_future
-        import pprint
-
-        pprint.pprint(["_waiters", conn._waiters])
         list(conn._waiters[key])[0].cancel()
         with pytest.raises(asyncio.CancelledError):
             await task


### PR DESCRIPTION
A deadlock that could occur while attempting to get a new connection slot after a timeout.

The connector was not cancellation-safe.

fixes #9670

will need to backport https://github.com/aio-libs/aiohttp/pull/9600 to 3.10 as well