### PR TITLE
Avoid duplicate `content_length` fetch to prepare web response headers

### DIFF
--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -399,7 +399,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
                 headers[hdrs.TRANSFER_ENCODING] = "chunked"
             if hdrs.CONTENT_LENGTH in headers:
                 del headers[hdrs.CONTENT_LENGTH]
-        elif self._length_check:
+        elif self._length_check:  # Disabled for WebSockets
             writer.length = self.content_length
             if writer.length is None:
                 if version >= HttpVersion11:
@@ -420,7 +420,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             # https://datatracker.ietf.org/doc/html/rfc9112#section-6.1-13
             if hdrs.TRANSFER_ENCODING in headers:
                 del headers[hdrs.TRANSFER_ENCODING]
-        elif self.content_length != 0:
+        elif writer.length != 0:
             # https://www.rfc-editor.org/rfc/rfc9110#section-8.3-5
             headers.setdefault(hdrs.CONTENT_TYPE, "application/octet-stream")
         headers.setdefault(hdrs.DATE, rfc822_formatted_time())

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -420,7 +420,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             # https://datatracker.ietf.org/doc/html/rfc9112#section-6.1-13
             if hdrs.TRANSFER_ENCODING in headers:
                 del headers[hdrs.TRANSFER_ENCODING]
-        elif writer.length != 0:
+        elif (writer.length if self._length_check else self.content_length) != 0:
             # https://www.rfc-editor.org/rfc/rfc9110#section-8.3-5
             headers.setdefault(hdrs.CONTENT_TYPE, "application/octet-stream")
         headers.setdefault(hdrs.DATE, rfc822_formatted_time())


### PR DESCRIPTION
issue #2779

Note: we don't have a benchmark for generating a web response yet so its only visible in the other side of client get request.
<img width="286" alt="Screenshot 2024-11-06 at 10 19 30 PM" src="https://github.com/user-attachments/assets/d46a52a9-5886-4e92-bf7e-7118a22c7f21">



<img width="683" alt="Screenshot 2024-11-06 at 10 18 11 PM" src="https://github.com/user-attachments/assets/259a685e-4c51-4ce2-86ba-f1b20754305c">
