### PR TITLE
Small cleanups to enabling compression in web_response

### DIFF
--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -344,14 +344,14 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
     async def _start_compression(self, request: "BaseRequest") -> None:
         if self._compression_force:
             await self._do_start_compression(self._compression_force)
-        else:
-            # Encoding comparisons should be case-insensitive
-            # https://www.rfc-editor.org/rfc/rfc9110#section-8.4.1
-            accept_encoding = request.headers.get(hdrs.ACCEPT_ENCODING, "").lower()
-            for value, coding in CONTENT_CODINGS.items():
-                if value in accept_encoding:
-                    await self._do_start_compression(coding)
-                    return
+            return
+        # Encoding comparisons should be case-insensitive
+        # https://www.rfc-editor.org/rfc/rfc9110#section-8.4.1
+        accept_encoding = request.headers.get(hdrs.ACCEPT_ENCODING, "").lower()
+        for value, coding in CONTENT_CODINGS.items():
+            if value in accept_encoding:
+                await self._do_start_compression(coding)
+                return
 
     async def prepare(self, request: "BaseRequest") -> Optional[AbstractStreamWriter]:
         if self._eof_sent:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -44,6 +44,7 @@ from .payload import Payload
 from .typedefs import JSONEncoder, LooseHeaders
 
 REASON_PHRASES = {http_status.value: http_status.phrase for http_status in HTTPStatus}
+LARGE_BODY_SIZE = 1024**2
 
 __all__ = ("ContentCoding", "StreamResponse", "Response", "json_response")
 
@@ -716,7 +717,7 @@ class Response(StreamResponse):
             executor=self._zlib_executor,
         )
         assert self._body is not None
-        if self._zlib_executor_size is None and len(self._body) > 1024 * 1024:
+        if self._zlib_executor_size is None and len(self._body) > LARGE_BODY_SIZE:
             warnings.warn(
                 "Synchronous compression of large response bodies "
                 f"({len(self._body)} bytes) might block the async event loop. "

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -427,6 +427,24 @@ async def test_force_compression_deflate() -> None:
     assert "deflate" == resp.headers.get(hdrs.CONTENT_ENCODING)
 
 
+async def test_force_compression_deflate_large_payload() -> None:
+    """Make sure a warning is thrown for large payloads compressed in the event loop."""
+    req = make_request(
+        "GET", "/", headers=CIMultiDict({hdrs.ACCEPT_ENCODING: "gzip, deflate"})
+    )
+    resp = web.Response(body=b"large")
+
+    resp.enable_compression(web.ContentCoding.deflate)
+    assert resp.compression
+
+    with pytest.warns(
+        Warning, match="Synchronous compression of large response bodies"
+    ), mock.patch("aiohttp.web_response.LARGE_BODY_SIZE", 2):
+        msg = await resp.prepare(req)
+        assert msg is not None
+    assert "deflate" == resp.headers.get(hdrs.CONTENT_ENCODING)
+
+
 async def test_force_compression_no_accept_deflate() -> None:
     req = make_request("GET", "/")
     resp = web.StreamResponse()


### PR DESCRIPTION
- Return early if identity to save some indent
- Use identity checks for enums since they are singletons
- Remove assertions that will always be True
- Add missing coverage
