### PR TITLE
Avoid calling the drain helper in `WebSocketWriter` if the protocol is not paused

### DIFF
--- a/CHANGES/9796.misc.rst
+++ b/CHANGES/9796.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of the ``WebsocketWriter`` when the protocol is not paused -- by :user:`bdraco`.

--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -155,7 +155,8 @@ class WebSocketWriter:
         # if the writer is not paused.
         if self._output_size > self._limit:
             self._output_size = 0
-            await self.protocol._drain_helper()
+            if self.protocol.writing_paused:
+                await self.protocol._drain_helper()
 
     def _make_compress_obj(self, compress: int) -> ZLibCompressor:
         return ZLibCompressor(

--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -155,7 +155,7 @@ class WebSocketWriter:
         # if the writer is not paused.
         if self._output_size > self._limit:
             self._output_size = 0
-            if self.protocol.writing_paused:
+            if self.protocol._paused:
                 await self.protocol._drain_helper()
 
     def _make_compress_obj(self, compress: int) -> ZLibCompressor:


### PR DESCRIPTION
We already know its connected or it would have raised for `is_closing` so we can guard calling the coro with a check to see if its paused