### PR TITLE
Fix compressed get request benchmark payload length

### DIFF
--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -136,7 +136,7 @@ def test_get_request_with_251308_compressed_chunked_payload(
     )
 
     async def handler(request: web.Request) -> web.Response:
-        resp = web.Response(body=payload)
+        resp = web.Response(body=payload, zlib_executor_size=16384)
         resp.enable_compression()
         return resp
 

--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -120,20 +120,20 @@ def test_one_hundred_get_requests_with_512kib_chunked_payload(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_five_get_requests_with_567296_compressed_chunked_payload(
+def test_get_request_with_251308_compressed_chunked_payload(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 5 compressed GET requests with a payload of 567296."""
-    message_count = 5
-    # This payload compresses poorly to ~567296 bytes.
-    payload = (
-        bytes(range(0, 256))
-        + bytes(range(255, 0, -1))
-        + bytes(range(0, 128))
-        + bytes(range(255, 0, -1))
-    ) * 1024
+    """Benchmark compressed GET requests with a payload of 251308."""
+    # This payload compresses to 251308 bytes
+    payload = b"".join(
+        [
+            bytes((*range(0, i), *range(i, 0, -1)))
+            for _ in range(255)
+            for i in range(255)
+        ]
+    )
 
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(body=payload)
@@ -145,9 +145,8 @@ def test_five_get_requests_with_567296_compressed_chunked_payload(
 
     async def run_client_benchmark() -> None:
         client = await aiohttp_client(app)
-        for _ in range(message_count):
-            resp = await client.get("/")
-            await resp.read()
+        resp = await client.get("/")
+        await resp.read()
         await client.close()
 
     @benchmark


### PR DESCRIPTION
The payload length was much smaller than expected because zlib more efficient than expected and previous testing to calculate the payload size was incorrect
