### PR TITLE
[PR #5431/751c3c4 backport][3.11] Re-introduce `pytest-xdist` in supported envs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -204,14 +204,15 @@ jobs:
         COLOR: yes
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
       run: >-  # `exit 1` makes sure that the job remains red with flaky runs
-        pytest --no-cov -vvvvv --lf && exit 1
+        pytest --no-cov --numprocesses=0 -vvvvv --lf && exit 1
       shell: bash
     - name: Run dev_mode tests
       env:
         COLOR: yes
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
         PIP_USER: 1
-      run: python -X dev -m pytest -m dev_mode --cov-append
+        PYTHONDEVMODE: 1
+      run: pytest -m dev_mode --cov-append --numprocesses=0
       shell: bash
     - name: Turn coverage into xml
       env:
@@ -276,7 +277,7 @@ jobs:
       uses: CodSpeedHQ/action@v3
       with:
         token: ${{ secrets.CODSPEED_TOKEN }}
-        run: python -Im pytest --no-cov -vvvvv --codspeed
+        run: python -Im pytest --no-cov --numprocesses=0 -vvvvv --codspeed
 
 
   check:  # This job does nothing and is only used for the branch protection

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,6 +18,8 @@ alabaster==0.7.13
     # via sphinx
 annotated-types==0.7.0
     # via pydantic
+apipkg==1.5
+    # via execnet
 async-timeout==4.0.3 ; python_version < "3.11"
     # via
     #   -r requirements/runtime-deps.in
@@ -71,6 +73,8 @@ filelock==3.16.1
     # via
     #   pytest-codspeed
     #   virtualenv
+execnet==2.1.1
+    # via pytest-xdist
 freezegun==1.5.1
     # via
     #   -r requirements/lint.in
@@ -144,7 +148,11 @@ propcache==0.2.0
     #   -r requirements/runtime-deps.in
     #   yarl
 proxy-py==2.4.9
-    # via -r requirements/test.in
+    # via
+    #   -r requirements/lint.in
+    #   -r requirements/test.in
+py==1.11.0
+    # via pytest
 pycares==4.4.0
     # via aiodns
 pycparser==2.22
@@ -174,7 +182,20 @@ pytest==8.3.3
     #   pytest-codspeed
     #   pytest-cov
     #   pytest-mock
+    #   pytest-xdist
 pytest-codspeed==3.0.0
+    # via
+    #   -r requirements/lint.in
+    #   -r requirements/test.in
+pytest-cov==5.0.0
+    # via -r requirements/test.in
+pytest-mock==3.14.0
+    # via -r requirements/test.in
+pytest-xdist==3.6.1
+    # via -r requirements/test.txt
+python-dateutil==2.8.2
+    # via freezegun
+python-on-whales==0.71.0
     # via
     #   -r requirements/lint.in
     #   -r requirements/test.in

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,10 +3,11 @@
 coverage
 freezegun
 mypy; implementation_name == "cpython"
-proxy.py >= 2.4.4rc4
+proxy.py >= 2.4.4rc5
 pytest
 pytest-cov
 pytest-mock
+pytest-xdist
 pytest_codspeed
 python-on-whales
 re-assert

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -39,6 +39,8 @@ cryptography==43.0.3
     # via trustme
 exceptiongroup==1.2.2
     # via pytest
+execnet==2.1.1
+    # via pytest-xdist
 filelock==3.16.1
     # via pytest-codspeed
 freezegun==1.5.1
@@ -80,6 +82,8 @@ propcache==0.2.0
     #   yarl
 proxy-py==2.4.9
     # via -r requirements/test.in
+py==1.11.0
+    # via pytest
 pycares==4.4.0
     # via aiodns
 pycparser==2.22
@@ -97,10 +101,14 @@ pytest==8.3.3
     #   pytest-cov
     #   pytest-mock
 pytest-codspeed==3.0.0
-    # via -r requirements/test.in
+    # via
+    #   -r requirements/test.in
+    #   pytest-xdist
 pytest-cov==5.0.0
     # via -r requirements/test.in
 pytest-mock==3.14.0
+    # via -r requirements/test.in
+pytest-xdist==3.6.1
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via freezegun

--- a/setup.cfg
+++ b/setup.cfg
@@ -125,6 +125,9 @@ exclude_lines =
 
 [tool:pytest]
 addopts =
+    # `pytest-xdist`:
+    --numprocesses=auto
+
     # show 10 slowest invocations:
     --durations=10
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -559,18 +559,6 @@ async def test_release_close(loop, key) -> None:
     await conn.close()
 
 
-async def test_release_proto_closed_future(
-    loop: asyncio.AbstractEventLoop, key: ConnectionKey
-) -> None:
-    conn = aiohttp.BaseConnector()
-    protocol = mock.Mock(should_close=True, closed=loop.create_future())
-    conn._release(key, protocol)
-    # See PR #6321
-    assert protocol.closed.result() is None
-
-    await conn.close()
-
-
 async def test__release_acquired_per_host1(
     loop: asyncio.AbstractEventLoop, key: ConnectionKey
 ) -> None:
@@ -2715,18 +2703,21 @@ async def test_connect_with_limit_cancelled(loop) -> None:
     await conn.close()
 
 
-async def test_connect_with_capacity_release_waiters(loop) -> None:
-    def check_with_exc(err):
-        conn = aiohttp.BaseConnector(limit=1, loop=loop)
-        conn._create_connection = mock.Mock()
-        conn._create_connection.return_value = loop.create_future()
-        conn._create_connection.return_value.set_exception(err)
+async def test_connect_with_capacity_release_waiters(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    async def check_with_exc(err: Exception) -> None:
+        conn = aiohttp.BaseConnector(limit=1)
+        with mock.patch.object(
+            conn, "_create_connection", autospec=True, spec_set=True, side_effect=err
+        ):
+            with pytest.raises(Exception):
+                req = mock.Mock()
+                await conn.connect(req, [], ClientTimeout())
 
-        with pytest.raises(Exception):
-            req = mock.Mock()
-            yield from conn.connect(req, None, ClientTimeout())
+            assert not conn._waiters
 
-        conn.close()
+        await conn.close()
 
     await check_with_exc(OSError(1, "permission error"))
     await check_with_exc(RuntimeError())

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -258,6 +258,8 @@ async def test_create_conn(loop) -> None:
     with pytest.raises(NotImplementedError):
         await conn._create_connection(object(), [], object())
 
+    await conn.close()
+
 
 async def test_connector_context_manager(loop) -> None:
     conn = aiohttp.BaseConnector(loop=loop)
@@ -554,6 +556,20 @@ async def test_release_close(loop, key) -> None:
     assert not conn._conns
     assert proto.close.called
 
+    await conn.close()
+
+
+async def test_release_proto_closed_future(
+    loop: asyncio.AbstractEventLoop, key: ConnectionKey
+) -> None:
+    conn = aiohttp.BaseConnector()
+    protocol = mock.Mock(should_close=True, closed=loop.create_future())
+    conn._release(key, protocol)
+    # See PR #6321
+    assert protocol.closed.result() is None
+
+    await conn.close()
+
 
 async def test__release_acquired_per_host1(
     loop: asyncio.AbstractEventLoop, key: ConnectionKey
@@ -561,6 +577,8 @@ async def test__release_acquired_per_host1(
     conn = aiohttp.BaseConnector()
     conn._release_acquired(key, create_mocked_conn(loop))
     assert len(conn._acquired_per_host) == 0
+
+    await conn.close()
 
 
 async def test__release_acquired_per_host2(
@@ -571,6 +589,8 @@ async def test__release_acquired_per_host2(
     conn._acquired_per_host[key].add(handler)
     conn._release_acquired(key, handler)
     assert len(conn._acquired_per_host) == 0
+
+    await conn.close()
 
 
 async def test__release_acquired_per_host3(
@@ -584,6 +604,8 @@ async def test__release_acquired_per_host3(
     conn._release_acquired(key, handler)
     assert len(conn._acquired_per_host) == 1
     assert conn._acquired_per_host[key] == {handler2}
+
+    await conn.close()
 
 
 async def test_tcp_connector_certificate_error(
@@ -604,6 +626,8 @@ async def test_tcp_connector_certificate_error(
     assert isinstance(ctx.value.certificate_error, ssl.CertificateError)
     assert isinstance(ctx.value, aiohttp.ClientSSLError)
 
+    await conn.close()
+
 
 async def test_tcp_connector_server_hostname_default(
     loop: Any, start_connection: mock.AsyncMock
@@ -619,6 +643,8 @@ async def test_tcp_connector_server_hostname_default(
 
         with closing(await conn.connect(req, [], ClientTimeout())):
             assert create_connection.call_args.kwargs["server_hostname"] == "127.0.0.1"
+
+    await conn.close()
 
 
 async def test_tcp_connector_server_hostname_override(
@@ -637,6 +663,8 @@ async def test_tcp_connector_server_hostname_override(
 
         with closing(await conn.connect(req, [], ClientTimeout())):
             assert create_connection.call_args.kwargs["server_hostname"] == "localhost"
+
+    await conn.close()
 
 
 async def test_tcp_connector_multiple_hosts_errors(loop) -> None:
@@ -791,6 +819,8 @@ async def test_tcp_connector_multiple_hosts_errors(loop) -> None:
 
     established_connection.close()
 
+    await conn.close()
+
 
 @pytest.mark.parametrize(
     ("happy_eyeballs_delay"),
@@ -864,6 +894,8 @@ async def test_tcp_connector_happy_eyeballs(
     assert connected
 
     established_connection.close()
+
+    await conn.close()
 
 
 async def test_tcp_connector_interleave(loop: Any) -> None:
@@ -941,6 +973,8 @@ async def test_tcp_connector_interleave(loop: Any) -> None:
     assert success_ips == [ip4]
     assert interleave == 2
     established_connection.close()
+
+    await conn.close()
 
 
 async def test_tcp_connector_family_is_respected(loop: Any) -> None:
@@ -1112,6 +1146,8 @@ async def test_tcp_connector_multiple_hosts_one_timeout(
 
     established_connection.close()
 
+    await conn.close()
+
 
 async def test_tcp_connector_resolve_host(loop: asyncio.AbstractEventLoop) -> None:
     conn = aiohttp.TCPConnector(use_dns_cache=True)
@@ -1130,6 +1166,8 @@ async def test_tcp_connector_resolve_host(loop: asyncio.AbstractEventLoop) -> No
                 assert rec["host"] in ("::1", "fe80::1", "fe80::1%lo0")
             else:
                 assert rec["host"] == "::1"
+
+    await conn.close()
 
 
 @pytest.fixture
@@ -1151,6 +1189,8 @@ async def test_tcp_connector_dns_cache_not_expired(loop, dns_response) -> None:
         await conn._resolve_host("localhost", 8080)
         m_resolver().resolve.assert_called_once_with("localhost", 8080, family=0)
 
+        await conn.close()
+
 
 async def test_tcp_connector_dns_cache_forever(loop, dns_response) -> None:
     with mock.patch("aiohttp.connector.DefaultResolver") as m_resolver:
@@ -1159,6 +1199,8 @@ async def test_tcp_connector_dns_cache_forever(loop, dns_response) -> None:
         await conn._resolve_host("localhost", 8080)
         await conn._resolve_host("localhost", 8080)
         m_resolver().resolve.assert_called_once_with("localhost", 8080, family=0)
+
+        await conn.close()
 
 
 async def test_tcp_connector_use_dns_cache_disabled(loop, dns_response) -> None:
@@ -1174,6 +1216,8 @@ async def test_tcp_connector_use_dns_cache_disabled(loop, dns_response) -> None:
             ]
         )
 
+        await conn.close()
+
 
 async def test_tcp_connector_dns_throttle_requests(loop, dns_response) -> None:
     with mock.patch("aiohttp.connector.DefaultResolver") as m_resolver:
@@ -1184,6 +1228,8 @@ async def test_tcp_connector_dns_throttle_requests(loop, dns_response) -> None:
         await asyncio.sleep(0)
         await asyncio.sleep(0)
         m_resolver().resolve.assert_called_once_with("localhost", 8080, family=0)
+
+        await conn.close()
 
 
 async def test_tcp_connector_dns_throttle_requests_exception_spread(loop) -> None:
@@ -1199,6 +1245,8 @@ async def test_tcp_connector_dns_throttle_requests_exception_spread(loop) -> Non
         await asyncio.sleep(0)
         assert r1.exception() == e
         assert r2.exception() == e
+
+        await conn.close()
 
 
 async def test_tcp_connector_dns_throttle_requests_cancelled_when_close(
@@ -1217,6 +1265,8 @@ async def test_tcp_connector_dns_throttle_requests_cancelled_when_close(
 
         with pytest.raises(asyncio.CancelledError):
             await f
+
+        await conn.close()
 
 
 @pytest.fixture
@@ -1258,6 +1308,8 @@ async def test_tcp_connector_cancel_dns_error_captured(
 
         gc.collect()
         assert exception_handler_called is False
+
+        await conn.close()
 
 
 async def test_tcp_connector_dns_tracing(loop, dns_response) -> None:
@@ -1301,6 +1353,8 @@ async def test_tcp_connector_dns_tracing(loop, dns_response) -> None:
         on_dns_cache_hit.assert_called_once_with(
             session, trace_config_ctx, aiohttp.TraceDnsCacheHitParams("localhost")
         )
+
+        await conn.close()
 
 
 async def test_tcp_connector_dns_tracing_cache_disabled(loop, dns_response) -> None:
@@ -1355,6 +1409,8 @@ async def test_tcp_connector_dns_tracing_cache_disabled(loop, dns_response) -> N
             ]
         )
 
+        await conn.close()
+
 
 async def test_tcp_connector_dns_tracing_throttle_requests(loop, dns_response) -> None:
     session = mock.Mock()
@@ -1384,6 +1440,8 @@ async def test_tcp_connector_dns_tracing_throttle_requests(loop, dns_response) -
             session, trace_config_ctx, aiohttp.TraceDnsCacheMissParams("localhost")
         )
 
+        await conn.close()
+
 
 async def test_dns_error(loop) -> None:
     connector = aiohttp.TCPConnector(loop=loop)
@@ -1396,6 +1454,8 @@ async def test_dns_error(loop) -> None:
     with pytest.raises(aiohttp.ClientConnectorError):
         await connector.connect(req, [], ClientTimeout())
 
+    await connector.close()
+
 
 async def test_get_pop_empty_conns(loop) -> None:
     # see issue #473
@@ -1404,6 +1464,8 @@ async def test_get_pop_empty_conns(loop) -> None:
     conn._conns[key] = []
     assert await conn._get(key, []) is None
     assert not conn._conns
+
+    await conn.close()
 
 
 async def test_release_close_do_not_add_to_pool(loop, key) -> None:
@@ -1415,6 +1477,8 @@ async def test_release_close_do_not_add_to_pool(loop, key) -> None:
     conn._acquired.add(proto)
     conn._release(key, proto)
     assert not conn._conns
+
+    await conn.close()
 
 
 async def test_release_close_do_not_delete_existing_connections(key) -> None:
@@ -1453,6 +1517,8 @@ async def test_release_not_opened(loop, key) -> None:
     conn._release(key, proto)
     assert proto.close.called
 
+    await conn.close()
+
 
 async def test_connect(loop, key) -> None:
     proto = mock.Mock()
@@ -1472,6 +1538,8 @@ async def test_connect(loop, key) -> None:
     assert connection.transport is proto.transport
     assert isinstance(connection, Connection)
     connection.close()
+
+    await conn.close()
 
 
 async def test_connect_tracing(loop) -> None:
@@ -1581,6 +1649,8 @@ async def test_exception_during_connection_queued_tracing(
     assert not conn._waiters
     assert not conn._acquired
     assert key not in conn._acquired_per_host
+
+    await conn.close()
 
 
 async def test_exception_during_connection_reuse_tracing(
@@ -1697,8 +1767,18 @@ async def test_ctor_cleanup() -> None:
     assert conn._cleanup_handle is None
     assert conn._cleanup_closed_handle is not None
 
+    await conn.close()
+
 
 async def test_cleanup(key: ConnectionKey) -> None:
+    # The test sets the clock to 300s. It starts with 2 connections in the
+    # pool. The first connection has use time of 10s. When cleanup reaches it,
+    # it computes the deadline = 300 - 15.0 = 285.0 (15s being the default
+    # keep-alive timeout value), then checks that it's overdue because
+    # 10 - 285.0 < 0, and releases it since it's in connected state. The second
+    # connection, though, is in disconnected state so it doesn't bother to
+    # check if it's past due and closes the underlying transport.
+
     m1 = mock.Mock()
     m2 = mock.Mock()
     m1.is_connected.return_value = True
@@ -1710,15 +1790,16 @@ async def test_cleanup(key: ConnectionKey) -> None:
 
     loop = mock.Mock()
     loop.time.return_value = 300
-    conn = aiohttp.BaseConnector(loop=loop)
-    conn._conns = testset
-    existing_handle = conn._cleanup_handle = mock.Mock()
+    async with aiohttp.BaseConnector() as conn:
+        conn._loop = loop
+        conn._conns = testset
+        existing_handle = conn._cleanup_handle = mock.Mock()
 
-    with mock.patch("aiohttp.connector.monotonic", return_value=300):
-        conn._cleanup()
-    assert existing_handle.cancel.called
-    assert conn._conns == {}
-    assert conn._cleanup_handle is None
+        with mock.patch("aiohttp.connector.monotonic", return_value=300):
+            conn._cleanup()
+        assert existing_handle.cancel.called
+        assert conn._conns == {}
+        assert conn._cleanup_handle is None
 
 
 @pytest.mark.usefixtures("enable_cleanup_closed")
@@ -1745,6 +1826,9 @@ async def test_cleanup_close_ssl_transport(
     assert existing_handle.cancel.called
     assert conn._conns == {}
     assert conn._cleanup_closed_transports == [transport]
+
+    await conn.close()
+    await asyncio.sleep(0)  # Give cleanup a chance to close transports
 
 
 async def test_cleanup2(loop: asyncio.AbstractEventLoop, key: ConnectionKey) -> None:
@@ -1811,6 +1895,8 @@ async def test_cleanup_closed(
     assert loop.call_at.called
     assert cleanup_closed_handle.cancel.called
 
+    await conn.close()
+
 
 async def test_cleanup_closed_is_noop_on_fixed_cpython() -> None:
     """Ensure that enable_cleanup_closed is a noop on fixed Python versions."""
@@ -1832,6 +1918,8 @@ async def test_cleanup_closed_disabled(
     assert tr.abort.called
     assert not conn._cleanup_closed_transports
 
+    await conn.close()
+
 
 async def test_tcp_connector_ctor() -> None:
     conn = aiohttp.TCPConnector()
@@ -1839,6 +1927,8 @@ async def test_tcp_connector_ctor() -> None:
 
     assert conn.use_dns_cache
     assert conn.family == 0
+
+    await conn.close()
 
 
 async def test_tcp_connector_allowed_protocols(loop: asyncio.AbstractEventLoop) -> None:
@@ -1857,6 +1947,8 @@ async def test_tcp_connector_ctor_fingerprint_valid(
     valid = aiohttp.Fingerprint(hashlib.sha256(b"foo").digest())
     conn = aiohttp.TCPConnector(ssl=valid, loop=loop)
     assert conn._ssl is valid
+
+    await conn.close()
 
 
 async def test_insecure_fingerprint_md5(loop) -> None:
@@ -1893,11 +1985,15 @@ async def test_tcp_connector_clear_dns_cache(loop) -> None:
     with pytest.raises(KeyError):
         conn._cached_hosts.next_addrs(("localhost", 124))
 
+    await conn.close()
+
 
 async def test_tcp_connector_clear_dns_cache_bad_args(loop) -> None:
     conn = aiohttp.TCPConnector(loop=loop)
     with pytest.raises(ValueError):
         conn.clear_dns_cache("localhost")
+
+    await conn.close()
 
 
 async def test___get_ssl_context1() -> None:
@@ -1905,6 +2001,8 @@ async def test___get_ssl_context1() -> None:
     req = mock.Mock()
     req.is_ssl.return_value = False
     assert conn._get_ssl_context(req) is None
+
+    await conn.close()
 
 
 async def test___get_ssl_context2(loop) -> None:
@@ -1915,6 +2013,8 @@ async def test___get_ssl_context2(loop) -> None:
     req.ssl = ctx
     assert conn._get_ssl_context(req) is ctx
 
+    await conn.close()
+
 
 async def test___get_ssl_context3(loop) -> None:
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
@@ -1923,6 +2023,8 @@ async def test___get_ssl_context3(loop) -> None:
     req.is_ssl.return_value = True
     req.ssl = True
     assert conn._get_ssl_context(req) is ctx
+
+    await conn.close()
 
 
 async def test___get_ssl_context4(loop) -> None:
@@ -1933,6 +2035,8 @@ async def test___get_ssl_context4(loop) -> None:
     req.ssl = False
     assert conn._get_ssl_context(req) is _SSL_CONTEXT_UNVERIFIED
 
+    await conn.close()
+
 
 async def test___get_ssl_context5(loop) -> None:
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
@@ -1942,6 +2046,8 @@ async def test___get_ssl_context5(loop) -> None:
     req.ssl = aiohttp.Fingerprint(hashlib.sha256(b"1").digest())
     assert conn._get_ssl_context(req) is _SSL_CONTEXT_UNVERIFIED
 
+    await conn.close()
+
 
 async def test___get_ssl_context6() -> None:
     conn = aiohttp.TCPConnector()
@@ -1949,6 +2055,8 @@ async def test___get_ssl_context6() -> None:
     req.is_ssl.return_value = True
     req.ssl = True
     assert conn._get_ssl_context(req) is _SSL_CONTEXT_VERIFIED
+
+    await conn.close()
 
 
 async def test_ssl_context_once() -> None:
@@ -2344,6 +2452,8 @@ async def test_ctor_with_default_loop(loop) -> None:
     conn = aiohttp.BaseConnector()
     assert loop is conn._loop
 
+    await conn.close()
+
 
 async def test_base_connector_allows_high_level_protocols(
     loop: asyncio.AbstractEventLoop,
@@ -2616,11 +2726,11 @@ async def test_connect_with_capacity_release_waiters(loop) -> None:
             req = mock.Mock()
             yield from conn.connect(req, None, ClientTimeout())
 
-        assert not conn._waiters
+        conn.close()
 
-    check_with_exc(OSError(1, "permission error"))
-    check_with_exc(RuntimeError())
-    check_with_exc(asyncio.TimeoutError())
+    await check_with_exc(OSError(1, "permission error"))
+    await check_with_exc(RuntimeError())
+    await check_with_exc(asyncio.TimeoutError())
 
 
 async def test_connect_with_limit_concurrent(loop) -> None:
@@ -2700,6 +2810,8 @@ async def test_connect_waiters_cleanup(loop) -> None:
     await asyncio.sleep(0)
     assert not conn._waiters.keys()
 
+    await conn.close()
+
 
 async def test_connect_waiters_cleanup_key_error(loop) -> None:
     proto = mock.Mock()
@@ -2722,6 +2834,8 @@ async def test_connect_waiters_cleanup_key_error(loop) -> None:
     t.cancel()
     await asyncio.sleep(0)
     assert not conn._waiters.keys() == []
+
+    await conn.close()
 
 
 async def test_close_with_acquired_connection(loop) -> None:
@@ -2753,6 +2867,8 @@ async def test_close_with_acquired_connection(loop) -> None:
 async def test_default_force_close(loop) -> None:
     connector = aiohttp.BaseConnector(loop=loop)
     assert not connector.force_close
+
+    await connector.close()
 
 
 async def test_limit_property(loop) -> None:
@@ -2834,6 +2950,8 @@ async def test_error_on_connection(loop, key) -> None:
     assert proto in conn._acquired
     ret.release()
 
+    await conn.close()
+
 
 async def test_cancelled_waiter(loop) -> None:
     conn = aiohttp.BaseConnector(limit=1, loop=loop)
@@ -2855,6 +2973,8 @@ async def test_cancelled_waiter(loop) -> None:
 
     with pytest.raises(asyncio.CancelledError):
         await conn2
+
+    await conn.close()
 
 
 async def test_error_on_connection_with_cancelled_waiter(loop, key) -> None:
@@ -2905,6 +3025,8 @@ async def test_error_on_connection_with_cancelled_waiter(loop, key) -> None:
     assert ret.protocol == proto
     assert proto in conn._acquired
     ret.release()
+
+    await conn.close()
 
 
 async def test_tcp_connector(aiohttp_client, loop) -> None:
@@ -2975,6 +3097,8 @@ async def test_default_use_dns_cache() -> None:
     conn = aiohttp.TCPConnector()
     assert conn.use_dns_cache
 
+    await conn.close()
+
 
 async def test_ssl_none() -> None:
     conn = aiohttp.TCPConnector(ssl=None)
@@ -2996,6 +3120,8 @@ async def test_resolver_not_called_with_address_is_ip(loop) -> None:
         await connector.connect(req, None, ClientTimeout())
 
     resolver.resolve.assert_not_called()
+
+    await connector.close()
 
 
 async def test_tcp_connector_raise_connector_ssl_error(
@@ -3024,6 +3150,8 @@ async def test_tcp_connector_raise_connector_ssl_error(
     assert isinstance(ctx.value.certificate_error, ssl.SSLError)
 
     await session.close()
+
+    await conn.close()
 
 
 @pytest.mark.parametrize(
@@ -3281,6 +3409,8 @@ async def test_connector_cache_trace_race():
     traces = [DummyTracer()]
     assert await connector._resolve_host("", 0, traces) == [token]
 
+    await connector.close()
+
 
 async def test_connector_throttle_trace_race(loop):
     key = ("", 0)
@@ -3300,6 +3430,8 @@ async def test_connector_throttle_trace_race(loop):
     connector._throttle_dns_futures[key] = set()
     traces = [DummyTracer()]
     assert await connector._resolve_host("", 0, traces) == [token]
+
+    await connector.close()
 
 
 async def test_connector_does_not_remove_needed_waiters(

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -44,6 +44,7 @@ _TARGET_TIMINGS_BY_PYTHON_VERSION = {
 
 
 @pytest.mark.internal
+@pytest.mark.dev_mode
 @pytest.mark.skipif(
     not sys.platform.startswith("linux") or platform.python_implementation() == "PyPy",
     reason="Timing is more reliable on Linux",

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -28,8 +28,18 @@ def test_web___all__(pytester: pytest.Pytester) -> None:
     result.assert_outcomes(passed=0, errors=0)
 
 
+_IS_CI_ENV = os.getenv("CI") == "true"
+_XDIST_WORKER_COUNT = int(os.getenv("PYTEST_XDIST_WORKER_COUNT", 0))
+_IS_XDIST_RUN = _XDIST_WORKER_COUNT > 1
+
 _TARGET_TIMINGS_BY_PYTHON_VERSION = {
-    "3.12": 250,  # 3.12 is expected to be a bit slower due to performance trade-offs
+    "3.12": (
+        # 3.12 is expected to be a bit slower due to performance trade-offs,
+        # and even slower under pytest-xdist, especially in CI
+        _XDIST_WORKER_COUNT * 100 * (1 if _IS_CI_ENV else 1.53)
+        if _IS_XDIST_RUN
+        else 250
+    ),
 }
 
 

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -99,6 +99,7 @@ async def web_server_endpoint_url(
 # Filter out the warning from
 # https://github.com/abhinavsingh/proxy.py/blob/30574fd0414005dfa8792a6e797023e862bdcf43/proxy/common/utils.py#L226
 # otherwise this test will fail because the proxy will die with an error.
+@pytest.mark.usefixtures("loop")
 async def test_secure_https_proxy_absolute_path(
     client_ssl_ctx: ssl.SSLContext,
     secure_proxy_url: URL,
@@ -119,6 +120,7 @@ async def test_secure_https_proxy_absolute_path(
 
     await sess.close()
     await conn.close()
+    await asyncio.sleep(0.1)
 
     # https://docs.aiohttp.org/en/v3.8.0/client_advanced.html#graceful-shutdown
     await asyncio.sleep(0.1)
@@ -193,6 +195,8 @@ async def test_https_proxy_unsupported_tls_in_tls(
 
     await sess.close()
     await conn.close()
+
+    await asyncio.sleep(0.1)
 
 
 @pytest.fixture


### PR DESCRIPTION
Co-authored-by: J. Nick Koston <nick@koston.org>
(cherry picked from commit 751c3c4e17d621ffc91b79dccb4e2a5ef8b42888)
