### PR TITLE
Ensure Cython WebSocket parser can handle frames of 2**23 in size

### DIFF
--- a/CHANGES/9781.feature.rst
+++ b/CHANGES/9781.feature.rst
@@ -1,0 +1,1 @@
+9543.feature.rst

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -70,12 +70,12 @@ cdef class WebSocketReader:
     cdef object _frame_fin
     cdef object _frame_opcode
     cdef object _frame_payload
-    cdef unsigned int _frame_payload_len
+    cdef unsigned long long _frame_payload_len
 
     cdef bytes _tail
     cdef bint _has_mask
     cdef bytes _frame_mask
-    cdef unsigned int _payload_length
+    cdef unsigned long long _payload_length
     cdef unsigned int _payload_length_flag
     cdef object _compressed
     cdef object _decompressobj


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This is technically allowed if the limit is increased high enough https://www.rfc-editor.org/rfc/rfc6455#section-5.2

However its unlikely to happen since you would need at least 9.22 exabytes of RAM assuming there is no copy of the message ever

The default max message size is 4194304 so this went unnoticed

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no