### PR TITLE
Speed up preparing headers by avoiding populating cookies when there are no cookies

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -457,6 +457,7 @@ def is_ip_address(host: Optional[str]) -> bool:
 _cached_current_datetime: Optional[int] = None
 _cached_formatted_datetime = ""
 
+
 def rfc822_formatted_time() -> str:
     global _cached_current_datetime
     global _cached_formatted_datetime
@@ -1004,6 +1005,7 @@ class CookieMixin:
             httponly=httponly,
             samesite=samesite,
         )
+
 
 def populate_with_cookies(headers: "CIMultiDict[str]", cookies: SimpleCookie) -> None:
     for cookie in cookies.values():

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -457,7 +457,6 @@ def is_ip_address(host: Optional[str]) -> bool:
 _cached_current_datetime: Optional[int] = None
 _cached_formatted_datetime = ""
 
-
 def rfc822_formatted_time() -> str:
     global _cached_current_datetime
     global _cached_formatted_datetime
@@ -1005,7 +1004,6 @@ class CookieMixin:
             httponly=httponly,
             samesite=samesite,
         )
-
 
 def populate_with_cookies(headers: "CIMultiDict[str]", cookies: SimpleCookie) -> None:
     for cookie in cookies.values():

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -380,7 +380,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             keep_alive = request.keep_alive
         self._keep_alive = keep_alive
 
-        version = request._version
+        version = request.version
 
         headers = self._headers
         if self._cookies:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -380,10 +380,11 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             keep_alive = request.keep_alive
         self._keep_alive = keep_alive
 
-        version = request.version
+        version = request._version
 
         headers = self._headers
-        populate_with_cookies(headers, self.cookies)
+        if self._cookies:
+            populate_with_cookies(headers, self._cookies)
 
         if self._compression:
             await self._start_compression(request)
@@ -431,8 +432,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             if keep_alive:
                 if version == HttpVersion10:
                     headers[hdrs.CONNECTION] = "keep-alive"
-            else:
-                if version == HttpVersion11:
+                elif version == HttpVersion11:
                     headers[hdrs.CONNECTION] = "close"
 
     async def _write_headers(self) -> None:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -432,8 +432,8 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             if keep_alive:
                 if version == HttpVersion10:
                     headers[hdrs.CONNECTION] = "keep-alive"
-                elif version == HttpVersion11:
-                    headers[hdrs.CONNECTION] = "close"
+            elif version == HttpVersion11:
+                headers[hdrs.CONNECTION] = "close"
 
     async def _write_headers(self) -> None:
         request = self._req


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do? 

These changes speed up the aiohttp server by modifying code within `handle_request` and `finish_response` across files 

Fixes partially #2779 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  *  `9745.bugfix.rst`

    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`ok3ks`.
    ```
