### PR TITLE
Small performance improvement to Cython `HttpParser` `process_header`

### DIFF
--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -296,6 +296,7 @@ cdef class HttpParser:
         str     _path
         str     _reason
         object  _headers
+        object  _headers_add
         list    _raw_headers
         bint    _upgraded
         list    _messages
@@ -376,7 +377,10 @@ cdef class HttpParser:
         self._last_error = None
         self._limit = limit
 
+        self._headers_add = self._headers.add
+
     cdef _process_header(self):
+        cdef str value
         if self._raw_name:
             raw_name = bytes(self._raw_name)
             raw_value = bytes(self._raw_value)
@@ -384,7 +388,7 @@ cdef class HttpParser:
             name = find_header(raw_name)
             value = raw_value.decode('utf-8', 'surrogateescape')
 
-            self._headers.add(name, value)
+            self._headers_add(name, value)
 
             if name is CONTENT_ENCODING:
                 self._content_encoding = value

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -377,8 +377,6 @@ cdef class HttpParser:
         self._last_error = None
         self._limit = limit
 
-        self._headers_add = self._headers.add
-
     cdef _process_header(self):
         cdef str value
         if self._raw_name:
@@ -676,6 +674,7 @@ cdef int cb_on_message_begin(cparser.llhttp_t* parser) except -1:
 
     pyparser._started = True
     pyparser._headers = CIMultiDict()
+    pyparser._headers_add = pyparser._headers.add
     pyparser._raw_headers = []
     PyByteArray_Resize(pyparser._buf, 0)
     pyparser._path = None


### PR DESCRIPTION
- Avoid a `str` check on each header
- Avoid looking up the `add` method on every header