### PR TITLE
Simplify header and method lookups

### DIFF
--- a/CHANGES/9722.misc.rst
+++ b/CHANGES/9722.misc.rst
@@ -1,1 +1,1 @@
-Replace internal helper methods ``method_must_be_empty_body`` and ``status_code_must_be_empty_body`` with simple set lookups -- by :user:`bdraco`.
+Replace internal helper methods ``method_must_be_empty_body`` and ``status_code_must_be_empty_body`` with simple `set` lookups -- by :user:`bdraco`.

--- a/CHANGES/9722.misc.rst
+++ b/CHANGES/9722.misc.rst
@@ -1,0 +1,1 @@
+Replace internal helper methods ``method_must_be_empty_body`` and ``status_code_must_be_empty_body`` with simple set lookups -- by :user:`bdraco`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -94,10 +94,10 @@ from .connector import (
 from .cookiejar import CookieJar
 from .helpers import (
     _SENTINEL,
+    EMPTY_BODY_METHODS,
     BasicAuth,
     TimeoutHandle,
     get_env_proxy_for_url,
-    method_must_be_empty_body,
     sentinel,
     strip_auth_from_url,
 )
@@ -648,7 +648,7 @@ class ClientSession:
                     assert conn.protocol is not None
                     conn.protocol.set_response_params(
                         timer=timer,
-                        skip_payload=method_must_be_empty_body(method),
+                        skip_payload=method in EMPTY_BODY_METHODS,
                         read_until_eof=read_until_eof,
                         auto_decompress=auto_decompress,
                         read_timeout=real_timeout.sock_read,

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -12,10 +12,10 @@ from .client_exceptions import (
 )
 from .helpers import (
     _EXC_SENTINEL,
+    EMPTY_BODY_STATUS_CODES,
     BaseTimerContext,
     set_exception,
     set_result,
-    status_code_must_be_empty_body,
 )
 from .http import HttpResponseParser, RawResponseMessage, WebSocketReader
 from .http_exceptions import HttpProcessingError
@@ -300,9 +300,7 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
 
                     self._payload = payload
 
-                    if self._skip_payload or status_code_must_be_empty_body(
-                        message.code
-                    ):
+                    if self._skip_payload or message.code in EMPTY_BODY_STATUS_CODES:
                         self.feed_data((message, EMPTY_PAYLOAD))
                     else:
                         self.feed_data((message, payload))

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -4,7 +4,6 @@ import contextlib
 import dataclasses
 import functools
 import io
-import itertools
 import re
 import sys
 import traceback
@@ -177,9 +176,6 @@ class ClientRequest:
     }
     POST_METHODS = {hdrs.METH_PATCH, hdrs.METH_POST, hdrs.METH_PUT}
     ALL_METHODS = GET_METHODS.union(POST_METHODS).union({hdrs.METH_DELETE})
-    _HOST_STRINGS = frozenset(
-        map("".join, itertools.product(*zip("host".upper(), "host".lower())))
-    )
 
     DEFAULT_HEADERS = {
         hdrs.ACCEPT: "*/*",
@@ -380,7 +376,7 @@ class ClientRequest:
 
         for key, value in headers:  # type: ignore[misc]
             # A special case for Host header
-            if key in self._HOST_STRINGS:
+            if key in hdrs.HOST_ALL:
                 self.headers[key] = value
             else:
                 self.headers.add(key, value)

--- a/aiohttp/hdrs.py
+++ b/aiohttp/hdrs.py
@@ -2,6 +2,7 @@
 
 # After changing the file content call ./tools/gen.py
 # to regenerate the headers parser
+import itertools
 from typing import Final, Set
 
 from multidict import istr
@@ -106,3 +107,15 @@ WWW_AUTHENTICATE: Final[istr] = istr("WWW-Authenticate")
 X_FORWARDED_FOR: Final[istr] = istr("X-Forwarded-For")
 X_FORWARDED_HOST: Final[istr] = istr("X-Forwarded-Host")
 X_FORWARDED_PROTO: Final[istr] = istr("X-Forwarded-Proto")
+
+# These are the upper/lower case variants of the headers/methods
+# Example: {'hOst', 'host', 'HoST', 'HOSt', 'hOsT', 'HosT', 'hoSt', ...}
+METH_HEAD_ALL: Final = frozenset(
+    map("".join, itertools.product(*zip(METH_HEAD.upper(), METH_HEAD.lower())))
+)
+METH_CONNECT_ALL: Final = frozenset(
+    map("".join, itertools.product(*zip(METH_CONNECT.upper(), METH_CONNECT.lower())))
+)
+HOST_ALL: Final = frozenset(
+    map("".join, itertools.product(*zip(HOST.upper(), HOST.lower())))
+)

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -76,7 +76,7 @@ sentinel = _SENTINEL.sentinel
 NO_EXTENSIONS = bool(os.environ.get("AIOHTTP_NO_EXTENSIONS"))
 
 # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
-EMPTY_BODY_STATUS_CODES = {204, 304, *range(100, 200)}
+EMPTY_BODY_STATUS_CODES = frozenset((204, 304, *range(100, 200)))
 
 DEBUG = sys.flags.dev_mode or (
     not sys.flags.ignore_environment and bool(os.environ.get("PYTHONASYNCIODEBUG"))

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -77,6 +77,9 @@ NO_EXTENSIONS = bool(os.environ.get("AIOHTTP_NO_EXTENSIONS"))
 
 # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
 EMPTY_BODY_STATUS_CODES = frozenset((204, 304, *range(100, 200)))
+# https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
+# https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.2
+EMPTY_BODY_METHODS = hdrs.METH_HEAD_ALL
 
 DEBUG = sys.flags.dev_mode or (
     not sys.flags.ignore_environment and bool(os.environ.get("PYTHONASYNCIODEBUG"))
@@ -1054,16 +1057,9 @@ def must_be_empty_body(method: str, code: int) -> bool:
     """Check if a request must return an empty body."""
     return (
         code in EMPTY_BODY_STATUS_CODES
-        or method_must_be_empty_body(method)
-        or (200 <= code < 300 and method.upper() == hdrs.METH_CONNECT)
+        or method in EMPTY_BODY_METHODS
+        or (200 <= code < 300 and method in hdrs.METH_CONNECT_ALL)
     )
-
-
-def method_must_be_empty_body(method: str) -> bool:
-    """Check if a method must return an empty body."""
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.1
-    # https://datatracker.ietf.org/doc/html/rfc9112#section-6.3-2.2
-    return method.upper() == hdrs.METH_HEAD
 
 
 def should_remove_content_length(method: str, code: int) -> bool:
@@ -1074,5 +1070,5 @@ def should_remove_content_length(method: str, code: int) -> bool:
     # https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6-8
     # https://www.rfc-editor.org/rfc/rfc9110.html#section-15.4.5-4
     return code in EMPTY_BODY_STATUS_CODES or (
-        200 <= code < 300 and method.upper() == hdrs.METH_CONNECT
+        200 <= code < 300 and method in hdrs.METH_CONNECT_ALL
     )

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -30,10 +30,10 @@ from .compression_utils import HAS_BROTLI, BrotliDecompressor, ZLibDecompressor
 from .helpers import (
     _EXC_SENTINEL,
     DEBUG,
+    EMPTY_BODY_METHODS,
     EMPTY_BODY_STATUS_CODES,
     NO_EXTENSIONS,
     BaseTimerContext,
-    method_must_be_empty_body,
     set_exception,
 )
 from .http_exceptions import (
@@ -365,7 +365,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         assert self.protocol is not None
                         # calculate payload
                         empty_body = code in EMPTY_BODY_STATUS_CODES or bool(
-                            method and method_must_be_empty_body(method)
+                            method and method in EMPTY_BODY_METHODS
                         )
                         if not empty_body and (
                             ((length is not None and length > 0) or msg.chunked)

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -30,11 +30,11 @@ from .compression_utils import HAS_BROTLI, BrotliDecompressor, ZLibDecompressor
 from .helpers import (
     _EXC_SENTINEL,
     DEBUG,
+    EMPTY_BODY_STATUS_CODES,
     NO_EXTENSIONS,
     BaseTimerContext,
     method_must_be_empty_body,
     set_exception,
-    status_code_must_be_empty_body,
 )
 from .http_exceptions import (
     BadHttpMessage,
@@ -364,7 +364,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
 
                         assert self.protocol is not None
                         # calculate payload
-                        empty_body = status_code_must_be_empty_body(code) or bool(
+                        empty_body = code in EMPTY_BODY_STATUS_CODES or bool(
                             method and method_must_be_empty_body(method)
                         )
                         if not empty_body and (

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -27,7 +27,6 @@ from .abc import AbstractStreamWriter
 from .compression_utils import ZLibCompressor
 from .helpers import (
     ETAG_ANY,
-    HEAD_METHOD,
     QUOTED_ETAG_RE,
     CookieMixin,
     ETag,
@@ -697,7 +696,7 @@ class Response(StreamResponse):
                 body_len = len(self._body) if self._body else "0"
                 # https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6-7
                 if body_len != "0" or (
-                    self.status != 304 and request.method not in HEAD_METHOD
+                    self.status != 304 and request.method not in hdrs.METH_HEAD_ALL
                 ):
                     self._headers[hdrs.CONTENT_LENGTH] = str(body_len)
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -27,6 +27,7 @@ from .abc import AbstractStreamWriter
 from .compression_utils import ZLibCompressor
 from .helpers import (
     ETAG_ANY,
+    HEAD_METHOD,
     QUOTED_ETAG_RE,
     CookieMixin,
     ETag,
@@ -696,7 +697,7 @@ class Response(StreamResponse):
                 body_len = len(self._body) if self._body else "0"
                 # https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6-7
                 if body_len != "0" or (
-                    self.status != 304 and request.method.upper() != hdrs.METH_HEAD
+                    self.status != 304 and request.method not in HEAD_METHOD
                 ):
                     self._headers[hdrs.CONTENT_LENGTH] = str(body_len)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1115,9 +1115,9 @@ def test_read_basicauth_from_empty_netrc() -> None:
 
 def test_method_must_be_empty_body() -> None:
     """Test that HEAD is the only method that unequivocally must have an empty body."""
-    assert "HEAD" in EMPTY_BODY_METHODS is True
+    assert "HEAD" in EMPTY_BODY_METHODS
     # CONNECT is only empty on a successful response
-    assert "CONNECT" in EMPTY_BODY_METHODS is False
+    assert "CONNECT" not in EMPTY_BODY_METHODS
 
 
 def test_should_remove_content_length_is_subset_of_must_be_empty_body() -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -16,8 +16,8 @@ from yarl import URL
 
 from aiohttp import helpers, web
 from aiohttp.helpers import (
+    EMPTY_BODY_METHODS,
     is_expected_content_type,
-    method_must_be_empty_body,
     must_be_empty_body,
     parse_http_date,
     should_remove_content_length,
@@ -1115,9 +1115,9 @@ def test_read_basicauth_from_empty_netrc() -> None:
 
 def test_method_must_be_empty_body() -> None:
     """Test that HEAD is the only method that unequivocally must have an empty body."""
-    assert method_must_be_empty_body("HEAD") is True
+    assert "HEAD" in EMPTY_BODY_METHODS is True
     # CONNECT is only empty on a successful response
-    assert method_must_be_empty_body("CONNECT") is False
+    assert "CONNECT" in EMPTY_BODY_METHODS is False
 
 
 def test_should_remove_content_length_is_subset_of_must_be_empty_body() -> None:


### PR DESCRIPTION
Replace `method_must_be_empty_body` and `status_code_must_be_empty_body` with a simple set constant, and avoid many `.upper()` calls

~2% speed up
<img width="602" alt="Screenshot 2024-11-09 at 9 18 18 AM" src="https://github.com/user-attachments/assets/d6821ac6-4168-42d4-92d9-92b8447cfc76">
