### PR TITLE
[3.11] Fix WebSocket reader flow control size calculation for multi-byte data

### DIFF
--- a/CHANGES/9686.bugfix.rst
+++ b/CHANGES/9686.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the WebSocket flow control calculation undercounting with multi-byte data -- by :user:`bdraco`.

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -4,7 +4,7 @@ from typing import Final, List, Optional, Set, Tuple, Union
 
 from ..compression_utils import ZLibDecompressor
 from ..helpers import set_exception
-from ..streams import DataQueue
+from ..streams import FlowControlDataQueue
 from .helpers import UNPACK_CLOSE_CODE, UNPACK_LEN3, websocket_mask
 from .models import (
     WS_DEFLATE_TRAILING,
@@ -42,7 +42,10 @@ TUPLE_NEW = tuple.__new__
 
 class WebSocketReader:
     def __init__(
-        self, queue: DataQueue[WSMessage], max_msg_size: int, compress: bool = True
+        self,
+        queue: FlowControlDataQueue[WSMessage],
+        max_msg_size: int,
+        compress: bool = True,
     ) -> None:
         self.queue = queue
         self._queue_feed_data = queue.feed_data
@@ -185,7 +188,8 @@ class WebSocketReader:
                     # This is not type safe, but many tests should fail in
                     # test_client_ws_functional.py if this is wrong.
                     self._queue_feed_data(
-                        TUPLE_NEW(WSMessage, (WS_MSG_TYPE_TEXT, text, "")), len(text)
+                        TUPLE_NEW(WSMessage, (WS_MSG_TYPE_TEXT, text, "")),
+                        len(payload_merged),
                     )
                 else:
                     self._queue_feed_data(

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -330,6 +330,7 @@ UI
 un
 unawaited
 unclosed
+undercounting
 unhandled
 unicode
 unittest

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -613,9 +613,6 @@ def test_flow_control_binary(
     assert protocol._reading_paused is True
 
 
-@pytest.mark.xfail(
-    reason="Flow control is currently broken on master branch; see #9686"
-)
 def test_flow_control_multi_byte_text(
     protocol: BaseProtocol,
     out_low_limit: aiohttp.FlowControlDataQueue[WSMessage],


### PR DESCRIPTION
The decoded size was passed to the `FlowControlDataQueue` instead of the bytes size which meant multi-byte characters would be under counted.

Note that this code is completely different on 3.11/3.10 than `master` so this PR is directly to 3.11