### PR TITLE
Increase allowed import time for Python 3.12/3.13 to 265

### DIFF
--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -38,7 +38,7 @@ _TARGET_TIMINGS_BY_PYTHON_VERSION = {
         # and even slower under pytest-xdist, especially in CI
         _XDIST_WORKER_COUNT * 100 * (1 if _IS_CI_ENV else 1.53)
         if _IS_XDIST_RUN
-        else 250
+        else 265
     ),
 }
 _TARGET_TIMINGS_BY_PYTHON_VERSION["3.13"] = _TARGET_TIMINGS_BY_PYTHON_VERSION["3.12"]


### PR DESCRIPTION
I ran a profile of the imports and did not find any one thing that was causing the import time to jump up. The bulk of the time outside of bootstrap is spent in typing.py, and since we do not want to discourage adding more typing it seems like we need to increase this.

Additional discussion in https://github.com/aio-libs/aiohttp/pull/9828#issuecomment-2470808177

<img width="511" alt="Screenshot 2024-11-12 at 9 24 55 AM" src="https://github.com/user-attachments/assets/f474e906-98c2-471b-aa3a-9dce87b11d1e">

