### PR TITLE
[PR #9710/b40265e backport][3.10] Remove redundant `protocol.should_close` check in `Connection._release`

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -186,9 +186,7 @@ class Connection:
         self._notify_release()
 
         if self._protocol is not None:
-            self._connector._release(
-                self._key, self._protocol, should_close=self._protocol.should_close
-            )
+            self._connector._release(self._key, self._protocol)
             self._protocol = None
 
     @property

--- a/tests/test_client_connection.py
+++ b/tests/test_client_connection.py
@@ -112,7 +112,7 @@ def test_release(connector, key, protocol, loop) -> None:
     conn.release()
     assert not protocol.transport.close.called
     assert conn._protocol is None
-    connector._release.assert_called_with(key, protocol, should_close=False)
+    connector._release.assert_called_with(key, protocol)
     assert conn.closed
 
 
@@ -123,7 +123,7 @@ def test_release_proto_should_close(connector, key, protocol, loop) -> None:
     conn.release()
     assert not protocol.transport.close.called
     assert conn._protocol is None
-    connector._release.assert_called_with(key, protocol, should_close=True)
+    connector._release.assert_called_with(key, protocol)
     assert conn.closed
 
 


### PR DESCRIPTION
(cherry picked from commit b40265eeafbe10d28146e476fe33cbb29539eb12)
