### PR TITLE
Disable Python 3.14 builds

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -155,10 +155,10 @@ jobs:
             no-extensions: 'Y'
             os: ubuntu
             experimental: false
-          - os: ubuntu
-            pyver: "3.14"
-            experimental: true
-            no-extensions: 'Y'
+          # - os: ubuntu
+          #   pyver: "3.14"
+          #   experimental: true
+          #   no-extensions: 'Y'
       fail-fast: true
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ matrix.experimental }}


### PR DESCRIPTION
Now aiohttp cannot be *installed* on Python 3.14 because the lack of dependencies support.
It leads to non-required but annoying red cross label for every CI build.

Let's skip the Python 3.14 build matrix until 3.14rc will be published, aiohttp dependencies compile py-3.14 compatible distributions, and all will be ready for migration.

Right now I'm disappointing to see red cross for every CI run, I should open it to figure out is it a critical failure or py-3.14 problem that could be ignored.