### PR TITLE
[PR #9686/ea1c084 backport][3.10] Fix WebSocket reader flow control size calculation for multi-byte data

### DIFF
--- a/CHANGES/9686.bugfix.rst
+++ b/CHANGES/9686.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the WebSocket flow control calculation undercounting with multi-byte data -- by :user:`bdraco`.

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -417,7 +417,7 @@ class WebSocketReader:
 
                     # tuple.__new__ is used to avoid the overhead of the lambda
                     msg = tuple.__new__(WSMessage, (WSMsgType.TEXT, text, ""))
-                    self.queue.feed_data(msg, len(text))
+                    self.queue.feed_data(msg, len(payload_merged))
                     continue
 
                 # tuple.__new__ is used to avoid the overhead of the lambda

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -330,6 +330,7 @@ UI
 un
 unawaited
 unclosed
+undercounting
 unhandled
 unicode
 unittest

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -558,9 +558,6 @@ def test_flow_control_binary(
     assert protocol._reading_paused is True
 
 
-@pytest.mark.xfail(
-    reason="Flow control is currently broken on master branch; see #9686"
-)
 def test_flow_control_multi_byte_text(
     protocol: BaseProtocol,
     out_low_limit: aiohttp.FlowControlDataQueue[WSMessage],


### PR DESCRIPTION
(cherry picked from commit ea1c084d9f49e91feb2e92fea307260ad3f47376)
