### PR TITLE
Avoid duplicate len calls in StreamReader.feed_data

### DIFF
--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -272,9 +272,10 @@ class StreamReader(AsyncStreamReaderMixin):
         if not data:
             return
 
-        self._size += len(data)
+        data_len = len(data)
+        self._size += data_len
         self._buffer.append(data)
-        self.total_bytes += len(data)
+        self.total_bytes += data_len
 
         waiter = self._waiter
         if waiter is not None:


### PR DESCRIPTION
Noticed the duplicate call on the same data while looking at the payload lookup profile

![same_len](https://github.com/user-attachments/assets/1ce83a00-b709-4f72-b12e-55893791ee0c)
