### PR TITLE
[PR #9997/8c36b51 backport][3.12] Restore the ``force_close`` method to the ``ResponseHandler``

### DIFF
--- a/CHANGES/9997.bugfix.rst
+++ b/CHANGES/9997.bugfix.rst
@@ -1,0 +1,1 @@
+Restored the ``force_close`` method to the ``ResponseHandler`` -- by :user:`bdraco`.

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -60,6 +60,9 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
             or self._tail
         )
 
+    def force_close(self) -> None:
+        self._should_close = True
+
     def close(self) -> None:
         transport = self.transport
         if transport is not None:

--- a/tests/test_client_proto.py
+++ b/tests/test_client_proto.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest import mock
 
 from yarl import URL
@@ -9,7 +10,18 @@ from aiohttp.client_reqrep import ClientResponse
 from aiohttp.helpers import TimerNoop
 
 
-async def test_oserror(loop) -> None:
+async def test_force_close(loop: asyncio.AbstractEventLoop) -> None:
+    """Ensure that the force_close method sets the should_close attribute to True.
+
+    This is used externally in aiodocker
+    https://github.com/aio-libs/aiodocker/issues/920
+    """
+    proto = ResponseHandler(loop=loop)
+    proto.force_close()
+    assert proto.should_close
+
+
+async def test_oserror(loop: asyncio.AbstractEventLoop) -> None:
     proto = ResponseHandler(loop=loop)
     transport = mock.Mock()
     proto.connection_made(transport)


### PR DESCRIPTION
(cherry picked from commit 8c36b51e479bf2eec5ad71043c07232dc26d1582)
