### PR TITLE
Make import test run in dev mode only

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -44,6 +44,7 @@ _TARGET_TIMINGS_BY_PYTHON_VERSION = {
 
 
 @pytest.mark.internal
+@pytest.mark.dev_mode
 @pytest.mark.skipif(
     not sys.platform.startswith("linux") or platform.python_implementation() == "PyPy",
     reason="Timing is more reliable on Linux",


### PR DESCRIPTION
Having this test run with xdist makes the timing unreliable and it must run isolated. We will likely come up with a better solution in the future, however we want to keep the CI going so move it to dev mode for now
