### PR TITLE
Release 3.11.0b4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,7 @@
 
 .. towncrier release notes start
 
-3.11.0b3 (2024-11-05)
+3.11.0b4 (2024-11-07)
 =====================
 
 Bug fixes
@@ -48,6 +48,14 @@ Bug fixes
 
 
 
+- Fixed :py:meth:`WebSocketResponse.close() <aiohttp.web.WebSocketResponse.close>` to discard non-close messages within its timeout window after sending close -- by :user:`lenard-mosys`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`9506`.
+
+
+
 - Fixed a deadlock that could occur while attempting to get a new connection slot after a timeout -- by :user:`bdraco`.
 
   The connector was not cancellation-safe.
@@ -65,6 +73,14 @@ Bug fixes
 
   *Related issues and pull requests on GitHub:*
   :issue:`9672`.
+
+
+
+- Fixed the WebSocket flow control calculation undercounting with multi-byte data -- by :user:`bdraco`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`9686`.
 
 
 
@@ -219,6 +235,14 @@ Removals and backward incompatible breaking changes
 
   *Related issues and pull requests on GitHub:*
   :issue:`9600`.
+
+
+
+- Changed ``ClientRequest.request_info`` to be a `NamedTuple` to improve client performance -- by :user:`bdraco`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`9692`.
 
 
 

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.11.0b3"
+__version__ = "3.11.0b4"
 
 from typing import TYPE_CHECKING, Tuple
 


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/actions/runs/11733162485

<img width="504" alt="Screenshot 2024-11-07 at 5 15 08 PM" src="https://github.com/user-attachments/assets/1e305165-edba-4e70-9f1a-d53393f3e2c1">
<img width="519" alt="Screenshot 2024-11-07 at 5 15 16 PM" src="https://github.com/user-attachments/assets/196d4c8b-e005-418f-af65-dd317117fa76">
<img width="566" alt="Screenshot 2024-11-07 at 5 15 26 PM" src="https://github.com/user-attachments/assets/98264b78-b50e-4397-ab2b-a25a6eef119b">
<img width="579" alt="Screenshot 2024-11-07 at 5 15 34 PM" src="https://github.com/user-attachments/assets/6ff3317d-c924-489b-9454-98c35b88f42a">
<img width="510" alt="Screenshot 2024-11-07 at 5 15 48 PM" src="https://github.com/user-attachments/assets/6ceac0d7-e6a6-4bdc-98c9-d26f59a0c987">


aiohttp 3.10.0 yarl 1.9.5
![aiohttp_3_10_0_yarl_1_9_5](https://github.com/user-attachments/assets/539f32f1-ef98-45c3-9d89-48dd0f1304ff)

aiohttp 3.11.0b0 yarl 1.17.0
![aiohttp_3_11_0b0_yarl_1_17_0](https://github.com/user-attachments/assets/b29a5735-eb17-42bb-9745-2bd723745137)

aiohttp 3.11.0b4 yarl 1.17.1
![aiohttp_3_11_0b4_yarl_1_17_1](https://github.com/user-attachments/assets/83c28f56-b242-4fea-b5af-378c1ac022a4)

