### PR TITLE
Return early in WebSocket `receive` if there is no processing to do

### DIFF
--- a/CHANGES/9679.misc.rst
+++ b/CHANGES/9679.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of calling ``receive`` for WebSockets for the most common message types -- by :user:`bdraco`.

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -17,7 +17,7 @@ from .http import (
     WSMessage,
     WSMsgType,
 )
-from .http_websocket import WebSocketWriter, WSMessageError
+from .http_websocket import _INTERNAL_RECEIVE_TYPES, WebSocketWriter, WSMessageError
 from .streams import EofStream, FlowControlDataQueue
 from .typedefs import (
     DEFAULT_JSON_DECODER,
@@ -359,6 +359,11 @@ class ClientWebSocketResponse:
                 self._close_code = WSCloseCode.ABNORMAL_CLOSURE
                 await self.close()
                 return WSMessageError(data=exc)
+
+            if msg.type not in _INTERNAL_RECEIVE_TYPES:
+                # If its not a close/closing/ping/pong message
+                # we can return it immediately
+                return msg
 
             if msg.type is WSMsgType.CLOSE:
                 self._set_closing()

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -22,6 +22,12 @@ from ._websocket.models import (
 from ._websocket.reader import WebSocketReader
 from ._websocket.writer import WebSocketWriter
 
+# Messages that the WebSocketResponse.receive needs to handle internally
+_INTERNAL_RECEIVE_TYPES = frozenset(
+    (WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.PING, WSMsgType.PONG)
+)
+
+
 __all__ = (
     "WS_CLOSED_MESSAGE",
     "WS_CLOSING_MESSAGE",

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -27,7 +27,7 @@ from .http import (
     ws_ext_gen,
     ws_ext_parse,
 )
-from .http_websocket import WSMessageError
+from .http_websocket import _INTERNAL_RECEIVE_TYPES, WSMessageError
 from .log import ws_logger
 from .streams import EofStream, FlowControlDataQueue
 from .typedefs import JSONDecoder, JSONEncoder
@@ -580,6 +580,11 @@ class WebSocketResponse(StreamResponse):
                 self._set_closing(WSCloseCode.ABNORMAL_CLOSURE)
                 await self.close()
                 return WSMessageError(data=exc)
+
+            if msg.type not in _INTERNAL_RECEIVE_TYPES:
+                # If its not a close/closing/ping/pong message
+                # we can return it immediately
+                return msg
 
             if msg.type is WSMsgType.CLOSE:
                 self._set_closing(msg.data)


### PR DESCRIPTION
`receive` is a hot path for many downstream applications. In most we can avoid the linear search of message types to see if they need additional processing

extracted from #9666

<img width="352" alt="Screenshot 2024-11-03 at 9 10 03 PM" src="https://github.com/user-attachments/assets/e7de7c8c-7408-43c4-b101-e6339fac8652">

19% speed up to `receive` for common message types. closing/closing/ping/pong will be a tiny bit slower since it has to do the `PySequence_Contains` but for any WebSocket connection that has any sort of volume, `TEXT` or `BINARY` is going to significant exceed these message types.