### PR TITLE
Restore only construct the allowed_methods set once for a `StaticResource`

### DIFF
--- a/CHANGES/9972.bugfix.rst
+++ b/CHANGES/9972.bugfix.rst
@@ -1,3 +1,1 @@
-Reverted an optimization to avoid rebuilding the allowed methods for ``StaticResource`` on every request -- by :user:`bdraco`.
-
-``aiohttp-cors`` needs to be able to modify the allowed methods at run time via this internal.
+Fixed ``StaticResource`` not allowing the ``OPTIONS`` method after calling ``set_options_route`` -- by :user:`bdraco`.

--- a/CHANGES/9976.bugfix.rst
+++ b/CHANGES/9976.bugfix.rst
@@ -1,0 +1,1 @@
+9972.bugfix.rst

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -557,6 +557,7 @@ class StaticResource(PrefixResource):
                 "HEAD", self._handle, self, expect_handler=expect_handler
             ),
         }
+        self._allowed_methods = set(self._routes)
 
     def url_for(  # type: ignore[override]
         self,
@@ -616,6 +617,7 @@ class StaticResource(PrefixResource):
         self._routes["OPTIONS"] = ResourceRoute(
             "OPTIONS", handler, self, expect_handler=self._expect_handler
         )
+        self._allowed_methods.add("OPTIONS")
 
     async def resolve(self, request: Request) -> _Resolve:
         path = request.rel_url.path_safe
@@ -623,7 +625,7 @@ class StaticResource(PrefixResource):
         if not path.startswith(self._prefix2) and path != self._prefix:
             return None, set()
 
-        allowed_methods = set(self._routes)
+        allowed_methods = self._allowed_methods
         if method not in allowed_methods:
             return None, allowed_methods
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -528,6 +528,7 @@ async def test_add_static_access_resources(router: web.UrlDispatcher) -> None:
         "/st", pathlib.Path(aiohttp.__file__).parent, name="static"
     )
     resource._routes[hdrs.METH_OPTIONS] = resource._routes[hdrs.METH_GET]
+    resource._allowed_methods.add(hdrs.METH_OPTIONS)
     mapping, allowed_methods = await resource.resolve(
         make_mocked_request("OPTIONS", "/st/path")
     )


### PR DESCRIPTION
Was reverted in #9972 because it introduced a regression with adding and OPTIONS method. Fix the ``set_options_route`` call instead and restore the change. There is now test coverage for this case as well via #9975
