### PR TITLE
Release 3.11.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,36 @@
 
 .. towncrier release notes start
 
+3.11.4 (2024-11-18)
+===================
+
+Bug fixes
+---------
+
+- Fixed ``StaticResource`` not allowing the ``OPTIONS`` method after calling ``set_options_route`` -- by :user:`bdraco`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`9972`, :issue:`9975`, :issue:`9976`.
+
+
+
+
+Miscellaneous internal changes
+------------------------------
+
+- Improved performance of creating web responses when there are no cookies -- by :user:`bdraco`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`9895`.
+
+
+
+
+----
+
+
 3.11.3 (2024-11-18)
 ===================
 

--- a/CHANGES/9895.misc.rst
+++ b/CHANGES/9895.misc.rst
@@ -1,1 +1,0 @@
-Improved performance of creating web responses when there are no cookies -- by :user:`bdraco`.

--- a/CHANGES/9972.bugfix.rst
+++ b/CHANGES/9972.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed ``StaticResource`` not allowing the ``OPTIONS`` method after calling ``set_options_route`` -- by :user:`bdraco`.

--- a/CHANGES/9975.bugfix.rst
+++ b/CHANGES/9975.bugfix.rst
@@ -1,1 +1,0 @@
-9972.bugfix.rst

--- a/CHANGES/9976.bugfix.rst
+++ b/CHANGES/9976.bugfix.rst
@@ -1,1 +1,0 @@
-9972.bugfix.rst

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.11.4.dev0"
+__version__ = "3.11.4"
 
 from typing import TYPE_CHECKING, Tuple
 


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/actions/runs/11907139622
Doing another release for the regression with `StaticResource` which caused a problem with `aiohttp-cors` with 3.11.3.  `aiohttp-cors` accesses `StaticResource._routes` which was a bit unexpected, and coverage now exists for this via #9975.
<img width="674" alt="Screenshot 2024-11-18 at 11 47 47 PM" src="https://github.com/user-attachments/assets/f1cc230a-acf4-44a9-84c4-be53640eb5dd">

