### PR TITLE
Remove connector close workaround for older Python versions

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -701,10 +701,6 @@ class BaseConnector:
         if should_close or protocol.should_close:
             transport = protocol.transport
             protocol.close()
-            # TODO: Remove once fixed: https://bugs.python.org/issue39951
-            # See PR #6321
-            set_result(protocol.closed, None)
-
             if key.is_ssl and not self._cleanup_closed_disabled:
                 self._cleanup_closed_transports.append(transport)
             return

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -586,18 +586,6 @@ async def test_release_close(key: ConnectionKey) -> None:
     await conn.close()
 
 
-async def test_release_proto_closed_future(
-    loop: asyncio.AbstractEventLoop, key: ConnectionKey
-) -> None:
-    conn = aiohttp.BaseConnector()
-    protocol = mock.Mock(should_close=True, closed=loop.create_future())
-    conn._release(key, protocol)
-    # See PR #6321
-    assert protocol.closed.result() is None
-
-    await conn.close()
-
-
 async def test__release_acquired_per_host1(
     loop: asyncio.AbstractEventLoop, key: ConnectionKey
 ) -> None:


### PR DESCRIPTION
The TODO is fixed on all supported versions which was added in https://github.com/aio-libs/aiohttp/pull/6321

https://github.com/python/cpython/issues/84132

Note this code is not present in 3.x
