### PR TITLE
Release 3.11.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,24 @@
 
 .. towncrier release notes start
 
+3.11.5 (2024-11-19)
+===================
+
+Bug fixes
+---------
+
+- Fixed the ``ANY`` method not appearing in :meth:`~aiohttp.web.UrlDispatcher.routes` -- by :user:`bdraco`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`9899`, :issue:`9987`.
+
+
+
+
+----
+
+
 3.11.4 (2024-11-18)
 ===================
 

--- a/CHANGES/9899.bugfix.rst
+++ b/CHANGES/9899.bugfix.rst
@@ -1,1 +1,0 @@
-9987.bugfix.rst

--- a/CHANGES/9987.bugfix.rst
+++ b/CHANGES/9987.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed the ``ANY`` method not appearing in :meth:`~aiohttp.web.UrlDispatcher.routes` -- by :user:`bdraco`.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.11.5.dev0"
+__version__ = "3.11.5"
 
 from typing import TYPE_CHECKING, Tuple
 


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/actions/runs/11915537436

One more release to fix compat in https://github.com/aio-libs/aiohttp-apischema/pull/44

<img width="684" alt="Screenshot 2024-11-19 at 8 41 27 AM" src="https://github.com/user-attachments/assets/111a3104-efc1-4e30-893e-ad63aed85096">
