### PR TITLE
Defer creation of SimpleCookie objects in the web server until needed

### DIFF
--- a/CHANGES/9895.misc.rst
+++ b/CHANGES/9895.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of creating web responses when there are no cookies -- by :user:`bdraco`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -949,9 +949,6 @@ class CookieMixin:
         """
         if self._cookies is None:
             self._cookies = SimpleCookie()  # type: ignore[misc]
-        elif (old := self._cookies.get(name)) is not None and old.coded_value == "":
-            # deleted cookie
-            self._cookies.pop(name, None)
 
         self._cookies[name] = value
         c = self._cookies[name]

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -926,7 +926,7 @@ class CookieMixin:
     @property
     def cookies(self) -> SimpleCookie:
         if self._cookies is None:
-            self._cookies = SimpleCookie()
+            self._cookies = SimpleCookie()  # type: ignore[misc]
         return self._cookies
 
     def set_cookie(
@@ -948,7 +948,7 @@ class CookieMixin:
         Also updates only those params which are not None.
         """
         if self._cookies is None:
-            self._cookies = SimpleCookie()
+            self._cookies = SimpleCookie()  # type: ignore[misc]
         elif (old := self._cookies.get(name)) is not None and old.coded_value == "":
             # deleted cookie
             self._cookies.pop(name, None)

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -630,14 +630,14 @@ class Response(StreamResponse):
 
     @text.setter
     def text(self, text: str) -> None:
-        assert isinstance(text, str), "text argument must be str (%r)" % type(text)
+        assert isinstance(text, str), f"text argument must be str ({type(text)!r})"
 
         if self.content_type == "application/octet-stream":
             self.content_type = "text/plain"
-        if self.charset is None:
-            self.charset = "utf-8"
+        if (charset := self.charset) is None:
+            charset = self.charset = "utf-8"
 
-        self._body = text.encode(self.charset)
+        self._body = text.encode(charset)
         self._compressed_body = None
 
     @property

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -630,14 +630,14 @@ class Response(StreamResponse):
 
     @text.setter
     def text(self, text: str) -> None:
-        assert isinstance(text, str), f"text argument must be str ({type(text)!r})"
+        assert isinstance(text, str), "text argument must be str (%r)" % type(text)
 
         if self.content_type == "application/octet-stream":
             self.content_type = "text/plain"
-        if (charset := self.charset) is None:
-            charset = self.charset = "utf-8"
+        if self.charset is None:
+            self.charset = "utf-8"
 
-        self._body = text.encode(charset)
+        self._body = text.encode(self.charset)
         self._compressed_body = None
 
     @property

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -916,7 +916,8 @@ def test_cookies_mixin() -> None:
 
     sut.set_cookie("name", "value")
     assert str(sut.cookies) == "Set-Cookie: name=value; Path=/"
-    # Verify setting the cookie again
+    sut.set_cookie("name", "")
+    assert str(sut.cookies) == 'Set-Cookie: name=""; Path=/'
     sut.set_cookie("name", "value")
     assert str(sut.cookies) == "Set-Cookie: name=value; Path=/"
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -936,6 +936,8 @@ def test_cookies_mixin() -> None:
         "expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/"
     )
     assert str(sut.cookies) == expected
+    sut.del_cookie("name")
+    assert str(sut.cookies) == expected
 
     sut.set_cookie("name", "value", domain="local.host")
     expected = "Set-Cookie: name=value; Domain=local.host; Path=/"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -916,6 +916,10 @@ def test_cookies_mixin() -> None:
 
     sut.set_cookie("name", "value")
     assert str(sut.cookies) == "Set-Cookie: name=value; Path=/"
+    # Verify setting the cookie again
+    sut.set_cookie("name", "value")
+    assert str(sut.cookies) == "Set-Cookie: name=value; Path=/"
+
     sut.set_cookie("name", "other_value")
     assert str(sut.cookies) == "Set-Cookie: name=other_value; Path=/"
 


### PR DESCRIPTION
related issue #2779

We create these objects even if there are no cookies.  There are some small performance improvements and some memory savings on each request.  