### PR TITLE
[PR #9741/acc2912 backport][3.11] Fix race getting an unused port when there are multiple test runners

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ import pytest
 
 from aiohttp.client_proto import ResponseHandler
 from aiohttp.http import WS_KEY
-from aiohttp.test_utils import loop_context
+from aiohttp.test_utils import get_unused_port_socket, loop_context
 
 try:
     import trustme
@@ -249,3 +249,18 @@ def enable_cleanup_closed() -> Generator[None, None, None]:
     """
     with mock.patch("aiohttp.connector.NEEDS_CLEANUP_CLOSED", True):
         yield
+
+
+@pytest.fixture
+def unused_port_socket() -> Generator[socket.socket, None, None]:
+    """Return a socket that is unused on the current host.
+
+    Unlike aiohttp_used_port, the socket is yielded so there is no
+    race condition between checking if the port is in use and
+    binding to it later in the test.
+    """
+    s = get_unused_port_socket("127.0.0.1")
+    try:
+        yield s
+    finally:
+        s.close()

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -9,7 +9,16 @@ import ssl
 import subprocess
 import sys
 import time
-from typing import AsyncIterator, Callable, NoReturn, Set
+from typing import (
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Coroutine,
+    NoReturn,
+    Optional,
+    Set,
+    Tuple,
+)
 from unittest import mock
 from uuid import uuid4
 
@@ -440,8 +449,10 @@ def test_run_app_https(patched_loop) -> None:
     )
 
 
-def test_run_app_nondefault_host_port(patched_loop, aiohttp_unused_port) -> None:
-    port = aiohttp_unused_port()
+def test_run_app_nondefault_host_port(
+    patched_loop: asyncio.AbstractEventLoop, unused_port_socket: socket.socket
+) -> None:
+    port = unused_port_socket.getsockname()[1]
     host = "127.0.0.1"
 
     app = web.Application()
@@ -454,7 +465,24 @@ def test_run_app_nondefault_host_port(patched_loop, aiohttp_unused_port) -> None
     )
 
 
-def test_run_app_multiple_hosts(patched_loop) -> None:
+def test_run_app_with_sock(
+    patched_loop: asyncio.AbstractEventLoop, unused_port_socket: socket.socket
+) -> None:
+    sock = unused_port_socket
+    app = web.Application()
+    web.run_app(
+        app,
+        sock=sock,
+        print=stopper(patched_loop),
+        loop=patched_loop,
+    )
+
+    patched_loop.create_server.assert_called_with(  # type: ignore[attr-defined]
+        mock.ANY, sock=sock, ssl=None, backlog=128
+    )
+
+
+def test_run_app_multiple_hosts(patched_loop: asyncio.AbstractEventLoop) -> None:
     hosts = ("127.0.0.1", "127.0.0.2")
 
     app = web.Application()
@@ -931,8 +959,16 @@ class TestShutdown:
         asyncio.get_running_loop().call_soon(self.raiser)
         return web.Response()
 
-    def run_app(self, port: int, timeout: int, task, extra_test=None) -> asyncio.Task:
+    def run_app(
+        self,
+        sock: socket.socket,
+        timeout: int,
+        task: Callable[[], Coroutine[None, None, None]],
+        extra_test: Optional[Callable[[ClientSession], Awaitable[None]]] = None,
+    ) -> Tuple["asyncio.Task[None]", int]:
         num_connections = -1
+        t = test_task = None
+        port = sock.getsockname()[1]
 
         class DictRecordClear(dict):
             def clear(self):
@@ -956,7 +992,7 @@ class TestShutdown:
                     try:
                         with pytest.raises(asyncio.TimeoutError):
                             async with sess.get(
-                                f"http://localhost:{port}/",
+                                f"http://127.0.0.1:{port}/",
                                 timeout=ClientTimeout(total=0.1),
                             ):
                                 pass
@@ -964,7 +1000,7 @@ class TestShutdown:
                         await asyncio.sleep(0.5)
                     else:
                         break
-                async with sess.get(f"http://localhost:{port}/stop"):
+                async with sess.get(f"http://127.0.0.1:{port}/stop"):
                     pass
 
                 if extra_test:
@@ -988,15 +1024,14 @@ class TestShutdown:
         app.router.add_get("/", handler)
         app.router.add_get("/stop", self.stop)
 
-        with mock.patch("aiohttp.web_app.Server", ServerWithRecordClear):
-            web.run_app(app, port=port, shutdown_timeout=timeout)
+        with mock.patch("aiohttp.web_runner.Server", ServerWithRecordClear):
+            web.run_app(app, sock=sock, shutdown_timeout=timeout)
+        assert test_task is not None
         assert test_task.exception() is None
         return t, num_connections
 
-    def test_shutdown_wait_for_handler(
-        self, aiohttp_unused_port: Callable[[], int]
-    ) -> None:
-        port = aiohttp_unused_port()
+    def test_shutdown_wait_for_handler(self, unused_port_socket: socket.socket) -> None:
+        sock = unused_port_socket
         finished = False
 
         async def task():
@@ -1004,17 +1039,15 @@ class TestShutdown:
             await asyncio.sleep(2)
             finished = True
 
-        t, connection_count = self.run_app(port, 3, task)
+        t, connection_count = self.run_app(sock, 3, task)
 
         assert finished is True
         assert t.done()
         assert not t.cancelled()
         assert connection_count == 0
 
-    def test_shutdown_timeout_handler(
-        self, aiohttp_unused_port: Callable[[], int]
-    ) -> None:
-        port = aiohttp_unused_port()
+    def test_shutdown_timeout_handler(self, unused_port_socket: socket.socket) -> None:
+        sock = unused_port_socket
         finished = False
 
         async def task():
@@ -1022,7 +1055,7 @@ class TestShutdown:
             await asyncio.sleep(2)
             finished = True
 
-        t, connection_count = self.run_app(port, 1, task)
+        t, connection_count = self.run_app(sock, 1, task)
 
         assert finished is False
         assert t.done()
@@ -1030,9 +1063,9 @@ class TestShutdown:
         assert connection_count == 1
 
     def test_shutdown_timeout_not_reached(
-        self, aiohttp_unused_port: Callable[[], int]
+        self, unused_port_socket: socket.socket
     ) -> None:
-        port = aiohttp_unused_port()
+        sock = unused_port_socket
         finished = False
 
         async def task():
@@ -1041,7 +1074,8 @@ class TestShutdown:
             finished = True
 
         start_time = time.time()
-        t, connection_count = self.run_app(port, 15, task)
+
+        t, connection_count = self.run_app(sock, 15, task)
 
         assert finished is True
         assert t.done()
@@ -1050,9 +1084,10 @@ class TestShutdown:
         assert time.time() - start_time < 10
 
     def test_shutdown_new_conn_rejected(
-        self, aiohttp_unused_port: Callable[[], int]
+        self, unused_port_socket: socket.socket
     ) -> None:
-        port = aiohttp_unused_port()
+        sock = unused_port_socket
+        port = sock.getsockname()[1]
         finished = False
 
         async def task() -> None:
@@ -1066,25 +1101,26 @@ class TestShutdown:
             with pytest.raises(ClientConnectorError):
                 # Use a new session to try and open a new connection.
                 async with ClientSession() as sess:
-                    async with sess.get(f"http://localhost:{port}/"):
+                    async with sess.get(f"http://127.0.0.1:{port}/"):
                         pass
             assert finished is False
 
-        t, connection_count = self.run_app(port, 10, task, test)
+        t, connection_count = self.run_app(sock, 10, task, test)
 
         assert finished is True
         assert t.done()
         assert connection_count == 0
 
     def test_shutdown_pending_handler_responds(
-        self, aiohttp_unused_port: Callable[[], int]
+        self, unused_port_socket: socket.socket
     ) -> None:
-        port = aiohttp_unused_port()
+        sock = unused_port_socket
+        port = sock.getsockname()[1]
         finished = False
 
         async def test() -> None:
-            async def test_resp(sess):
-                async with sess.get(f"http://localhost:{port}/") as resp:
+            async def test_resp(sess: ClientSession) -> None:
+                async with sess.get(f"http://127.0.0.1:{port}/") as resp:
                     assert await resp.text() == "FOO"
 
             await asyncio.sleep(1)
@@ -1092,7 +1128,7 @@ class TestShutdown:
                 t = asyncio.create_task(test_resp(sess))
                 await asyncio.sleep(1)
                 # Handler is in-progress while we trigger server shutdown.
-                async with sess.get(f"http://localhost:{port}/stop"):
+                async with sess.get(f"http://127.0.0.1:{port}/stop"):
                     pass
 
                 assert finished is False
@@ -1117,19 +1153,22 @@ class TestShutdown:
         app.router.add_get("/", handler)
         app.router.add_get("/stop", self.stop)
 
-        web.run_app(app, port=port, shutdown_timeout=5)
+        web.run_app(app, sock=sock, shutdown_timeout=5)
+        assert t is not None
         assert t.exception() is None
         assert finished is True
 
     def test_shutdown_close_idle_keepalive(
-        self, aiohttp_unused_port: Callable[[], int]
+        self, unused_port_socket: socket.socket
     ) -> None:
-        port = aiohttp_unused_port()
+        sock = unused_port_socket
+        port = sock.getsockname()[1]
+        t = None
 
         async def test() -> None:
             await asyncio.sleep(1)
             async with ClientSession() as sess:
-                async with sess.get(f"http://localhost:{port}/stop"):
+                async with sess.get(f"http://127.0.0.1:{port}/stop"):
                     pass
 
                 # Hold on to keep-alive connection.
@@ -1148,15 +1187,14 @@ class TestShutdown:
         app.cleanup_ctx.append(run_test)
         app.router.add_get("/stop", self.stop)
 
-        web.run_app(app, port=port, shutdown_timeout=10)
+        web.run_app(app, sock=sock, shutdown_timeout=10)
         # If connection closed, then test() will be cancelled in cleanup_ctx.
         # If not, then shutdown_timeout will allow it to sleep until complete.
         assert t.cancelled()
 
-    def test_shutdown_close_websockets(
-        self, aiohttp_unused_port: Callable[[], int]
-    ) -> None:
-        port = aiohttp_unused_port()
+    def test_shutdown_close_websockets(self, unused_port_socket: socket.socket) -> None:
+        sock = unused_port_socket
+        port = sock.getsockname()[1]
         WS = web.AppKey("ws", Set[web.WebSocketResponse])
         client_finished = server_finished = False
 
@@ -1177,8 +1215,8 @@ class TestShutdown:
         async def test() -> None:
             await asyncio.sleep(1)
             async with ClientSession() as sess:
-                async with sess.ws_connect(f"http://localhost:{port}/ws") as ws:
-                    async with sess.get(f"http://localhost:{port}/stop"):
+                async with sess.ws_connect(f"http://127.0.0.1:{port}/ws") as ws:
+                    async with sess.get(f"http://127.0.0.1:{port}/stop"):
                         pass
 
                     async for msg in ws:
@@ -1203,22 +1241,23 @@ class TestShutdown:
         app.router.add_get("/stop", self.stop)
 
         start = time.time()
-        web.run_app(app, port=port, shutdown_timeout=10)
+        web.run_app(app, sock=sock, shutdown_timeout=10)
         assert time.time() - start < 5
         assert client_finished
         assert server_finished
 
     def test_shutdown_handler_cancellation_suppressed(
-        self, aiohttp_unused_port: Callable[[], int]
+        self, unused_port_socket: socket.socket
     ) -> None:
-        port = aiohttp_unused_port()
+        sock = unused_port_socket
+        port = sock.getsockname()[1]
         actions = []
 
         async def test() -> None:
             async def test_resp(sess):
                 t = ClientTimeout(total=0.4)
                 with pytest.raises(asyncio.TimeoutError):
-                    async with sess.get(f"http://localhost:{port}/", timeout=t) as resp:
+                    async with sess.get(f"http://127.0.0.1:{port}/", timeout=t) as resp:
                         assert await resp.text() == "FOO"
                 actions.append("CANCELLED")
 
@@ -1227,7 +1266,7 @@ class TestShutdown:
                 await asyncio.sleep(0.5)
                 # Handler is in-progress while we trigger server shutdown.
                 actions.append("PRESTOP")
-                async with sess.get(f"http://localhost:{port}/stop"):
+                async with sess.get(f"http://127.0.0.1:{port}/stop"):
                     pass
 
                 actions.append("STOPPING")
@@ -1255,6 +1294,7 @@ class TestShutdown:
         app.router.add_get("/", handler)
         app.router.add_get("/stop", self.stop)
 
-        web.run_app(app, port=port, shutdown_timeout=2, handler_cancellation=True)
+        web.run_app(app, sock=sock, shutdown_timeout=2, handler_cancellation=True)
+        assert t is not None
         assert t.exception() is None
         assert actions == ["CANCELLED", "SUPPRESSED", "PRESTOP", "STOPPING", "DONE"]

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1024,9 +1024,8 @@ class TestShutdown:
         app.router.add_get("/", handler)
         app.router.add_get("/stop", self.stop)
 
-        with mock.patch("aiohttp.web_runner.Server", ServerWithRecordClear):
+        with mock.patch("aiohttp.web_app.Server", ServerWithRecordClear):
             web.run_app(app, sock=sock, shutdown_timeout=timeout)
-        assert test_task is not None
         assert test_task.exception() is None
         return t, num_connections
 
@@ -1295,6 +1294,5 @@ class TestShutdown:
         app.router.add_get("/stop", self.stop)
 
         web.run_app(app, sock=sock, shutdown_timeout=2, handler_cancellation=True)
-        assert t is not None
         assert t.exception() is None
         assert actions == ["CANCELLED", "SUPPRESSED", "PRESTOP", "STOPPING", "DONE"]

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -375,9 +375,16 @@ async def test_client_context_manager_response(method, app, loop) -> None:
                 assert "Hello, world" in text
 
 
-async def test_custom_port(loop, app, aiohttp_unused_port) -> None:
-    port = aiohttp_unused_port()
-    client = _TestClient(TestServer(app, loop=loop, port=port), loop=loop)
+async def test_custom_port(
+    loop: asyncio.AbstractEventLoop,
+    app: web.Application,
+    unused_port_socket: socket,
+) -> None:
+    sock = unused_port_socket
+    port = sock.getsockname()[1]
+    client = _TestClient(
+        TestServer(app, port=port, socket_factory=lambda *args, **kwargs: sock)
+    )
     await client.start_server()
 
     assert client.server.port == port

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -194,7 +194,6 @@ async def test_handler_cancellation(unused_port_socket: socket.socket) -> None:
     site = web.SockSite(runner, sock=sock)
 
     await site.start()
-    assert runner.server is not None
     try:
         assert runner.server.handler_cancellation, "Flag was not propagated"
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import socket
 from contextlib import suppress
 from unittest import mock
 
@@ -169,9 +170,10 @@ async def test_raw_server_html_exception_debug(aiohttp_raw_server, aiohttp_clien
     logger.exception.assert_called_with("Error handling request", exc_info=exc)
 
 
-async def test_handler_cancellation(aiohttp_unused_port) -> None:
+async def test_handler_cancellation(unused_port_socket: socket.socket) -> None:
     event = asyncio.Event()
-    port = aiohttp_unused_port()
+    sock = unused_port_socket
+    port = sock.getsockname()[1]
 
     async def on_request(_: web.Request) -> web.Response:
         nonlocal event
@@ -189,10 +191,10 @@ async def test_handler_cancellation(aiohttp_unused_port) -> None:
     runner = web.AppRunner(app, handler_cancellation=True)
     await runner.setup()
 
-    site = web.TCPSite(runner, host="localhost", port=port)
+    site = web.SockSite(runner, sock=sock)
 
     await site.start()
-
+    assert runner.server is not None
     try:
         assert runner.server.handler_cancellation, "Flag was not propagated"
 
@@ -200,7 +202,7 @@ async def test_handler_cancellation(aiohttp_unused_port) -> None:
             timeout=client.ClientTimeout(total=0.1)
         ) as sess:
             with pytest.raises(asyncio.TimeoutError):
-                await sess.get(f"http://localhost:{port}/")
+                await sess.get(f"http://127.0.0.1:{port}/")
 
         with suppress(asyncio.TimeoutError):
             await asyncio.wait_for(event.wait(), timeout=1)
@@ -209,10 +211,11 @@ async def test_handler_cancellation(aiohttp_unused_port) -> None:
         await asyncio.gather(runner.shutdown(), site.stop())
 
 
-async def test_no_handler_cancellation(aiohttp_unused_port) -> None:
+async def test_no_handler_cancellation(unused_port_socket: socket.socket) -> None:
     timeout_event = asyncio.Event()
     done_event = asyncio.Event()
-    port = aiohttp_unused_port()
+    sock = unused_port_socket
+    port = sock.getsockname()[1]
     started = False
 
     async def on_request(_: web.Request) -> web.Response:
@@ -228,16 +231,15 @@ async def test_no_handler_cancellation(aiohttp_unused_port) -> None:
     runner = web.AppRunner(app)
     await runner.setup()
 
-    site = web.TCPSite(runner, host="localhost", port=port)
+    site = web.SockSite(runner, sock=sock)
 
     await site.start()
-
     try:
         async with client.ClientSession(
             timeout=client.ClientTimeout(total=0.2)
         ) as sess:
             with pytest.raises(asyncio.TimeoutError):
-                await sess.get(f"http://localhost:{port}/")
+                await sess.get(f"http://127.0.0.1:{port}/")
         await asyncio.sleep(0.1)
         timeout_event.set()
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -3,7 +3,7 @@ import asyncio
 import os
 import socket
 import ssl
-from typing import TYPE_CHECKING, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Dict, Optional
 from unittest import mock
 
 import pytest
@@ -209,13 +209,11 @@ def test__get_valid_log_format_exc(worker: base_worker.GunicornWebWorker) -> Non
 async def test__run_ok_parent_changed(
     worker: base_worker.GunicornWebWorker,
     loop: asyncio.AbstractEventLoop,
-    aiohttp_unused_port: Callable[[], int],
+    unused_port_socket: socket.socket,
 ) -> None:
     worker.ppid = 0
     worker.alive = True
-    sock = socket.socket()
-    addr = ("localhost", aiohttp_unused_port())
-    sock.bind(addr)
+    sock = unused_port_socket
     worker.sockets = [sock]
     worker.log = mock.Mock()
     worker.loop = loop
@@ -232,13 +230,11 @@ async def test__run_ok_parent_changed(
 async def test__run_exc(
     worker: base_worker.GunicornWebWorker,
     loop: asyncio.AbstractEventLoop,
-    aiohttp_unused_port: Callable[[], int],
+    unused_port_socket: socket.socket,
 ) -> None:
     worker.ppid = os.getppid()
     worker.alive = True
-    sock = socket.socket()
-    addr = ("localhost", aiohttp_unused_port())
-    sock.bind(addr)
+    sock = unused_port_socket
     worker.sockets = [sock]
     worker.log = mock.Mock()
     worker.loop = loop


### PR DESCRIPTION
(cherry picked from commit acc2912ff36725dc3b435158895f38d55f346fb5)
