### PR TITLE
[PR #9975/8704bc7 backport][3.12] Add test coverage for accessing StaticResource._routes

### DIFF
--- a/CHANGES/9975.bugfix.rst
+++ b/CHANGES/9975.bugfix.rst
@@ -1,0 +1,1 @@
+9972.bugfix.rst

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1,6 +1,7 @@
 import pathlib
 import re
 from collections.abc import Container, Iterable, Mapping, MutableMapping, Sized
+from typing import NoReturn
 from urllib.parse import quote, unquote
 
 import pytest
@@ -486,7 +487,42 @@ async def test_static_not_match(router) -> None:
     assert (None, set()) == ret
 
 
-def test_dynamic_with_trailing_slash(router) -> None:
+async def test_add_static_access_resources(router: web.UrlDispatcher) -> None:
+    """Test accessing resource._routes externally.
+
+    aiohttp-cors accesses the resource._routes, this test ensures that this
+    continues to work.
+    """
+    # https://github.com/aio-libs/aiohttp-cors/blob/38c6c17bffc805e46baccd7be1b4fd8c69d95dc3/aiohttp_cors/urldispatcher_router_adapter.py#L187
+    resource = router.add_static(
+        "/st", pathlib.Path(aiohttp.__file__).parent, name="static"
+    )
+    resource._routes[hdrs.METH_OPTIONS] = resource._routes[hdrs.METH_GET]
+    mapping, allowed_methods = await resource.resolve(
+        make_mocked_request("OPTIONS", "/st/path")
+    )
+    assert mapping is not None
+    assert allowed_methods == {hdrs.METH_GET, hdrs.METH_OPTIONS, hdrs.METH_HEAD}
+
+
+async def test_add_static_set_options_route(router: web.UrlDispatcher) -> None:
+    """Ensure set_options_route works as expected."""
+    resource = router.add_static(
+        "/st", pathlib.Path(aiohttp.__file__).parent, name="static"
+    )
+
+    async def handler(request: web.Request) -> NoReturn:
+        assert False
+
+    resource.set_options_route(handler)
+    mapping, allowed_methods = await resource.resolve(
+        make_mocked_request("OPTIONS", "/st/path")
+    )
+    assert mapping is not None
+    assert allowed_methods == {hdrs.METH_GET, hdrs.METH_OPTIONS, hdrs.METH_HEAD}
+
+
+def test_dynamic_with_trailing_slash(router: web.UrlDispatcher) -> None:
     handler = make_handler()
     router.add_route("GET", "/get/{name}/", handler, name="name")
     route = router["name"]


### PR DESCRIPTION
(cherry picked from commit 8704bc74f127497496d4e3241304a6f6d2346494)
