### PR TITLE
[PR #9895/d8ec1b4 backport][3.12] Defer creation of SimpleCookie objects in the web server until needed

### DIFF
--- a/CHANGES/9895.misc.rst
+++ b/CHANGES/9895.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of creating web responses when there are no cookies -- by :user:`bdraco`.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -93,7 +93,7 @@ class StreamResponse(BaseClass, HeadersMixin):
         self._compression = False
         self._compression_strategy: int = zlib.Z_DEFAULT_STRATEGY
         self._compression_force: Optional[ContentCoding] = None
-        self._cookies = SimpleCookie()
+        self._cookies: Optional[SimpleCookie] = None
 
         self._req: Optional[BaseRequest] = None
         self._payload_writer: Optional[AbstractStreamWriter] = None
@@ -209,6 +209,8 @@ class StreamResponse(BaseClass, HeadersMixin):
 
     @property
     def cookies(self) -> SimpleCookie:
+        if self._cookies is None:
+            self._cookies = SimpleCookie()
         return self._cookies
 
     def set_cookie(
@@ -230,10 +232,8 @@ class StreamResponse(BaseClass, HeadersMixin):
         Sets new cookie or updates existent with new value.
         Also updates only those params which are not None.
         """
-        old = self._cookies.get(name)
-        if old is not None and old.coded_value == "":
-            # deleted cookie
-            self._cookies.pop(name, None)
+        if self._cookies is None:
+            self._cookies = SimpleCookie()
 
         self._cookies[name] = value
         c = self._cookies[name]
@@ -277,7 +277,8 @@ class StreamResponse(BaseClass, HeadersMixin):
         Creates new empty expired cookie.
         """
         # TODO: do we need domain/path here?
-        self._cookies.pop(name, None)
+        if self._cookies is not None:
+            self._cookies.pop(name, None)
         self.set_cookie(
             name,
             "",

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -864,6 +864,10 @@ def test_response_cookies() -> None:
 
     resp.set_cookie("name", "value")
     assert str(resp.cookies) == "Set-Cookie: name=value; Path=/"
+    resp.set_cookie("name", "")
+    assert str(resp.cookies) == 'Set-Cookie: name=""; Path=/'
+    resp.set_cookie("name", "value")
+    assert str(resp.cookies) == "Set-Cookie: name=value; Path=/"
     resp.set_cookie("name", "other_value")
     assert str(resp.cookies) == "Set-Cookie: name=other_value; Path=/"
 
@@ -879,6 +883,8 @@ def test_response_cookies() -> None:
         "expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; Path=/"
     )
     assert Matches(expected) == str(resp.cookies)
+    resp.del_cookie("name")
+    assert str(resp.cookies) == Matches(expected)
 
     resp.set_cookie("name", "value", domain="local.host")
     expected = "Set-Cookie: name=value; Domain=local.host; Path=/"


### PR DESCRIPTION
(cherry picked from commit d8ec1b42a845460cc3966673d40130939fef2ca7)
