### PR TITLE
Restore the ``force_close`` method to the ``ResponseHandler``

### DIFF
--- a/CHANGES/9997.bugfix.rst
+++ b/CHANGES/9997.bugfix.rst
@@ -1,0 +1,1 @@
+Restored the ``force_close`` method to the ``ResponseHandler`` -- by :user:`bdraco`.

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -64,6 +64,9 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
             or self._tail
         )
 
+    def force_close(self) -> None:
+        self._should_close = True
+
     def close(self) -> None:
         transport = self.transport
         if transport is not None:

--- a/tests/test_client_proto.py
+++ b/tests/test_client_proto.py
@@ -12,6 +12,17 @@ from aiohttp.helpers import TimerNoop
 from aiohttp.http_parser import RawResponseMessage
 
 
+async def test_force_close(loop: asyncio.AbstractEventLoop) -> None:
+    """Ensure that the force_close method sets the should_close attribute to True.
+
+    This is used externally in aiodocker
+    https://github.com/aio-libs/aiodocker/issues/920
+    """
+    proto = ResponseHandler(loop=loop)
+    proto.force_close()
+    assert proto.should_close
+
+
 async def test_oserror(loop: asyncio.AbstractEventLoop) -> None:
     proto = ResponseHandler(loop=loop)
     transport = mock.Mock()


### PR DESCRIPTION
fixes https://github.com/aio-libs/aiodocker/issues/920

Was removed in https://github.com/aio-libs/aiohttp/pull/8920