### PR TITLE
DNM: Avoid bytes join and memory copy on single chunk

### DIFF
--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -401,7 +401,7 @@ class StreamReader(AsyncStreamReaderMixin):
                 if not block:
                     break
                 blocks.append(block)
-            return b"".join(blocks)
+            return b"".join(blocks) if len(blocks) > 1 else blocks[0] if blocks else b""
 
         # TODO: should be `if` instead of `while`
         # because waiter maybe triggered on chunk end,
@@ -470,7 +470,7 @@ class StreamReader(AsyncStreamReaderMixin):
             blocks.append(block)
             n -= len(block)
 
-        return b"".join(blocks)
+        return b"".join(blocks) if len(blocks) > 1 else blocks[0] if blocks else b""
 
     def read_nowait(self, n: int = -1) -> bytes:
         # default was changed to be consistent with .read(-1)
@@ -527,7 +527,7 @@ class StreamReader(AsyncStreamReaderMixin):
                 if n == 0:
                     break
 
-        return b"".join(chunks) if chunks else b""
+        return b"".join(chunks) if len(chunks) > 1 else chunks[0] if chunks else b""
 
 
 class EmptyStreamReader(StreamReader):  # lgtm [py/missing-call-to-init]


### PR DESCRIPTION
In many cases we end up reading a single chunk, especially from json apis

Note that we have no benchmarks that call `.read()` on the body of the response currently so this will not show any difference

Manual benchmarks for now.. Shows ~4.5% speed up, but we should write a proper codspeed benchmark to verify before considering moving this forward
[aiohttp_get_profiler.zip](https://github.com/user-attachments/files/17709767/aiohttp_get_profiler.zip)
