### PR TITLE
Fix incorrect typing on `WebSocketResponse._handshake`

### DIFF
--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -125,7 +125,7 @@ class WebSocketResponse(StreamResponse):
         if heartbeat is not None:
             self._pong_heartbeat = heartbeat / 2.0
         self._pong_response_cb: Optional[asyncio.TimerHandle] = None
-        self._compress = compress
+        self._compress: Union[bool, int] = compress
         self._max_msg_size = max_msg_size
         self._ping_task: Optional[asyncio.Task[None]] = None
         self._writer_limit = writer_limit

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -5,7 +5,7 @@ import dataclasses
 import hashlib
 import json
 import sys
-from typing import Any, Final, Iterable, Optional, Tuple
+from typing import Any, Final, Iterable, Optional, Tuple, Union
 
 from multidict import CIMultiDict
 
@@ -333,7 +333,7 @@ class WebSocketResponse(StreamResponse):
         self.set_status(101)
         self.headers.update(headers)
         self.force_close()
-        self._compress = bool(compress)
+        self._compress = compress
         transport = request._protocol.transport
         assert transport is not None
         writer = WebSocketWriter(
@@ -386,7 +386,7 @@ class WebSocketResponse(StreamResponse):
         return self._ws_protocol
 
     @property
-    def compress(self) -> bool:
+    def compress(self) -> Union[int, bool]:
         return self._compress
 
     def get_extra_info(self, name: str, default: Any = None) -> Any:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -358,7 +358,9 @@ class WebSocketResponse(StreamResponse):
         assert loop is not None
         self._reader = WebSocketDataQueue(request._protocol, 2**16, loop=loop)
         request.protocol.set_parser(
-            WebSocketReader(self._reader, self._max_msg_size, compress=self._compress)
+            WebSocketReader(
+                self._reader, self._max_msg_size, compress=bool(self._compress)
+            )
         )
         # disable HTTP keepalive for WebSocket
         request.protocol.keep_alive(False)

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -242,7 +242,7 @@ class WebSocketResponse(StreamResponse):
 
     def _handshake(
         self, request: BaseRequest
-    ) -> Tuple["CIMultiDict[str]", str, bool, bool]:
+    ) -> Tuple["CIMultiDict[str]", str, int, bool]:
         headers = request.headers
         if "websocket" != headers.get(hdrs.UPGRADE, "").lower().strip():
             raise HTTPBadRequest(
@@ -323,7 +323,7 @@ class WebSocketResponse(StreamResponse):
             protocol,
             compress,
             notakeover,
-        )  # type: ignore[return-value]
+        )
 
     def _pre_start(self, request: BaseRequest) -> Tuple[str, WebSocketWriter]:
         self._loop = request._loop
@@ -333,7 +333,7 @@ class WebSocketResponse(StreamResponse):
         self.set_status(101)
         self.headers.update(headers)
         self.force_close()
-        self._compress = compress
+        self._compress = bool(compress)
         transport = request._protocol.transport
         assert transport is not None
         writer = WebSocketWriter(

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -242,7 +242,7 @@ class WebSocketResponse(StreamResponse):
 
     def _handshake(
         self, request: BaseRequest
-    ) -> Tuple["CIMultiDict[str]", str, int, bool]:
+    ) -> Tuple["CIMultiDict[str]", Optional[str], int, bool]:
         headers = request.headers
         if "websocket" != headers.get(hdrs.UPGRADE, "").lower().strip():
             raise HTTPBadRequest(
@@ -260,7 +260,7 @@ class WebSocketResponse(StreamResponse):
             )
 
         # find common sub-protocol between client and server
-        protocol = None
+        protocol: Optional[str] = None
         if hdrs.SEC_WEBSOCKET_PROTOCOL in headers:
             req_protocols = [
                 str(proto.strip())
@@ -325,7 +325,7 @@ class WebSocketResponse(StreamResponse):
             notakeover,
         )
 
-    def _pre_start(self, request: BaseRequest) -> Tuple[str, WebSocketWriter]:
+    def _pre_start(self, request: BaseRequest) -> Tuple[Optional[str], WebSocketWriter]:
         self._loop = request._loop
 
         headers, protocol, compress, notakeover = self._handshake(request)
@@ -347,7 +347,7 @@ class WebSocketResponse(StreamResponse):
         return protocol, writer
 
     def _post_start(
-        self, request: BaseRequest, protocol: str, writer: WebSocketWriter
+        self, request: BaseRequest, protocol: Optional[str], writer: WebSocketWriter
     ) -> None:
         self._ws_protocol = protocol
         self._writer = writer


### PR DESCRIPTION
The compress type is an `int` not a `bool`. The protocol type can be `None`

