### PR TITLE
Refactor Resource.resolve to avoid linear search of methods

### DIFF
--- a/CHANGES/9899.misc.rst
+++ b/CHANGES/9899.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of resolving resources when multiple methods are registered for the same route -- by :user:`bdraco`.

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -361,8 +361,7 @@ class Resource(AbstractResource):
             self._routes[route.method] = route
 
     async def resolve(self, request: Request) -> _Resolve:
-        match_dict = self._match(request.rel_url.path_safe)
-        if match_dict is None:
+        if (match_dict := self._match(request.rel_url.path_safe)) is None:
             return None, set()
         if route := self._routes.get(request.method) or self._any_route:
             return UrlMappingMatchInfo(match_dict, route), self._allowed_methods

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -339,11 +339,11 @@ class Resource(AbstractResource):
         *,
         expect_handler: Optional[_ExpectHandler] = None,
     ) -> "ResourceRoute":
-        if method in self._routes or self._any_route is not None:
+        if (route := self._routes.get(method)) or self._any_route is not None:
             raise RuntimeError(
                 "Added route will never be executed, "
                 "method {route.method} is already "
-                "registered".format(route=self._routes.get(method, self._any_route))
+                "registered".format(route=route or self._any_route)
             )
 
         route_obj = ResourceRoute(method, handler, self, expect_handler=expect_handler)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -339,11 +339,11 @@ class Resource(AbstractResource):
         *,
         expect_handler: Optional[_ExpectHandler] = None,
     ) -> "ResourceRoute":
-        if (route := self._routes.get(method)) or self._any_route is not None:
+        if route := self._routes.get(method) or self._any_route:
             raise RuntimeError(
                 "Added route will never be executed, "
                 "method {route.method} is already "
-                "registered".format(route=route or self._any_route)
+                "registered".format(route=route)
             )
 
         route_obj = ResourceRoute(method, handler, self, expect_handler=expect_handler)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -364,17 +364,8 @@ class Resource(AbstractResource):
         match_dict = self._match(request.rel_url.path_safe)
         if match_dict is None:
             return None, set()
-        request_method = request.method
-        if request_method in self._routes:
-            return (
-                UrlMappingMatchInfo(match_dict, self._routes[request_method]),
-                self._allowed_methods,
-            )
-        if self._any_route is not None:
-            return (
-                UrlMappingMatchInfo(match_dict, self._any_route),
-                self._allowed_methods,
-            )
+        if route := self._routes.get(request.method) or self._any_route:
+            return UrlMappingMatchInfo(match_dict, route), self._allowed_methods
         return None, self._allowed_methods
 
     @abc.abstractmethod

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -116,6 +116,9 @@ class _InfoDict(TypedDict, total=False):
 
 
 class AbstractResource(Sized, Iterable["AbstractRoute"]):
+
+    __slots__ = ("_name",)
+
     def __init__(self, *, name: Optional[str] = None) -> None:
         self._name = name
 
@@ -326,6 +329,9 @@ async def _default_expect_handler(request: Request) -> None:
 
 
 class Resource(AbstractResource):
+
+    __slots__ = ("_routes", "_any_route", "_allowed_methods")
+
     def __init__(self, *, name: Optional[str] = None) -> None:
         super().__init__(name=name)
         self._routes: Dict[str, ResourceRoute] = {}
@@ -381,6 +387,9 @@ class Resource(AbstractResource):
 
 
 class PlainResource(Resource):
+
+    __slots__ = ("_path",)
+
     def __init__(self, path: str, *, name: Optional[str] = None) -> None:
         super().__init__(name=name)
         assert not path or path.startswith("/")
@@ -421,6 +430,9 @@ class PlainResource(Resource):
 
 
 class DynamicResource(Resource):
+
+    __slots__ = ("_orig_path", "_pattern", "_formatter")
+
     DYN = re.compile(r"\{(?P<var>[_a-zA-Z][_a-zA-Z0-9]*)\}")
     DYN_WITH_RE = re.compile(r"\{(?P<var>[_a-zA-Z][_a-zA-Z0-9]*):(?P<re>.+)\}")
     GOOD = r"[^{}/]+"
@@ -496,6 +508,9 @@ class DynamicResource(Resource):
 
 
 class PrefixResource(AbstractResource):
+
+    __slots__ = ("_prefix", "_prefix2")
+
     def __init__(self, prefix: str, *, name: Optional[str] = None) -> None:
         assert not prefix or prefix.startswith("/"), prefix
         assert prefix in ("", "/") or not prefix.endswith("/"), prefix
@@ -522,6 +537,16 @@ class PrefixResource(AbstractResource):
 
 class StaticResource(PrefixResource):
     VERSION_KEY = "v"
+
+    __slots__ = (
+        "_directory",
+        "_show_index",
+        "_chunk_size",
+        "_follow_symlinks",
+        "_expect_handler",
+        "_append_version",
+        "_routes",
+    )
 
     def __init__(
         self,
@@ -726,6 +751,9 @@ class StaticResource(PrefixResource):
 
 
 class PrefixedSubAppResource(PrefixResource):
+
+    __slots__ = ("_app",)
+
     def __init__(self, prefix: str, app: "Application") -> None:
         super().__init__(prefix)
         self._app = app

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -342,8 +342,8 @@ class Resource(AbstractResource):
         if route := self._routes.get(method) or self._any_route:
             raise RuntimeError(
                 "Added route will never be executed, "
-                "method {route.method} is already "
-                "registered".format(route=route)
+                f"method {route.method} is already "
+                "registered"
             )
 
         route_obj = ResourceRoute(method, handler, self, expect_handler=expect_handler)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -364,9 +364,10 @@ class Resource(AbstractResource):
         match_dict = self._match(request.rel_url.path_safe)
         if match_dict is None:
             return None, set()
-        if request.method in self._routes:
+        request_method = request.method
+        if request_method in self._routes:
             return (
-                UrlMappingMatchInfo(match_dict, self._routes[request.method]),
+                UrlMappingMatchInfo(match_dict, self._routes[request_method]),
                 self._allowed_methods,
             )
         if self._any_route is not None:

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -339,7 +339,7 @@ class Resource(AbstractResource):
         *,
         expect_handler: Optional[_ExpectHandler] = None,
     ) -> "ResourceRoute":
-        if route := self._routes.get(method) or self._any_route:
+        if route := self._routes.get(method, self._any_route):
             raise RuntimeError(
                 "Added route will never be executed, "
                 f"method {route.method} is already "
@@ -363,7 +363,7 @@ class Resource(AbstractResource):
     async def resolve(self, request: Request) -> _Resolve:
         if (match_dict := self._match(request.rel_url.path_safe)) is None:
             return None, set()
-        if route := self._routes.get(request.method) or self._any_route:
+        if route := self._routes.get(request.method, self._any_route):
             return UrlMappingMatchInfo(match_dict, route), self._allowed_methods
         return None, self._allowed_methods
 

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -116,9 +116,6 @@ class _InfoDict(TypedDict, total=False):
 
 
 class AbstractResource(Sized, Iterable["AbstractRoute"]):
-
-    __slots__ = ("_name",)
-
     def __init__(self, *, name: Optional[str] = None) -> None:
         self._name = name
 
@@ -329,9 +326,6 @@ async def _default_expect_handler(request: Request) -> None:
 
 
 class Resource(AbstractResource):
-
-    __slots__ = ("_routes", "_any_route", "_allowed_methods")
-
     def __init__(self, *, name: Optional[str] = None) -> None:
         super().__init__(name=name)
         self._routes: Dict[str, ResourceRoute] = {}
@@ -387,9 +381,6 @@ class Resource(AbstractResource):
 
 
 class PlainResource(Resource):
-
-    __slots__ = ("_path",)
-
     def __init__(self, path: str, *, name: Optional[str] = None) -> None:
         super().__init__(name=name)
         assert not path or path.startswith("/")
@@ -430,9 +421,6 @@ class PlainResource(Resource):
 
 
 class DynamicResource(Resource):
-
-    __slots__ = ("_orig_path", "_pattern", "_formatter")
-
     DYN = re.compile(r"\{(?P<var>[_a-zA-Z][_a-zA-Z0-9]*)\}")
     DYN_WITH_RE = re.compile(r"\{(?P<var>[_a-zA-Z][_a-zA-Z0-9]*):(?P<re>.+)\}")
     GOOD = r"[^{}/]+"
@@ -508,9 +496,6 @@ class DynamicResource(Resource):
 
 
 class PrefixResource(AbstractResource):
-
-    __slots__ = ("_prefix", "_prefix2")
-
     def __init__(self, prefix: str, *, name: Optional[str] = None) -> None:
         assert not prefix or prefix.startswith("/"), prefix
         assert prefix in ("", "/") or not prefix.endswith("/"), prefix
@@ -537,16 +522,6 @@ class PrefixResource(AbstractResource):
 
 class StaticResource(PrefixResource):
     VERSION_KEY = "v"
-
-    __slots__ = (
-        "_directory",
-        "_show_index",
-        "_chunk_size",
-        "_follow_symlinks",
-        "_expect_handler",
-        "_append_version",
-        "_routes",
-    )
 
     def __init__(
         self,
@@ -751,9 +726,6 @@ class StaticResource(PrefixResource):
 
 
 class PrefixedSubAppResource(PrefixResource):
-
-    __slots__ = ("_app",)
-
     def __init__(self, prefix: str, app: "Application") -> None:
         super().__init__(prefix)
         self._app = app


### PR DESCRIPTION
The average time complexity of `Resource.resolve` is now `O(1)` instead of `O(number_of_methods)`

https://github.com/aio-libs/aiohttp/issues/2779#issuecomment-2477962741

Looks to be 
~14% faster with a single method
~2.5x faster for the multiple methods 

<img width="743" alt="Screenshot 2024-11-15 at 8 30 25 AM" src="https://github.com/user-attachments/assets/aa9c2a69-36c3-4a65-8ade-10a616ec26bb">


