### PR TITLE
[PR #3753/401c256 backport][3.11] Warn on non-URL for `cookie_jar.filter_cookies()` call

### DIFF
--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -9,6 +9,7 @@ import pathlib
 import pickle
 import re
 import time
+import warnings
 from collections import defaultdict
 from http.cookies import BaseCookie, Morsel, SimpleCookie
 from typing import (
@@ -309,7 +310,16 @@ class CookieJar(AbstractCookieJar):
         if not self._cookies:
             # Skip rest of function if no non-expired cookies.
             return filtered
-        request_url = URL(request_url)
+        if type(request_url) is not URL:
+            warnings.warn(
+                (
+                    "filter_cookies expects yarl.URL instances only,"
+                    f"and will stop working in 4.x, got {type(request_url)}"
+                ),
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            request_url = URL(request_url)
         hostname = request_url.raw_host or ""
 
         is_not_secure = request_url.scheme not in ("https", "wss")

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -312,10 +312,8 @@ class CookieJar(AbstractCookieJar):
             return filtered
         if type(request_url) is not URL:
             warnings.warn(
-                (
-                    "filter_cookies expects yarl.URL instances only,"
-                    f"and will stop working in 4.x, got {type(request_url)}"
-                ),
+                "filter_cookies expects yarl.URL instances only,"
+                f"and will stop working in 4.x, got {type(request_url)}",
                 DeprecationWarning,
                 stacklevel=2,
             )

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -315,6 +315,7 @@ async def test_filter_cookies_with_domain_path_lookup_multilevelpath(
 
 async def test_filter_cookies_str_deprecated(loop: asyncio.AbstractEventLoop) -> None:
     jar = CookieJar()
+    jar.update_cookies(SimpleCookie("shared-cookie=first; Domain=example.com;"))
     with pytest.warns(DeprecationWarning):
         jar.filter_cookies("http://éé.com")
 

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -313,6 +313,12 @@ async def test_filter_cookies_with_domain_path_lookup_multilevelpath(
         assert c in expected_cookies
 
 
+async def test_filter_cookies_str_deprecated(loop: asyncio.AbstractEventLoop) -> None:
+    jar = CookieJar()
+    with pytest.warns(DeprecationWarning):
+        jar.filter_cookies("http://éé.com")
+
+
 async def test_domain_filter_ip_cookie_send() -> None:
     jar = CookieJar()
     cookies = SimpleCookie(


### PR DESCRIPTION
Note that this does not prevent `str` from being used, back-porting so users don't get a surprise when they update to 4.x and it will stop working later without a warning.

Also all examples of using `filter_cookies` have been removed from the docs since the original PR so its even less likely someone is doing this.

* Enforce URL for cookie_jar.filter_cookies() call

* Add deprecation warning for strings

(cherry picked from commit 401c2560c4b8fc5d497ec6125953298135dc6f17)
