### PR TITLE
Implement zero copy writes in `StreamWriter`

### DIFF
--- a/CHANGES/9839.misc.rst
+++ b/CHANGES/9839.misc.rst
@@ -1,1 +1,1 @@
-Implemented zerocopy writes for ``StreamWriter`` -- by :user:`bdraco`.
+Implemented zero copy writes for ``StreamWriter`` -- by :user:`bdraco`.

--- a/CHANGES/9839.misc.rst
+++ b/CHANGES/9839.misc.rst
@@ -1,0 +1,1 @@
+Implemented zerocopy writes for ``StreamWriter`` -- by :user:`bdraco`.

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -177,10 +177,10 @@ class StreamWriter(AbstractStreamWriter):
             if self.chunked:
                 chunk_len_pre = f"{chunks_len:x}\r\n".encode("ascii")
                 self._writelines((chunk_len_pre, *chunks, b"\r\n0\r\n\r\n"))
-            elif len(chunks) == 1:
-                self._write(chunks[0])
-            else:
+            elif len(chunks) > 1:
                 self._writelines(chunks)
+            else:
+                self._write(chunks[0])
         elif self.chunked:
             if chunk:
                 chunk_len_pre = f"{len(chunk):x}\r\n".encode("ascii")

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -165,8 +165,7 @@ class StreamWriter(AbstractStreamWriter):
         if self._compress:
             chunks: List[bytes] = []
             chunks_len = 0
-            if chunk:
-                compressed_chunk = await self._compress.compress(chunk)
+            if chunk and (compressed_chunk := await self._compress.compress(chunk)):
                 chunks_len = len(compressed_chunk)
                 chunks.append(compressed_chunk)
 
@@ -183,6 +182,8 @@ class StreamWriter(AbstractStreamWriter):
                             b"\r\n0\r\n\r\n",
                         )
                     )
+                elif len(chunks) == 1:
+                    self._write(chunks[0])
                 else:
                     self._writelines(chunks)
         elif self.chunked:

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -173,19 +173,18 @@ class StreamWriter(AbstractStreamWriter):
             chunks_len += len(flush_chunk)
             chunks.append(flush_chunk)
 
-            if chunks_len:
-                if self.chunked:
-                    self._writelines(
-                        (
-                            f"{chunks_len:x}\r\n".encode("ascii"),
-                            *chunks,
-                            b"\r\n0\r\n\r\n",
-                        )
+            if self.chunked:
+                self._writelines(
+                    (
+                        f"{chunks_len:x}\r\n".encode("ascii"),
+                        *chunks,
+                        b"\r\n0\r\n\r\n",
                     )
-                elif len(chunks) == 1:
-                    self._write(chunks[0])
-                else:
-                    self._writelines(chunks)
+                )
+            elif chunks_len and len(chunks) == 1:
+                self._write(chunks[0])
+            elif chunks_len:
+                self._writelines(chunks)
         elif self.chunked:
             if chunk:
                 self._writelines(

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -2,7 +2,16 @@
 
 import asyncio
 import zlib
-from typing import Any, Awaitable, Callable, List, NamedTuple, Optional, Union  # noqa
+from typing import (  # noqa
+    Any,
+    Awaitable,
+    Callable,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Union,
+)
 
 from multidict import CIMultiDict
 
@@ -76,7 +85,7 @@ class StreamWriter(AbstractStreamWriter):
             raise ClientConnectionResetError("Cannot write to closing transport")
         transport.write(chunk)
 
-    def _writelines(self, chunks: List[bytes]) -> None:
+    def _writelines(self, chunks: Iterable[bytes]) -> None:
         size = 0
         for chunk in chunks:
             size += len(chunk)
@@ -122,7 +131,7 @@ class StreamWriter(AbstractStreamWriter):
         if chunk:
             if self.chunked:
                 self._writelines(
-                    [f"{len(chunk):x}\r\n".encode("ascii"), chunk, b"\r\n"]
+                    (f"{len(chunk):x}\r\n".encode("ascii"), chunk, b"\r\n")
                 )
             else:
                 self._write(chunk)
@@ -168,18 +177,18 @@ class StreamWriter(AbstractStreamWriter):
             if chunks_len:
                 if self.chunked:
                     self._writelines(
-                        [
+                        (
                             f"{len(chunks_len):x}\r\n".encode("ascii"),
                             *chunks,
                             b"\r\n0\r\n\r\n",
-                        ]
+                        )
                     )
                 else:
                     self._writelines(chunks)
         elif self.chunked:
             if chunk:
                 self._writelines(
-                    [f"{len(chunk):x}\r\n".encode("ascii"), chunk, b"\r\n0\r\n\r\n"]
+                    (f"{len(chunk):x}\r\n".encode("ascii"), chunk, b"\r\n0\r\n\r\n")
                 )
             else:
                 self._write(b"0\r\n\r\n")

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -174,22 +174,16 @@ class StreamWriter(AbstractStreamWriter):
             chunks.append(flush_chunk)
 
             if self.chunked:
-                self._writelines(
-                    (
-                        f"{chunks_len:x}\r\n".encode("ascii"),
-                        *chunks,
-                        b"\r\n0\r\n\r\n",
-                    )
-                )
+                chunk_pre = f"{chunks_len:x}\r\n".encode("ascii")
+                self._writelines((chunk_pre, *chunks, b"\r\n0\r\n\r\n"))
             elif chunks_len and len(chunks) == 1:
                 self._write(chunks[0])
             elif chunks_len:
                 self._writelines(chunks)
         elif self.chunked:
             if chunk:
-                self._writelines(
-                    (f"{len(chunk):x}\r\n".encode("ascii"), chunk, b"\r\n0\r\n\r\n")
-                )
+                chunk_pre = f"{len(chunk):x}\r\n".encode("ascii")
+                self._writelines((chunk_pre, chunk, b"\r\n0\r\n\r\n"))
             else:
                 self._write(b"0\r\n\r\n")
         elif chunk:

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -174,12 +174,16 @@ class StreamWriter(AbstractStreamWriter):
             chunks.append(flush_chunk)
 
             if self.chunked:
-                chunk_len_pre = f"{chunks_len:x}\r\n".encode("ascii")
-                self._writelines((chunk_len_pre, *chunks, b"\r\n0\r\n\r\n"))
-            elif chunks_len and len(chunks) == 1:
-                self._write(chunks[0])
+                if chunks_len:
+                    chunk_len_pre = f"{chunks_len:x}\r\n".encode("ascii")
+                    self._writelines((chunk_len_pre, *chunks, b"\r\n0\r\n\r\n"))
+                else:
+                    self._write(b"0\r\n\r\n")
             elif chunks_len:
-                self._writelines(chunks)
+                if len(chunks) == 1:
+                    self._write(chunks[0])
+                else:
+                    self._writelines(chunks)
         elif self.chunked:
             if chunk:
                 chunk_len_pre = f"{len(chunk):x}\r\n".encode("ascii")

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -174,16 +174,16 @@ class StreamWriter(AbstractStreamWriter):
             chunks.append(flush_chunk)
 
             if self.chunked:
-                chunk_pre = f"{chunks_len:x}\r\n".encode("ascii")
-                self._writelines((chunk_pre, *chunks, b"\r\n0\r\n\r\n"))
+                chunk_len_pre = f"{chunks_len:x}\r\n".encode("ascii")
+                self._writelines((chunk_len_pre, *chunks, b"\r\n0\r\n\r\n"))
             elif chunks_len and len(chunks) == 1:
                 self._write(chunks[0])
             elif chunks_len:
                 self._writelines(chunks)
         elif self.chunked:
             if chunk:
-                chunk_pre = f"{len(chunk):x}\r\n".encode("ascii")
-                self._writelines((chunk_pre, chunk, b"\r\n0\r\n\r\n"))
+                chunk_len_pre = f"{len(chunk):x}\r\n".encode("ascii")
+                self._writelines((chunk_len_pre, chunk, b"\r\n0\r\n\r\n"))
             else:
                 self._write(b"0\r\n\r\n")
         elif chunk:

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -172,18 +172,15 @@ class StreamWriter(AbstractStreamWriter):
             flush_chunk = self._compress.flush()
             chunks_len += len(flush_chunk)
             chunks.append(flush_chunk)
+            assert chunks_len
 
             if self.chunked:
-                if chunks_len:
-                    chunk_len_pre = f"{chunks_len:x}\r\n".encode("ascii")
-                    self._writelines((chunk_len_pre, *chunks, b"\r\n0\r\n\r\n"))
-                else:
-                    self._write(b"0\r\n\r\n")
-            elif chunks_len:
-                if len(chunks) == 1:
-                    self._write(chunks[0])
-                else:
-                    self._writelines(chunks)
+                chunk_len_pre = f"{chunks_len:x}\r\n".encode("ascii")
+                self._writelines((chunk_len_pre, *chunks, b"\r\n0\r\n\r\n"))
+            elif len(chunks) == 1:
+                self._write(chunks[0])
+            else:
+                self._writelines(chunks)
         elif self.chunked:
             if chunk:
                 chunk_len_pre = f"{len(chunk):x}\r\n".encode("ascii")

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -169,9 +169,9 @@ class StreamWriter(AbstractStreamWriter):
                 chunks_len = len(compressed_chunk)
                 chunks.append(compressed_chunk)
 
-            if flush_chunk := self._compress.flush():
-                chunks_len += len(flush_chunk)
-                chunks.append(flush_chunk)
+            flush_chunk = self._compress.flush()
+            chunks_len += len(flush_chunk)
+            chunks.append(flush_chunk)
 
             if chunks_len:
                 if self.chunked:

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -178,7 +178,7 @@ class StreamWriter(AbstractStreamWriter):
                 if self.chunked:
                     self._writelines(
                         (
-                            f"{len(chunks_len):x}\r\n".encode("ascii"),
+                            f"{chunks_len:x}\r\n".encode("ascii"),
                             *chunks,
                             b"\r\n0\r\n\r\n",
                         )

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -81,7 +81,7 @@ def protocol(
 
 
 @pytest.fixture
-def transport(buf: bytearray) -> Any:
+def transport(buf: bytearray) -> mock.Mock:
     transport = mock.create_autospec(asyncio.Transport, spec_set=True, instance=True)
 
     def write(chunk: bytes) -> None:
@@ -94,7 +94,7 @@ def transport(buf: bytearray) -> Any:
     transport.write.side_effect = write
     transport.writelines.side_effect = writelines
     transport.is_closing.return_value = False
-    return transport
+    return transport  # type: ignore[no-any-return]
 
 
 @pytest.fixture

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -94,6 +94,7 @@ def transport(buf: bytearray) -> mock.Mock:
     transport.write.side_effect = write
     transport.writelines.side_effect = writelines
     transport.is_closing.return_value = False
+
     return transport  # type: ignore[no-any-return]
 
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -5,7 +5,16 @@ import pathlib
 import sys
 import zlib
 from http.cookies import BaseCookie, Morsel, SimpleCookie
-from typing import Any, AsyncIterator, Callable, Dict, Iterator, List, Protocol
+from typing import (
+    Any,
+    AsyncIterator,
+    Callable,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Protocol,
+)
 from unittest import mock
 
 import pytest
@@ -72,16 +81,20 @@ def protocol(
 
 
 @pytest.fixture
-def transport(buf: bytearray) -> mock.Mock:
-    transport = mock.create_autospec(asyncio.Transport, spec_set=True)
+def transport(buf: bytearray) -> Any:
+    transport = mock.create_autospec(asyncio.Transport, spec_set=True, instance=True)
 
     def write(chunk: bytes) -> None:
         buf.extend(chunk)
 
-    transport.write.side_effect = write
-    transport.is_closing.return_value = False
+    def writelines(chunks: Iterable[bytes]) -> None:
+        for chunk in chunks:
+            buf.extend(chunk)
 
-    return transport  # type: ignore[no-any-return]
+    transport.write.side_effect = write
+    transport.writelines.side_effect = writelines
+    transport.is_closing.return_value = False
+    return transport
 
 
 @pytest.fixture

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -228,13 +228,14 @@ async def test_write_large_payload_deflate_compression_chunked_data_in_eof(
     msg.enable_chunking()
 
     await msg.write(b"data" * 4096)
-    # This payload compresses poorly to ~512KiB.
-    payload = (
-        bytes(range(0, 256))
-        + bytes(range(255, 0, -1))
-        + bytes(range(0, 128))
-        + bytes(range(255, 0, -1))
-    ) * 1024
+    # This payload compresses to 251308 bytes
+    payload = b"".join(
+        [
+            bytes((*range(0, i), *range(i, 0, -1)))
+            for _ in range(255)
+            for i in range(255)
+        ]
+    )
     await msg.write_eof(payload)
 
     chunks = [c[1][0][1] for c in list(transport.writelines.mock_calls)]  # type: ignore[attr-defined]

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -228,13 +228,13 @@ async def test_write_large_payload_deflate_compression_chunked_data_in_eof(
     msg.enable_chunking()
 
     await msg.write(b"data" * 4096)
-    # This payload compresses poorly to ~256KiB.
+    # This payload compresses poorly to ~512KiB.
     payload = (
         bytes(range(0, 256))
         + bytes(range(255, 0, -1))
         + bytes(range(0, 128))
         + bytes(range(255, 0, -1))
-    ) * 512
+    ) * 1024
     await msg.write_eof(payload)
 
     chunks = [c[1][0][1] for c in list(transport.writelines.mock_calls)]  # type: ignore[attr-defined]

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -1,7 +1,7 @@
 # Tests for aiohttp/http_writer.py
 import array
 import asyncio
-from typing import Any
+from typing import Any, Iterable
 from unittest import mock
 
 import pytest
@@ -24,7 +24,12 @@ def transport(buf: bytearray) -> Any:
     def write(chunk: bytes) -> None:
         buf.extend(chunk)
 
+    def writelines(chunks: Iterable[bytes]) -> None:
+        for chunk in chunks:
+            buf.extend(chunk)
+
     transport.write.side_effect = write
+    transport.writelines.side_effect = writelines
     transport.is_closing.return_value = False
     return transport
 
@@ -116,11 +121,12 @@ async def test_write_payload_chunked_filter(
     await msg.write(b"ta")
     await msg.write_eof()
 
-    content = b"".join([c[1][0] for c in list(transport.write.mock_calls)])  # type: ignore[attr-defined]
+    content = b"".join([b"".join(c[1][0]) for c in list(transport.writelines.mock_calls)])  # type: ignore[attr-defined]
+    content += b"".join([c[1][0] for c in list(transport.write.mock_calls)])  # type: ignore[attr-defined]
     assert content.endswith(b"2\r\nda\r\n2\r\nta\r\n0\r\n\r\n")
 
 
-async def test_write_payload_chunked_filter_mutiple_chunks(
+async def test_write_payload_chunked_filter_multiple_chunks(
     protocol: BaseProtocol,
     transport: asyncio.Transport,
     loop: asyncio.AbstractEventLoop,
@@ -133,7 +139,8 @@ async def test_write_payload_chunked_filter_mutiple_chunks(
     await msg.write(b"at")
     await msg.write(b"a2")
     await msg.write_eof()
-    content = b"".join([c[1][0] for c in list(transport.write.mock_calls)])  # type: ignore[attr-defined]
+    content = b"".join([b"".join(c[1][0]) for c in list(transport.writelines.mock_calls)])  # type: ignore[attr-defined]
+    content += b"".join([c[1][0] for c in list(transport.write.mock_calls)])  # type: ignore[attr-defined]
     assert content.endswith(
         b"2\r\nda\r\n2\r\nta\r\n2\r\n1d\r\n2\r\nat\r\n2\r\na2\r\n0\r\n\r\n"
     )
@@ -154,6 +161,24 @@ async def test_write_payload_deflate_compression(
     assert all(chunks)
     content = b"".join(chunks)
     assert COMPRESSED == content.split(b"\r\n\r\n", 1)[-1]
+
+
+async def test_write_payload_deflate_compression_chunked(
+    protocol: BaseProtocol,
+    transport: asyncio.Transport,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    expected = b"2\r\nx\x9c\r\na\r\nKI,I\x04\x00\x04\x00\x01\x9b\r\n0\r\n\r\n"
+    msg = http.StreamWriter(protocol, loop)
+    msg.enable_compression("deflate")
+    msg.enable_chunking()
+    await msg.write(b"data")
+    await msg.write_eof()
+
+    chunks = [b"".join(c[1][0]) for c in list(transport.writelines.mock_calls)]  # type: ignore[attr-defined]
+    assert all(chunks)
+    content = b"".join(chunks)
+    assert content == expected
 
 
 async def test_write_payload_deflate_and_chunked(

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -231,10 +231,10 @@ async def test_write_large_payload_deflate_compression_chunked_data_in_eof(
     # This payload compresses to 1111 bytes
     payload = b"".join([bytes((*range(0, i), *range(i, 0, -1))) for i in range(255)])
     await msg.write_eof(payload)
-    assert not transport.write.called
+    assert not transport.write.called  # type: ignore[attr-defined]
 
     chunks = []
-    for write_lines_call in transport.writelines.mock_calls:
+    for write_lines_call in transport.writelines.mock_calls:  # type: ignore[attr-defined]
         chunked_payload = list(write_lines_call[1][0])[1:]
         chunked_payload.pop()
         chunks.extend(chunked_payload)


### PR DESCRIPTION
https://github.com/python/cpython/issues/91166 made `writelines` zero copy for Python 3.12+. 

<img width="705" alt="Screenshot 2024-11-12 at 10 45 28 AM" src="https://github.com/user-attachments/assets/767bade8-99ca-4062-8fa8-ed34309b571d">

finishing a chunk has a lot of `memcpy`. Even if zero copy isn't implement for old python it will use `b"".join()` since it has a more efficient implementation in https://github.com/python/cpython/blob/91f4908798074db6c41925b4417bee1f933aca93/Objects/stringlib/join.h#L36 vs constructing a new bytes string for every add operation https://github.com/aio-libs/aiohttp/pull/9838 shows the bytes join is also faster, just not as fast as the zero copy write