### PR TITLE
Fix missing `reader_c.c` file in Makefile `.install-deps`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ generate-llhttp: .llhttp-gen
 .PHONY: cythonize
 cythonize: .install-cython $(PYXS:.pyx=.c) aiohttp/_websocket/reader_c.c
 
-.install-deps: .install-cython $(PYXS:.pyx=.c) $(call to-hash,$(CYS) $(REQS))
+.install-deps: .install-cython $(PYXS:.pyx=.c) aiohttp/_websocket/reader_c.c $(call to-hash,$(CYS) $(REQS))
 	@python -m pip install -r requirements/dev.in -c requirements/dev.txt
 	@touch .install-deps
 


### PR DESCRIPTION
`make install-dev` was not creating `reader_c.c` which meant to get a working dev env, `make cythonize` had to be run before `make install-dev`
