### PR TITLE
Increase allowed benchmark run time to 7 minutes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -260,7 +260,7 @@ jobs:
     needs: gen_llhttp
 
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 7
     steps:
     - name: Checkout project
       uses: actions/checkout@v4


### PR DESCRIPTION
We have a lot of benchmarks now. Sometimes they take a bit longer to run and we get unlucky and the job fails

https://github.com/aio-libs/aiohttp/actions/runs/11914927085/job/33204143694?pr=9989

7 minutes is still shorter than the pypy runs