### PR TITLE
Remove redundant `protocol.should_close` check in `Connection._release`

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -169,9 +169,7 @@ class Connection:
         self._notify_release()
 
         if self._protocol is not None:
-            self._connector._release(
-                self._key, self._protocol, should_close=self._protocol.should_close
-            )
+            self._connector._release(self._key, self._protocol)
             self._protocol = None
 
     @property

--- a/tests/test_client_connection.py
+++ b/tests/test_client_connection.py
@@ -149,7 +149,7 @@ def test_release(
     assert protocol.transport is not None
     assert not protocol.transport.close.called  # type: ignore[attr-defined]
     assert conn._protocol is None
-    connector._release.assert_called_with(key, protocol, should_close=False)  # type: ignore[attr-defined]
+    connector._release.assert_called_with(key, protocol)  # type: ignore[attr-defined]
     assert conn.closed
 
 
@@ -166,7 +166,7 @@ def test_release_proto_should_close(
     assert protocol.transport is not None
     assert not protocol.transport.close.called  # type: ignore[attr-defined]
     assert conn._protocol is None
-    connector._release.assert_called_with(key, protocol, should_close=True)  # type: ignore[attr-defined]
+    connector._release.assert_called_with(key, protocol)  # type: ignore[attr-defined]
     assert conn.closed
 
 


### PR DESCRIPTION
`BaseConnector._release` always checks `protocol.should_close` so there is no need to pass it in and do the check twice in `Connection._release` as well

https://github.com/aio-libs/aiohttp/blob/5241897f6459926028803caaa4782b8ba84f0562/aiohttp/connector.py#L681

https://github.com/aio-libs/aiohttp/blob/5241897f6459926028803caaa4782b8ba84f0562/aiohttp/connector.py#L173

The connector tests already have multiple tests with `create_mocked_conn(loop, should_close=False)` and `create_mocked_conn(loop, should_close=True)`

Noticed on the profile is was called from both places in the same call stack
<img width="341" alt="Screenshot 2024-11-07 at 3 02 08 PM" src="https://github.com/user-attachments/assets/9f0a05c4-03dc-4724-a235-b02af9610ba8">

<img width="341" alt="Screenshot 2024-11-07 at 3 03 07 PM" src="https://github.com/user-attachments/assets/3b4c35e8-ef26-4092-84d8-6834096784bf">

