### PR TITLE
Adjust client payload benchmarks to better represent real world cases

### DIFF
--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -33,14 +33,14 @@ def test_one_hundred_simple_get_requests(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_one_hundred_get_requests_with_2048_chunked_payload(
+def test_one_hundred_get_requests_with_1024_chunked_payload(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 100 GET requests with a small payload of 2048 bytes."""
+    """Benchmark 100 GET requests with a small payload of 1024 bytes."""
     message_count = 100
-    payload = b"a" * 2048
+    payload = b"a" * 1024
 
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(body=payload)
@@ -62,14 +62,14 @@ def test_one_hundred_get_requests_with_2048_chunked_payload(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_one_hundred_get_requests_with_32768_chunked_payload(
+def test_one_hundred_get_requests_with_30000_chunked_payload(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 100 GET requests with a payload of 32768 bytes."""
+    """Benchmark 100 GET requests with a payload of 30000 bytes."""
     message_count = 100
-    payload = b"a" * 32768
+    payload = b"a" * 30000
 
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(body=payload)
@@ -91,14 +91,14 @@ def test_one_hundred_get_requests_with_32768_chunked_payload(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_one_hundred_get_requests_with_1mib_chunked_payload(
+def test_one_hundred_get_requests_with_512kib_chunked_payload(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 100 GET requests with a payload of 1MiB bytes."""
+    """Benchmark 100 GET requests with a payload of 512KiB."""
     message_count = 100
-    payload = b"a" * 1024**2
+    payload = b"a" * (2**19)
 
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(body=payload)
@@ -120,14 +120,14 @@ def test_one_hundred_get_requests_with_1mib_chunked_payload(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_one_hundred_get_requests_with_2048_content_length_payload(
+def test_one_hundred_get_requests_with_1024_content_length_payload(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 100 GET requests with a small payload of 2048 bytes."""
+    """Benchmark 100 GET requests with a small payload of 1024 bytes."""
     message_count = 100
-    payload = b"a" * 2048
+    payload = b"a" * 1024
     headers = {hdrs.CONTENT_LENGTH: str(len(payload))}
 
     async def handler(request: web.Request) -> web.Response:
@@ -148,14 +148,14 @@ def test_one_hundred_get_requests_with_2048_content_length_payload(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_one_hundred_get_requests_with_32768_content_length_payload(
+def test_one_hundred_get_requests_with_30000_content_length_payload(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 100 GET requests with a payload of 32768 bytes."""
+    """Benchmark 100 GET requests with a payload of 30000 bytes."""
     message_count = 100
-    payload = b"a" * 32768
+    payload = b"a" * 30000
     headers = {hdrs.CONTENT_LENGTH: str(len(payload))}
 
     async def handler(request: web.Request) -> web.Response:
@@ -176,14 +176,14 @@ def test_one_hundred_get_requests_with_32768_content_length_payload(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_one_hundred_get_requests_with_1mib_content_length_payload(
+def test_one_hundred_get_requests_with_512kib_content_length_payload(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 100 GET requests with a payload of 1MiB bytes."""
+    """Benchmark 100 GET requests with a payload of 512KiB."""
     message_count = 100
-    payload = b"a" * 1024**2
+    payload = b"a" * (2**19)
     headers = {hdrs.CONTENT_LENGTH: str(len(payload))}
 
     async def handler(request: web.Request) -> web.Response:


### PR DESCRIPTION
We are interested in benchmarking various payload sizes at different buffering cut offs to see the `memcpy` and buffering impacts

2048 was too high as most small payloads are < 1024
32768 was two high as it always did two reads for this case so it wasn't giving us a case for a single large read.
1MiB was fine but 512KiB is also fine as it still gives us a benchmark for a multi-read case but there was no need to go that high as it didn't change the profile and only made the benchmark run longer

~~Note I'm testing on mac. I'm going to test on linux shortly since thats where the bulk of our users are. The breakpoints are going to be dictated by the kernel.  If the linux buffer sizes are lower by default, I'll adjust the 2nd one down some more. Ideally we keep it as high as possible to see the memcpy effects but not so high that the message ends up in multiple reads~~ 

The 30000 size is good for linux as well as it results in a single read.