### PR TITLE
Avoid pack overhead for large websocket messages

### DIFF
--- a/aiohttp/_websocket/helpers.py
+++ b/aiohttp/_websocket/helpers.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Final, List, Optional, Pattern, Tuple
 from ..helpers import NO_EXTENSIONS
 from .models import WSHandshakeError
 
-UNPACK_LEN3 = Struct("!Q").unpack_from
 UNPACK_CLOSE_CODE = Struct("!H").unpack
 PACK_LEN1 = Struct("!BB").pack
 PACK_LEN2 = Struct("!BBH").pack

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -15,7 +15,6 @@ cdef unsigned int OP_CODE_CLOSE
 cdef unsigned int OP_CODE_PING
 cdef unsigned int OP_CODE_PONG
 
-cdef object UNPACK_LEN3
 cdef object UNPACK_CLOSE_CODE
 cdef object TUPLE_NEW
 
@@ -102,6 +101,7 @@ cdef class WebSocketReader:
         first_byte="unsigned char",
         second_byte="unsigned char",
         end_pos="unsigned int",
+        i="unsigned int",
         has_mask=bint,
         fin=bint,
     )

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -9,7 +9,7 @@ from ..base_protocol import BaseProtocol
 from ..compression_utils import ZLibDecompressor
 from ..helpers import _EXC_SENTINEL, set_exception
 from ..streams import EofStream
-from .helpers import UNPACK_CLOSE_CODE, UNPACK_LEN3, websocket_mask
+from .helpers import UNPACK_CLOSE_CODE, websocket_mask
 from .models import (
     WS_DEFLATE_TRAILING,
     WebSocketError,
@@ -408,9 +408,10 @@ class WebSocketReader:
                 elif length_flag > 126:
                     if buf_length - start_pos < 8:
                         break
-                    data = buf[start_pos : start_pos + 8]
+                    for i in range(8):
+                        first_byte = buf[start_pos + i]
+                        self._payload_length = (self._payload_length << 8) | first_byte
                     start_pos += 8
-                    self._payload_length = UNPACK_LEN3(data)[0]
                 else:
                     self._payload_length = length_flag
 


### PR DESCRIPTION
TODO: needs a test to unpack 2^63 as the length of the message