### PR TITLE
[3.11] Restore `FlowControlDataQueue` class

### DIFF
--- a/CHANGES/9963.bugfix.rst
+++ b/CHANGES/9963.bugfix.rst
@@ -1,0 +1,3 @@
+Restored the ``FlowControlDataQueue`` class -- by :user:`bdraco`.
+
+This class is no longer used internally, and will be permanently removed in the next major version.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -93,6 +93,7 @@ from .streams import (
     EMPTY_PAYLOAD as EMPTY_PAYLOAD,
     DataQueue as DataQueue,
     EofStream as EofStream,
+    FlowControlDataQueue as FlowControlDataQueue,
     StreamReader as StreamReader,
 )
 from .tracing import (
@@ -148,6 +149,7 @@ __all__: Tuple[str, ...] = (
     "ConnectionTimeoutError",
     "ContentTypeError",
     "Fingerprint",
+    "FlowControlDataQueue",
     "InvalidURL",
     "InvalidUrlClientError",
     "InvalidUrlRedirectClientError",

--- a/tests/test_flowcontrol_streams.py
+++ b/tests/test_flowcontrol_streams.py
@@ -154,8 +154,12 @@ def test_flow_control_data_queue_feed_pause(
     """Test feeding data and pausing the reader."""
     buffer._protocol._reading_paused = False
     buffer.feed_data(object(), 100)
-
     assert buffer._protocol.pause_reading.called
+
+    buffer._protocol._reading_paused = True
+    buffer._protocol.pause_reading.reset_mock()
+    buffer.feed_data(object(), 100)
+    assert not buffer._protocol.pause_reading.called
 
 
 async def test_flow_control_data_queue_resume_on_read(
@@ -167,3 +171,12 @@ async def test_flow_control_data_queue_resume_on_read(
     buffer._protocol._reading_paused = True
     await buffer.read()
     assert buffer._protocol.resume_reading.called
+
+
+async def test_flow_control_data_queue_read_eof(
+    buffer: streams.FlowControlDataQueue,
+) -> None:
+    """Test that reading after eof raises EofStream."""
+    buffer.feed_eof()
+    with pytest.raises(streams.EofStream):
+        await buffer.read()


### PR DESCRIPTION
We no longer use `FlowControlDataQueue` internally as it was removed in #9793. It was assumed (incorrectly) it was not used externally. At least `aiodocker` uses it. There may be others so we will restore it for 3.11.

Please note that it will go away permanently in 4.x so its will probably be best to vendor the code in this PR if you will still need this class when 4.x is released.

fixes https://github.com/aio-libs/aiodocker/issues/918
