### PR TITLE
[3.11] Make creating `RequestInfo` backwards compatible with 3.10

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -42,6 +42,7 @@ from .client_exceptions import (
 from .compression_utils import HAS_BROTLI
 from .formdata import FormData
 from .helpers import (
+    _SENTINEL,
     BaseTimerContext,
     BasicAuth,
     HeadersMixin,
@@ -103,11 +104,25 @@ class ContentDisposition:
     filename: Optional[str]
 
 
-class RequestInfo(NamedTuple):
+class _RequestInfo(NamedTuple):
     url: URL
     method: str
     headers: "CIMultiDictProxy[str]"
     real_url: URL
+
+
+class RequestInfo(_RequestInfo):
+
+    def __new__(
+        cls,
+        url: URL,
+        method: str,
+        headers: "CIMultiDictProxy[str]",
+        real_url: URL = _SENTINEL,
+    ) -> "RequestInfo":
+        return tuple.__new__(
+            cls, (url, method, headers, url if real_url is _SENTINEL else real_url)
+        )
 
 
 class Fingerprint:


### PR DESCRIPTION
It was unexpected that this object was being created directly
outside of aiohttp internals. While it looks like its only
used for mocking downstream, we can accomodate that by subclassing
the NamedTuple and providing a `__new__` while keeping the faster
`tuple.__new__` internally.

fixes #9866