### PR TITLE
Add `__slots__` to `UrlMappingMatchInfo`

### DIFF
--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -59,6 +59,9 @@ class AbstractRouter(ABC):
 
 
 class AbstractMatchInfo(ABC):
+
+    __slots__ = ()
+
     @property  # pragma: no branch
     @abstractmethod
     def handler(self) -> Callable[[Request], Awaitable[StreamResponse]]:

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -227,6 +227,9 @@ class AbstractRoute(abc.ABC):
 
 
 class UrlMappingMatchInfo(BaseDict, AbstractMatchInfo):
+
+    __slots__ = ("_route", "_apps", "_current_app", "_frozen")
+
     def __init__(self, match_dict: Dict[str, str], route: AbstractRoute):
         super().__init__(match_dict)
         self._route = route
@@ -289,6 +292,9 @@ class UrlMappingMatchInfo(BaseDict, AbstractMatchInfo):
 
 
 class MatchInfoError(UrlMappingMatchInfo):
+
+    __slots__ = ("_exception",)
+
     def __init__(self, http_exception: HTTPException) -> None:
         self._exception = http_exception
         super().__init__({}, SystemRoute(self._exception))

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -230,7 +230,7 @@ class UrlMappingMatchInfo(BaseDict, AbstractMatchInfo):
 
     __slots__ = ("_route", "_apps", "_current_app", "_frozen")
 
-    def __init__(self, match_dict: Dict[str, str], route: AbstractRoute):
+    def __init__(self, match_dict: Dict[str, str], route: AbstractRoute) -> None:
         super().__init__(match_dict)
         self._route = route
         self._apps: List[Application] = []


### PR DESCRIPTION
We churn these objects on every request, this will save a bit of RAM.

I was a bit surprised that the benchmark shows it makes a measurable difference in `__init__`
<img width="251" alt="Screenshot 2024-11-11 at 9 33 53 AM" src="https://github.com/user-attachments/assets/1a7e8dd6-820d-4155-b9d7-6faa0d2a7fd5">
<img width="253" alt="Screenshot 2024-11-11 at 9 33 49 AM" src="https://github.com/user-attachments/assets/13698dcd-b950-4c08-b45c-2af23a24fbe7">

and `add_app`
<img width="243" alt="Screenshot 2024-11-11 at 9 39 20 AM" src="https://github.com/user-attachments/assets/9be0458d-685d-4ac3-ba3d-d0a70d8ee747">
