### PR TITLE
[PR #9851/541d86d backport][3.11] Fix incorrect parsing of chunk extensions with the pure Python parser

### DIFF
--- a/CHANGES/9851.bugfix.rst
+++ b/CHANGES/9851.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed incorrect parsing of chunk extensions with the pure Python parser -- by :user:`bdraco`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -845,6 +845,13 @@ class HttpPayloadParser:
                         i = chunk.find(CHUNK_EXT, 0, pos)
                         if i >= 0:
                             size_b = chunk[:i]  # strip chunk-extensions
+                            # Verify no LF in the chunk-extension
+                            if b"\n" in (ext := chunk[i:pos]):
+                                exc = BadHttpMessage(
+                                    f"Unexpected LF in chunk-extension: {ext!r}"
+                                )
+                                set_exception(self.payload, exc)
+                                raise exc
                         else:
                             size_b = chunk[:pos]
 


### PR DESCRIPTION
(cherry picked from commit 541d86d9e7884590c655876cd40042565293d8df)
