### PR TITLE
[PR #9672/afb5ebb backport][3.11] Reuse the oldest keep-alive connection first

### DIFF
--- a/CHANGES/9672.bugfix.rst
+++ b/CHANGES/9672.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed the keep-alive connection pool to be FIFO instead of LIFO -- by :user:`bdraco`.
+
+Keep-alive connections are more likely to be reused before they disconnect.

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -3,6 +3,7 @@ import contextlib
 import gc
 import io
 import json
+from collections import deque
 from http.cookies import SimpleCookie
 from typing import Any, Awaitable, Callable, List
 from unittest import mock
@@ -32,7 +33,7 @@ def connector(loop):
 
     conn = loop.run_until_complete(make_conn())
     proto = mock.Mock()
-    conn._conns["a"] = [(proto, 123)]
+    conn._conns["a"] = deque([(proto, 123)])
     yield conn
     loop.run_until_complete(conn.close())
 


### PR DESCRIPTION
(cherry picked from commit afb5ebb912ebe1cf88e0d2c19d5f240ffb0b72ee)
