### PR TITLE
Fixes issues with test_web_urldispatcher when it encounters OS AF_UNIX too long

### DIFF
--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -547,14 +547,15 @@ async def test_access_compressed_file_as_symlink(
 
 
 async def test_access_special_resource(
-    tmp_path_factory: pytest.TempPathFactory, aiohttp_client: AiohttpClient
+    unix_sockname: str, aiohttp_client: AiohttpClient
 ) -> None:
     """Test access to non-regular files is forbidden using a UNIX domain socket."""
     if not getattr(socket, "AF_UNIX", None):
         pytest.skip("UNIX domain sockets not supported")
 
-    tmp_path = tmp_path_factory.mktemp("special")
-    my_special = tmp_path / "sock"
+    my_special = pathlib.Path(unix_sockname)
+    tmp_path = my_special.parent
+    
     my_socket = socket.socket(socket.AF_UNIX)
     my_socket.bind(str(my_special))
     assert my_special.is_socket()

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -555,7 +555,7 @@ async def test_access_special_resource(
 
     my_special = pathlib.Path(unix_sockname)
     tmp_path = my_special.parent
-    
+
     my_socket = socket.socket(socket.AF_UNIX)
     my_socket.bind(str(my_special))
     assert my_special.is_socket()


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

This pull request fixes test_web_urldispatcher where there's an OS ERROR: AF_UNIX path too long when this command is ran 

`pytest  -n auto --dist loadscope`

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

No, I don't think so

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->



## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  #9728.bugfix.rst
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`ok3ks`.
    ```
