### PR TITLE
Reduce memcpy with chunked encoding

### DIFF
--- a/CHANGES/9838.misc.rst
+++ b/CHANGES/9838.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of writing chunked payloads by reducing memory copy -- by :user:`bdraco`.

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -110,8 +110,9 @@ class StreamWriter(AbstractStreamWriter):
 
         if chunk:
             if self.chunked:
-                chunk_len_pre = ("%x\r\n" % len(chunk)).encode("ascii")
-                chunk = chunk_len_pre + chunk + b"\r\n"
+                chunk = b"".join(
+                    (f"{len(chunk):x}\r\n".encode("ascii"), chunk, b"\r\n")
+                )
 
             self._write(chunk)
 
@@ -147,13 +148,15 @@ class StreamWriter(AbstractStreamWriter):
 
             chunk += self._compress.flush()
             if chunk and self.chunked:
-                chunk_len = ("%x\r\n" % len(chunk)).encode("ascii")
-                chunk = chunk_len + chunk + b"\r\n0\r\n\r\n"
+                chunk = b"".join(
+                    (f"{len(chunk):x}\r\n".encode("ascii"), chunk, b"\r\n0\r\n\r\n")
+                )
         else:
             if self.chunked:
                 if chunk:
-                    chunk_len = ("%x\r\n" % len(chunk)).encode("ascii")
-                    chunk = chunk_len + chunk + b"\r\n0\r\n\r\n"
+                    chunk = b"".join(
+                        (f"{len(chunk):x}\r\n".encode("ascii"), chunk, b"\r\n0\r\n\r\n")
+                    )
                 else:
                     chunk = b"0\r\n\r\n"
 


### PR DESCRIPTION
<img width="705" alt="Screenshot 2024-11-12 at 10 45 28 AM" src="https://github.com/user-attachments/assets/767bade8-99ca-4062-8fa8-ed34309b571d">


finishing a chunk has a lot of `memcpy`. We can switch it to a `b"".join()` since it has a more efficient implementation in https://github.com/python/cpython/blob/91f4908798074db6c41925b4417bee1f933aca93/Objects/stringlib/join.h#L36 vs constructing a new bytes string for every add operation