### PR TITLE
[PR #9600/e6187f6 backport][3.10] Avoid starting connection timeout when a connection is already available

### DIFF
--- a/CHANGES/9600.breaking.rst
+++ b/CHANGES/9600.breaking.rst
@@ -1,0 +1,3 @@
+Improved performance of the connector when a connection can be reused -- by :user:`bdraco`.
+
+If ``BaseConnector.connect`` has been subclassed and replaced with custom logic, the ``ceil_timeout`` must be added.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -89,7 +89,6 @@ from .helpers import (
     DEBUG,
     BasicAuth,
     TimeoutHandle,
-    ceil_timeout,
     get_env_proxy_for_url,
     method_must_be_empty_body,
     sentinel,
@@ -661,13 +660,9 @@ class ClientSession:
 
                     # connection timeout
                     try:
-                        async with ceil_timeout(
-                            real_timeout.connect,
-                            ceil_threshold=real_timeout.ceil_threshold,
-                        ):
-                            conn = await self._connector.connect(
-                                req, traces=traces, timeout=real_timeout
-                            )
+                        conn = await self._connector.connect(
+                            req, traces=traces, timeout=real_timeout
+                        )
                     except asyncio.TimeoutError as exc:
                         raise ConnectionTimeoutError(
                             f"Connection timeout to host {url}"

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -294,6 +294,7 @@ ssl
 SSLContext
 startup
 subapplication
+subclassed
 subclasses
 subdirectory
 submodules


### PR DESCRIPTION
This was originally planned not to backport to 3.10, but its needed to fixup https://github.com/aio-libs/aiohttp/pull/9670

(cherry picked from commit e6187f6808d647243d8cee115ec24c3eb1421183)
