### PR TITLE
Combine duplicate logic in `Response.write_eof`

### DIFF
--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -673,16 +673,13 @@ class Response(StreamResponse):
         assert not data, f"data arg is not supported, got {data!r}"
         assert self._req is not None
         assert self._payload_writer is not None
-        if body is not None:
-            if self._must_be_empty_body:
-                await super().write_eof()
-            elif isinstance(self._body, Payload):
-                await self._body.write(self._payload_writer)
-                await super().write_eof()
-            else:
-                await super().write_eof(cast(bytes, body))
-        else:
+        if body is None or self._must_be_empty_body:
             await super().write_eof()
+        elif isinstance(self._body, Payload):
+            await self._body.write(self._payload_writer)
+            await super().write_eof()
+        else:
+            await super().write_eof(cast(bytes, body))
 
     async def _start(self, request: "BaseRequest") -> AbstractStreamWriter:
         if hdrs.CONTENT_LENGTH in self._headers:


### PR DESCRIPTION
There were two branches that called `await super().write_eof()` that could be combined