### PR TITLE
Add test coverage for accessing StaticResource._routes

### DIFF
--- a/CHANGES/9975.bugfix.rst
+++ b/CHANGES/9975.bugfix.rst
@@ -1,0 +1,1 @@
+9972.bugfix.rst

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -520,7 +520,7 @@ async def test_static_not_match(router: web.UrlDispatcher) -> None:
 async def test_add_static_access_resources(router: web.UrlDispatcher) -> None:
     """Test accessing resource._routes externally.
 
-    aiohttp-cors access the resource._routes, this test ensures that this
+    aiohttp-cors accesses the resource._routes, this test ensures that this
     continues to work.
     """
     # https://github.com/aio-libs/aiohttp-cors/blob/38c6c17bffc805e46baccd7be1b4fd8c69d95dc3/aiohttp_cors/urldispatcher_router_adapter.py#L187

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -517,6 +517,23 @@ async def test_static_not_match(router: web.UrlDispatcher) -> None:
     assert (None, set()) == ret
 
 
+async def test_add_static_mutate_resources(router: web.UrlDispatcher) -> None:
+    """Test mutating resource._routes to add an options method.
+
+    aiohttp-cors mutates the resource._routes, this test ensures that this
+    continues to work.
+    """
+    resource = router.add_static(
+        "/st", pathlib.Path(aiohttp.__file__).parent, name="static"
+    )
+    resource._routes[hdrs.METH_OPTIONS] = resource._routes[hdrs.METH_GET]
+    mapping, allowed_methods = await resource.resolve(
+        make_mocked_request("OPTIONS", "/st/path")
+    )
+    assert mapping is not None
+    assert allowed_methods == {hdrs.METH_GET, hdrs.METH_OPTIONS, hdrs.METH_HEAD}
+
+
 def test_dynamic_with_trailing_slash(router: web.UrlDispatcher) -> None:
     handler = make_handler()
     router.add_route("GET", "/get/{name}/", handler, name="name")

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -535,6 +535,19 @@ async def test_add_static_mutate_resources(router: web.UrlDispatcher) -> None:
     assert allowed_methods == {hdrs.METH_GET, hdrs.METH_OPTIONS, hdrs.METH_HEAD}
 
 
+async def test_add_static_set_options_route(router: web.UrlDispatcher) -> None:
+    """Ensure set_options_route works as expected."""
+    resource = router.add_static(
+        "/st", pathlib.Path(aiohttp.__file__).parent, name="static"
+    )
+    resource.set_options_route(resource._routes[hdrs.METH_GET])
+    mapping, allowed_methods = await resource.resolve(
+        make_mocked_request("OPTIONS", "/st/path")
+    )
+    assert mapping is not None
+    assert allowed_methods == {hdrs.METH_GET, hdrs.METH_OPTIONS, hdrs.METH_HEAD}
+
+
 def test_dynamic_with_trailing_slash(router: web.UrlDispatcher) -> None:
     handler = make_handler()
     router.add_route("GET", "/get/{name}/", handler, name="name")

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -523,6 +523,7 @@ async def test_add_static_mutate_resources(router: web.UrlDispatcher) -> None:
     aiohttp-cors mutates the resource._routes, this test ensures that this
     continues to work.
     """
+    # https://github.com/aio-libs/aiohttp-cors/blob/38c6c17bffc805e46baccd7be1b4fd8c69d95dc3/aiohttp_cors/urldispatcher_router_adapter.py#L187
     resource = router.add_static(
         "/st", pathlib.Path(aiohttp.__file__).parent, name="static"
     )

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -517,10 +517,10 @@ async def test_static_not_match(router: web.UrlDispatcher) -> None:
     assert (None, set()) == ret
 
 
-async def test_add_static_mutate_resources(router: web.UrlDispatcher) -> None:
-    """Test mutating resource._routes to add an options method.
+async def test_add_static_access_resources(router: web.UrlDispatcher) -> None:
+    """Test accessing resource._routes externally.
 
-    aiohttp-cors mutates the resource._routes, this test ensures that this
+    aiohttp-cors access the resource._routes, this test ensures that this
     continues to work.
     """
     # https://github.com/aio-libs/aiohttp-cors/blob/38c6c17bffc805e46baccd7be1b4fd8c69d95dc3/aiohttp_cors/urldispatcher_router_adapter.py#L187
@@ -540,7 +540,11 @@ async def test_add_static_set_options_route(router: web.UrlDispatcher) -> None:
     resource = router.add_static(
         "/st", pathlib.Path(aiohttp.__file__).parent, name="static"
     )
-    resource.set_options_route(resource._routes[hdrs.METH_GET])
+
+    async def handler(request: web.Request) -> NoReturn:
+        assert False
+
+    resource.set_options_route(handler)
     mapping, allowed_methods = await resource.resolve(
         make_mocked_request("OPTIONS", "/st/path")
     )


### PR DESCRIPTION
#9911 optimized this to only build the set once, however ``aiohttp-cors`` relies on being able to access `StaticResouce._routes`
https://github.com/aio-libs/aiohttp-cors/blob/38c6c17bffc805e46baccd7be1b4fd8c69d95dc3/aiohttp_cors/urldispatcher_router_adapter.py#L187 so it was reverted in #9972

Since this requirement is unexpected, and therefore hard to discover, add a test for it.