### PR TITLE
Add coverage to ensure `ClientRequest.write_bytes` is called for a chunked empty body

### DIFF
--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -915,6 +915,25 @@ async def test_chunked2(loop: asyncio.AbstractEventLoop, conn: mock.Mock) -> Non
     resp.close()
 
 
+async def test_chunked_empty_body(
+    loop: asyncio.AbstractEventLoop, conn: mock.Mock
+) -> None:
+    """Ensure write_bytes is called even if the body is empty."""
+    req = ClientRequest(
+        "post",
+        URL("http://python.org/"),
+        chunked=True,
+        loop=loop,
+        data=b"",
+    )
+    with mock.patch.object(req, "write_bytes") as write_bytes:
+        resp = await req.send(conn)
+    assert "chunked" == req.headers["TRANSFER-ENCODING"]
+    assert write_bytes.called
+    await req.close()
+    resp.close()
+
+
 async def test_chunked_explicit(
     loop: asyncio.AbstractEventLoop, conn: mock.Mock
 ) -> None:


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/pull/9757#issuecomment-2471259861 I was worried 9757 might have introduced a regression but it appears its fine. Add some coverage for this area to make sure we do not introduce one in the future from refactoring

We still need to write the `0` chunk for empty body when sending chunked
