### PR TITLE
Fix improperly closed WebSocket connections generating a backtrace

### DIFF
--- a/CHANGES/9883.bugfix.rst
+++ b/CHANGES/9883.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed improperly closed WebSocket connections generating a backtrace -- by :user:`bdraco`.

--- a/CHANGES/9883.bugfix.rst
+++ b/CHANGES/9883.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed improperly closed WebSocket connections generating a backtrace -- by :user:`bdraco`.
+Fixed improperly closed WebSocket connections generating an unhandled exception -- by :user:`bdraco`.

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -69,6 +69,9 @@ class WebSocketDataQueue:
         self._get_buffer = self._buffer.popleft
         self._put_buffer = self._buffer.append
 
+    def is_eof(self) -> bool:
+        return self._eof
+
     def exception(self) -> Optional[Union[Type[BaseException], BaseException]]:
         return self._exception
 

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -1279,7 +1279,7 @@ async def test_websocket_connection_cancellation(
 
     async def websocket_task() -> None:
         resp = await client.ws_connect("/")
-        assert resp is not None  # ensure we hold a reference to the websocket
+        assert resp is not None  # ensure we hold a reference to the response
         # The test harness will cleanup the unclosed websocket
         # for us, so we need to copy the websockets to ensure
         # we can control the cleanup

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -1296,6 +1296,8 @@ async def test_websocket_connection_cancellation(
     websocket = websockets[0]
     websockets.clear()
     # Ensure any __del__ methods is called
+    # since when it gets gc'd it not
+    # reproducible
     del websocket._response
 
     # Cleanup properly

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -1294,9 +1294,7 @@ async def test_websocket_connection_cancellation(
         await task
 
     websocket = websockets.pop()
-    # Ensure any __del__ methods is called
-    # since when it gets gc'd it not
-    # reproducible
+    # Call the `__del__` methods manually since when it gets gc'd it not reproducible
     del websocket._response
 
     # Cleanup properly

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -1279,13 +1279,13 @@ async def test_websocket_connection_cancellation(
 
     async def websocket_task() -> None:
         resp = await client.ws_connect("/")
+        assert resp
         # The test harness will cleanup the unclosed websocket
         # for us, so we need to copy the websockets to ensure
         # we can control the cleanup
         sync_future.set_result(client._websockets.copy())
         client._websockets.clear()
         await asyncio.sleep(0)
-        await resp.close()
 
     task = loop.create_task(websocket_task())
     websockets = await sync_future

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -1239,11 +1239,11 @@ async def test_websocket_connection_not_closed_property(
 ) -> None:
     """Test that closing the connection via __del__ does not raise an exception."""
 
-    async def handler(request: web.Request) -> web.WebSocketResponse:
+    async def handler(request: web.Request) -> NoReturn:
         ws = web.WebSocketResponse()
         await ws.prepare(request)
         await ws.close()
-        return ws
+        assert False
 
     app = web.Application()
     app.router.add_route("GET", "/", handler)

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -1293,8 +1293,7 @@ async def test_websocket_connection_cancellation(
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    websocket = websockets[0]
-    websockets.clear()
+    websocket = websockets.pop()
     # Ensure any __del__ methods is called
     # since when it gets gc'd it not
     # reproducible

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -1279,7 +1279,7 @@ async def test_websocket_connection_cancellation(
 
     async def websocket_task() -> None:
         resp = await client.ws_connect("/")
-        assert resp
+        assert resp is not None  # ensure we hold a reference to the websocket
         # The test harness will cleanup the unclosed websocket
         # for us, so we need to copy the websockets to ensure
         # we can control the cleanup


### PR DESCRIPTION
We should only be generating a backtrace if [`loop.get_debug()`](https://github.com/aio-libs/aiohttp/blob/9e3a3280c2d9369653b09c7d770d682302b0c521/aiohttp/client_reqrep.py#L905C27-L905C36) is enabled when these get cleaned up by `__del__` in `ClientResponse`. Because the `is_eof` method wasn't present on [`WebSocketDataQueue`](https://github.com/aio-libs/aiohttp/blob/9e3a3280c2d9369653b09c7d770d682302b0c521/aiohttp/_websocket/reader_py.py#L52) it would check [`protocol.should_close`](https://github.com/aio-libs/aiohttp/blob/9e3a3280c2d9369653b09c7d770d682302b0c521/aiohttp/connector.py#L698) via [`Connection.release()`](https://github.com/aio-libs/aiohttp/blob/9e3a3280c2d9369653b09c7d770d682302b0c521/aiohttp/client_reqrep.py#L902) which wasn't there and generate a backtrace.

This is likely happening in #9880 as a result of cancellation.

The test harness was a bit too helpful in this case as it automatically cleanups unclosed WebSocket connections which meant the missing `is_eof` method went unnoticed.

fixes #9880