### PR TITLE
Avoid creating body writer task when there is no body

### DIFF
--- a/CHANGES/9757.misc.rst
+++ b/CHANGES/9757.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of sending HTTP requests when there is no body -- by :user:`bdraco`.

--- a/aiohttp/base_protocol.py
+++ b/aiohttp/base_protocol.py
@@ -30,7 +30,7 @@ class BaseProtocol(asyncio.Protocol):
         return self.transport is not None
 
     @property
-    def paused(self) -> bool:
+    def writing_paused(self) -> bool:
         return self._paused
 
     def pause_writing(self) -> None:

--- a/aiohttp/base_protocol.py
+++ b/aiohttp/base_protocol.py
@@ -29,6 +29,10 @@ class BaseProtocol(asyncio.Protocol):
         """Return True if the connection is open."""
         return self.transport is not None
 
+    @property
+    def paused(self) -> bool:
+        return self._paused
+
     def pause_writing(self) -> None:
         assert not self._paused
         self._paused = True

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -681,7 +681,7 @@ class ClientRequest:
             self.body
             or self._continue is not None
             or self.compress
-            or writer.chunked
+            or self.chunked
             or protocol.paused
         ):
             coro = self.write_bytes(writer, conn)

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -677,22 +677,29 @@ class ClientRequest:
         v = self.version
         status_line = f"{self.method} {path} HTTP/{v.major}.{v.minor}"
         await writer.write_headers(status_line, self.headers)
-        coro = self.write_bytes(writer, conn)
+        if self.body is not None or self._continue is not None or protocol.paused:
+            coro = self.write_bytes(writer, conn)
 
-        task: Optional["asyncio.Task[None]"]
-        if sys.version_info >= (3, 12):
-            # Optimization for Python 3.12, try to write
-            # bytes immediately to avoid having to schedule
-            # the task on the event loop.
-            task = asyncio.Task(coro, loop=self.loop, eager_start=True)
+            task: Optional["asyncio.Task[None]"]
+            if sys.version_info >= (3, 12):
+                # Optimization for Python 3.12, try to write
+                # bytes immediately to avoid having to schedule
+                # the task on the event loop.
+                task = asyncio.Task(coro, loop=self.loop, eager_start=True)
+            else:
+                task = self.loop.create_task(coro)
+
+            if task.done():
+                task = None
+            else:
+                self._writer = task
         else:
-            task = self.loop.create_task(coro)
-
-        if task.done():
+            # We have nothing to write because
+            # - there is no body
+            # - the protocol is not paused
+            # - we are not waiting for a 100-continue response
+            protocol.start_timeout()
             task = None
-        else:
-            self._writer = task
-
         response_class = self.response_class
         assert response_class is not None
         self.response = response_class(

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -677,10 +677,9 @@ class ClientRequest:
         v = self.version
         status_line = f"{self.method} {path} HTTP/{v.major}.{v.minor}"
         await writer.write_headers(status_line, self.headers)
+        task: Optional["asyncio.Task[None]"]
         if self.body or self._continue is not None or protocol.writing_paused:
             coro = self.write_bytes(writer, conn)
-
-            task: Optional["asyncio.Task[None]"]
             if sys.version_info >= (3, 12):
                 # Optimization for Python 3.12, try to write
                 # bytes immediately to avoid having to schedule
@@ -688,7 +687,6 @@ class ClientRequest:
                 task = asyncio.Task(coro, loop=self.loop, eager_start=True)
             else:
                 task = self.loop.create_task(coro)
-
             if task.done():
                 task = None
             else:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -677,7 +677,7 @@ class ClientRequest:
         v = self.version
         status_line = f"{self.method} {path} HTTP/{v.major}.{v.minor}"
         await writer.write_headers(status_line, self.headers)
-        if self.body is not None or self._continue is not None or protocol.paused:
+        if self.body or self._continue is not None or protocol.paused:
             coro = self.write_bytes(writer, conn)
 
             task: Optional["asyncio.Task[None]"]

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -707,7 +707,7 @@ class ClientRequest:
             # - we do not have a compressed payload
             # - we are not waiting for a 100-continue response
             protocol.start_timeout()
-            await writer.write_eof()
+            writer.set_eof()
             task = None
         response_class = self.response_class
         assert response_class is not None

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -696,7 +696,7 @@ class ClientRequest:
         else:
             # We have nothing to write because
             # - there is no body
-            # - the protocol is not paused
+            # - the protocol does not have writing paused
             # - we are not waiting for a 100-continue response
             protocol.start_timeout()
             writer.set_eof()

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -677,13 +677,7 @@ class ClientRequest:
         v = self.version
         status_line = f"{self.method} {path} HTTP/{v.major}.{v.minor}"
         await writer.write_headers(status_line, self.headers)
-        if (
-            self.body
-            or self._continue is not None
-            or self.compress
-            or self.chunked
-            or protocol.writing_paused
-        ):
+        if self.body or self._continue is not None or protocol.writing_paused:
             coro = self.write_bytes(writer, conn)
 
             task: Optional["asyncio.Task[None]"]
@@ -703,8 +697,6 @@ class ClientRequest:
             # We have nothing to write because
             # - there is no body
             # - the protocol is not paused
-            # - we do not have a chunk to write (not chunked)
-            # - we do not have a compressed payload
             # - we are not waiting for a 100-continue response
             protocol.start_timeout()
             writer.set_eof()

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -682,7 +682,7 @@ class ClientRequest:
             or self._continue is not None
             or self.compress
             or self.chunked
-            or protocol.paused
+            or protocol.writing_paused
         ):
             coro = self.write_bytes(writer, conn)
 

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -130,6 +130,10 @@ class StreamWriter(AbstractStreamWriter):
         buf = _serialize_headers(status_line, headers)
         self._write(buf)
 
+    def set_eof(self) -> None:
+        """Indicate that the message is complete."""
+        self._eof = True
+
     async def write_eof(self, chunk: bytes = b"") -> None:
         if self._eof:
             return

--- a/tests/test_base_protocol.py
+++ b/tests/test_base_protocol.py
@@ -18,8 +18,10 @@ async def test_pause_writing() -> None:
     loop = asyncio.get_event_loop()
     pr = BaseProtocol(loop)
     assert not pr._paused
+    assert not pr.writing_paused
     pr.pause_writing()
     assert pr._paused
+    assert pr.writing_paused
 
 
 async def test_pause_reading_no_transport() -> None:

--- a/tests/test_base_protocol.py
+++ b/tests/test_base_protocol.py
@@ -18,10 +18,10 @@ async def test_pause_writing() -> None:
     loop = asyncio.get_event_loop()
     pr = BaseProtocol(loop)
     assert not pr._paused
-    assert pr.writing_paused is True
+    assert pr.writing_paused is False
     pr.pause_writing()
     assert pr._paused
-    assert pr.writing_paused is False  # type: ignore[unreachable]
+    assert pr.writing_paused is True  # type: ignore[unreachable]
 
 
 async def test_pause_reading_no_transport() -> None:

--- a/tests/test_base_protocol.py
+++ b/tests/test_base_protocol.py
@@ -18,10 +18,10 @@ async def test_pause_writing() -> None:
     loop = asyncio.get_event_loop()
     pr = BaseProtocol(loop)
     assert not pr._paused
-    assert not pr.writing_paused
+    assert pr.writing_paused is True
     pr.pause_writing()
     assert pr._paused
-    assert pr.writing_paused
+    assert pr.writing_paused is False  # type: ignore[unreachable]
 
 
 async def test_pause_reading_no_transport() -> None:

--- a/tests/test_benchmarks_client_request.py
+++ b/tests/test_benchmarks_client_request.py
@@ -90,7 +90,7 @@ def test_send_client_request_one_hundred(
             self.transport = MockTransport()
 
         @property
-        def paused(self) -> bool:
+        def writing_paused(self) -> bool:
             return False
 
         async def _drain_helper(self) -> None:

--- a/tests/test_benchmarks_client_request.py
+++ b/tests/test_benchmarks_client_request.py
@@ -89,6 +89,10 @@ def test_send_client_request_one_hundred(
         def __init__(self) -> None:
             self.transport = MockTransport()
 
+        @property
+        def paused(self) -> bool:
+            return False
+
         async def _drain_helper(self) -> None:
             """Swallow drain."""
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -1540,10 +1540,7 @@ async def test_POST_MultiDict(aiohttp_client: AiohttpClient) -> None:
         assert 200 == resp.status
 
 
-@pytest.mark.parametrize("data", (None, b""))
-async def test_GET_DEFLATE(
-    aiohttp_client: AiohttpClient, data: Optional[bytes]
-) -> None:
+async def test_GET_DEFLATE(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
         return web.json_response({"ok": True})
 
@@ -1566,7 +1563,7 @@ async def test_GET_DEFLATE(
         app.router.add_get("/", handler)
         client = await aiohttp_client(app)
 
-        async with client.get("/", data=data, compress=True) as resp:
+        async with client.get("/", data=b"", compress=True) as resp:
             assert resp.status == 200
             content = await resp.json()
             assert content == {"ok": True}
@@ -1574,6 +1571,24 @@ async def test_GET_DEFLATE(
     assert write_mock is not None
     # No chunks should have been sent for an empty body.
     write_mock.assert_not_called()
+
+
+async def test_GET_DEFLATE_no_body(aiohttp_client: AiohttpClient) -> None:
+    async def handler(request: web.Request) -> web.Response:
+        return web.json_response({"ok": True})
+
+    with mock.patch.object(ClientRequest, "write_bytes") as mock_write_bytes:
+        app = web.Application()
+        app.router.add_get("/", handler)
+        client = await aiohttp_client(app)
+
+        async with client.get("/", data=None, compress=True) as resp:
+            assert resp.status == 200
+            content = await resp.json()
+            assert content == {"ok": True}
+
+    # No chunks should have been sent for an empty body.
+    mock_write_bytes.assert_not_called()
 
 
 async def test_POST_DATA_DEFLATE(aiohttp_client: AiohttpClient) -> None:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -918,7 +918,7 @@ async def test_request_tracing_url_params(
             assert to_trace_urls(on_request_redirect) == []
             assert to_trace_urls(on_request_end) == [to_url("/?x=0")]
             assert to_trace_urls(on_request_exception) == []
-            assert to_trace_urls(on_request_chunk_sent) == [to_url("/?x=0")]
+            assert to_trace_urls(on_request_chunk_sent) == []
             assert to_trace_urls(on_response_chunk_received) == [to_url("/?x=0")]
             assert to_trace_urls(on_request_headers_sent) == [to_url("/?x=0")]
 
@@ -934,10 +934,7 @@ async def test_request_tracing_url_params(
             assert to_trace_urls(on_request_redirect) == [to_url("/redirect?x=0")]
             assert to_trace_urls(on_request_end) == [to_url("/")]
             assert to_trace_urls(on_request_exception) == []
-            assert to_trace_urls(on_request_chunk_sent) == [
-                to_url("/redirect?x=0"),
-                to_url("/"),
-            ]
+            assert to_trace_urls(on_request_chunk_sent) == []
             assert to_trace_urls(on_response_chunk_received) == [to_url("/")]
             assert to_trace_urls(on_request_headers_sent) == [
                 to_url("/redirect?x=0"),

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -360,3 +360,19 @@ async def test_write_headers_prevents_injection(
     wrong_headers = CIMultiDict({"Content-Length": "256\r\nSet-Cookie: abc=123"})
     with pytest.raises(ValueError):
         await msg.write_headers(status_line, wrong_headers)
+
+
+async def test_set_eof_after_write_headers(
+    protocol: BaseProtocol,
+    transport: mock.Mock,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    msg = http.StreamWriter(protocol, loop)
+    status_line = "HTTP/1.1 200 OK"
+    good_headers = CIMultiDict({"Set-Cookie": "abc=123"})
+    await msg.write_headers(status_line, good_headers)
+    assert transport.write.called
+    transport.write.reset_mock()
+    msg.set_eof()
+    await msg.write_eof()
+    assert not transport.write.called


### PR DESCRIPTION
The client would create a task to write the body even if the body was `b""`

Since `GET` requests tend to be some of the most common, it makes sense to optimize for the case where only headers are sent.

aiohttp 3.11.0b4 yarl 1.17.1
![aiohttp_3_11_0b4_yarl_1_17_1](https://github.com/user-attachments/assets/83c28f56-b242-4fea-b5af-378c1ac022a4)


This PR:
![b5](https://github.com/user-attachments/assets/6e2e7500-9734-44c1-b829-a07a4795a895)
