### PR TITLE
[PR #9685/5241897 backport][3.11] Fix WebSocket reader flow control calculations

### DIFF
--- a/CHANGES/9685.breaking.rst
+++ b/CHANGES/9685.breaking.rst
@@ -1,0 +1,1 @@
+``FlowControlDataQueue`` has been replaced with the ``WebSocketDataQueue`` -- by :user:`bdraco`.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -93,7 +93,6 @@ from .streams import (
     EMPTY_PAYLOAD as EMPTY_PAYLOAD,
     DataQueue as DataQueue,
     EofStream as EofStream,
-    FlowControlDataQueue as FlowControlDataQueue,
     StreamReader as StreamReader,
 )
 from .tracing import (
@@ -216,7 +215,6 @@ __all__: Tuple[str, ...] = (
     "DataQueue",
     "EMPTY_PAYLOAD",
     "EofStream",
-    "FlowControlDataQueue",
     "StreamReader",
     # tracing
     "TraceConfig",

--- a/aiohttp/_websocket/reader.py
+++ b/aiohttp/_websocket/reader.py
@@ -5,17 +5,27 @@ from typing import TYPE_CHECKING
 from ..helpers import NO_EXTENSIONS
 
 if TYPE_CHECKING or NO_EXTENSIONS:  # pragma: no cover
-    from .reader_py import WebSocketReader as WebSocketReaderPython
+    from .reader_py import (
+        WebSocketDataQueue as WebSocketDataQueuePython,
+        WebSocketReader as WebSocketReaderPython,
+    )
 
     WebSocketReader = WebSocketReaderPython
+    WebSocketDataQueue = WebSocketDataQueuePython
 else:
     try:
         from .reader_c import (  # type: ignore[import-not-found]
+            WebSocketDataQueue as WebSocketDataQueueCython,
             WebSocketReader as WebSocketReaderCython,
         )
 
         WebSocketReader = WebSocketReaderCython
+        WebSocketDataQueue = WebSocketDataQueueCython
     except ImportError:  # pragma: no cover
-        from .reader_py import WebSocketReader as WebSocketReaderPython
+        from .reader_py import (
+            WebSocketDataQueue as WebSocketDataQueuePython,
+            WebSocketReader as WebSocketReaderPython,
+        )
 
         WebSocketReader = WebSocketReaderPython
+        WebSocketDataQueue = WebSocketDataQueuePython

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -46,8 +46,7 @@ cdef class WebSocketDataQueue:
 
     cdef void _release_waiter(self)
 
-    @cython.locals(size="unsigned int")
-    cpdef void feed_data(self, object data)
+    cpdef void feed_data(self, object data, unsigned int size)
 
     @cython.locals(size="unsigned int")
     cdef _read_from_buffer(self)

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -31,11 +31,30 @@ cdef set MESSAGE_TYPES_WITH_CONTENT
 cdef tuple EMPTY_FRAME
 cdef tuple EMPTY_FRAME_ERROR
 
+cdef class WebSocketDataQueue:
+
+    cdef unsigned int _size
+    cdef public object _protocol
+    cdef unsigned int _limit
+    cdef object _loop
+    cdef bint _eof
+    cdef object _waiter
+    cdef object _exception
+    cdef public object _buffer
+    cdef object _get_buffer
+    cdef object _put_buffer
+
+    cdef void _release_waiter(self)
+
+    @cython.locals(size="unsigned int")
+    cpdef void feed_data(self, object data)
+
+    @cython.locals(size="unsigned int")
+    cdef _read_from_buffer(self)
 
 cdef class WebSocketReader:
 
-    cdef object queue
-    cdef object _queue_feed_data
+    cdef WebSocketDataQueue queue
     cdef unsigned int _max_msg_size
 
     cdef Exception _exc

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -66,12 +66,12 @@ class WebSocketDataQueue:
         self._get_buffer = self._buffer.popleft
         self._put_buffer = self._buffer.append
 
-    def exception(self) -> Optional[Union[Type[BaseException], BaseException]]:
+    def exception(self) -> Optional[Union[BaseException]]:
         return self._exception
 
     def set_exception(
         self,
-        exc: Union[Type[BaseException], BaseException],
+        exc: Union[BaseException],
         exc_cause: builtins.BaseException = _EXC_SENTINEL,
     ) -> None:
         self._eof = True

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -43,6 +43,8 @@ EMPTY_FRAME = (False, b"")
 
 TUPLE_NEW = tuple.__new__
 
+int_ = int
+
 
 class WebSocketDataQueue:
     """WebSocketDataQueue resumes and pauses an underlying stream.
@@ -89,8 +91,7 @@ class WebSocketDataQueue:
         self._eof = True
         self._release_waiter()
 
-    def feed_data(self, data: "WSMessage", size: int) -> None:
-        size = data.size
+    def feed_data(self, data: "WSMessage", size: "int_") -> None:
         self._size += size
         self._put_buffer((data, size))
         self._release_waiter()

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -71,7 +71,7 @@ class WebSocketDataQueue:
 
     def set_exception(
         self,
-        exc: BaseException,
+        exc: "BaseException",
         exc_cause: builtins.BaseException = _EXC_SENTINEL,
     ) -> None:
         self._eof = True

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -274,8 +274,7 @@ class WebSocketReader:
                         len(payload_merged),
                     )
             elif opcode == OP_CODE_CLOSE:
-                payload_len = len(payload)
-                if payload_len >= 2:
+                if len(payload) >= 2:
                     close_code = UNPACK_CLOSE_CODE(payload[:2])[0]
                     if close_code < 3000 and close_code not in ALLOWED_CLOSE_CODES:
                         raise WebSocketError(

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -3,7 +3,7 @@
 import asyncio
 import builtins
 from collections import deque
-from typing import Deque, Final, List, Optional, Set, Tuple, Type, Union
+from typing import Deque, Final, List, Optional, Set, Tuple, Union
 
 from ..base_protocol import BaseProtocol
 from ..compression_utils import ZLibDecompressor
@@ -61,17 +61,17 @@ class WebSocketDataQueue:
         self._loop = loop
         self._eof = False
         self._waiter: Optional[asyncio.Future[None]] = None
-        self._exception: Union[Type[BaseException], BaseException, None] = None
+        self._exception: Union[BaseException, None] = None
         self._buffer: Deque[Tuple[WSMessage, int]] = deque()
         self._get_buffer = self._buffer.popleft
         self._put_buffer = self._buffer.append
 
-    def exception(self) -> Optional[Union[BaseException]]:
+    def exception(self) -> Optional[BaseException]:
         return self._exception
 
     def set_exception(
         self,
-        exc: Union[BaseException],
+        exc: BaseException,
         exc_cause: builtins.BaseException = _EXC_SENTINEL,
     ) -> None:
         self._eof = True

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -1,10 +1,14 @@
 """Reader for WebSocket protocol versions 13 and 8."""
 
-from typing import Final, List, Optional, Set, Tuple, Union
+import asyncio
+import builtins
+from collections import deque
+from typing import Deque, Final, List, Optional, Set, Tuple, Type, Union
 
+from ..base_protocol import BaseProtocol
 from ..compression_utils import ZLibDecompressor
-from ..helpers import set_exception
-from ..streams import FlowControlDataQueue
+from ..helpers import _EXC_SENTINEL, set_exception
+from ..streams import EofStream
 from .helpers import UNPACK_CLOSE_CODE, UNPACK_LEN3, websocket_mask
 from .models import (
     WS_DEFLATE_TRAILING,
@@ -40,15 +44,87 @@ EMPTY_FRAME = (False, b"")
 TUPLE_NEW = tuple.__new__
 
 
+class WebSocketDataQueue:
+    """WebSocketDataQueue resumes and pauses an underlying stream.
+
+    It is a destination for WebSocket data.
+    """
+
+    def __init__(
+        self, protocol: BaseProtocol, limit: int, *, loop: asyncio.AbstractEventLoop
+    ) -> None:
+        self._size = 0
+        self._protocol = protocol
+        self._limit = limit * 2
+        self._loop = loop
+        self._eof = False
+        self._waiter: Optional[asyncio.Future[None]] = None
+        self._exception: Union[Type[BaseException], BaseException, None] = None
+        self._buffer: Deque[Tuple[WSMessage, int]] = deque()
+        self._get_buffer = self._buffer.popleft
+        self._put_buffer = self._buffer.append
+
+    def exception(self) -> Optional[Union[Type[BaseException], BaseException]]:
+        return self._exception
+
+    def set_exception(
+        self,
+        exc: Union[Type[BaseException], BaseException],
+        exc_cause: builtins.BaseException = _EXC_SENTINEL,
+    ) -> None:
+        self._eof = True
+        self._exception = exc
+        if (waiter := self._waiter) is not None:
+            self._waiter = None
+            set_exception(waiter, exc, exc_cause)
+
+    def _release_waiter(self) -> None:
+        if (waiter := self._waiter) is None:
+            return
+        self._waiter = None
+        if not waiter.done():
+            waiter.set_result(None)
+
+    def feed_eof(self) -> None:
+        self._eof = True
+        self._release_waiter()
+
+    def feed_data(self, data: "WSMessage", size: int) -> None:
+        size = data.size
+        self._size += size
+        self._put_buffer((data, size))
+        self._release_waiter()
+        if self._size > self._limit and not self._protocol._reading_paused:
+            self._protocol.pause_reading()
+
+    async def read(self) -> WSMessage:
+        if not self._buffer and not self._eof:
+            assert not self._waiter
+            self._waiter = self._loop.create_future()
+            try:
+                await self._waiter
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                self._waiter = None
+                raise
+        return self._read_from_buffer()
+
+    def _read_from_buffer(self) -> WSMessage:
+        if self._buffer:
+            data, size = self._get_buffer()
+            self._size -= size
+            if self._size < self._limit and self._protocol._reading_paused:
+                self._protocol.resume_reading()
+            return data
+        if self._exception is not None:
+            raise self._exception
+        raise EofStream
+
+
 class WebSocketReader:
     def __init__(
-        self,
-        queue: FlowControlDataQueue[WSMessage],
-        max_msg_size: int,
-        compress: bool = True,
+        self, queue: WebSocketDataQueue, max_msg_size: int, compress: bool = True
     ) -> None:
         self.queue = queue
-        self._queue_feed_data = queue.feed_data
         self._max_msg_size = max_msg_size
 
         self._exc: Optional[Exception] = None
@@ -187,17 +263,18 @@ class WebSocketReader:
                     # bottleneck, so we use tuple.__new__ to improve performance.
                     # This is not type safe, but many tests should fail in
                     # test_client_ws_functional.py if this is wrong.
-                    self._queue_feed_data(
+                    self.queue.feed_data(
                         TUPLE_NEW(WSMessage, (WS_MSG_TYPE_TEXT, text, "")),
                         len(payload_merged),
                     )
                 else:
-                    self._queue_feed_data(
+                    self.queue.feed_data(
                         TUPLE_NEW(WSMessage, (WS_MSG_TYPE_BINARY, payload_merged, "")),
                         len(payload_merged),
                     )
             elif opcode == OP_CODE_CLOSE:
-                if len(payload) >= 2:
+                payload_len = len(payload)
+                if payload_len >= 2:
                     close_code = UNPACK_CLOSE_CODE(payload[:2])[0]
                     if close_code < 3000 and close_code not in ALLOWED_CLOSE_CODES:
                         raise WebSocketError(
@@ -221,14 +298,14 @@ class WebSocketReader:
                 else:
                     msg = TUPLE_NEW(WSMessage, (WSMsgType.CLOSE, 0, ""))
 
-                self._queue_feed_data(msg, 0)
+                self.queue.feed_data(msg, 0)
             elif opcode == OP_CODE_PING:
                 msg = TUPLE_NEW(WSMessage, (WSMsgType.PING, payload, ""))
-                self._queue_feed_data(msg, len(payload))
+                self.queue.feed_data(msg, len(payload))
 
             elif opcode == OP_CODE_PONG:
                 msg = TUPLE_NEW(WSMessage, (WSMsgType.PONG, payload, ""))
-                self._queue_feed_data(msg, len(payload))
+                self.queue.feed_data(msg, len(payload))
 
             else:
                 raise WebSocketError(

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -43,7 +43,7 @@ EMPTY_FRAME = (False, b"")
 
 TUPLE_NEW = tuple.__new__
 
-int_ = int
+int_ = int  # Prevent Cython from converting to PyInt
 
 
 class WebSocketDataQueue:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -37,6 +37,7 @@ from multidict import CIMultiDict, MultiDict, MultiDictProxy, istr
 from yarl import URL
 
 from . import hdrs, http, payload
+from ._websocket.reader import WebSocketDataQueue
 from .abc import AbstractCookieJar
 from .client_exceptions import (
     ClientConnectionError,
@@ -100,8 +101,7 @@ from .helpers import (
     strip_auth_from_url,
 )
 from .http import WS_KEY, HttpVersion, WebSocketReader, WebSocketWriter
-from .http_websocket import WSHandshakeError, WSMessage, ws_ext_gen, ws_ext_parse
-from .streams import FlowControlDataQueue
+from .http_websocket import WSHandshakeError, ws_ext_gen, ws_ext_parse
 from .tracing import Trace, TraceConfig
 from .typedefs import JSONEncoder, LooseCookies, LooseHeaders, Query, StrOrURL
 
@@ -1098,9 +1098,7 @@ class ClientSession:
 
             transport = conn.transport
             assert transport is not None
-            reader: FlowControlDataQueue[WSMessage] = FlowControlDataQueue(
-                conn_proto, 2**16, loop=self._loop
-            )
+            reader = WebSocketDataQueue(conn_proto, 2**16, loop=self._loop)
             conn_proto.set_parser(WebSocketReader(reader, max_msg_size), reader)
             writer = WebSocketWriter(
                 conn_proto,

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -151,7 +151,7 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
     def set_parser(self, parser: Any, payload: Any) -> None:
         # TODO: actual types are:
         #   parser: WebSocketReader
-        #   payload: FlowControlDataQueue
+        #   payload: WebSocketDataQueue
         # but they are not generi enough
         # Need an ABC for both types
         self._payload = payload

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -174,7 +174,7 @@ class ClientWebSocketResponse:
         self._exception = exc
         self._response.close()
         if self._waiting and not self._closing:
-            self._reader.feed_data(WSMessage(WSMsgType.ERROR, exc, None))
+            self._reader.feed_data(WSMessage(WSMsgType.ERROR, exc, None), 0)
 
     def _set_closed(self) -> None:
         """Set the connection to closed.

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -7,6 +7,7 @@ from typing import Any, Optional, Type, cast
 
 import attr
 
+from ._websocket.reader import WebSocketDataQueue
 from .client_exceptions import ClientError, ServerTimeoutError, WSMessageTypeError
 from .client_reqrep import ClientResponse
 from .helpers import calculate_timeout_when, set_result
@@ -19,7 +20,7 @@ from .http import (
     WSMsgType,
 )
 from .http_websocket import _INTERNAL_RECEIVE_TYPES, WebSocketWriter
-from .streams import EofStream, FlowControlDataQueue
+from .streams import EofStream
 from .typedefs import (
     DEFAULT_JSON_DECODER,
     DEFAULT_JSON_ENCODER,
@@ -45,7 +46,7 @@ DEFAULT_WS_CLIENT_TIMEOUT = ClientWSTimeout(ws_receive=None, ws_close=10.0)
 class ClientWebSocketResponse:
     def __init__(
         self,
-        reader: "FlowControlDataQueue[WSMessage]",
+        reader: WebSocketDataQueue,
         writer: WebSocketWriter,
         protocol: Optional[str],
         response: ClientResponse,

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -750,14 +750,14 @@ _EXC_SENTINEL = BaseException()
 class ErrorableProtocol(Protocol):
     def set_exception(
         self,
-        exc: Union[Type[BaseException], BaseException],
+        exc: BaseException,
         exc_cause: BaseException = ...,
     ) -> None: ...  # pragma: no cover
 
 
 def set_exception(
-    fut: Union["asyncio.Future[_T]", ErrorableProtocol],
-    exc: Union[Type[BaseException], BaseException],
+    fut: "asyncio.Future[_T] | ErrorableProtocol",
+    exc: BaseException,
     exc_cause: BaseException = _EXC_SENTINEL,
 ) -> None:
     """Set future exception.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -750,7 +750,7 @@ _EXC_SENTINEL = BaseException()
 class ErrorableProtocol(Protocol):
     def set_exception(
         self,
-        exc: BaseException,
+        exc: Union[Type[BaseException], BaseException],
         exc_cause: BaseException = ...,
     ) -> None: ...  # pragma: no cover
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -756,8 +756,8 @@ class ErrorableProtocol(Protocol):
 
 
 def set_exception(
-    fut: "asyncio.Future[_T] | ErrorableProtocol",
-    exc: BaseException,
+    fut: Union["asyncio.Future[_T]", ErrorableProtocol],
+    exc: Union[Type[BaseException], BaseException],
     exc_cause: BaseException = _EXC_SENTINEL,
 ) -> None:
     """Set future exception.

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -10,9 +10,7 @@ from typing import (
     List,
     Optional,
     Tuple,
-    Type,
     TypeVar,
-    Union,
 )
 
 from .base_protocol import BaseProtocol
@@ -623,8 +621,8 @@ class DataQueue(Generic[_T]):
         self._loop = loop
         self._eof = False
         self._waiter: Optional[asyncio.Future[None]] = None
-        self._exception: Union[Type[BaseException], BaseException, None] = None
-        self._buffer: Deque[_T] = collections.deque()
+        self._exception: Optional[BaseException] = None
+        self._buffer: Deque[Tuple[_T, int]] = collections.deque()
 
     def __len__(self) -> int:
         return len(self._buffer)
@@ -649,8 +647,8 @@ class DataQueue(Generic[_T]):
             self._waiter = None
             set_exception(waiter, exc, exc_cause)
 
-    def feed_data(self, data: _T) -> None:
-        self._buffer.append(data)
+    def feed_data(self, data: _T, size: int = 0) -> None:
+        self._buffer.append((data, size))
         if (waiter := self._waiter) is not None:
             self._waiter = None
             set_result(waiter, None)

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -10,6 +10,7 @@ import attr
 from multidict import CIMultiDict
 
 from . import hdrs
+from ._websocket.reader import WebSocketDataQueue
 from ._websocket.writer import DEFAULT_LIMIT
 from .abc import AbstractStreamWriter
 from .client_exceptions import WSMessageTypeError
@@ -29,7 +30,7 @@ from .http import (
 )
 from .http_websocket import _INTERNAL_RECEIVE_TYPES
 from .log import ws_logger
-from .streams import EofStream, FlowControlDataQueue
+from .streams import EofStream
 from .typedefs import JSONDecoder, JSONEncoder
 from .web_exceptions import HTTPBadRequest, HTTPException
 from .web_request import BaseRequest
@@ -79,7 +80,7 @@ class WebSocketResponse(StreamResponse):
         self._protocols = protocols
         self._ws_protocol: Optional[str] = None
         self._writer: Optional[WebSocketWriter] = None
-        self._reader: Optional[FlowControlDataQueue[WSMessage]] = None
+        self._reader: Optional[WebSocketDataQueue] = None
         self._closed = False
         self._closing = False
         self._conn_lost = 0
@@ -329,7 +330,7 @@ class WebSocketResponse(StreamResponse):
 
         loop = self._loop
         assert loop is not None
-        self._reader = FlowControlDataQueue(request._protocol, 2**16, loop=loop)
+        self._reader = WebSocketDataQueue(request._protocol, 2**16, loop=loop)
         request.protocol.set_parser(
             WebSocketReader(self._reader, self._max_msg_size, compress=self._compress)
         )

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -192,7 +192,7 @@ class WebSocketResponse(StreamResponse):
         self._set_code_close_transport(WSCloseCode.ABNORMAL_CLOSURE)
         self._exception = exc
         if self._waiting and not self._closing and self._reader is not None:
-            self._reader.feed_data(WSMessage(WSMsgType.ERROR, exc, None))
+            self._reader.feed_data(WSMessage(WSMsgType.ERROR, exc, None), 0)
 
     def _set_closed(self) -> None:
         """Set the connection to closed.
@@ -465,7 +465,7 @@ class WebSocketResponse(StreamResponse):
             assert self._loop is not None
             assert self._close_wait is None
             self._close_wait = self._loop.create_future()
-            reader.feed_data(WS_CLOSING_MESSAGE)
+            reader.feed_data(WS_CLOSING_MESSAGE, 0)
             await self._close_wait
 
         if self._closing:

--- a/tests/test_benchmarks_http_websocket.py
+++ b/tests/test_benchmarks_http_websocket.py
@@ -5,22 +5,17 @@ from typing import Union
 
 from pytest_codspeed import BenchmarkFixture
 
-from aiohttp import DataQueue
 from aiohttp._websocket.helpers import MSG_SIZE, PACK_LEN3
+from aiohttp._websocket.reader import WebSocketDataQueue
 from aiohttp.base_protocol import BaseProtocol
-from aiohttp.http_websocket import (
-    WebSocketReader,
-    WebSocketWriter,
-    WSMessage,
-    WSMsgType,
-)
+from aiohttp.http_websocket import WebSocketReader, WebSocketWriter, WSMsgType
 
 
 def test_read_large_binary_websocket_messages(
     loop: asyncio.AbstractEventLoop, benchmark: BenchmarkFixture
 ) -> None:
     """Read one hundred large binary websocket messages."""
-    queue: DataQueue[WSMessage] = DataQueue(loop=loop)
+    queue = WebSocketDataQueue(BaseProtocol(loop), 2**16, loop=loop)
     reader = WebSocketReader(queue, max_msg_size=2**18)
 
     # PACK3 has a minimum message length of 2**16 bytes.
@@ -41,7 +36,7 @@ def test_read_one_hundred_websocket_text_messages(
     loop: asyncio.AbstractEventLoop, benchmark: BenchmarkFixture
 ) -> None:
     """Benchmark reading 100 WebSocket text messages."""
-    queue: DataQueue[WSMessage] = DataQueue(loop=loop)
+    queue = WebSocketDataQueue(BaseProtocol(loop), 2**16, loop=loop)
     reader = WebSocketReader(queue, max_msg_size=2**16)
     raw_message = (
         b'\x81~\x01!{"id":1,"src":"shellyplugus-c049ef8c30e4","dst":"aios-1453812500'

--- a/tests/test_flowcontrol_streams.py
+++ b/tests/test_flowcontrol_streams.py
@@ -15,11 +15,6 @@ def stream(loop, protocol):
     return streams.StreamReader(protocol, limit=1, loop=loop)
 
 
-@pytest.fixture
-def buffer(loop, protocol):
-    return streams.FlowControlDataQueue(protocol, limit=1, loop=loop)
-
-
 class TestFlowControlStreamReader:
     async def test_read(self, stream) -> None:
         stream.feed_data(b"da", 2)
@@ -107,19 +102,4 @@ class TestFlowControlStreamReader:
         stream._protocol._reading_paused = False
         res = stream.read_nowait(5)
         assert res == b""
-        assert stream._protocol.resume_reading.call_count == 1
-
-
-class TestFlowControlDataQueue:
-    def test_feed_pause(self, buffer) -> None:
-        buffer._protocol._reading_paused = False
-        buffer.feed_data(object(), 100)
-
-        assert buffer._protocol.pause_reading.called
-
-    async def test_resume_on_read(self, buffer) -> None:
-        buffer.feed_data(object(), 100)
-
-        buffer._protocol._reading_paused = True
-        await buffer.read()
-        assert buffer._protocol.resume_reading.called
+        assert stream._protocol.resume_reading.call_count == 1  # type: ignore[attr-defined]

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -13,6 +13,7 @@ from yarl import URL
 
 import aiohttp
 from aiohttp import http_exceptions, streams
+from aiohttp.base_protocol import BaseProtocol
 from aiohttp.http_parser import (
     NO_EXTENSIONS,
     DeflateBuffer,
@@ -1561,17 +1562,17 @@ def test_parse_bad_method_for_c_parser_raises(loop, protocol):
 
 
 class TestParsePayload:
-    async def test_parse_eof_payload(self, stream) -> None:
-        out = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+    async def test_parse_eof_payload(self, protocol: BaseProtocol) -> None:
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out)
         p.feed_data(b"data")
         p.feed_eof()
 
         assert out.is_eof()
-        assert [(bytearray(b"data"), 4)] == list(out._buffer)
+        assert [(bytearray(b"data"))] == list(out._buffer)
 
-    async def test_parse_length_payload_eof(self, stream) -> None:
-        out = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+    async def test_parse_length_payload_eof(self, protocol: BaseProtocol) -> None:
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
 
         p = HttpPayloadParser(out, length=4)
         p.feed_data(b"da")
@@ -1579,15 +1580,19 @@ class TestParsePayload:
         with pytest.raises(http_exceptions.ContentLengthError):
             p.feed_eof()
 
-    async def test_parse_chunked_payload_size_error(self, stream) -> None:
-        out = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+    async def test_parse_chunked_payload_size_error(
+        self, protocol: BaseProtocol
+    ) -> None:
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, chunked=True)
         with pytest.raises(http_exceptions.TransferEncodingError):
             p.feed_data(b"blah\r\n")
         assert isinstance(out.exception(), http_exceptions.TransferEncodingError)
 
-    async def test_parse_chunked_payload_split_end(self, protocol) -> None:
-        out = aiohttp.StreamReader(protocol, 2**16, loop=None)
+    async def test_parse_chunked_payload_split_end(
+        self, protocol: BaseProtocol
+    ) -> None:
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, chunked=True)
         p.feed_data(b"4\r\nasdf\r\n0\r\n")
         p.feed_data(b"\r\n")
@@ -1595,8 +1600,10 @@ class TestParsePayload:
         assert out.is_eof()
         assert b"asdf" == b"".join(out._buffer)
 
-    async def test_parse_chunked_payload_split_end2(self, protocol) -> None:
-        out = aiohttp.StreamReader(protocol, 2**16, loop=None)
+    async def test_parse_chunked_payload_split_end2(
+        self, protocol: BaseProtocol
+    ) -> None:
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, chunked=True)
         p.feed_data(b"4\r\nasdf\r\n0\r\n\r")
         p.feed_data(b"\n")
@@ -1604,8 +1611,10 @@ class TestParsePayload:
         assert out.is_eof()
         assert b"asdf" == b"".join(out._buffer)
 
-    async def test_parse_chunked_payload_split_end_trailers(self, protocol) -> None:
-        out = aiohttp.StreamReader(protocol, 2**16, loop=None)
+    async def test_parse_chunked_payload_split_end_trailers(
+        self, protocol: BaseProtocol
+    ) -> None:
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, chunked=True)
         p.feed_data(b"4\r\nasdf\r\n0\r\n")
         p.feed_data(b"Content-MD5: 912ec803b2ce49e4a541068d495ab570\r\n")
@@ -1614,8 +1623,10 @@ class TestParsePayload:
         assert out.is_eof()
         assert b"asdf" == b"".join(out._buffer)
 
-    async def test_parse_chunked_payload_split_end_trailers2(self, protocol) -> None:
-        out = aiohttp.StreamReader(protocol, 2**16, loop=None)
+    async def test_parse_chunked_payload_split_end_trailers2(
+        self, protocol: BaseProtocol
+    ) -> None:
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, chunked=True)
         p.feed_data(b"4\r\nasdf\r\n0\r\n")
         p.feed_data(b"Content-MD5: 912ec803b2ce49e4a541068d495ab570\r\n\r")
@@ -1624,8 +1635,10 @@ class TestParsePayload:
         assert out.is_eof()
         assert b"asdf" == b"".join(out._buffer)
 
-    async def test_parse_chunked_payload_split_end_trailers3(self, protocol) -> None:
-        out = aiohttp.StreamReader(protocol, 2**16, loop=None)
+    async def test_parse_chunked_payload_split_end_trailers3(
+        self, protocol: BaseProtocol
+    ) -> None:
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, chunked=True)
         p.feed_data(b"4\r\nasdf\r\n0\r\nContent-MD5: ")
         p.feed_data(b"912ec803b2ce49e4a541068d495ab570\r\n\r\n")
@@ -1633,8 +1646,10 @@ class TestParsePayload:
         assert out.is_eof()
         assert b"asdf" == b"".join(out._buffer)
 
-    async def test_parse_chunked_payload_split_end_trailers4(self, protocol) -> None:
-        out = aiohttp.StreamReader(protocol, 2**16, loop=None)
+    async def test_parse_chunked_payload_split_end_trailers4(
+        self, protocol: BaseProtocol
+    ) -> None:
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, chunked=True)
         p.feed_data(b"4\r\nasdf\r\n0\r\nC")
         p.feed_data(b"ontent-MD5: 912ec803b2ce49e4a541068d495ab570\r\n\r\n")
@@ -1642,82 +1657,93 @@ class TestParsePayload:
         assert out.is_eof()
         assert b"asdf" == b"".join(out._buffer)
 
-    async def test_http_payload_parser_length(self, stream) -> None:
-        out = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+    async def test_http_payload_parser_length(self, protocol: BaseProtocol) -> None:
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, length=2)
         eof, tail = p.feed_data(b"1245")
         assert eof
 
-        assert b"12" == b"".join(d for d, _ in out._buffer)
+        assert b"12" == out._buffer[0]
         assert b"45" == tail
 
-    async def test_http_payload_parser_deflate(self, stream) -> None:
+    async def test_http_payload_parser_deflate(self, protocol: BaseProtocol) -> None:
         # c=compressobj(wbits=15); b''.join([c.compress(b'data'), c.flush()])
         COMPRESSED = b"x\x9cKI,I\x04\x00\x04\x00\x01\x9b"
 
         length = len(COMPRESSED)
-        out = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, length=length, compression="deflate")
         p.feed_data(COMPRESSED)
-        assert b"data" == b"".join(d for d, _ in out._buffer)
+        assert b"data" == out._buffer[0]
         assert out.is_eof()
 
-    async def test_http_payload_parser_deflate_no_hdrs(self, stream: Any) -> None:
+    async def test_http_payload_parser_deflate_no_hdrs(
+        self, protocol: BaseProtocol
+    ) -> None:
         """Tests incorrectly formed data (no zlib headers)."""
         # c=compressobj(wbits=-15); b''.join([c.compress(b'data'), c.flush()])
         COMPRESSED = b"KI,I\x04\x00"
 
         length = len(COMPRESSED)
-        out = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, length=length, compression="deflate")
         p.feed_data(COMPRESSED)
-        assert b"data" == b"".join(d for d, _ in out._buffer)
+        assert b"data" == out._buffer[0]
         assert out.is_eof()
 
-    async def test_http_payload_parser_deflate_light(self, stream) -> None:
+    async def test_http_payload_parser_deflate_light(
+        self, protocol: BaseProtocol
+    ) -> None:
         # c=compressobj(wbits=9); b''.join([c.compress(b'data'), c.flush()])
         COMPRESSED = b"\x18\x95KI,I\x04\x00\x04\x00\x01\x9b"
 
         length = len(COMPRESSED)
-        out = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, length=length, compression="deflate")
         p.feed_data(COMPRESSED)
-        assert b"data" == b"".join(d for d, _ in out._buffer)
+
+        assert b"data" == out._buffer[0]
         assert out.is_eof()
 
-    async def test_http_payload_parser_deflate_split(self, stream) -> None:
-        out = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+    async def test_http_payload_parser_deflate_split(
+        self, protocol: BaseProtocol
+    ) -> None:
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, compression="deflate")
         # Feeding one correct byte should be enough to choose exact
         # deflate decompressor
-        p.feed_data(b"x", 1)
-        p.feed_data(b"\x9cKI,I\x04\x00\x04\x00\x01\x9b", 11)
+        p.feed_data(b"x")
+        p.feed_data(b"\x9cKI,I\x04\x00\x04\x00\x01\x9b")
         p.feed_eof()
-        assert b"data" == b"".join(d for d, _ in out._buffer)
+        assert b"data" == out._buffer[0]
 
-    async def test_http_payload_parser_deflate_split_err(self, stream) -> None:
-        out = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+    async def test_http_payload_parser_deflate_split_err(
+        self, protocol: BaseProtocol
+    ) -> None:
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, compression="deflate")
         # Feeding one wrong byte should be enough to choose exact
         # deflate decompressor
-        p.feed_data(b"K", 1)
-        p.feed_data(b"I,I\x04\x00", 5)
+        p.feed_data(b"K")
+        p.feed_data(b"I,I\x04\x00")
         p.feed_eof()
-        assert b"data" == b"".join(d for d, _ in out._buffer)
+        assert b"data" == out._buffer[0]
 
-    async def test_http_payload_parser_length_zero(self, stream) -> None:
-        out = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+    async def test_http_payload_parser_length_zero(
+        self, protocol: BaseProtocol
+    ) -> None:
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, length=0)
         assert p.done
         assert out.is_eof()
 
     @pytest.mark.skipif(brotli is None, reason="brotli is not installed")
-    async def test_http_payload_brotli(self, stream) -> None:
+    async def test_http_payload_brotli(self, protocol: BaseProtocol) -> None:
         compressed = brotli.compress(b"brotli data")
-        out = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, length=len(compressed), compression="br")
         p.feed_data(compressed)
-        assert b"brotli data" == b"".join(d for d, _ in out._buffer)
+        assert b"brotli data" == out._buffer[0]
         assert out.is_eof()
 
 
@@ -1731,7 +1757,7 @@ class TestDeflateBuffer:
 
         # First byte should be b'x' in order code not to change the decoder.
         dbuf.feed_data(b"xxxx", 4)
-        assert [b"line"] == list(d for d, _ in buf._buffer)
+        assert [b"line"] == list(buf._buffer)
 
     async def test_feed_data_err(self, stream) -> None:
         buf = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
@@ -1746,19 +1772,19 @@ class TestDeflateBuffer:
             # Should start with b'x', otherwise code switch mocked decoder.
             dbuf.feed_data(b"xsomedata", 9)
 
-    async def test_feed_eof(self, stream) -> None:
-        buf = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+    async def test_feed_eof(self, protocol: BaseProtocol) -> None:
+        buf = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         dbuf = DeflateBuffer(buf, "deflate")
 
         dbuf.decompressor = mock.Mock()
         dbuf.decompressor.flush.return_value = b"line"
 
         dbuf.feed_eof()
-        assert [b"line"] == list(d for d, _ in buf._buffer)
+        assert [b"line"] == list(buf._buffer)
         assert buf._eof
 
-    async def test_feed_eof_err_deflate(self, stream) -> None:
-        buf = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+    async def test_feed_eof_err_deflate(self, protocol: BaseProtocol) -> None:
+        buf = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         dbuf = DeflateBuffer(buf, "deflate")
 
         dbuf.decompressor = mock.Mock()
@@ -1768,8 +1794,8 @@ class TestDeflateBuffer:
         with pytest.raises(http_exceptions.ContentEncodingError):
             dbuf.feed_eof()
 
-    async def test_feed_eof_no_err_gzip(self, stream) -> None:
-        buf = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+    async def test_feed_eof_no_err_gzip(self, protocol: BaseProtocol) -> None:
+        buf = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         dbuf = DeflateBuffer(buf, "gzip")
 
         dbuf.decompressor = mock.Mock()
@@ -1777,10 +1803,10 @@ class TestDeflateBuffer:
         dbuf.decompressor.eof = False
 
         dbuf.feed_eof()
-        assert [b"line"] == list(d for d, _ in buf._buffer)
+        assert [b"line"] == list(buf._buffer)
 
-    async def test_feed_eof_no_err_brotli(self, stream) -> None:
-        buf = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+    async def test_feed_eof_no_err_brotli(self, protocol: BaseProtocol) -> None:
+        buf = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         dbuf = DeflateBuffer(buf, "br")
 
         dbuf.decompressor = mock.Mock()
@@ -1788,10 +1814,10 @@ class TestDeflateBuffer:
         dbuf.decompressor.eof = False
 
         dbuf.feed_eof()
-        assert [b"line"] == list(d for d, _ in buf._buffer)
+        assert [b"line"] == list(buf._buffer)
 
-    async def test_empty_body(self, stream) -> None:
-        buf = aiohttp.StreamReader(stream, 2**16, loop=asyncio.get_event_loop())
+    async def test_empty_body(self, protocol: BaseProtocol) -> None:
+        buf = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         dbuf = DeflateBuffer(buf, "deflate")
         dbuf.feed_eof()
 

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -258,7 +258,7 @@ async def test_raise_writer_limit(make_request) -> None:
     assert ws._reader is not None
     assert ws._writer is not None
     assert ws._writer._limit == 1234567
-    ws._reader.feed_data(WS_CLOSED_MESSAGE)
+    ws._reader.feed_data(WS_CLOSED_MESSAGE, 0)
     await ws.close()
 
 
@@ -279,7 +279,7 @@ async def test_recv_str_closed(make_request) -> None:
     ws = web.WebSocketResponse()
     await ws.prepare(req)
     assert ws._reader is not None
-    ws._reader.feed_data(WS_CLOSED_MESSAGE)
+    ws._reader.feed_data(WS_CLOSED_MESSAGE, 0)
     await ws.close()
 
     with pytest.raises(
@@ -305,7 +305,7 @@ async def test_recv_bytes_closed(make_request) -> None:
     ws = web.WebSocketResponse()
     await ws.prepare(req)
     assert ws._reader is not None
-    ws._reader.feed_data(WS_CLOSED_MESSAGE)
+    ws._reader.feed_data(WS_CLOSED_MESSAGE, 0)
     await ws.close()
 
     with pytest.raises(
@@ -331,7 +331,7 @@ async def test_send_frame_closed(make_request) -> None:
     ws = WebSocketResponse()
     await ws.prepare(req)
     assert ws._reader is not None
-    ws._reader.feed_data(WS_CLOSED_MESSAGE)
+    ws._reader.feed_data(WS_CLOSED_MESSAGE, 0)
     await ws.close()
 
     with pytest.raises(ConnectionError):

--- a/tests/test_websocket_data_queue.py
+++ b/tests/test_websocket_data_queue.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from aiohttp._websocket.models import WSMessageBinary
+from aiohttp._websocket.models import WSMessage, WSMsgType
 from aiohttp._websocket.reader import WebSocketDataQueue
 from aiohttp.base_protocol import BaseProtocol
 
@@ -24,12 +24,12 @@ class TestWebSocketDataQueue:
     def test_feed_pause(self, buffer: WebSocketDataQueue) -> None:
         buffer._protocol._reading_paused = False
         for _ in range(3):
-            buffer.feed_data(WSMessageBinary(b"x", size=1))
+            buffer.feed_data(WSMessage(data=b"x", type=WSMsgType.BINARY, extra=""), 1)
 
         assert buffer._protocol.pause_reading.called  # type: ignore[attr-defined]
 
     async def test_resume_on_read(self, buffer: WebSocketDataQueue) -> None:
-        buffer.feed_data(WSMessageBinary(b"x", size=1))
+        buffer.feed_data(WSMessage(data=b"x", type=WSMsgType.BINARY, extra=""), 1)
 
         buffer._protocol._reading_paused = True
         await buffer.read()

--- a/tests/test_websocket_data_queue.py
+++ b/tests/test_websocket_data_queue.py
@@ -1,0 +1,36 @@
+import asyncio
+from unittest import mock
+
+import pytest
+
+from aiohttp._websocket.models import WSMessageBinary
+from aiohttp._websocket.reader import WebSocketDataQueue
+from aiohttp.base_protocol import BaseProtocol
+
+
+@pytest.fixture
+def protocol() -> BaseProtocol:
+    return mock.create_autospec(BaseProtocol, spec_set=True, instance=True, _reading_paused=False)  # type: ignore[no-any-return]
+
+
+@pytest.fixture
+def buffer(
+    loop: asyncio.AbstractEventLoop, protocol: BaseProtocol
+) -> WebSocketDataQueue:
+    return WebSocketDataQueue(protocol, limit=1, loop=loop)
+
+
+class TestWebSocketDataQueue:
+    def test_feed_pause(self, buffer: WebSocketDataQueue) -> None:
+        buffer._protocol._reading_paused = False
+        for _ in range(3):
+            buffer.feed_data(WSMessageBinary(b"x", size=1))
+
+        assert buffer._protocol.pause_reading.called  # type: ignore[attr-defined]
+
+    async def test_resume_on_read(self, buffer: WebSocketDataQueue) -> None:
+        buffer.feed_data(WSMessageBinary(b"x", size=1))
+
+        buffer._protocol._reading_paused = True
+        await buffer.read()
+        assert buffer._protocol.resume_reading.called  # type: ignore[attr-defined]

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -225,7 +225,7 @@ def test_parse_frame_header_payload_size(out, parser) -> None:
     ids=["bytes", "bytearray", "memoryview"],
 )
 def test_ping_frame(
-    out: aiohttp.DataQueue[WSMessage],
+    out: WebSocketDataQueue,
     parser: WebSocketReader,
     data: Union[bytes, bytearray, memoryview],
 ) -> None:
@@ -545,8 +545,10 @@ def test_parse_compress_error_frame(parser) -> None:
     assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
 
 
-async def test_parse_no_compress_frame_single(loop: asyncio.AbstractEventLoop) -> None:
-    parser_no_compress = WebSocketReader(aiohttp.DataQueue(loop), 0, compress=False)
+async def test_parse_no_compress_frame_single(
+    loop: asyncio.AbstractEventLoop, out: WebSocketDataQueue
+) -> None:
+    parser_no_compress = WebSocketReader(out, 0, compress=False)
     with pytest.raises(WebSocketError) as ctx:
         parser_no_compress.parse_frame(struct.pack("!BB", 0b11000001, 0b00000001))
         parser_no_compress.parse_frame(b"1")

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -5,7 +5,8 @@ from unittest import mock
 
 import pytest
 
-from aiohttp import DataQueue, WSMessage, WSMsgType
+from aiohttp import WSMsgType
+from aiohttp._websocket.reader import WebSocketDataQueue
 from aiohttp.http import WebSocketReader, WebSocketWriter
 from aiohttp.test_utils import make_mocked_coro
 
@@ -144,7 +145,8 @@ async def test_concurrent_messages(
         "aiohttp._websocket.writer.WEBSOCKET_MAX_SYNC_CHUNK_SIZE", max_sync_chunk_size
     ):
         writer = WebSocketWriter(protocol, transport, compress=15)
-        queue: DataQueue[WSMessage] = DataQueue(asyncio.get_running_loop())
+        loop = asyncio.get_running_loop()
+        queue = WebSocketDataQueue(mock.Mock(_reading_paused=False), 2**16, loop=loop)
         reader = WebSocketReader(queue, 50000)
         writers = []
         payloads = []


### PR DESCRIPTION
Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
(cherry picked from commit 5241897f6459926028803caaa4782b8ba84f0562)

Note that the code that changed WebSocket messages to be a Union of different types has been stripped out, and the size argument/internal tuple to `feed_data` has been retained for compatibility with 3.11