### PR TITLE
Remove __author__ from __dir__

### DIFF
--- a/CHANGES/9918.bugfix.rst
+++ b/CHANGES/9918.bugfix.rst
@@ -1,0 +1,1 @@
+Removed non-existing `__author__` from `__dir__` -- by :user:`Dreamsorcerer`.

--- a/CHANGES/9918.bugfix.rst
+++ b/CHANGES/9918.bugfix.rst
@@ -1,1 +1,1 @@
-Removed non-existing `__author__` from `__dir__` -- by :user:`Dreamsorcerer`.
+Removed non-existing ``__author__`` from ``dir(aiohttp)`` -- by :user:`Dreamsorcerer`.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -227,7 +227,7 @@ __all__: Tuple[str, ...] = (
 
 
 def __dir__() -> Tuple[str, ...]:
-    return __all__ + ("__author__", "__doc__")
+    return __all__ + ("__doc__",)
 
 
 def __getattr__(name: str) -> object:


### PR DESCRIPTION
We don't actually define this. This was a mistake I made a few years ago in #6591.

Fixes #9914.