### PR TITLE
Small cleanups to creating a ClientRequest

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -273,9 +273,7 @@ class ClientRequest:
         if data is not None or self.method not in self.GET_METHODS:
             self.update_transfer_encoding()
         self.update_expect_continue(expect100)
-        if traces is None:
-            traces = []
-        self._traces = traces
+        self._traces = [] if traces is None else traces
 
     def __reset_writer(self, _: object = None) -> None:
         self.__writer = None

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -25,7 +25,6 @@ from typing import (
     Tuple,
     Type,
     Union,
-    cast,
 )
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
@@ -233,11 +232,17 @@ class ClientRequest:
                 f"Method cannot contain non-token characters {method!r} "
                 f"(found at least {match.group()!r})"
             )
-        assert isinstance(url, URL), url
-        assert isinstance(proxy, (URL, type(None))), proxy
+
+        # URL forbids subclasses, so a simple type check is enough.
+        assert type(url) is URL, url
+        if proxy is not None:
+            assert type(proxy) is URL, proxy
+
         # FIXME: session is None in tests only, need to fix tests
         # assert session is not None
-        self._session = cast("ClientSession", session)
+        if TYPE_CHECKING:
+            assert session is not None
+        self._session = session
         if params:
             url = url.extend_query(params)
         self.original_url = url

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -226,18 +226,15 @@ class ClientRequest:
         trust_env: bool = False,
         server_hostname: Optional[str] = None,
     ):
-        match = _CONTAINS_CONTROL_CHAR_RE.search(method)
-        if match:
+        if match := _CONTAINS_CONTROL_CHAR_RE.search(method):
             raise ValueError(
                 f"Method cannot contain non-token characters {method!r} "
                 f"(found at least {match.group()!r})"
             )
-
         # URL forbids subclasses, so a simple type check is enough.
         assert type(url) is URL, url
         if proxy is not None:
             assert type(proxy) is URL, proxy
-
         # FIXME: session is None in tests only, need to fix tests
         # assert session is not None
         if TYPE_CHECKING:


### PR DESCRIPTION
- Change URL checks to `type` instead of `isinstance` (faster) since sub-classing is forbidden
- Change `cast` to `assert` since its only used for tests
