### PR TITLE
Add benchmarks for creating web responses

### DIFF
--- a/tests/test_benchmarks_web_response.py
+++ b/tests/test_benchmarks_web_response.py
@@ -14,13 +14,10 @@ def test_simple_web_response(
     """Benchmark creating 100 simple web.Response."""
     response_count = 100
 
-    async def run_web_response_benchmark() -> None:
-        for _ in range(response_count):
-            web.Response()
-
     @benchmark
     def _run() -> None:
-        loop.run_until_complete(run_web_response_benchmark())
+        for _ in range(response_count):
+            web.Response()
 
 
 def test_web_response_with_headers(
@@ -35,13 +32,10 @@ def test_web_response_with_headers(
         "Date": "Sun, 01 Aug 2021 12:00:00 GMT",
     }
 
-    async def run_web_response_benchmark() -> None:
-        for _ in range(response_count):
-            web.Response(headers=headers)
-
     @benchmark
     def _run() -> None:
-        loop.run_until_complete(run_web_response_benchmark())
+        for _ in range(response_count):
+            web.Response(headers=headers)
 
 
 def test_web_response_with_bytes_body(
@@ -51,13 +45,10 @@ def test_web_response_with_bytes_body(
     """Benchmark creating 100 web.Response with bytes."""
     response_count = 100
 
-    async def run_web_response_benchmark() -> None:
-        for _ in range(response_count):
-            web.Response(body=b"Hello, World!")
-
     @benchmark
     def _run() -> None:
-        loop.run_until_complete(run_web_response_benchmark())
+        for _ in range(response_count):
+            web.Response(body=b"Hello, World!")
 
 
 def test_web_response_with_text_body(
@@ -67,13 +58,10 @@ def test_web_response_with_text_body(
     """Benchmark creating 100 web.Response with text."""
     response_count = 100
 
-    async def run_web_response_benchmark() -> None:
-        for _ in range(response_count):
-            web.Response(text="Hello, World!")
-
     @benchmark
     def _run() -> None:
-        loop.run_until_complete(run_web_response_benchmark())
+        for _ in range(response_count):
+            web.Response(text="Hello, World!")
 
 
 def test_simple_web_stream_response(
@@ -83,10 +71,7 @@ def test_simple_web_stream_response(
     """Benchmark creating 100 simple web.StreamResponse."""
     response_count = 100
 
-    async def run_web_response_benchmark() -> None:
-        for _ in range(response_count):
-            web.StreamResponse()
-
     @benchmark
     def _run() -> None:
-        loop.run_until_complete(run_web_response_benchmark())
+        for _ in range(response_count):
+            web.StreamResponse()

--- a/tests/test_benchmarks_web_response.py
+++ b/tests/test_benchmarks_web_response.py
@@ -1,16 +1,11 @@
 """codspeed benchmarks for the web responses."""
 
-import asyncio
-
 from pytest_codspeed import BenchmarkFixture
 
 from aiohttp import web
 
 
-def test_simple_web_response(
-    loop: asyncio.AbstractEventLoop,
-    benchmark: BenchmarkFixture,
-) -> None:
+def test_simple_web_response(benchmark: BenchmarkFixture) -> None:
     """Benchmark creating 100 simple web.Response."""
     response_count = 100
 
@@ -20,10 +15,7 @@ def test_simple_web_response(
             web.Response()
 
 
-def test_web_response_with_headers(
-    loop: asyncio.AbstractEventLoop,
-    benchmark: BenchmarkFixture,
-) -> None:
+def test_web_response_with_headers(benchmark: BenchmarkFixture) -> None:
     """Benchmark creating 100 web.Response with headers."""
     response_count = 100
     headers = {
@@ -39,7 +31,6 @@ def test_web_response_with_headers(
 
 
 def test_web_response_with_bytes_body(
-    loop: asyncio.AbstractEventLoop,
     benchmark: BenchmarkFixture,
 ) -> None:
     """Benchmark creating 100 web.Response with bytes."""
@@ -51,10 +42,7 @@ def test_web_response_with_bytes_body(
             web.Response(body=b"Hello, World!")
 
 
-def test_web_response_with_text_body(
-    loop: asyncio.AbstractEventLoop,
-    benchmark: BenchmarkFixture,
-) -> None:
+def test_web_response_with_text_body(benchmark: BenchmarkFixture) -> None:
     """Benchmark creating 100 web.Response with text."""
     response_count = 100
 
@@ -64,10 +52,7 @@ def test_web_response_with_text_body(
             web.Response(text="Hello, World!")
 
 
-def test_simple_web_stream_response(
-    loop: asyncio.AbstractEventLoop,
-    benchmark: BenchmarkFixture,
-) -> None:
+def test_simple_web_stream_response(benchmark: BenchmarkFixture) -> None:
     """Benchmark creating 100 simple web.StreamResponse."""
     response_count = 100
 

--- a/tests/test_benchmarks_web_response.py
+++ b/tests/test_benchmarks_web_response.py
@@ -1,0 +1,92 @@
+"""codspeed benchmarks for the web responses."""
+
+import asyncio
+
+from pytest_codspeed import BenchmarkFixture
+
+from aiohttp import web
+
+
+def test_simple_web_response(
+    loop: asyncio.AbstractEventLoop,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark creating 100 simple web.Response."""
+    response_count = 100
+
+    async def run_web_response_benchmark() -> None:
+        for _ in range(response_count):
+            web.Response()
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_web_response_benchmark())
+
+
+def test_web_response_with_headers(
+    loop: asyncio.AbstractEventLoop,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark creating 100 web.Response with headers."""
+    response_count = 100
+    headers = {
+        "Content-Type": "text/plain",
+        "Server": "aiohttp",
+        "Date": "Sun, 01 Aug 2021 12:00:00 GMT",
+    }
+
+    async def run_web_response_benchmark() -> None:
+        for _ in range(response_count):
+            web.Response(headers=headers)
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_web_response_benchmark())
+
+
+def test_web_response_with_bytes_body(
+    loop: asyncio.AbstractEventLoop,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark creating 100 web.Response with bytes."""
+    response_count = 100
+
+    async def run_web_response_benchmark() -> None:
+        for _ in range(response_count):
+            web.Response(body=b"Hello, World!")
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_web_response_benchmark())
+
+
+def test_web_response_with_text_body(
+    loop: asyncio.AbstractEventLoop,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark creating 100 web.Response with text."""
+    response_count = 100
+
+    async def run_web_response_benchmark() -> None:
+        for _ in range(response_count):
+            web.Response(text="Hello, World!")
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_web_response_benchmark())
+
+
+def test_simple_web_stream_response(
+    loop: asyncio.AbstractEventLoop,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark creating 100 simple web.StreamResponse."""
+    response_count = 100
+
+    async def run_web_response_benchmark() -> None:
+        for _ in range(response_count):
+            web.StreamResponse()
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_web_response_benchmark())


### PR DESCRIPTION
Focused benchmark to measure changes in `web.*Response` creation time for https://github.com/aio-libs/aiohttp/pull/9895

related issue https://github.com/aio-libs/aiohttp/issues/2779