### PR TITLE
[PR #9692/e85db24 backport][3.11] Change `RequestInfo` to be a `NamedTuple` to improve performances

### DIFF
--- a/CHANGES/9692.breaking.rst
+++ b/CHANGES/9692.breaking.rst
@@ -1,0 +1,1 @@
+Changed ``ClientRequest.request_info`` to be a `NamedTuple` to improve client performance -- by :user:`bdraco`.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1483,7 +1483,7 @@ Response object
 
    .. attribute:: request_info
 
-       A namedtuple with request URL and headers from :class:`~aiohttp.ClientRequest`
+       A :class:`typing.NamedTuple` with request URL and headers from :class:`~aiohttp.ClientRequest`
        object, :class:`aiohttp.RequestInfo` instance.
 
    .. method:: get_encoding()
@@ -1842,7 +1842,7 @@ Utilities
 
 .. class:: RequestInfo()
 
-   A data class with request URL and headers from :class:`~aiohttp.ClientRequest`
+   A :class:`typing.NamedTuple` with request URL and headers from :class:`~aiohttp.ClientRequest`
    object, available as :attr:`ClientResponse.request_info` attribute.
 
    .. attribute:: url

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -121,7 +121,7 @@ def test_version_default(make_request) -> None:
 def test_request_info(make_request) -> None:
     req = make_request("get", "http://python.org/")
     assert req.request_info == aiohttp.RequestInfo(
-        URL("http://python.org/"), "GET", req.headers
+        URL("http://python.org/"), "GET", req.headers, URL("http://python.org/")
     )
 
 

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -987,7 +987,7 @@ def test_response_request_info() -> None:
     response = ClientResponse(
         "get",
         URL(url),
-        request_info=RequestInfo(url, "get", headers),
+        request_info=RequestInfo(url, "get", headers, url),
         writer=WriterMock(),
         continue100=None,
         timer=TimerNoop(),
@@ -1006,7 +1006,7 @@ def test_request_info_in_exception() -> None:
     response = ClientResponse(
         "get",
         URL(url),
-        request_info=RequestInfo(url, "get", headers),
+        request_info=RequestInfo(url, "get", headers, url),
         writer=WriterMock(),
         continue100=None,
         timer=TimerNoop(),
@@ -1027,7 +1027,7 @@ def test_no_redirect_history_in_exception() -> None:
     response = ClientResponse(
         "get",
         URL(url),
-        request_info=RequestInfo(url, "get", headers),
+        request_info=RequestInfo(url, "get", headers, url),
         writer=WriterMock(),
         continue100=None,
         timer=TimerNoop(),
@@ -1050,7 +1050,7 @@ def test_redirect_history_in_exception() -> None:
     response = ClientResponse(
         "get",
         URL(url),
-        request_info=RequestInfo(url, "get", headers),
+        request_info=RequestInfo(url, "get", headers, url),
         writer=WriterMock(),
         continue100=None,
         timer=TimerNoop(),
@@ -1064,7 +1064,7 @@ def test_redirect_history_in_exception() -> None:
     hist_response = ClientResponse(
         "get",
         URL(hist_url),
-        request_info=RequestInfo(url, "get", headers),
+        request_info=RequestInfo(url, "get", headers, url),
         writer=WriterMock(),
         continue100=None,
         timer=TimerNoop(),


### PR DESCRIPTION
(cherry picked from commit e85db24d78c01598395ee0d1c16d19bce54118ba)


aiohttp 3.11.0b1 yarl 1.17.1  (no change from b1/b2)
![aiohttp 3 11 0b1+change yarl 1 17 1](https://github.com/user-attachments/assets/b6bcf7ea-0259-4f52-a780-8f716a5f25ae)

this change
![aiohttp_3_11_0b4_yarl_1_17_1](https://github.com/user-attachments/assets/3a049c98-fa3f-4334-8427-494472add661)
