### PR TITLE
Make creating `RequestInfo` backwards compatible with 3.10

### DIFF
--- a/CHANGES/9873.bugfix.rst
+++ b/CHANGES/9873.bugfix.rst
@@ -1,0 +1,1 @@
+Added a backward compatibility layer to `~aiohttp.RequestInfo` to allow creating these objects without a `real_url` -- by :user:`bdraco`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -121,6 +121,10 @@ class RequestInfo(_RequestInfo):
         headers: "CIMultiDictProxy[str]",
         real_url: URL = _SENTINEL,
     ) -> "RequestInfo":
+        """Create a new RequestInfo instance.
+
+        For backwards compatibility, the real_url parameter is optional.
+        """
         return tuple.__new__(
             cls, (url, method, headers, url if real_url is _SENTINEL else real_url)
         )

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -119,7 +119,7 @@ class RequestInfo(_RequestInfo):
         url: URL,
         method: str,
         headers: "CIMultiDictProxy[str]",
-        real_url: URL = _SENTINEL,
+        real_url: URL = _SENTINEL,  # type: ignore[assignment]
     ) -> "RequestInfo":
         """Create a new RequestInfo instance.
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -43,6 +43,7 @@ from .compression_utils import HAS_BROTLI
 from .formdata import FormData
 from .hdrs import CONTENT_TYPE
 from .helpers import (
+    _SENTINEL,
     BaseTimerContext,
     BasicAuth,
     HeadersMixin,
@@ -104,11 +105,25 @@ class ContentDisposition:
     filename: Optional[str]
 
 
-class RequestInfo(NamedTuple):
+class _RequestInfo(NamedTuple):
     url: URL
     method: str
     headers: "CIMultiDictProxy[str]"
     real_url: URL
+
+
+class RequestInfo(_RequestInfo):
+
+    def __new__(
+        cls,
+        url: URL,
+        method: str,
+        headers: "CIMultiDictProxy[str]",
+        real_url: URL = _SENTINEL,
+    ) -> "RequestInfo":
+        return tuple.__new__(
+            cls, (url, method, headers, url if real_url is _SENTINEL else real_url)
+        )
 
 
 class Fingerprint:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -345,7 +345,9 @@ class ClientRequest:
     def request_info(self) -> RequestInfo:
         headers: CIMultiDictProxy[str] = CIMultiDictProxy(self.headers)
         # These are created on every request, so we use a NamedTuple
-        # for performance reasons.
+        # for performance reasons. We don't use the RequestInfo.__new__
+        # method because it has a different signature which is provided
+        # for backwards compatibility only.
         return tuple.__new__(
             RequestInfo, (self.url, self.method, headers, self.original_url)
         )

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1544,3 +1544,31 @@ async def test_connection_key_without_proxy() -> None:
     )
     assert req.connection_key.proxy_headers_hash is None
     await req.close()
+
+
+def test_request_info_back_compat() -> None:
+    """Test RequestInfo can be created without real_url."""
+    url = URL("http://example.com")
+    other_url = URL("http://example.org")
+    assert (
+        aiohttp.RequestInfo(url=url, method="GET", headers=CIMultiDict()).real_url
+        is url
+    )
+    assert aiohttp.RequestInfo(url, "GET", CIMultiDict()).real_url is url
+    assert aiohttp.RequestInfo(url, "GET", CIMultiDict(), real_url=url).real_url is url
+    assert (
+        aiohttp.RequestInfo(url, "GET", CIMultiDict(), real_url=other_url).real_url
+        is other_url
+    )
+
+
+def test_request_info_tuple_new() -> None:
+    """Test RequestInfo must be created with real_url using tuple.__new__."""
+    url = URL("http://example.com")
+    with pytest.raises(IndexError):
+        tuple.__new__(aiohttp.RequestInfo, (url, "GET", CIMultiDict())).real_url
+
+    assert (
+        tuple.__new__(aiohttp.RequestInfo, (url, "GET", CIMultiDict(), url)).real_url
+        is url
+    )

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1551,13 +1551,24 @@ def test_request_info_back_compat() -> None:
     url = URL("http://example.com")
     other_url = URL("http://example.org")
     assert (
-        aiohttp.RequestInfo(url=url, method="GET", headers=CIMultiDict()).real_url
+        aiohttp.RequestInfo(
+            url=url, method="GET", headers=CIMultiDictProxy(CIMultiDict())
+        ).real_url
         is url
     )
-    assert aiohttp.RequestInfo(url, "GET", CIMultiDict()).real_url is url
-    assert aiohttp.RequestInfo(url, "GET", CIMultiDict(), real_url=url).real_url is url
     assert (
-        aiohttp.RequestInfo(url, "GET", CIMultiDict(), real_url=other_url).real_url
+        aiohttp.RequestInfo(url, "GET", CIMultiDictProxy(CIMultiDict())).real_url is url
+    )
+    assert (
+        aiohttp.RequestInfo(
+            url, "GET", CIMultiDictProxy(CIMultiDict()), real_url=url
+        ).real_url
+        is url
+    )
+    assert (
+        aiohttp.RequestInfo(
+            url, "GET", CIMultiDictProxy(CIMultiDict()), real_url=other_url
+        ).real_url
         is other_url
     )
 
@@ -1566,9 +1577,13 @@ def test_request_info_tuple_new() -> None:
     """Test RequestInfo must be created with real_url using tuple.__new__."""
     url = URL("http://example.com")
     with pytest.raises(IndexError):
-        tuple.__new__(aiohttp.RequestInfo, (url, "GET", CIMultiDict())).real_url
+        tuple.__new__(
+            aiohttp.RequestInfo, (url, "GET", CIMultiDictProxy(CIMultiDict()))
+        ).real_url
 
     assert (
-        tuple.__new__(aiohttp.RequestInfo, (url, "GET", CIMultiDict(), url)).real_url
+        tuple.__new__(
+            aiohttp.RequestInfo, (url, "GET", CIMultiDictProxy(CIMultiDict()), url)
+        ).real_url
         is url
     )


### PR DESCRIPTION
It was unexpected that this object was being created directly outside of `aiohttp` internals. While it looks like its only used for mocking internal state downstream, we can accommodate that by subclassing the `NamedTuple` and providing a `__new__` while keeping the faster `tuple.__new__` internally.

We might remove the back-compat later in 4.x development cycle, however since its currently being used downstream to mock internals and there isn't a better prescribed way to do that, leave it for now.

fixes #9866

