### PR TITLE
[PR #9741/acc2912 backport][3.10] Fix race getting an unused port when there are multiple test runners

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ import pytest
 
 from aiohttp.client_proto import ResponseHandler
 from aiohttp.http import WS_KEY
-from aiohttp.test_utils import loop_context
+from aiohttp.test_utils import get_unused_port_socket, loop_context
 
 try:
     import trustme
@@ -249,3 +249,18 @@ def enable_cleanup_closed() -> Generator[None, None, None]:
     """
     with mock.patch("aiohttp.connector.NEEDS_CLEANUP_CLOSED", True):
         yield
+
+
+@pytest.fixture
+def unused_port_socket() -> Generator[socket.socket, None, None]:
+    """Return a socket that is unused on the current host.
+
+    Unlike aiohttp_used_port, the socket is yielded so there is no
+    race condition between checking if the port is in use and
+    binding to it later in the test.
+    """
+    s = get_unused_port_socket("127.0.0.1")
+    try:
+        yield s
+    finally:
+        s.close()

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -344,7 +344,7 @@ async def test_client_context_manager_response(method, app, loop) -> None:
 async def test_custom_port(
     loop: asyncio.AbstractEventLoop,
     app: web.Application,
-    unused_port_socket: socket.socket,
+    unused_port_socket: socket,
 ) -> None:
     sock = unused_port_socket
     port = sock.getsockname()[1]

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import gzip
 from socket import socket
 from typing import Any
@@ -340,9 +341,16 @@ async def test_client_context_manager_response(method, app, loop) -> None:
                 assert "Hello, world" in text
 
 
-async def test_custom_port(loop, app, aiohttp_unused_port) -> None:
-    port = aiohttp_unused_port()
-    client = _TestClient(_TestServer(app, loop=loop, port=port), loop=loop)
+async def test_custom_port(
+    loop: asyncio.AbstractEventLoop,
+    app: web.Application,
+    unused_port_socket: socket.socket,
+) -> None:
+    sock = unused_port_socket
+    port = sock.getsockname()[1]
+    client = _TestClient(
+        _TestServer(app, port=port, socket_factory=lambda *args, **kwargs: sock)
+    )
     await client.start_server()
 
     assert client.server.port == port

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3,7 +3,7 @@ import asyncio
 import os
 import socket
 import ssl
-from typing import TYPE_CHECKING, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 from unittest import mock
 
 import pytest
@@ -209,13 +209,11 @@ def test__get_valid_log_format_exc(worker: base_worker.GunicornWebWorker) -> Non
 async def test__run_ok_parent_changed(
     worker: base_worker.GunicornWebWorker,
     loop: asyncio.AbstractEventLoop,
-    aiohttp_unused_port: Callable[[], int],
+    unused_port_socket: socket.socket,
 ) -> None:
     worker.ppid = 0
     worker.alive = True
-    sock = socket.socket()
-    addr = ("localhost", aiohttp_unused_port())
-    sock.bind(addr)
+    sock = unused_port_socket
     worker.sockets = [sock]
     worker.log = mock.Mock()
     worker.loop = loop
@@ -232,13 +230,11 @@ async def test__run_ok_parent_changed(
 async def test__run_exc(
     worker: base_worker.GunicornWebWorker,
     loop: asyncio.AbstractEventLoop,
-    aiohttp_unused_port: Callable[[], int],
+    unused_port_socket: socket.socket,
 ) -> None:
     worker.ppid = os.getppid()
     worker.alive = True
-    sock = socket.socket()
-    addr = ("localhost", aiohttp_unused_port())
-    sock.bind(addr)
+    sock = unused_port_socket
     worker.sockets = [sock]
     worker.log = mock.Mock()
     worker.loop = loop


### PR DESCRIPTION
(cherry picked from commit acc2912ff36725dc3b435158895f38d55f346fb5)
