### PR TITLE
Fix flakey test_import_time with Python 3.13

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -41,6 +41,7 @@ _TARGET_TIMINGS_BY_PYTHON_VERSION = {
         else 250
     ),
 }
+_TARGET_TIMINGS_BY_PYTHON_VERSION["3.13"] = _TARGET_TIMINGS_BY_PYTHON_VERSION["3.12"]
 
 
 @pytest.mark.internal

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -34,7 +34,7 @@ _IS_XDIST_RUN = _XDIST_WORKER_COUNT > 1
 
 _TARGET_TIMINGS_BY_PYTHON_VERSION = {
     "3.12": (
-        # 3.12 is expected to be a bit slower due to performance trade-offs,
+        # 3.12+ is expected to be a bit slower due to performance trade-offs,
         # and even slower under pytest-xdist, especially in CI
         _XDIST_WORKER_COUNT * 100 * (1 if _IS_CI_ENV else 1.53)
         if _IS_XDIST_RUN


### PR DESCRIPTION
Python 3.13 still has the same performance trade-off inherited from 3.12 which makes this test flakey.

Match the timings for 3.13 to 3.12

I intentionally did not make it > 3.12 so we have to think about it for when 3.14 comes out to see if it still has the same trade-offs