### PR TITLE
Improve performance of the access logger when its disabled

### DIFF
--- a/CHANGES/9822.feature.rst
+++ b/CHANGES/9822.feature.rst
@@ -1,0 +1,1 @@
+Added an :attr:`~aiohttp.abc.AbstractAccessLogger.enabled` property to :class:`aiohttp.abc.AbstractAccessLogger` to dynamically check if logging is enabled -- by :user:`bdraco`.

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -235,12 +235,24 @@ class AbstractAccessLogger(ABC):
     def log(self, request: BaseRequest, response: StreamResponse, time: float) -> None:
         """Emit log to logger."""
 
+    @property
+    def enabled(self) -> bool:
+        """Check if logger is enabled."""
+        return True
+
 
 class AbstractAsyncAccessLogger(ABC):
     """Abstract asynchronous writer to access log."""
+
+    __slots__ = ()
 
     @abstractmethod
     async def log(
         self, request: BaseRequest, response: StreamResponse, request_start: float
     ) -> None:
         """Emit log to logger."""
+
+    @property
+    def enabled(self) -> bool:
+        """Check if logger is enabled."""
+        return True

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -227,6 +227,8 @@ class AbstractStreamWriter(ABC):
 class AbstractAccessLogger(ABC):
     """Abstract writer to access log."""
 
+    __slots__ = ("logger", "log_format")
+
     def __init__(self, logger: logging.Logger, log_format: str) -> None:
         self.logger = logger
         self.log_format = log_format

--- a/aiohttp/web_log.py
+++ b/aiohttp/web_log.py
@@ -181,6 +181,7 @@ class AccessLogger(AbstractAccessLogger):
     ) -> Iterable[Tuple[str, Callable[[BaseRequest, StreamResponse, float], str]]]:
         return [(key, method(request, response, time)) for key, method in self._methods]
 
+    @property
     def enabled(self) -> bool:
         """Check if logger is enabled."""
         # Avoid formatting the log line if it will not be emitted.

--- a/aiohttp/web_log.py
+++ b/aiohttp/web_log.py
@@ -181,10 +181,12 @@ class AccessLogger(AbstractAccessLogger):
     ) -> Iterable[Tuple[str, Callable[[BaseRequest, StreamResponse, float], str]]]:
         return [(key, method(request, response, time)) for key, method in self._methods]
 
+    def enabled(self) -> bool:
+        """Check if logger is enabled."""
+        # Avoid formatting the log line if it will not be emitted.
+        return self.logger.isEnabledFor(logging.INFO)
+
     def log(self, request: BaseRequest, response: StreamResponse, time: float) -> None:
-        if not self.logger.isEnabledFor(logging.INFO):
-            # Avoid formatting the log line if it will not be emitted.
-            return
         try:
             fmt_info = self._format_line(request, response, time)
 

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -182,7 +182,7 @@ Abstract Access Logger
 
       :param float time: Time taken to serve the request.
 
-   .. method:: enabled
+   .. attribute:: enabled
 
         Return True if logger is enabled.
 

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -182,7 +182,7 @@ Abstract Access Logger
 
       :param float time: Time taken to serve the request.
 
-   .. attr:: enabled
+   .. method:: enabled
 
         Return True if logger is enabled.
 

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -182,6 +182,15 @@ Abstract Access Logger
 
       :param float time: Time taken to serve the request.
 
+   .. attr:: enabled
+
+        Return True if logger is enabled.
+
+        Override this property if logging is disabled to avoid the
+        overhead of calculating details to feed the logger.
+
+        This property may be omitted if logging is always enabled.
+
 
 Abstract Resolver
 -------------------------------

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -139,6 +139,15 @@ If your logging needs to perform IO you can instead inherit from
                                     f'"{request.method} {request.path} '
                                     f'done in {time}s: {response.status}')
 
+      @property
+      def enabled(self):
+          """Return True if logger is enabled.
+
+          Override this property if logging is disabled to avoid the
+          overhead of calculating details to feed the logger.
+          """
+          return True
+
 
 This also allows access to the results of coroutines on the ``request`` and
 ``response``, e.g. ``request.text()``.

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -114,6 +114,16 @@ Example of a drop-in replacement for the default access logger::
                            f'"{request.method} {request.path} '
                            f'done in {time}s: {response.status}')
 
+      @property
+      def enabled(self):
+          """Return True if logger is enabled.
+
+          Override this property if logging is disabled to avoid the
+          overhead of calculating details to feed the logger.
+
+          This property may be omitted if logging is always enabled.
+          """
+          return self.logger.isEnabledFor(logging.INFO)
 
 .. versionadded:: 4.0.0
 
@@ -146,7 +156,7 @@ If your logging needs to perform IO you can instead inherit from
           Override this property if logging is disabled to avoid the
           overhead of calculating details to feed the logger.
           """
-          return True
+          return self.logger.isEnabledFor(logging.INFO)
 
 
 This also allows access to the results of coroutines on the ``request`` and

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -140,7 +140,7 @@ If your logging needs to perform IO you can instead inherit from
                                     f'done in {time}s: {response.status}')
 
       @property
-      def enabled(self):
+      def enabled(self) -> bool:
           """Return True if logger is enabled.
 
           Override this property if logging is disabled to avoid the

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -301,7 +301,7 @@ async def test_logger_does_not_log_when_not_enabled(
         def log(
             self, request: web.BaseRequest, response: web.StreamResponse, time: float
         ) -> None:
-            assert False, "This should not be called"
+            self.logger.critical("This should not be logged")  # pragma: no cover
 
         @property
         def enabled(self) -> bool:
@@ -313,3 +313,4 @@ async def test_logger_does_not_log_when_not_enabled(
     client = await aiohttp_client(server)
     resp = await client.get("/")
     assert 200 == resp.status
+    assert "This should not be logged" not in caplog.text

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -301,7 +301,7 @@ async def test_logger_does_not_log_when_not_enabled(
         def log(
             self, request: web.BaseRequest, response: web.StreamResponse, time: float
         ) -> None:
-            self.logger.critical("This should not be logged")
+            assert False, "This should not be called"
 
         @property
         def enabled(self) -> bool:
@@ -313,4 +313,3 @@ async def test_logger_does_not_log_when_not_enabled(
     client = await aiohttp_client(server)
     resp = await client.get("/")
     assert 200 == resp.status
-    assert "This should not be logged" not in caplog.text

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -297,11 +297,13 @@ async def test_logger_does_not_log_when_not_enabled(
         return web.Response()
 
     class Logger(AbstractAccessLogger):
+
         def log(
             self, request: web.BaseRequest, response: web.StreamResponse, time: float
         ) -> None:
-            self.logger.info("This should not be logged")
+            self.logger.critical("This should not be logged")
 
+        @property
         def enabled(self) -> bool:
             return False
 

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -275,8 +275,8 @@ async def test_contextvars_logger(
     assert msg == "contextvars: uuid"
 
 
-def test_logger_does_nothing_when_disabled(caplog: pytest.LogCaptureFixture) -> None:
-    """Test that the logger does nothing when the log level is disabled."""
+def test_access_logger_feeds_logger(caplog: pytest.LogCaptureFixture) -> None:
+    """Test that the logger still works."""
     mock_logger = logging.getLogger("test.aiohttp.log")
     mock_logger.setLevel(logging.INFO)
     access_logger = AccessLogger(mock_logger, "%b")
@@ -284,3 +284,31 @@ def test_logger_does_nothing_when_disabled(caplog: pytest.LogCaptureFixture) -> 
         mock.Mock(name="mock_request"), mock.Mock(name="mock_response"), 42
     )
     assert "mock_response" in caplog.text
+
+
+async def test_logger_does_not_log_when_not_enabled(
+    aiohttp_server: AiohttpServer,
+    aiohttp_client: AiohttpClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test logger does nothing when not enabled."""
+
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response()
+
+    class Logger(AbstractAccessLogger):
+        def log(
+            self, request: web.BaseRequest, response: web.StreamResponse, time: float
+        ) -> None:
+            self.logger.info("This should not be logged")
+
+        def enabled(self) -> bool:
+            return False
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    server = await aiohttp_server(app, access_log_class=Logger)
+    client = await aiohttp_client(server)
+    resp = await client.get("/")
+    assert 200 == resp.status
+    assert "This should not be logged" not in caplog.text


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Most of the time in the access logger is spent calling `clock_gettime`, move the check to see if its enabled to an `enabled` property so we do not have to fetch time and throw it away.

<img width="986" alt="Screenshot 2024-11-11 at 2 09 02 PM" src="https://github.com/user-attachments/assets/ec0aa5aa-4f55-4841-8b73-2d6b599fcafa">


<img width="747" alt="Screenshot 2024-11-11 at 2 18 35 PM" src="https://github.com/user-attachments/assets/5a2f151a-13cf-4fbb-8a10-df79f793fd6b">


## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no