### PR TITLE
Add target-version to black config (#9962)

### DIFF
--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -43,7 +43,7 @@ class AiohttpClient(Protocol):
         __param: Application,
         *,
         server_kwargs: Optional[Dict[str, Any]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> TestClient[Request, Application]: ...
     @overload
     async def __call__(
@@ -51,7 +51,7 @@ class AiohttpClient(Protocol):
         __param: BaseTestServer,
         *,
         server_kwargs: Optional[Dict[str, Any]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> TestClient[BaseRequest, None]: ...
 
 
@@ -379,7 +379,7 @@ def aiohttp_client(loop: asyncio.AbstractEventLoop) -> Iterator[AiohttpClient]:
         __param: Application,
         *,
         server_kwargs: Optional[Dict[str, Any]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> TestClient[Request, Application]: ...
 
     @overload
@@ -387,14 +387,14 @@ def aiohttp_client(loop: asyncio.AbstractEventLoop) -> Iterator[AiohttpClient]:
         __param: BaseTestServer,
         *,
         server_kwargs: Optional[Dict[str, Any]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> TestClient[BaseRequest, None]: ...
 
     async def go(
         __param: Union[Application, BaseTestServer],
         *args: Any,
         server_kwargs: Optional[Dict[str, Any]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> TestClient[Any, Any]:
         if isinstance(__param, Callable) and not isinstance(  # type: ignore[arg-type]
             __param, (Application, BaseTestServer)

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -85,7 +85,7 @@ class AsyncResolver(AbstractResolver):
         self,
         loop: Optional[asyncio.AbstractEventLoop] = None,
         *args: Any,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         if aiodns is None:
             raise RuntimeError("Resolver requires aiodns library")

--- a/aiohttp/web_server.py
+++ b/aiohttp/web_server.py
@@ -20,7 +20,7 @@ class Server:
         request_factory: Optional[_RequestFactory] = None,
         handler_cancellation: bool = False,
         loop: Optional[asyncio.AbstractEventLoop] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         self._loop = loop or asyncio.get_running_loop()
         self._connections: Dict[RequestHandler, asyncio.Transport] = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,3 +87,8 @@ ignore-words-list = 'te'
 # TODO(3.13): Remove aiohttp.helpers once https://github.com/python/cpython/pull/106771
 # is available in all supported cpython versions
 exclude-modules = "(^aiohttp\\.helpers)"
+
+[tool.black]
+# TODO: Remove when project metadata is moved here.
+# Black can read the value from [project.requires-python].
+target-version = ["py39", "py310", "py311", "py312"]

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2955,9 +2955,10 @@ async def test_creds_in_auth_and_redirect_url(
 
     connector = aiohttp.TCPConnector(resolver=FakeResolver(), ssl=False)
 
-    async with aiohttp.ClientSession(connector=connector) as client, client.get(
-        url_from, auth=aiohttp.BasicAuth("user", "pass")
-    ) as resp:
+    async with (
+        aiohttp.ClientSession(connector=connector) as client,
+        client.get(url_from, auth=aiohttp.BasicAuth("user", "pass")) as resp,
+    ):
         assert len(resp.history) == 1
         assert str(resp.url) == "http://example.com"
         assert resp.status == 200

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -515,11 +515,12 @@ async def test_ws_connect_allowed_protocols(
         return create_mocked_conn()
 
     connector = session._connector
-    with mock.patch.object(connector, "connect", connect), mock.patch.object(
-        connector, "_create_connection", create_connection
-    ), mock.patch.object(connector, "_release"), mock.patch(
-        "aiohttp.client.os"
-    ) as m_os:
+    with (
+        mock.patch.object(connector, "connect", connect),
+        mock.patch.object(connector, "_create_connection", create_connection),
+        mock.patch.object(connector, "_release"),
+        mock.patch("aiohttp.client.os") as m_os,
+    ):
         m_os.urandom.return_value = key_data
         await session.ws_connect(f"{protocol}://example")
 
@@ -576,11 +577,12 @@ async def test_ws_connect_unix_socket_allowed_protocols(
         return create_mocked_conn()
 
     connector = session._connector
-    with mock.patch.object(connector, "connect", connect), mock.patch.object(
-        connector, "_create_connection", create_connection
-    ), mock.patch.object(connector, "_release"), mock.patch(
-        "aiohttp.client.os"
-    ) as m_os:
+    with (
+        mock.patch.object(connector, "connect", connect),
+        mock.patch.object(connector, "_create_connection", create_connection),
+        mock.patch.object(connector, "_release"),
+        mock.patch("aiohttp.client.os") as m_os,
+    ):
         m_os.urandom.return_value = key_data
         await session.ws_connect(f"{protocol}://example")
 

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -51,9 +51,10 @@ async def test_ws_connect_read_timeout_is_reset_to_inf(
         hdrs.SEC_WEBSOCKET_PROTOCOL: "chat",
     }
     resp.connection.protocol.read_timeout = 0.5
-    with mock.patch("aiohttp.client.os") as m_os, mock.patch(
-        "aiohttp.client.ClientSession.request"
-    ) as m_req:
+    with (
+        mock.patch("aiohttp.client.os") as m_os,
+        mock.patch("aiohttp.client.ClientSession.request") as m_req,
+    ):
         m_os.urandom.return_value = key_data
         m_req.return_value = loop.create_future()
         m_req.return_value.set_result(resp)
@@ -80,9 +81,10 @@ async def test_ws_connect_read_timeout_stays_inf(
         hdrs.SEC_WEBSOCKET_PROTOCOL: "chat",
     }
     resp.connection.protocol.read_timeout = None
-    with mock.patch("aiohttp.client.os") as m_os, mock.patch(
-        "aiohttp.client.ClientSession.request"
-    ) as m_req:
+    with (
+        mock.patch("aiohttp.client.os") as m_os,
+        mock.patch("aiohttp.client.ClientSession.request") as m_req,
+    ):
         m_os.urandom.return_value = key_data
         m_req.return_value = loop.create_future()
         m_req.return_value.set_result(resp)
@@ -111,9 +113,10 @@ async def test_ws_connect_read_timeout_reset_to_max(
         hdrs.SEC_WEBSOCKET_PROTOCOL: "chat",
     }
     resp.connection.protocol.read_timeout = 0.5
-    with mock.patch("aiohttp.client.os") as m_os, mock.patch(
-        "aiohttp.client.ClientSession.request"
-    ) as m_req:
+    with (
+        mock.patch("aiohttp.client.os") as m_os,
+        mock.patch("aiohttp.client.ClientSession.request") as m_req,
+    ):
         m_os.urandom.return_value = key_data
         m_req.return_value = loop.create_future()
         m_req.return_value.set_result(resp)
@@ -416,9 +419,11 @@ async def test_close_connection_lost(
         hdrs.SEC_WEBSOCKET_ACCEPT: ws_key,
     }
     mresp.connection.protocol.read_timeout = None
-    with mock.patch("aiohttp.client.WebSocketWriter"), mock.patch(
-        "aiohttp.client.os"
-    ) as m_os, mock.patch("aiohttp.client.ClientSession.request") as m_req:
+    with (
+        mock.patch("aiohttp.client.WebSocketWriter"),
+        mock.patch("aiohttp.client.os") as m_os,
+        mock.patch("aiohttp.client.ClientSession.request") as m_req,
+    ):
         m_os.urandom.return_value = key_data
         m_req.return_value = loop.create_future()
         m_req.return_value.set_result(mresp)

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -756,11 +756,14 @@ async def test_heartbeat_connection_closed(aiohttp_client: AiohttpClient) -> Non
     # since if we closed the connection normally, the client would
     # would cancel the heartbeat task and we wouldn't get a ping
     assert resp._conn is not None
-    with mock.patch.object(
-        resp._conn.transport, "write", side_effect=ClientConnectionResetError
-    ), mock.patch.object(
-        resp._writer, "send_frame", wraps=resp._writer.send_frame
-    ) as send_frame:
+    with (
+        mock.patch.object(
+            resp._conn.transport, "write", side_effect=ClientConnectionResetError
+        ),
+        mock.patch.object(
+            resp._writer, "send_frame", wraps=resp._writer.send_frame
+        ) as send_frame,
+    ):
         await resp.receive()
         ping_count = send_frame.call_args_list.count(mock.call(b"", WSMsgType.PING))
     # Connection should be closed roughly after 1.5x heartbeat.

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -783,16 +783,24 @@ async def test_tcp_connector_multiple_hosts_errors(loop) -> None:
 
         assert False
 
-    with mock.patch.object(
-        conn, "_resolve_host", autospec=True, spec_set=True, side_effect=_resolve_host
-    ), mock.patch.object(
-        conn._loop,
-        "create_connection",
-        autospec=True,
-        spec_set=True,
-        side_effect=create_connection,
-    ), mock.patch(
-        "aiohttp.connector.aiohappyeyeballs.start_connection", start_connection
+    with (
+        mock.patch.object(
+            conn,
+            "_resolve_host",
+            autospec=True,
+            spec_set=True,
+            side_effect=_resolve_host,
+        ),
+        mock.patch.object(
+            conn._loop,
+            "create_connection",
+            autospec=True,
+            spec_set=True,
+            side_effect=create_connection,
+        ),
+        mock.patch(
+            "aiohttp.connector.aiohappyeyeballs.start_connection", start_connection
+        ),
     ):
         established_connection = await conn.connect(req, [], ClientTimeout())
 
@@ -945,16 +953,24 @@ async def test_tcp_connector_interleave(loop: Any) -> None:
         pr = create_mocked_conn(loop)
         return tr, pr
 
-    with mock.patch.object(
-        conn, "_resolve_host", autospec=True, spec_set=True, side_effect=_resolve_host
-    ), mock.patch.object(
-        conn._loop,
-        "create_connection",
-        autospec=True,
-        spec_set=True,
-        side_effect=create_connection,
-    ), mock.patch(
-        "aiohttp.connector.aiohappyeyeballs.start_connection", start_connection
+    with (
+        mock.patch.object(
+            conn,
+            "_resolve_host",
+            autospec=True,
+            spec_set=True,
+            side_effect=_resolve_host,
+        ),
+        mock.patch.object(
+            conn._loop,
+            "create_connection",
+            autospec=True,
+            spec_set=True,
+            side_effect=create_connection,
+        ),
+        mock.patch(
+            "aiohttp.connector.aiohappyeyeballs.start_connection", start_connection
+        ),
     ):
         established_connection = await conn.connect(req, [], ClientTimeout())
 
@@ -1113,16 +1129,24 @@ async def test_tcp_connector_multiple_hosts_one_timeout(
         pr = create_mocked_conn(loop)
         return tr, pr
 
-    with mock.patch.object(
-        conn, "_resolve_host", autospec=True, spec_set=True, side_effect=_resolve_host
-    ), mock.patch.object(
-        conn._loop,
-        "create_connection",
-        autospec=True,
-        spec_set=True,
-        side_effect=create_connection,
-    ), mock.patch(
-        "aiohttp.connector.aiohappyeyeballs.start_connection", start_connection
+    with (
+        mock.patch.object(
+            conn,
+            "_resolve_host",
+            autospec=True,
+            spec_set=True,
+            side_effect=_resolve_host,
+        ),
+        mock.patch.object(
+            conn._loop,
+            "create_connection",
+            autospec=True,
+            spec_set=True,
+            side_effect=create_connection,
+        ),
+        mock.patch(
+            "aiohttp.connector.aiohappyeyeballs.start_connection", start_connection
+        ),
     ):
         established_connection = await conn.connect(req, [], ClientTimeout())
 
@@ -1594,8 +1618,11 @@ async def test_exception_during_connetion_create_tracing(
     assert not conn._acquired
     assert key not in conn._acquired_per_host
 
-    with pytest.raises(asyncio.CancelledError), mock.patch.object(
-        conn, "_create_connection", autospec=True, spec_set=True, return_value=proto
+    with (
+        pytest.raises(asyncio.CancelledError),
+        mock.patch.object(
+            conn, "_create_connection", autospec=True, spec_set=True, return_value=proto
+        ),
     ):
         await conn.connect(req, traces, ClientTimeout())
 
@@ -1625,8 +1652,11 @@ async def test_exception_during_connection_queued_tracing(
     assert not conn._acquired
     assert key not in conn._acquired_per_host
 
-    with pytest.raises(asyncio.CancelledError), mock.patch.object(
-        conn, "_create_connection", autospec=True, spec_set=True, return_value=proto
+    with (
+        pytest.raises(asyncio.CancelledError),
+        mock.patch.object(
+            conn, "_create_connection", autospec=True, spec_set=True, return_value=proto
+        ),
     ):
         resp1 = await conn.connect(req, traces, ClientTimeout())
         assert resp1
@@ -1663,8 +1693,11 @@ async def test_exception_during_connection_reuse_tracing(
     assert not conn._acquired
     assert key not in conn._acquired_per_host
 
-    with pytest.raises(asyncio.CancelledError), mock.patch.object(
-        conn, "_create_connection", autospec=True, spec_set=True, return_value=proto
+    with (
+        pytest.raises(asyncio.CancelledError),
+        mock.patch.object(
+            conn, "_create_connection", autospec=True, spec_set=True, return_value=proto
+        ),
     ):
         resp = await conn.connect(req, traces, ClientTimeout())
         with mock.patch.object(resp.protocol, "should_close", False):
@@ -1888,8 +1921,9 @@ async def test_cleanup_closed(
 
 async def test_cleanup_closed_is_noop_on_fixed_cpython() -> None:
     """Ensure that enable_cleanup_closed is a noop on fixed Python versions."""
-    with mock.patch("aiohttp.connector.NEEDS_CLEANUP_CLOSED", False), pytest.warns(
-        DeprecationWarning, match="cleanup_closed ignored"
+    with (
+        mock.patch("aiohttp.connector.NEEDS_CLEANUP_CLOSED", False),
+        pytest.warns(DeprecationWarning, match="cleanup_closed ignored"),
     ):
         conn = aiohttp.BaseConnector(enable_cleanup_closed=True)
         assert conn._cleanup_closed_disabled is True
@@ -2143,9 +2177,12 @@ async def test_multiple_dns_resolution_requests_success(
     req = ClientRequest(
         "GET", URL("http://localhost:80"), loop=loop, response_class=mock.Mock()
     )
-    with mock.patch.object(conn._resolver, "resolve", delay_resolve), mock.patch(
-        "aiohttp.connector.aiohappyeyeballs.start_connection",
-        side_effect=OSError(1, "Forced connection to fail"),
+    with (
+        mock.patch.object(conn._resolver, "resolve", delay_resolve),
+        mock.patch(
+            "aiohttp.connector.aiohappyeyeballs.start_connection",
+            side_effect=OSError(1, "Forced connection to fail"),
+        ),
     ):
         task1 = asyncio.create_task(conn.connect(req, [], ClientTimeout()))
 
@@ -2193,9 +2230,12 @@ async def test_multiple_dns_resolution_requests_failure(
     req = ClientRequest(
         "GET", URL("http://localhost:80"), loop=loop, response_class=mock.Mock()
     )
-    with mock.patch.object(conn._resolver, "resolve", delay_resolve), mock.patch(
-        "aiohttp.connector.aiohappyeyeballs.start_connection",
-        side_effect=OSError(1, "Forced connection to fail"),
+    with (
+        mock.patch.object(conn._resolver, "resolve", delay_resolve),
+        mock.patch(
+            "aiohttp.connector.aiohappyeyeballs.start_connection",
+            side_effect=OSError(1, "Forced connection to fail"),
+        ),
     ):
         task1 = asyncio.create_task(conn.connect(req, [], ClientTimeout()))
 
@@ -2243,9 +2283,12 @@ async def test_multiple_dns_resolution_requests_cancelled(
     req = ClientRequest(
         "GET", URL("http://localhost:80"), loop=loop, response_class=mock.Mock()
     )
-    with mock.patch.object(conn._resolver, "resolve", delay_resolve), mock.patch(
-        "aiohttp.connector.aiohappyeyeballs.start_connection",
-        side_effect=OSError(1, "Forced connection to fail"),
+    with (
+        mock.patch.object(conn._resolver, "resolve", delay_resolve),
+        mock.patch(
+            "aiohttp.connector.aiohappyeyeballs.start_connection",
+            side_effect=OSError(1, "Forced connection to fail"),
+        ),
     ):
         task1 = asyncio.create_task(conn.connect(req, [], ClientTimeout()))
 
@@ -2301,9 +2344,12 @@ async def test_multiple_dns_resolution_requests_first_cancelled(
     req = ClientRequest(
         "GET", URL("http://localhost:80"), loop=loop, response_class=mock.Mock()
     )
-    with mock.patch.object(conn._resolver, "resolve", delay_resolve), mock.patch(
-        "aiohttp.connector.aiohappyeyeballs.start_connection",
-        side_effect=OSError(1, "Forced connection to fail"),
+    with (
+        mock.patch.object(conn._resolver, "resolve", delay_resolve),
+        mock.patch(
+            "aiohttp.connector.aiohappyeyeballs.start_connection",
+            side_effect=OSError(1, "Forced connection to fail"),
+        ),
     ):
         task1 = asyncio.create_task(conn.connect(req, [], ClientTimeout()))
 
@@ -2366,9 +2412,12 @@ async def test_multiple_dns_resolution_requests_first_fails_second_successful(
     req = ClientRequest(
         "GET", URL("http://localhost:80"), loop=loop, response_class=mock.Mock()
     )
-    with mock.patch.object(conn._resolver, "resolve", delay_resolve), mock.patch(
-        "aiohttp.connector.aiohappyeyeballs.start_connection",
-        side_effect=OSError(1, "Forced connection to fail"),
+    with (
+        mock.patch.object(conn._resolver, "resolve", delay_resolve),
+        mock.patch(
+            "aiohttp.connector.aiohappyeyeballs.start_connection",
+            side_effect=OSError(1, "Forced connection to fail"),
+        ),
     ):
         task1 = asyncio.create_task(conn.connect(req, [], ClientTimeout()))
 

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -257,9 +257,12 @@ async def test_write_payload_deflate_compression_chunked_connection_lost(
     msg.enable_compression("deflate")
     msg.enable_chunking()
     await msg.write(b"data")
-    with pytest.raises(
-        ClientConnectionResetError, match="Cannot write to closing transport"
-    ), mock.patch.object(transport, "is_closing", return_value=True):
+    with (
+        pytest.raises(
+            ClientConnectionResetError, match="Cannot write to closing transport"
+        ),
+        mock.patch.object(transport, "is_closing", return_value=True),
+    ):
         await msg.write_eof(b"end")
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -417,18 +417,21 @@ class TestProxy(unittest.TestCase):
                 fingerprint_mock.check.side_effect = aiohttp.ServerFingerprintMismatch(
                     b"exp", b"got", "example.com", 8080
                 )
-                with mock.patch.object(
-                    proxy_req,
-                    "send",
-                    autospec=True,
-                    spec_set=True,
-                    return_value=proxy_resp,
-                ), mock.patch.object(
-                    proxy_resp,
-                    "start",
-                    autospec=True,
-                    spec_set=True,
-                    return_value=mock.Mock(status=200),
+                with (
+                    mock.patch.object(
+                        proxy_req,
+                        "send",
+                        autospec=True,
+                        spec_set=True,
+                        return_value=proxy_resp,
+                    ),
+                    mock.patch.object(
+                        proxy_resp,
+                        "start",
+                        autospec=True,
+                        spec_set=True,
+                        return_value=mock.Mock(status=200),
+                    ),
                 ):
                     connector = self.loop.run_until_complete(make_conn())
                     host = [
@@ -441,30 +444,35 @@ class TestProxy(unittest.TestCase):
                             "flags": 0,
                         }
                     ]
-                    with mock.patch.object(
-                        connector,
-                        "_resolve_host",
-                        autospec=True,
-                        spec_set=True,
-                        return_value=host,
-                    ), mock.patch.object(
-                        connector,
-                        "_get_fingerprint",
-                        autospec=True,
-                        spec_set=True,
-                        return_value=fingerprint_mock,
-                    ), mock.patch.object(  # Called on connection to http://proxy.example.com
-                        self.loop,
-                        "create_connection",
-                        autospec=True,
-                        spec_set=True,
-                        return_value=(mock.Mock(), mock.Mock()),
-                    ), mock.patch.object(  # Called on connection to https://www.python.org
-                        self.loop,
-                        "start_tls",
-                        autospec=True,
-                        spec_set=True,
-                        return_value=TransportMock(),
+                    with (
+                        mock.patch.object(
+                            connector,
+                            "_resolve_host",
+                            autospec=True,
+                            spec_set=True,
+                            return_value=host,
+                        ),
+                        mock.patch.object(
+                            connector,
+                            "_get_fingerprint",
+                            autospec=True,
+                            spec_set=True,
+                            return_value=fingerprint_mock,
+                        ),
+                        mock.patch.object(  # Called on connection to http://proxy.example.com
+                            self.loop,
+                            "create_connection",
+                            autospec=True,
+                            spec_set=True,
+                            return_value=(mock.Mock(), mock.Mock()),
+                        ),
+                        mock.patch.object(  # Called on connection to https://www.python.org
+                            self.loop,
+                            "start_tls",
+                            autospec=True,
+                            spec_set=True,
+                            return_value=TransportMock(),
+                        ),
                     ):
                         req = ClientRequest(
                             "GET",

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -180,13 +180,16 @@ async def test_https_proxy_unsupported_tls_in_tls(
         r"$"
     )
 
-    with pytest.warns(
-        RuntimeWarning,
-        match=expected_warning_text,
-    ), pytest.raises(
-        ClientConnectionError,
-        match=expected_exception_reason,
-    ) as conn_err:
+    with (
+        pytest.warns(
+            RuntimeWarning,
+            match=expected_warning_text,
+        ),
+        pytest.raises(
+            ClientConnectionError,
+            match=expected_exception_reason,
+        ) as conn_err,
+    ):
         async with sess.get(url, proxy=secure_proxy_url, ssl=client_ssl_ctx):
             pass
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -491,9 +491,10 @@ async def test_force_compression_deflate_large_payload() -> None:
     resp.enable_compression(ContentCoding.deflate)
     assert resp.compression
 
-    with pytest.warns(
-        Warning, match="Synchronous compression of large response bodies"
-    ), mock.patch("aiohttp.web_response.LARGE_BODY_SIZE", 2):
+    with (
+        pytest.warns(Warning, match="Synchronous compression of large response bodies"),
+        mock.patch("aiohttp.web_response.LARGE_BODY_SIZE", 2),
+    ):
         msg = await resp.prepare(req)
         assert msg is not None
     assert "deflate" == resp.headers.get(hdrs.CONTENT_ENCODING)

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -738,11 +738,14 @@ async def test_heartbeat_connection_closed(
         # We patch write here to simulate a connection reset error
         # since if we closed the connection normally, the server would
         # would cancel the heartbeat task and we wouldn't get a ping
-        with mock.patch.object(
-            ws_server._req.transport, "write", side_effect=ConnectionResetError
-        ), mock.patch.object(
-            ws_server._writer, "send_frame", wraps=ws_server._writer.send_frame
-        ) as send_frame:
+        with (
+            mock.patch.object(
+                ws_server._req.transport, "write", side_effect=ConnectionResetError
+            ),
+            mock.patch.object(
+                ws_server._writer, "send_frame", wraps=ws_server._writer.send_frame
+            ) as send_frame,
+        ):
             try:
                 await ws_server.receive()
             finally:


### PR DESCRIPTION
Add `target-version` option to black config in `pyproject.toml` and
reformat code.

https://black.readthedocs.io/en/stable/usage_and_configuration/the_basics.html#t-target-version
(cherry picked from commit 00fd4eb62582caccfc721cb0c36e61f0350c2009)

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
