### PR TITLE
DNM: Remove reading flow control from WebSocket

### DIFF
--- a/CHANGES/9677.misc.rst
+++ b/CHANGES/9677.misc.rst
@@ -1,0 +1,3 @@
+Removed flow control from the WebSocket reader -- by :user:`bdraco`.
+
+The flow control did not function as expected because it counted all messages as having a size of `3`, and since it did not work, it was deemed unnecessary.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -84,13 +84,7 @@ from .payload import (
     payload_type,
 )
 from .resolver import AsyncResolver, DefaultResolver, ThreadedResolver
-from .streams import (
-    EMPTY_PAYLOAD,
-    DataQueue,
-    EofStream,
-    FlowControlDataQueue,
-    StreamReader,
-)
+from .streams import EMPTY_PAYLOAD, DataQueue, EofStream, StreamReader
 from .tracing import (
     TraceConfig,
     TraceConnectionCreateEndParams,
@@ -206,7 +200,6 @@ __all__: Tuple[str, ...] = (
     "DataQueue",
     "EMPTY_PAYLOAD",
     "EofStream",
-    "FlowControlDataQueue",
     "StreamReader",
     # tracing
     "TraceConfig",

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -102,7 +102,7 @@ from .helpers import (
 )
 from .http import WS_KEY, HttpVersion, WebSocketReader, WebSocketWriter
 from .http_websocket import WSHandshakeError, WSMessage, ws_ext_gen, ws_ext_parse
-from .streams import FlowControlDataQueue
+from .streams import DataQueue
 from .tracing import Trace, TraceConfig
 from .typedefs import JSONEncoder, LooseCookies, LooseHeaders, Query, StrOrURL
 
@@ -1035,9 +1035,7 @@ class ClientSession:
 
             transport = conn.transport
             assert transport is not None
-            reader: FlowControlDataQueue[WSMessage] = FlowControlDataQueue(
-                conn_proto, 2**16, loop=self._loop
-            )
+            reader: DataQueue[WSMessage] = DataQueue(self._loop)
             conn_proto.set_parser(WebSocketReader(reader, max_msg_size), reader)
             writer = WebSocketWriter(
                 conn_proto,

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -167,7 +167,7 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
     def set_parser(self, parser: Any, payload: Any) -> None:
         # TODO: actual types are:
         #   parser: WebSocketReader
-        #   payload: FlowControlDataQueue
+        #   payload: DataQueue
         # but they are not generi enough
         # Need an ABC for both types
         self._payload = payload

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -18,7 +18,7 @@ from .http import (
     WSMsgType,
 )
 from .http_websocket import WebSocketWriter, WSMessageError
-from .streams import EofStream, FlowControlDataQueue
+from .streams import DataQueue, EofStream
 from .typedefs import (
     DEFAULT_JSON_DECODER,
     DEFAULT_JSON_ENCODER,
@@ -46,7 +46,7 @@ DEFAULT_WS_CLIENT_TIMEOUT: Final[ClientWSTimeout] = ClientWSTimeout(
 class ClientWebSocketResponse:
     def __init__(
         self,
-        reader: "FlowControlDataQueue[WSMessage]",
+        reader: "DataQueue[WSMessage]",
         writer: WebSocketWriter,
         protocol: Optional[str],
         response: ClientResponse,

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -30,11 +30,9 @@ __all__ = (
     "EofStream",
     "StreamReader",
     "DataQueue",
-    "FlowControlDataQueue",
 )
 
 _T = TypeVar("_T")
-_SizedT = TypeVar("_SizedT", bound=collections.abc.Sized)
 
 
 class EofStream(Exception):
@@ -600,7 +598,7 @@ class EmptyStreamReader(StreamReader):  # lgtm [py/missing-call-to-init]
 EMPTY_PAYLOAD: Final[StreamReader] = EmptyStreamReader()
 
 
-class DataQueue(Generic[_SizedT]):
+class DataQueue(Generic[_T]):
     """DataQueue is a general-purpose blocking queue with one reader."""
 
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
@@ -608,7 +606,7 @@ class DataQueue(Generic[_SizedT]):
         self._eof = False
         self._waiter: Optional[asyncio.Future[None]] = None
         self._exception: Union[Type[BaseException], BaseException, None] = None
-        self._buffer: Deque[_SizedT] = collections.deque()
+        self._buffer: Deque[_T] = collections.deque()
 
     def __len__(self) -> int:
         return len(self._buffer)
@@ -633,7 +631,7 @@ class DataQueue(Generic[_SizedT]):
             self._waiter = None
             set_exception(waiter, exc, exc_cause)
 
-    def feed_data(self, data: _SizedT) -> None:
+    def feed_data(self, data: _T) -> None:
         self._buffer.append(data)
         if (waiter := self._waiter) is not None:
             self._waiter = None
@@ -654,7 +652,7 @@ class DataQueue(Generic[_SizedT]):
             self._waiter = None
             raise
 
-    async def read(self) -> _SizedT:
+    async def read(self) -> _T:
         if not self._buffer and not self._eof:
             await self._wait_for_data()
         if self._buffer:
@@ -663,42 +661,5 @@ class DataQueue(Generic[_SizedT]):
             raise self._exception
         raise EofStream
 
-    def __aiter__(self) -> AsyncStreamIterator[_SizedT]:
+    def __aiter__(self) -> AsyncStreamIterator[_T]:
         return AsyncStreamIterator(self.read)
-
-
-class FlowControlDataQueue(DataQueue[_SizedT]):
-    """FlowControlDataQueue resumes and pauses an underlying stream.
-
-    It is a destination for parsed data.
-    """
-
-    def __init__(
-        self, protocol: BaseProtocol, limit: int, *, loop: asyncio.AbstractEventLoop
-    ) -> None:
-        super().__init__(loop=loop)
-        self._size = 0
-        self._protocol = protocol
-        self._limit = limit * 2
-
-    def feed_data(self, data: _SizedT) -> None:
-        self._size += len(data)
-        self._buffer.append(data)
-        if (waiter := self._waiter) is not None:
-            self._waiter = None
-            set_result(waiter, None)
-        if self._size > self._limit and not self._protocol._reading_paused:
-            self._protocol.pause_reading()
-
-    async def read(self) -> _SizedT:
-        if not self._buffer and not self._eof:
-            await self._wait_for_data()
-        if self._buffer:
-            data = self._buffer.popleft()
-            self._size -= len(data)
-            if self._size < self._limit and self._protocol._reading_paused:
-                self._protocol.resume_reading()
-            return data
-        if self._exception is not None:
-            raise self._exception
-        raise EofStream

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -29,7 +29,7 @@ from .http import (
 )
 from .http_websocket import WSMessageError
 from .log import ws_logger
-from .streams import EofStream, FlowControlDataQueue
+from .streams import DataQueue, EofStream
 from .typedefs import JSONDecoder, JSONEncoder
 from .web_exceptions import HTTPBadRequest, HTTPException
 from .web_request import BaseRequest
@@ -105,7 +105,7 @@ class WebSocketResponse(StreamResponse):
         self._protocols = protocols
         self._ws_protocol: Optional[str] = None
         self._writer: Optional[WebSocketWriter] = None
-        self._reader: Optional[FlowControlDataQueue[WSMessage]] = None
+        self._reader: Optional[DataQueue[WSMessage]] = None
         self._closed = False
         self._closing = False
         self._conn_lost = 0
@@ -355,7 +355,7 @@ class WebSocketResponse(StreamResponse):
 
         loop = self._loop
         assert loop is not None
-        self._reader = FlowControlDataQueue(request._protocol, 2**16, loop=loop)
+        self._reader = DataQueue(loop)
         request.protocol.set_parser(
             WebSocketReader(self._reader, self._max_msg_size, compress=self._compress)
         )


### PR DESCRIPTION
edit: This works well enough on 3.11 and 3.10 because we send the size in https://github.com/aio-libs/aiohttp/blob/49f65e6ccbacc39127072bc0fa35c2efc965096e/aiohttp/streams.py#L700 so I think this needs to be restored to use that behavior instead.

alternative https://github.com/aio-libs/aiohttp/pull/9685

originally posted by Dreamsorcerer in https://github.com/aio-libs/aiohttp/pull/9659#discussion_r1828188535 :
> As DataQueue doesn't have _size anymore, the Generic should not require Sized anymore. Also, probably want to have WSMessage queues move to that, as they don't need the _size calculations.

It appears this has never worked correctly, and has always calculated the size of every WebSocket message as `3` which is the length of the `WSMessage` tuple, and since the limit was enforced at 2x, there would have to be `43690` queued WebSocket messages before reading would pause.

The downside to not pausing reads is we don't create back-pressure the other direction which means we keep filling memory by processing messages into the queue if for some reason the downstream application stops processing the data.  However since its always been `3` per message it seems unlikely this was needed.

This does not affect back-pressure for the writer as there is a drain when the outgoing builds up.

The alternative would be to rework it to be WebSocket specific and add the size of `msg.data`

codspeed shows ~4% speed up on WebSocket round trip.