### PR TITLE
Fix ``ANY`` method not appearing in the ``UrlDispatcher`` routes

### DIFF
--- a/CHANGES/9899.bugfix.rst
+++ b/CHANGES/9899.bugfix.rst
@@ -1,0 +1,1 @@
+9987.bugfix.rst

--- a/CHANGES/9987.bugfix.rst
+++ b/CHANGES/9987.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed the ``ANY`` method not appearing in meth:`~aiohttp.web.UrlDispatcher.routes` -- by :user:`bdraco`.
+Fixed the ``ANY`` method not appearing in :meth:`~aiohttp.web.UrlDispatcher.routes` -- by :user:`bdraco`.

--- a/CHANGES/9987.bugfix.rst
+++ b/CHANGES/9987.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the ``ANY`` method not appearing in the ``UrlDispatcher`` routes -- by :user:`bdraco`.

--- a/CHANGES/9987.bugfix.rst
+++ b/CHANGES/9987.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed the ``ANY`` method not appearing in the ``UrlDispatcher`` routes -- by :user:`bdraco`.
+Fixed the ``ANY`` method not appearing in meth:`~aiohttp.web.UrlDispatcher.routes` -- by :user:`bdraco`.

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -356,9 +356,8 @@ class Resource(AbstractResource):
         ), f"Instance of Route class is required, got {route!r}"
         if route.method == hdrs.METH_ANY:
             self._any_route = route
-        else:
-            self._allowed_methods.add(route.method)
-            self._routes[route.method] = route
+        self._allowed_methods.add(route.method)
+        self._routes[route.method] = route
 
     async def resolve(self, request: Request) -> _Resolve:
         if (match_dict := self._match(request.rel_url.path_safe)) is None:

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -271,6 +271,12 @@ async def test_any_method(router: web.UrlDispatcher) -> None:
     assert info1.route is info2.route
 
 
+async def test_any_method_appears_in_routes(router: web.UrlDispatcher) -> None:
+    handler = make_handler()
+    route = router.add_route(hdrs.METH_ANY, "/", handler)
+    assert route in router.routes()
+
+
 async def test_match_second_result_in_table(router: web.UrlDispatcher) -> None:
     handler1 = make_handler()
     handler2 = make_handler()


### PR DESCRIPTION
Regressed in #9899

The pseudo `ANY` method should still get added to `self._routes` and `self._allowed_methods` because external callers expect to inspect it.

Discovered in https://github.com/aio-libs/aiohttp-apischema/pull/44