### PR TITLE
Fix race getting an unused port when there are multiple test runners

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -212,7 +212,7 @@ jobs:
         PIP_USER: 1
       run: >-
         PATH="${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}"
-        pytest --junitxml=junit.xml
+        pytest -vvvs --junitxml=junit.xml
       shell: bash
     - name: Re-run the failing tests with maximum verbosity
       if: failure()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -212,7 +212,7 @@ jobs:
         PIP_USER: 1
       run: >-
         PATH="${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}"
-        pytest -vvvs --junitxml=junit.xml
+        pytest --junitxml=junit.xml
       shell: bash
     - name: Re-run the failing tests with maximum verbosity
       if: failure()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ import pytest
 
 from aiohttp.client_proto import ResponseHandler
 from aiohttp.http import WS_KEY
-from aiohttp.test_utils import loop_context
+from aiohttp.test_utils import get_unused_port_socket, loop_context
 
 try:
     import trustme
@@ -260,9 +260,8 @@ def unused_port_socket() -> Generator[socket.socket, None, None]:
     race condition between checking if the port is in use and
     binding to it later in the test.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        try:
-            yield s
-        finally:
-            s.close()
+    s = get_unused_port_socket("127.0.0.1")
+    try:
+        yield s
+    finally:
+        s.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -263,3 +263,4 @@ def unused_port_socket() -> Generator[socket.socket, None, None]:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         yield s
+        s.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -262,5 +262,7 @@ def unused_port_socket() -> Generator[socket.socket, None, None]:
     """
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
-        yield s
-        s.close()
+        try:
+            yield s
+        finally:
+            s.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -250,3 +250,16 @@ def enable_cleanup_closed() -> Generator[None, None, None]:
     """
     with mock.patch("aiohttp.connector.NEEDS_CLEANUP_CLOSED", True):
         yield
+
+
+@pytest.fixture
+def unused_port_socket() -> Generator[socket.socket, None, None]:
+    """Return a socket that is unused on the current host.
+
+    Unlike aiohttp_used_port, the socket is yielded so there is no
+    race condition between checking if the port is in use and
+    binding to it later in the test.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        yield s

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -494,15 +494,10 @@ def test_run_app_with_sock(
     patched_loop: asyncio.AbstractEventLoop, unused_port_socket: socket.socket
 ) -> None:
     sock = unused_port_socket
-    port = sock.getsockname()[1]
-    host = "127.0.0.1"
-
     app = web.Application()
     web.run_app(
         app,
         sock=sock,
-        host=host,
-        port=port,
         print=stopper(patched_loop),
         loop=patched_loop,
     )
@@ -1091,7 +1086,7 @@ class TestShutdown:
         app.router.add_get("/stop", self.stop)
 
         with mock.patch("aiohttp.web_runner.Server", ServerWithRecordClear):
-            web.run_app(app, sock=sock, port=port, shutdown_timeout=timeout)
+            web.run_app(app, sock=sock, shutdown_timeout=timeout)
         assert test_task is not None
         assert test_task.exception() is None
         assert t is not None
@@ -1224,7 +1219,7 @@ class TestShutdown:
         app.router.add_get("/", handler)
         app.router.add_get("/stop", self.stop)
 
-        web.run_app(app, sock=sock, port=port, shutdown_timeout=5)
+        web.run_app(app, sock=sock, shutdown_timeout=5)
         assert t is not None
         assert t.exception() is None
         assert finished is True
@@ -1257,7 +1252,7 @@ class TestShutdown:
         app.cleanup_ctx.append(run_test)
         app.router.add_get("/stop", self.stop)
 
-        web.run_app(app, sock=sock, port=port, shutdown_timeout=10)
+        web.run_app(app, sock=sock, shutdown_timeout=10)
         # If connection closed, then test() will be cancelled in cleanup_ctx.
         # If not, then shutdown_timeout will allow it to sleep until complete.
         assert t is not None
@@ -1312,7 +1307,7 @@ class TestShutdown:
         app.router.add_get("/stop", self.stop)
 
         start = time.time()
-        web.run_app(app, sock=sock, port=port, shutdown_timeout=10)
+        web.run_app(app, sock=sock, shutdown_timeout=10)
         assert time.time() - start < 5
         assert client_finished
         assert server_finished
@@ -1365,9 +1360,7 @@ class TestShutdown:
         app.router.add_get("/", handler)
         app.router.add_get("/stop", self.stop)
 
-        web.run_app(
-            app, sock=sock, port=port, shutdown_timeout=2, handler_cancellation=True
-        )
+        web.run_app(app, sock=sock, shutdown_timeout=2, handler_cancellation=True)
         assert t is not None
         assert t.exception() is None
         assert actions == ["CANCELLED", "SUPPRESSED", "PRESTOP", "STOPPING", "DONE"]

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1054,7 +1054,7 @@ class TestShutdown:
                     try:
                         with pytest.raises(asyncio.TimeoutError):
                             async with sess.get(
-                                f"http://localhost:{port}/",
+                                f"http://127.0.0.1:{port}/",
                                 timeout=ClientTimeout(total=0.2),
                             ):
                                 pass
@@ -1062,7 +1062,7 @@ class TestShutdown:
                         await asyncio.sleep(0.5)
                     else:
                         break
-                async with sess.get(f"http://localhost:{port}/stop"):
+                async with sess.get(f"http://127.0.0.1:{port}/stop"):
                     pass
 
                 if extra_test:
@@ -1163,7 +1163,7 @@ class TestShutdown:
             with pytest.raises(ClientConnectorError):
                 # Use a new session to try and open a new connection.
                 async with ClientSession() as sess:
-                    async with sess.get(f"http://localhost:{port}/"):
+                    async with sess.get(f"http://127.0.0.1:{port}/"):
                         pass
             assert finished is False
 
@@ -1183,7 +1183,7 @@ class TestShutdown:
 
         async def test() -> None:
             async def test_resp(sess: ClientSession) -> None:
-                async with sess.get(f"http://localhost:{port}/") as resp:
+                async with sess.get(f"http://127.0.0.1:{port}/") as resp:
                     assert await resp.text() == "FOO"
 
             await asyncio.sleep(1)
@@ -1191,7 +1191,7 @@ class TestShutdown:
                 t = asyncio.create_task(test_resp(sess))
                 await asyncio.sleep(1)
                 # Handler is in-progress while we trigger server shutdown.
-                async with sess.get(f"http://localhost:{port}/stop"):
+                async with sess.get(f"http://127.0.0.1:{port}/stop"):
                     pass
 
                 assert finished is False
@@ -1230,7 +1230,7 @@ class TestShutdown:
         async def test() -> None:
             await asyncio.sleep(1)
             async with ClientSession() as sess:
-                async with sess.get(f"http://localhost:{port}/stop"):
+                async with sess.get(f"http://127.0.0.1:{port}/stop"):
                     pass
 
                 # Hold on to keep-alive connection.
@@ -1278,8 +1278,8 @@ class TestShutdown:
         async def test() -> None:
             await asyncio.sleep(1)
             async with ClientSession() as sess:
-                async with sess.ws_connect(f"http://localhost:{port}/ws") as ws:
-                    async with sess.get(f"http://localhost:{port}/stop"):
+                async with sess.ws_connect(f"http://127.0.0.1:{port}/ws") as ws:
+                    async with sess.get(f"http://127.0.0.1:{port}/stop"):
                         pass
 
                     async for msg in ws:
@@ -1320,7 +1320,7 @@ class TestShutdown:
             async def test_resp(sess: ClientSession) -> None:
                 t = ClientTimeout(total=0.4)
                 with pytest.raises(asyncio.TimeoutError):
-                    async with sess.get(f"http://localhost:{port}/", timeout=t) as resp:
+                    async with sess.get(f"http://127.0.0.1:{port}/", timeout=t) as resp:
                         assert await resp.text() == "FOO"
                 actions.append("CANCELLED")
 
@@ -1329,7 +1329,7 @@ class TestShutdown:
                 await asyncio.sleep(0.5)
                 # Handler is in-progress while we trigger server shutdown.
                 actions.append("PRESTOP")
-                async with sess.get(f"http://localhost:{port}/stop"):
+                async with sess.get(f"http://127.0.0.1:{port}/stop"):
                     pass
 
                 actions.append("STOPPING")

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -492,7 +492,7 @@ def test_run_app_nondefault_host_port(
     )
 
     patched_loop.create_server.assert_called_with(  # type: ignore[attr-defined]
-        mock.ANY, host, port, ssl=None, backlog=128, reuse_address=None, reuse_port=None
+        mock.ANY, sock=sock, ssl=None, backlog=128
     )
 
 

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1048,7 +1048,7 @@ class TestShutdown:
                 self._connections = DictRecordClear()
 
         async def test() -> None:
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(1)
             async with ClientSession() as sess:
                 for _ in range(5):  # pragma: no cover
                     try:
@@ -1058,10 +1058,7 @@ class TestShutdown:
                                 timeout=ClientTimeout(total=0.2),
                             ):
                                 pass
-                    except ClientConnectorError as ex:
-                        import pprint
-
-                        pprint.pprint(["client connector error", ex])
+                    except ClientConnectorError:
                         await asyncio.sleep(0.5)
                     else:
                         break

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1055,7 +1055,7 @@ class TestShutdown:
                         with pytest.raises(asyncio.TimeoutError):
                             async with sess.get(
                                 f"http://localhost:{port}/",
-                                timeout=ClientTimeout(total=0.2),
+                                timeout=ClientTimeout(total=0.1),
                             ):
                                 pass
                     except ClientConnectorError:

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -477,6 +477,22 @@ def test_run_app_https(patched_loop: asyncio.AbstractEventLoop) -> None:
 def test_run_app_nondefault_host_port(
     patched_loop: asyncio.AbstractEventLoop, unused_port_socket: socket.socket
 ) -> None:
+    port = unused_port_socket.getsockname()[1]
+    host = "127.0.0.1"
+
+    app = web.Application()
+    web.run_app(
+        app, host=host, port=port, print=stopper(patched_loop), loop=patched_loop
+    )
+
+    patched_loop.create_server.assert_called_with(  # type: ignore[attr-defined]
+        mock.ANY, host, port, ssl=None, backlog=128, reuse_address=None, reuse_port=None
+    )
+
+
+def test_run_app_with_sock(
+    patched_loop: asyncio.AbstractEventLoop, unused_port_socket: socket.socket
+) -> None:
     sock = unused_port_socket
     port = sock.getsockname()[1]
     host = "127.0.0.1"

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1058,7 +1058,10 @@ class TestShutdown:
                                 timeout=ClientTimeout(total=0.2),
                             ):
                                 pass
-                    except ClientConnectorError:
+                    except ClientConnectorError as ex:
+                        import pprint
+
+                        pprint.pprint(["client connector error", ex])
                         await asyncio.sleep(0.5)
                     else:
                         break

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1048,7 +1048,7 @@ class TestShutdown:
                 self._connections = DictRecordClear()
 
         async def test() -> None:
-            await asyncio.sleep(1)
+            await asyncio.sleep(0.5)
             async with ClientSession() as sess:
                 for _ in range(5):  # pragma: no cover
                     try:

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -2,7 +2,7 @@ import asyncio
 import gzip
 import socket
 import sys
-from typing import Callable, Iterator, Mapping, NoReturn
+from typing import Iterator, Mapping, NoReturn
 from unittest import mock
 
 import pytest
@@ -364,10 +364,13 @@ async def test_client_context_manager_response(
 async def test_custom_port(
     loop: asyncio.AbstractEventLoop,
     app: web.Application,
-    aiohttp_unused_port: Callable[[], int],
+    unused_port_socket: socket.socket,
 ) -> None:
-    port = aiohttp_unused_port()
-    client = TestClient(TestServer(app, port=port))
+    sock = unused_port_socket
+    port = sock.getsockname()[1]
+    client = TestClient(
+        TestServer(app, port=port, socket_factory=lambda *args, **kwargs: sock)
+    )
     await client.start_server()
 
     assert client.server.port == port

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -237,8 +237,6 @@ async def test_handler_cancellation(unused_port_socket: socket.socket) -> None:
     site = web.SockSite(runner, sock=sock)
 
     await site.start()
-    await asyncio.sleep(0.5)
-
     assert runner.server is not None
     try:
         assert runner.server.handler_cancellation, "Flag was not propagated"
@@ -279,8 +277,6 @@ async def test_no_handler_cancellation(unused_port_socket: socket.socket) -> Non
     site = web.SockSite(runner, sock=sock)
 
     await site.start()
-    await asyncio.sleep(0.5)
-
     try:
         async with client.ClientSession(
             timeout=client.ClientTimeout(total=0.2)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -247,7 +247,7 @@ async def test_handler_cancellation(unused_port_socket: socket.socket) -> None:
             timeout=client.ClientTimeout(total=0.15)
         ) as sess:
             with pytest.raises(asyncio.TimeoutError):
-                await sess.get(f"http://localhost:{port}/")
+                await sess.get(f"http://127.0.0.1:{port}/")
 
         with suppress(asyncio.TimeoutError):
             await asyncio.wait_for(event.wait(), timeout=1)
@@ -286,7 +286,7 @@ async def test_no_handler_cancellation(unused_port_socket: socket.socket) -> Non
             timeout=client.ClientTimeout(total=0.2)
         ) as sess:
             with pytest.raises(asyncio.TimeoutError):
-                await sess.get(f"http://localhost:{port}/")
+                await sess.get(f"http://127.0.0.1:{port}/")
         await asyncio.sleep(0.1)
         timeout_event.set()
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1,6 +1,7 @@
 import asyncio
+import socket
 from contextlib import suppress
-from typing import Callable, NoReturn
+from typing import NoReturn
 from unittest import mock
 
 import pytest
@@ -212,9 +213,10 @@ async def test_raw_server_html_exception_debug(
     logger.exception.assert_called_with("Error handling request", exc_info=exc)
 
 
-async def test_handler_cancellation(aiohttp_unused_port: Callable[[], int]) -> None:
+async def test_handler_cancellation(unused_port_socket: socket.socket) -> None:
     event = asyncio.Event()
-    port = aiohttp_unused_port()
+    sock = unused_port_socket
+    port = sock.getsockname()[1]
 
     async def on_request(request: web.Request) -> web.Response:
         nonlocal event
@@ -232,7 +234,7 @@ async def test_handler_cancellation(aiohttp_unused_port: Callable[[], int]) -> N
     runner = web.AppRunner(app, handler_cancellation=True)
     await runner.setup()
 
-    site = web.TCPSite(runner, host="localhost", port=port)
+    site = web.SockSite(runner, sock=sock)
 
     await site.start()
 
@@ -253,10 +255,11 @@ async def test_handler_cancellation(aiohttp_unused_port: Callable[[], int]) -> N
         await asyncio.gather(runner.shutdown(), site.stop())
 
 
-async def test_no_handler_cancellation(aiohttp_unused_port: Callable[[], int]) -> None:
+async def test_no_handler_cancellation(unused_port_socket: socket.socket) -> None:
     timeout_event = asyncio.Event()
     done_event = asyncio.Event()
-    port = aiohttp_unused_port()
+    sock = unused_port_socket
+    port = sock.getsockname()[1]
     started = False
 
     async def on_request(request: web.Request) -> web.Response:
@@ -272,7 +275,7 @@ async def test_no_handler_cancellation(aiohttp_unused_port: Callable[[], int]) -
     runner = web.AppRunner(app)
     await runner.setup()
 
-    site = web.TCPSite(runner, host="localhost", port=port)
+    site = web.SockSite(runner, sock=sock)
 
     await site.start()
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -237,6 +237,7 @@ async def test_handler_cancellation(unused_port_socket: socket.socket) -> None:
     site = web.SockSite(runner, sock=sock)
 
     await site.start()
+    await asyncio.sleep(0.5)
 
     assert runner.server is not None
     try:
@@ -278,6 +279,7 @@ async def test_no_handler_cancellation(unused_port_socket: socket.socket) -> Non
     site = web.SockSite(runner, sock=sock)
 
     await site.start()
+    await asyncio.sleep(0.5)
 
     try:
         async with client.ClientSession(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3,7 +3,7 @@ import asyncio
 import os
 import socket
 import ssl
-from typing import TYPE_CHECKING, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 from unittest import mock
 
 import pytest
@@ -206,13 +206,11 @@ def test__get_valid_log_format_exc(worker: base_worker.GunicornWebWorker) -> Non
 async def test__run_ok_parent_changed(
     worker: base_worker.GunicornWebWorker,
     loop: asyncio.AbstractEventLoop,
-    aiohttp_unused_port: Callable[[], int],
+    unused_port_socket: socket.socket,
 ) -> None:
     worker.ppid = 0
     worker.alive = True
-    sock = socket.socket()
-    addr = ("localhost", aiohttp_unused_port())
-    sock.bind(addr)
+    sock = unused_port_socket
     worker.sockets = [sock]
     worker.log = mock.Mock()
     worker.loop = loop
@@ -229,13 +227,11 @@ async def test__run_ok_parent_changed(
 async def test__run_exc(
     worker: base_worker.GunicornWebWorker,
     loop: asyncio.AbstractEventLoop,
-    aiohttp_unused_port: Callable[[], int],
+    unused_port_socket: socket.socket,
 ) -> None:
     worker.ppid = os.getppid()
     worker.alive = True
-    sock = socket.socket()
-    addr = ("localhost", aiohttp_unused_port())
-    sock.bind(addr)
+    sock = unused_port_socket
     worker.sockets = [sock]
     worker.log = mock.Mock()
     worker.loop = loop


### PR DESCRIPTION
The `aiohttp_used_port` fixture finds a free port but it does not hold the socket so there is a race between when checking that the port is available, and when it actually gets used. When we run tests with xdist we would sometimes get a failure because multiple tests would try to use the same port

One step closer to unblocking https://github.com/aio-libs/aiohttp/pull/5431
