### PR TITLE
[PR #9883/a118114 backport][3.11] Fix improperly closed WebSocket connections generating a backtrace

### DIFF
--- a/CHANGES/9883.bugfix.rst
+++ b/CHANGES/9883.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed improperly closed WebSocket connections generating an unhandled exception -- by :user:`bdraco`.

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -66,6 +66,9 @@ class WebSocketDataQueue:
         self._get_buffer = self._buffer.popleft
         self._put_buffer = self._buffer.append
 
+    def is_eof(self) -> bool:
+        return self._eof
+
     def exception(self) -> Optional[BaseException]:
         return self._exception
 


### PR DESCRIPTION
(cherry picked from commit a11811471ded1a4df59302316d12fc90a3cfc819)
