### PR TITLE
Refactor payload registry to avoid linear searches for common types

### DIFF
--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -114,7 +114,7 @@ class PayloadRegistry:
             return data
         if self._first:
             for factory, type_ in self._first:
-                if isinstance(data, type):
+                if isinstance(data, type_):
                     return factory(data, *args, **kwargs)
         if factory := self._normal_lookup.get(type(data)):
             return factory(data, *args, **kwargs)

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -110,14 +110,17 @@ class PayloadRegistry:
         _CHAIN: "Type[chain[_PayloadRegistryItem]]" = chain,
         **kwargs: Any,
     ) -> "Payload":
-        if isinstance(data, Payload):
-            return data
         if self._first:
             for factory, type_ in self._first:
                 if isinstance(data, type_):
                     return factory(data, *args, **kwargs)
+        # Try the fast lookup first
         if lookup_factory := self._normal_lookup.get(type(data)):
             return lookup_factory(data, *args, **kwargs)
+        # Bail early if its already a Payload
+        if isinstance(data, Payload):
+            return data
+        # Fallback to the slower linear search
         for factory, type_ in _CHAIN(self._normal, self._last):
             if isinstance(data, type_):
                 return factory(data, *args, **kwargs)

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -116,8 +116,8 @@ class PayloadRegistry:
             for factory, type_ in self._first:
                 if isinstance(data, type_):
                     return factory(data, *args, **kwargs)
-        if factory := self._normal_lookup.get(type(data)):
-            return factory(data, *args, **kwargs)
+        if lookup_factory := self._normal_lookup.get(type(data)):
+            return lookup_factory(data, *args, **kwargs)
         for factory, type_ in _CHAIN(self._normal, self._last):
             if isinstance(data, type_):
                 return factory(data, *args, **kwargs)

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -113,13 +113,13 @@ class PayloadRegistry:
         if isinstance(data, Payload):
             return data
         if self._first:
-            for factory, type in self._first:
+            for factory, type_ in self._first:
                 if isinstance(data, type):
                     return factory(data, *args, **kwargs)
         if factory := self._normal_lookup.get(type(data)):
             return factory(data, *args, **kwargs)
-        for factory, type in _CHAIN(self._normal, self._last):
-            if isinstance(data, type):
+        for factory, type_ in _CHAIN(self._normal, self._last):
+            if isinstance(data, type_):
                 return factory(data, *args, **kwargs)
         raise LookupError()
 


### PR DESCRIPTION
closes #9419

Looks to be a ~2.4% speed up so probably not worth mentioning in a changelog message

<img width="253" alt="Screenshot 2024-11-10 at 9 57 48 AM" src="https://github.com/user-attachments/assets/a2684638-9687-4883-bf1e-1e114b188363">
<img width="248" alt="Screenshot 2024-11-10 at 9 57 54 AM" src="https://github.com/user-attachments/assets/9c3b2d89-bf25-4ca2-bb2a-327131b78001">
<img width="250" alt="Screenshot 2024-11-10 at 9 58 09 AM" src="https://github.com/user-attachments/assets/5ef03a39-adeb-46e2-86d9-614a4c100fa9">
<img width="245" alt="Screenshot 2024-11-10 at 9 58 15 AM" src="https://github.com/user-attachments/assets/8ec7341e-cf2a-41a4-b8df-e5086e8d5df9">
