### PR TITLE
[PR #9756/44d809f backport][3.11] Avoid tracking connections per host when there is no limit per host

### DIFF
--- a/CHANGES/9756.misc.rst
+++ b/CHANGES/9756.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of :py:class:`aiohttp.BaseConnector` when there is no ``limit_per_host`` -- by :user:`bdraco`.


### PR DESCRIPTION
(cherry picked from commit 44d809f330aa249de582d8c3cdfd284fb4247483)
