### PR TITLE
[PR #9784/2f6ff6d backport][3.11] Add benchmark for reading WebSocket payloads larger than 2**16

### DIFF
--- a/tests/test_benchmarks_http_websocket.py
+++ b/tests/test_benchmarks_http_websocket.py
@@ -6,7 +6,7 @@ from typing import Union
 from pytest_codspeed import BenchmarkFixture
 
 from aiohttp import DataQueue
-from aiohttp._websocket.helpers import MSG_SIZE
+from aiohttp._websocket.helpers import MSG_SIZE, PACK_LEN3
 from aiohttp.base_protocol import BaseProtocol
 from aiohttp.http_websocket import (
     WebSocketReader,
@@ -14,6 +14,27 @@ from aiohttp.http_websocket import (
     WSMessage,
     WSMsgType,
 )
+
+
+def test_read_large_binary_websocket_messages(
+    loop: asyncio.AbstractEventLoop, benchmark: BenchmarkFixture
+) -> None:
+    """Read one hundred large binary websocket messages."""
+    queue: DataQueue[WSMessage] = DataQueue(loop=loop)
+    reader = WebSocketReader(queue, max_msg_size=2**18)
+
+    # PACK3 has a minimum message length of 2**16 bytes.
+    message = b"x" * ((2**16) + 1)
+    msg_length = len(message)
+    first_byte = 0x80 | 0 | WSMsgType.BINARY.value
+    header = PACK_LEN3(first_byte, 127, msg_length)
+    raw_message = header + message
+    feed_data = reader.feed_data
+
+    @benchmark
+    def _run() -> None:
+        for _ in range(100):
+            feed_data(raw_message)
 
 
 def test_read_one_hundred_websocket_text_messages(


### PR DESCRIPTION
(cherry picked from commit 2f6ff6df5be1b935114ec511f936ae8ada0ef877)
