### PR TITLE
Enforce URL for `cookie_jar.filter_cookies()` call (#3753)

### DIFF
--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -9,6 +9,7 @@ import pathlib
 import pickle
 import re
 import time
+import warnings
 from collections import defaultdict
 from http.cookies import BaseCookie, Morsel, SimpleCookie
 from typing import (
@@ -309,7 +310,17 @@ class CookieJar(AbstractCookieJar):
         if not self._cookies:
             # Skip rest of function if no non-expired cookies.
             return filtered
-        request_url = URL(request_url)
+        if type(request_url) is not URL:
+            warnings.warn(
+                (
+                    "filter_cookies expects yarl.URL instances only,"
+                    f"and will stop working in 4.x, got {type(request_url)}"
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            request_url = URL(request_url)
+        filtered = SimpleCookie()
         hostname = request_url.raw_host or ""
 
         is_not_secure = request_url.scheme not in ("https", "wss")

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -277,6 +277,12 @@ async def test_filter_cookie_with_unicode_domain(loop) -> None:
         ),
     ),
 )
+async def test_filter_cookies_str_deprecated(loop: asyncio.AbstractEventLoop) -> None:
+    jar = CookieJar()
+    with pytest.warns(DeprecationWarning):
+        jar.filter_cookies("http://éé.com")
+
+
 async def test_filter_cookies_with_domain_path_lookup_multilevelpath(
     loop,
     url,


### PR DESCRIPTION
Note that this does not prevent `str` from being used, back-porting so users don't get a surprise when they update to 4.x and it will stop working.

* Enforce URL for cookie_jar.filter_cookies() call

* Add deprecation warning for strings

(cherry picked from commit 401c2560c4b8fc5d497ec6125953298135dc6f17)
