### PR TITLE
Experimental support for WebSocket extension `permessage-gzip`

### DIFF
--- a/CHANGES/9933.feature.rst
+++ b/CHANGES/9933.feature.rst
@@ -1,0 +1,1 @@
+Provided experimental support for communicating with WebSocket servers that require the `permessage-gzip` extension -- by :user:`jakob-keller`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -172,6 +172,7 @@ Jacob Champion
 Jaesung Lee
 Jake Davis
 Jakob Ackermann
+Jakob Keller
 Jakub Wilk
 Jan Buchar
 Jan Gosmann

--- a/aiohttp/_websocket/helpers.py
+++ b/aiohttp/_websocket/helpers.py
@@ -120,7 +120,7 @@ def ws_ext_parse(extstr: Optional[str], isserver: bool = False) -> Tuple[int, bo
                 break
         # Return Fail if client side and not match
         elif not isserver:
-            raise WSHandshakeError("Extension for deflate not supported" + ext.group(1))
+            raise WSHandshakeError("Extension for deflate not supported" + defext)
 
     return compress, notakeover
 

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -3,7 +3,7 @@
 import asyncio
 import builtins
 from collections import deque
-from typing import Deque, Final, List, Optional, Set, Tuple, Type, Union
+from typing import Deque, Final, List, Literal, Optional, Set, Tuple, Type, Union
 
 from ..base_protocol import BaseProtocol
 from ..compression_utils import ZLibDecompressor
@@ -131,7 +131,10 @@ class WebSocketDataQueue:
 
 class WebSocketReader:
     def __init__(
-        self, queue: WebSocketDataQueue, max_msg_size: int, compress: bool = True
+        self,
+        queue: WebSocketDataQueue,
+        max_msg_size: int,
+        compress: Union[bool, Literal["gzip"]] = True,
     ) -> None:
         self.queue = queue
         self._max_msg_size = max_msg_size
@@ -241,8 +244,9 @@ class WebSocketReader:
                 # received.
                 if compressed:
                     if not self._decompressobj:
+                        encoding = "gzip" if self._compress == "gzip" else None
                         self._decompressobj = ZLibDecompressor(
-                            suppress_deflate_header=True
+                            encoding=encoding, suppress_deflate_header=True
                         )
                     payload_merged = self._decompressobj.decompress_sync(
                         assembled_payload + WS_DEFLATE_TRAILING, self._max_msg_size

--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -161,7 +161,7 @@ class WebSocketWriter:
     def _make_compress_obj(self, compress: int) -> ZLibCompressor:
         return ZLibCompressor(
             level=zlib.Z_BEST_SPEED,
-            wbits=-compress,
+            wbits=-compress if compress <= zlib.MAX_WBITS else compress,
             max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Provides experimental support for communicating with WebSocket servers that require the non-standard `permessage-gzip` extension.

## Are there changes in behavior for the user?

None

## Is it a substantial burden for the maintainers to support this?

No

## Related issue number

Fixes #9933 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder