### PR TITLE
Revert "Only construct the `allowed_methods` `set` once for a `StaticResource`"

### DIFF
--- a/CHANGES/9972.bugfix.rst
+++ b/CHANGES/9972.bugfix.rst
@@ -1,0 +1,3 @@
+Reverted an optimization to avoid rebuilding the allowed methods for `StaticResource` on every request -- by :user:`bdraco`.
+
+``aiohttp-cors`` needs to be able to modify the allowed methods at run time via this internal.

--- a/CHANGES/9972.bugfix.rst
+++ b/CHANGES/9972.bugfix.rst
@@ -1,3 +1,3 @@
-Reverted an optimization to avoid rebuilding the allowed methods for `StaticResource` on every request -- by :user:`bdraco`.
+Reverted an optimization to avoid rebuilding the allowed methods for ``StaticResource`` on every request -- by :user:`bdraco`.
 
 ``aiohttp-cors`` needs to be able to modify the allowed methods at run time via this internal.

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -620,10 +620,10 @@ class StaticResource(PrefixResource):
     async def resolve(self, request: Request) -> _Resolve:
         path = request.rel_url.path_safe
         method = request.method
-        allowed_methods = set(self._routes)
         if not path.startswith(self._prefix2) and path != self._prefix:
             return None, set()
 
+        allowed_methods = set(self._routes)
         if method not in allowed_methods:
             return None, allowed_methods
 

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -557,7 +557,6 @@ class StaticResource(PrefixResource):
                 "HEAD", self._handle, self, expect_handler=expect_handler
             ),
         }
-        self._allowed_methods = set(self._routes)
 
     def url_for(  # type: ignore[override]
         self,
@@ -621,10 +620,10 @@ class StaticResource(PrefixResource):
     async def resolve(self, request: Request) -> _Resolve:
         path = request.rel_url.path_safe
         method = request.method
+        allowed_methods = set(self._routes)
         if not path.startswith(self._prefix2) and path != self._prefix:
             return None, set()
 
-        allowed_methods = self._allowed_methods
         if method not in allowed_methods:
             return None, allowed_methods
 


### PR DESCRIPTION
Reverts aio-libs/aiohttp#9911

`aiohttp-cors` accesses the protected `self._routes` here and relies on being able to add new methods
https://github.com/aio-libs/aiohttp-cors/blob/38c6c17bffc805e46baccd7be1b4fd8c69d95dc3/aiohttp_cors/urldispatcher_router_adapter.py#L187