### PR TITLE
[PR #9745/0d10447 backport][3.11] Speed up preparing headers by avoiding populating cookies when there are no cookies

### DIFF
--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -465,7 +465,6 @@ class StreamResponse(BaseClass, HeadersMixin):
         version = request.version
 
         headers = self._headers
-
         if self._cookies:
             for cookie in self._cookies.values():
                 value = cookie.output(header="")[1:]

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -465,9 +465,11 @@ class StreamResponse(BaseClass, HeadersMixin):
         version = request.version
 
         headers = self._headers
-        for cookie in self._cookies.values():
-            value = cookie.output(header="")[1:]
-            headers.add(hdrs.SET_COOKIE, value)
+
+        if self._cookies:
+            for cookie in self._cookies.values():
+                value = cookie.output(header="")[1:]
+                headers.add(hdrs.SET_COOKIE, value)
 
         if self._compression:
             await self._start_compression(request)
@@ -515,9 +517,8 @@ class StreamResponse(BaseClass, HeadersMixin):
             if keep_alive:
                 if version == HttpVersion10:
                     headers[hdrs.CONNECTION] = "keep-alive"
-            else:
-                if version == HttpVersion11:
-                    headers[hdrs.CONNECTION] = "close"
+            elif version == HttpVersion11:
+                headers[hdrs.CONNECTION] = "close"
 
     async def _write_headers(self) -> None:
         request = self._req

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -49,6 +49,7 @@ _TARGET_TIMINGS_BY_PYTHON_VERSION = {
     not sys.platform.startswith("linux") or platform.python_implementation() == "PyPy",
     reason="Timing is more reliable on Linux",
 )
+@pytest.mark.dev_mode
 def test_import_time(pytester: pytest.Pytester) -> None:
     """Check that importing aiohttp doesn't take too long.
 


### PR DESCRIPTION
Co-authored-by: Emmanuel Okedele <emmanuel@coefficient.ai>
Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
Co-authored-by: J. Nick Koston <nick@koston.org>
(cherry picked from commit 0d1044726c025688b1af2697da60f1cba9058d67)
