### PR TITLE
Fix client connection header not reflecting connector `force_close` value

### DIFF
--- a/CHANGES/10003.bugfix.rst
+++ b/CHANGES/10003.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the HTTP client not considering the connector's ``force_close`` value when setting the ``Connection`` header -- by :user:`bdraco`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -56,13 +56,7 @@ from .helpers import (
     set_exception,
     set_result,
 )
-from .http import (
-    SERVER_SOFTWARE,
-    HttpVersion,
-    HttpVersion10,
-    HttpVersion11,
-    StreamWriter,
-)
+from .http import SERVER_SOFTWARE, HttpVersion, StreamWriter
 from .log import client_logger
 from .streams import StreamReader
 from .typedefs import (
@@ -571,15 +565,6 @@ class ClientRequest:
         ):
             proxy_headers = CIMultiDict(proxy_headers)
         self.proxy_headers = proxy_headers
-
-    def keep_alive(self) -> bool:
-        if self.version >= HttpVersion11:
-            return self.headers.get(hdrs.CONNECTION) != "close"
-        if self.version == HttpVersion10:
-            # no headers means we close for Http 1.0
-            return self.headers.get(hdrs.CONNECTION) == "keep-alive"
-        # keep alive not supported at all
-        return False
 
     async def write_bytes(
         self, writer: AbstractStreamWriter, conn: "Connection"

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -56,13 +56,7 @@ from .helpers import (
     set_exception,
     set_result,
 )
-from .http import (
-    SERVER_SOFTWARE,
-    HttpVersion,
-    HttpVersion10,
-    HttpVersion11,
-    StreamWriter,
-)
+from .http import SERVER_SOFTWARE, HttpVersion, StreamWriter
 from .log import client_logger
 from .streams import StreamReader
 from .typedefs import (
@@ -572,15 +566,6 @@ class ClientRequest:
             proxy_headers = CIMultiDict(proxy_headers)
         self.proxy_headers = proxy_headers
 
-    def keep_alive(self) -> bool:
-        if self.version >= HttpVersion11:
-            return self.headers.get(hdrs.CONNECTION) != "close"
-        if self.version == HttpVersion10:
-            # no headers means we close for Http 1.0
-            return self.headers.get(hdrs.CONNECTION) == "keep-alive"
-        # keep alive not supported at all
-        return False
-
     async def write_bytes(
         self, writer: AbstractStreamWriter, conn: "Connection"
     ) -> None:
@@ -677,19 +662,6 @@ class ClientRequest:
             and hdrs.CONTENT_TYPE not in self.headers
         ):
             self.headers[hdrs.CONTENT_TYPE] = "application/octet-stream"
-
-        # set the connection header
-        connection = self.headers.get(hdrs.CONNECTION)
-        if not connection:
-            if self.keep_alive():
-                if self.version == HttpVersion10:
-                    connection = "keep-alive"
-            else:
-                if self.version == HttpVersion11:
-                    connection = "close"
-
-        if connection is not None:
-            self.headers[hdrs.CONNECTION] = connection
 
         # status + headers
         v = self.version

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -671,7 +671,7 @@ class ClientRequest:
 
         v = self.version
         if hdrs.CONNECTION not in self.headers:
-            if self._session.connector.force_close:
+            if conn._connector.force_close:
                 if v == HttpVersion11:
                     self.headers[hdrs.CONNECTION] = "close"
             elif v == HttpVersion10:

--- a/tests/test_benchmarks_client_request.py
+++ b/tests/test_benchmarks_client_request.py
@@ -99,10 +99,16 @@ def test_send_client_request_one_hundred(
         def start_timeout(self) -> None:
             """Swallow start_timeout."""
 
+    class MockConnector:
+
+        def __init__(self) -> None:
+            self.force_close = False
+
     class MockConnection:
         def __init__(self) -> None:
             self.transport = None
             self.protocol = MockProtocol()
+            self._connector = MockConnector()
 
     conn = MockConnection()
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -33,7 +33,6 @@ from aiohttp.client_reqrep import (
     _gen_default_accept_encoding,
 )
 from aiohttp.connector import Connection
-from aiohttp.http import HttpVersion
 from aiohttp.test_utils import make_mocked_coro
 from aiohttp.typedefs import LooseCookies
 
@@ -618,31 +617,6 @@ def test_cookie_coded_value_preserved(loop: asyncio.AbstractEventLoop) -> None:
     req = ClientRequest("get", URL("http://python.org"), loop=loop)
     req.update_cookies(cookies=SimpleCookie('ip-cookie="second"; Domain=127.0.0.1;'))
     assert req.headers["COOKIE"] == 'ip-cookie="second"'
-
-
-async def test_connection_header(
-    loop: asyncio.AbstractEventLoop, conn: mock.Mock
-) -> None:
-    req = ClientRequest("get", URL("http://python.org"), loop=loop)
-    with mock.patch.object(req, "keep_alive") as m:
-        req.headers.clear()
-
-        m.return_value = True
-        req.version = HttpVersion(1, 1)
-        req.headers.clear()
-        await req.send(conn)
-        assert req.headers.get("CONNECTION") is None
-
-        req.version = HttpVersion(1, 0)
-        req.headers.clear()
-        await req.send(conn)
-        assert req.headers.get("CONNECTION") == "keep-alive"
-
-        m.return_value = False
-        req.version = HttpVersion(1, 1)
-        req.headers.clear()
-        await req.send(conn)
-        assert req.headers.get("CONNECTION") == "close"
 
 
 async def test_no_content_length(

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -33,6 +33,7 @@ from aiohttp.client_reqrep import (
     _gen_default_accept_encoding,
 )
 from aiohttp.connector import Connection
+from aiohttp.http import HttpVersion10, HttpVersion11
 from aiohttp.test_utils import make_mocked_coro
 from aiohttp.typedefs import LooseCookies
 
@@ -593,6 +594,31 @@ def test_cookie_coded_value_preserved(loop: asyncio.AbstractEventLoop) -> None:
     req = ClientRequest("get", URL("http://python.org"), loop=loop)
     req.update_cookies(cookies=SimpleCookie('ip-cookie="second"; Domain=127.0.0.1;'))
     assert req.headers["COOKIE"] == 'ip-cookie="second"'
+
+
+async def test_connection_header(
+    loop: asyncio.AbstractEventLoop, conn: mock.Mock
+) -> None:
+    req = ClientRequest("get", URL("http://python.org"), loop=loop)
+    with mock.patch.object(req._session.connector, "force_close") as m:
+        req.headers.clear()
+
+        m.return_value = False
+        req.version = HttpVersion11
+        req.headers.clear()
+        await req.send(conn)
+        assert req.headers.get("CONNECTION") is None
+
+        req.version = HttpVersion10
+        req.headers.clear()
+        await req.send(conn)
+        assert req.headers.get("CONNECTION") == "keep-alive"
+
+        m.return_value = True
+        req.version = HttpVersion11
+        req.headers.clear()
+        await req.send(conn)
+        assert req.headers.get("CONNECTION") == "close"
 
 
 async def test_no_content_length(

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -600,25 +600,25 @@ async def test_connection_header(
     loop: asyncio.AbstractEventLoop, conn: mock.Mock
 ) -> None:
     req = ClientRequest("get", URL("http://python.org"), loop=loop)
-    with mock.patch.object(req._session.connector, "force_close") as m:
-        req.headers.clear()
+    req.headers.clear()
 
-        m.return_value = False
-        req.version = HttpVersion11
-        req.headers.clear()
+    req.version = HttpVersion11
+    req.headers.clear()
+    with mock.patch.object(conn._connector, "force_close", False):
         await req.send(conn)
-        assert req.headers.get("CONNECTION") is None
+    assert req.headers.get("CONNECTION") is None
 
-        req.version = HttpVersion10
-        req.headers.clear()
+    req.version = HttpVersion10
+    req.headers.clear()
+    with mock.patch.object(conn._connector, "force_close", False):
         await req.send(conn)
-        assert req.headers.get("CONNECTION") == "keep-alive"
+    assert req.headers.get("CONNECTION") == "keep-alive"
 
-        m.return_value = True
-        req.version = HttpVersion11
-        req.headers.clear()
+    req.version = HttpVersion11
+    req.headers.clear()
+    with mock.patch.object(conn._connector, "force_close", True):
         await req.send(conn)
-        assert req.headers.get("CONNECTION") == "close"
+    assert req.headers.get("CONNECTION") == "close"
 
 
 async def test_no_content_length(

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -155,30 +155,6 @@ def test_version_err(make_request: _RequestMaker) -> None:
         make_request("get", "http://python.org/", version="1.c")
 
 
-def test_keep_alive(make_request: _RequestMaker) -> None:
-    req = make_request("get", "http://python.org/", version=(0, 9))
-    assert not req.keep_alive()
-
-    req = make_request("get", "http://python.org/", version=(1, 0))
-    assert not req.keep_alive()
-
-    req = make_request(
-        "get",
-        "http://python.org/",
-        version=(1, 0),
-        headers={"connection": "keep-alive"},
-    )
-    assert req.keep_alive()
-
-    req = make_request("get", "http://python.org/", version=(1, 1))
-    assert req.keep_alive()
-
-    req = make_request(
-        "get", "http://python.org/", version=(1, 1), headers={"connection": "close"}
-    )
-    assert not req.keep_alive()
-
-
 def test_host_port_default_http(make_request: _RequestMaker) -> None:
     req = make_request("get", "http://python.org/")
     assert req.host == "python.org"

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -620,6 +620,12 @@ async def test_connection_header(
         await req.send(conn)
     assert req.headers.get("CONNECTION") == "close"
 
+    req.version = HttpVersion10
+    req.headers.clear()
+    with mock.patch.object(conn._connector, "force_close", True):
+        await req.send(conn)
+    assert not req.headers.get("CONNECTION")
+
 
 async def test_no_content_length(
     loop: asyncio.AbstractEventLoop, conn: mock.Mock

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -700,7 +700,6 @@ async def test_http11_keep_alive_default(aiohttp_client: AiohttpClient) -> None:
     resp.release()
 
 
-@pytest.mark.xfail
 async def test_http10_keep_alive_default(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
         return web.Response()


### PR DESCRIPTION
The `Connection` header should be set based on the `force_close` value in the connector.

It appears that the code to set the connection header had no effect because it calls `keep_alive` which checks the existing connection header and uses the result to set the headers in a block that only ever called when the connection header is not set.

AFIACT its not worked as expected since https://github.com/aio-libs/aiohttp/commit/8e6723afb5513dea58b2f53e4a8d0071430e3e83 where the `test_http10_keep_alive_default` test was marked as `xfail` and `HTTP/1.0` connections never set the `keep-alive` header but still expected to reuse the connection. Additionally if `force_close` was set on the connector we never told the remote we were going to close the connection by setting the connection header to `close` for the `HTTP/1.1` case.

The code was only being exercised because the test was mocking out `keep_alive` to impossible values that disagreed with the block in `send` that was only entered when the connection header was not set.

https://github.com/aio-libs/aiohttp/blob/af33a8224203b996190c4782b65446849f2be445/aiohttp/client_reqrep.py#L575

It's likely not many people are using `force_close` or setting the http version to 1.0 so the impact is minimal. On the plus side it makes sending requests 8% faster since it's not having to do all the useless checks now 