### PR TITLE
Add benchmark for sending client requests

### DIFF
--- a/tests/test_benchmarks_client_request.py
+++ b/tests/test_benchmarks_client_request.py
@@ -86,16 +86,13 @@ def test_send_client_request_one_hundred(
 
     class MockProtocol(asyncio.BaseProtocol):
 
-        def __init__(self):
+        def __init__(self) -> None:
             self.transport = MockTransport()
 
     class MockConnection:
-        def __init__(self):
+        def __init__(self) -> None:
             self.transport = None
             self.protocol = MockProtocol()
-
-        def get_extra_info(self, key):
-            return None
 
     conn = MockConnection()
 

--- a/tests/test_benchmarks_client_request.py
+++ b/tests/test_benchmarks_client_request.py
@@ -89,6 +89,12 @@ def test_send_client_request_one_hundred(
         def __init__(self) -> None:
             self.transport = MockTransport()
 
+        async def _drain_helper(self) -> None:
+            """Swallow drain."""
+
+        def start_timeout(self) -> None:
+            """Swallow start_timeout."""
+
     class MockConnection:
         def __init__(self) -> None:
             self.transport = None

--- a/tests/test_benchmarks_client_request.py
+++ b/tests/test_benchmarks_client_request.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from http.cookies import Morsel
+from typing import Union
 
 from pytest_codspeed import BenchmarkFixture
 from yarl import URL
@@ -65,3 +66,43 @@ def test_create_client_request_with_headers(
             chunked=None,
             expect100=False,
         )
+
+
+def test_send_client_request_one_hundred(
+    loop: asyncio.AbstractEventLoop, benchmark: BenchmarkFixture
+) -> None:
+    url = URL("http://python.org")
+    req = ClientRequest("get", url, loop=loop)
+
+    class MockTransport(asyncio.Transport):
+        """Mock transport for testing that do no real I/O."""
+
+        def is_closing(self) -> bool:
+            """Swallow is_closing."""
+            return False
+
+        def write(self, data: Union[bytes, bytearray, memoryview]) -> None:
+            """Swallow writes."""
+
+    class MockProtocol(asyncio.BaseProtocol):
+
+        def __init__(self):
+            self.transport = MockTransport()
+
+    class MockConnection:
+        def __init__(self):
+            self.transport = None
+            self.protocol = MockProtocol()
+
+        def get_extra_info(self, key):
+            return None
+
+    conn = MockConnection()
+
+    async def send_requests() -> None:
+        for _ in range(100):
+            await req.send(conn)
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(send_requests())

--- a/tests/test_benchmarks_client_request.py
+++ b/tests/test_benchmarks_client_request.py
@@ -104,7 +104,7 @@ def test_send_client_request_one_hundred(
 
     async def send_requests() -> None:
         for _ in range(100):
-            await req.send(conn)
+            await req.send(conn)  # type: ignore[arg-type]
 
     @benchmark
     def _run() -> None:


### PR DESCRIPTION
SSIA

Note that unittest mock objects are not used because they would impact the profiling