### PR TITLE
Replace get_event_loop with get_running_loop in the compressor

### DIFF
--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -79,8 +79,8 @@ class ZLibCompressor(ZlibBaseHandler):
                 self._max_sync_chunk_size is not None
                 and len(data) > self._max_sync_chunk_size
             ):
-                return await asyncio.get_event_loop().run_in_executor(
-                    self._executor, self.compress_sync, data
+                return await asyncio.get_running_loop().run_in_executor(
+                    self._executor, self._compressor.compress, data
                 )
             return self.compress_sync(data)
 
@@ -111,8 +111,8 @@ class ZLibDecompressor(ZlibBaseHandler):
             self._max_sync_chunk_size is not None
             and len(data) > self._max_sync_chunk_size
         ):
-            return await asyncio.get_event_loop().run_in_executor(
-                self._executor, self.decompress_sync, data, max_length
+            return await asyncio.get_running_loop().run_in_executor(
+                self._executor, self._decompressor.decompress, data, max_length
             )
         return self.decompress_sync(data, max_length)
 

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -70,6 +70,14 @@ class ZLibCompressor(ZlibBaseHandler):
         return self._compressor.compress(data)
 
     async def compress(self, data: bytes) -> bytes:
+        """Compress the data and returned the compressed bytes.
+
+        Note that flush() must be called after the last call to compress()
+
+        If the data size is large than the max_sync_chunk_size, the compression
+        will be done in the executor. Otherwise, the compression will be done
+        in the event loop.
+        """
         async with self._compress_lock:
             # To ensure the stream is consistent in the event
             # there are multiple writers, we need to lock
@@ -107,6 +115,12 @@ class ZLibDecompressor(ZlibBaseHandler):
         return self._decompressor.decompress(data, max_length)
 
     async def decompress(self, data: bytes, max_length: int = 0) -> bytes:
+        """Decompress the data and return the decompressed bytes.
+
+        If the data size is large than the max_sync_chunk_size, the decompression
+        will be done in the executor. Otherwise, the decompression will be done
+        in the event loop.
+        """
         if (
             self._max_sync_chunk_size is not None
             and len(data) > self._max_sync_chunk_size

--- a/tests/test_compression_utils.py
+++ b/tests/test_compression_utils.py
@@ -3,7 +3,7 @@
 from aiohttp.compression_utils import ZLibCompressor, ZLibDecompressor
 
 
-async def test_compression_round_trip_in_executor():
+async def test_compression_round_trip_in_executor() -> None:
     """Ensure that compression and decompression work correctly in the executor."""
     compressor = ZLibCompressor(max_sync_chunk_size=1)
     decompressor = ZLibDecompressor(max_sync_chunk_size=1)
@@ -13,7 +13,7 @@ async def test_compression_round_trip_in_executor():
     assert data == decompressed_data
 
 
-async def test_compression_round_trip_in_event_loop():
+async def test_compression_round_trip_in_event_loop() -> None:
     """Ensure that compression and decompression work correctly in the event loop."""
     compressor = ZLibCompressor(max_sync_chunk_size=10000)
     decompressor = ZLibDecompressor(max_sync_chunk_size=10000)

--- a/tests/test_compression_utils.py
+++ b/tests/test_compression_utils.py
@@ -1,0 +1,23 @@
+"""Tests for compression utils."""
+
+from aiohttp.compression_utils import ZLibCompressor, ZLibDecompressor
+
+
+async def test_compression_round_trip_in_executor():
+    """Ensure that compression and decompression work correctly in the executor."""
+    compressor = ZLibCompressor(max_sync_chunk_size=1)
+    decompressor = ZLibDecompressor(max_sync_chunk_size=1)
+    data = b"Hi" * 100
+    compressed_data = await compressor.compress(data) + compressor.flush()
+    decompressed_data = await decompressor.decompress(compressed_data)
+    assert data == decompressed_data
+
+
+async def test_compression_round_trip_in_event_loop():
+    """Ensure that compression and decompression work correctly in the event loop."""
+    compressor = ZLibCompressor(max_sync_chunk_size=10000)
+    decompressor = ZLibDecompressor(max_sync_chunk_size=10000)
+    data = b"Hi" * 100
+    compressed_data = await compressor.compress(data) + compressor.flush()
+    decompressed_data = await decompressor.decompress(compressed_data)
+    assert data == decompressed_data


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Replace `get_event_loop` with `get_running_loop` in the compressor.  This should never be called without a running event loop as its in an async function.

`asyncio.get_event_loop`:
> Deprecated since version 3.12: Deprecation warning is emitted if there is no current event loop. In some future Python release this will become an error

There was no need to call the sync wrapper function since we are already inside the object and can call the compressor/decompressor directly.

Adds missing test coverage

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no