### PR TITLE
Use SPDX license expression

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 maintainer = aiohttp team <team@aiohttp.org>
 maintainer_email = team@aiohttp.org
-license = Apache 2
+license = Apache-2.0
 license_files = LICENSE.txt
 classifiers =
   Development Status :: 5 - Production/Stable


### PR DESCRIPTION
## What do these changes do?
Use the SPDX license identifier as recommended by [PEP 639](https://peps.python.org/pep-0639/).
https://spdx.org/licenses/Apache-2.0.html