### PR TITLE
Switch WebSocketWriter to use `removesuffix` to drop compression trailer

### DIFF
--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -92,16 +92,16 @@ class WebSocketWriter:
                     self._compressobj = self._make_compress_obj(self.compress)
                 compressobj = self._compressobj
 
-            message = await compressobj.compress(message)
+            message = (
+                await compressobj.compress(message)
+                + compressobj.flush(
+                    zlib.Z_FULL_FLUSH if self.notakeover else zlib.Z_SYNC_FLUSH
+                )
+            ).removesuffix(WS_DEFLATE_TRAILING)
             # Its critical that we do not return control to the event
             # loop until we have finished sending all the compressed
             # data. Otherwise we could end up mixing compressed frames
             # if there are multiple coroutines compressing data.
-            message += compressobj.flush(
-                zlib.Z_FULL_FLUSH if self.notakeover else zlib.Z_SYNC_FLUSH
-            )
-            if message.endswith(WS_DEFLATE_TRAILING):
-                message = message[:-4]
 
         msg_length = len(message)
 


### PR DESCRIPTION
Now that Python 3.8 is no longer supported (`master` and `3.11` only) we can use `bytes.removesuffix`

This also takes care of one uncovered branch in the tests and brings the `WebSocketWriter` up to 100% line/branch coverage

Its small improvement, considering how much time the compression actually takes. It will be >10% if using `isal` for compression though since the compression overhead is far less when using alternative `zlib` see https://github.com/aio-libs/aiohttp/issues/9798
<img width="246" alt="Screenshot 2024-11-11 at 8 31 43 AM" src="https://github.com/user-attachments/assets/90c184f9-5dc1-4653-af3f-6f2da7a649e5">

