### PR TITLE
Avoid tracking connections per host when there is no limit per host

### DIFF
--- a/CHANGES/9756.misc.rst
+++ b/CHANGES/9756.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of :py:class:`aiohttp.BaseConnector` when there is no limit per host set -- by :user:`bdraco`.

--- a/CHANGES/9756.misc.rst
+++ b/CHANGES/9756.misc.rst
@@ -1,1 +1,1 @@
-Improved performance of :py:class:`aiohttp.BaseConnector` when there is no limit per host set -- by :user:`bdraco`.
+Improved performance of :py:class:`aiohttp.BaseConnector` when there is no ``limit_per_host`` -- by :user:`bdraco`.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -524,7 +524,8 @@ class BaseConnector:
                 ResponseHandler, _TransportPlaceholder(self._placeholder_future)
             )
             self._acquired.add(placeholder)
-            self._acquired_per_host[key].add(placeholder)
+            if self._limit_per_host:
+                self._acquired_per_host[key].add(placeholder)
 
             try:
                 # Traces are done inside the try block to ensure that the
@@ -550,11 +551,12 @@ class BaseConnector:
         # be no awaits after the proto is added to the acquired set
         # to ensure that the connection is not left in the acquired set
         # on cancellation.
-        acquired_per_host = self._acquired_per_host[key]
         self._acquired.remove(placeholder)
-        acquired_per_host.remove(placeholder)
         self._acquired.add(proto)
-        acquired_per_host.add(proto)
+        if self._limit_per_host:
+            acquired_per_host = self._acquired_per_host[key]
+            acquired_per_host.remove(placeholder)
+            acquired_per_host.add(proto)
         return Connection(self, key, proto, self._loop)
 
     async def _wait_for_available_connection(
@@ -619,7 +621,8 @@ class BaseConnector:
                     # The very last connection was reclaimed: drop the key
                     del self._conns[key]
                 self._acquired.add(proto)
-                self._acquired_per_host[key].add(proto)
+                if self._limit_per_host:
+                    self._acquired_per_host[key].add(proto)
                 if traces:
                     for trace in traces:
                         try:
@@ -673,7 +676,7 @@ class BaseConnector:
             return
 
         self._acquired.discard(proto)
-        if conns := self._acquired_per_host.get(key):
+        if self._limit_per_host and (conns := self._acquired_per_host.get(key)):
             conns.discard(proto)
             if not conns:
                 del self._acquired_per_host[key]


### PR DESCRIPTION
The BaseConnector always tracked connections per hosts even when the limit per host was disabled. All the book-keeping has overhead that we can avoid since in most cases there is no limit per host and no need to track connections per host.

`BaseConnector._available_connections()` was smart enough to skip checking the current connections if `limit_per_hosts` was not set, but the other areas still did all the book keeping even though it was ignored.

<img width="255" alt="Screenshot 2024-11-09 at 11 01 13 PM" src="https://github.com/user-attachments/assets/2c033c5e-e7d0-40f9-8908-48f8c1b7119b">
<img width="257" alt="Screenshot 2024-11-09 at 11 01 18 PM" src="https://github.com/user-attachments/assets/d7e885bf-38fa-4c72-a1d6-0a58627d6d01">
