### PR TITLE
DNM: Ensure manual builds use at least the same minimum Cython version used to build our wheels

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 46.4.0",
+    "Cython >= 3.0.11",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/discussions/9871#discussioncomment-11256618 showed some warnings/errors that are fixed in newer `Cython`.  We currently don't specify a minimum `Cython` version which means manual builds can result in broken builds if the `Cython` version being used for the build is too old.

This PR should not merge until we confirm this is the issue in the discussion