### PR TITLE
Avoid building `skip_headers` in `ClientSession._request` if it will be thrown away

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -490,10 +490,12 @@ class ClientSession:
         if url.scheme not in self._connector.allowed_protocol_schema_set:
             raise NonHttpUrlClientError(url)
 
-        skip_headers: Optional[set[str]] = None
-        skip_headers = (
-            None if skip_auto_headers is None else {istr(i) for i in skip_auto_headers}
-        )
+        skip_headers: Optional[Union[frozenset[istr], set[istr]]] = None
+        if skip_auto_headers is not None:
+            skip_headers = {istr(i) for i in skip_auto_headers}
+            skip_headers.update(self._skip_auto_headers)
+        elif self._skip_auto_headers is not None:
+            skip_headers = self._skip_auto_headers
 
         if proxy is None:
             proxy = self._default_proxy

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -358,11 +358,10 @@ class ClientSession:
         else:
             real_headers = CIMultiDict()
         self._default_headers: CIMultiDict[str] = real_headers
-        self._skip_auto_headers: Optional[FrozenSet[istr]]
         if skip_auto_headers is not None:
             self._skip_auto_headers = frozenset(istr(i) for i in skip_auto_headers)
         else:
-            self._skip_auto_headers = None
+            self._skip_auto_headers = frozenset()
 
         self._request_class = request_class
         self._response_class = response_class
@@ -494,9 +493,9 @@ class ClientSession:
         skip_headers: Optional[Union[frozenset[istr], set[istr]]] = None
         if skip_auto_headers is not None:
             skip_headers = {istr(i) for i in skip_auto_headers}
-            if self._skip_auto_headers is not None:
+            if self._skip_auto_headers:
                 skip_headers.update(self._skip_auto_headers)
-        elif self._skip_auto_headers is not None:
+        elif self._skip_auto_headers:
             skip_headers = self._skip_auto_headers
 
         if proxy is None:
@@ -1240,7 +1239,7 @@ class ClientSession:
     @property
     def skip_auto_headers(self) -> FrozenSet[istr]:
         """Headers for which autogeneration should be skipped"""
-        return self._skip_auto_headers or frozenset()
+        return self._skip_auto_headers
 
     @property
     def auth(self) -> Optional[BasicAuth]:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1239,7 +1239,7 @@ class ClientSession:
     @property
     def skip_auto_headers(self) -> FrozenSet[istr]:
         """Headers for which autogeneration should be skipped"""
-        return self._skip_auto_headers
+        return self._skip_auto_headers or frozenset()
 
     @property
     def auth(self) -> Optional[BasicAuth]:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -358,10 +358,11 @@ class ClientSession:
         else:
             real_headers = CIMultiDict()
         self._default_headers: CIMultiDict[str] = real_headers
+        self._skip_auto_headers: Optional[FrozenSet[istr]]
         if skip_auto_headers is not None:
             self._skip_auto_headers = frozenset(istr(i) for i in skip_auto_headers)
         else:
-            self._skip_auto_headers = frozenset()
+            self._skip_auto_headers = None
 
         self._request_class = request_class
         self._response_class = response_class

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -494,7 +494,8 @@ class ClientSession:
         skip_headers: Optional[Union[frozenset[istr], set[istr]]] = None
         if skip_auto_headers is not None:
             skip_headers = {istr(i) for i in skip_auto_headers}
-            skip_headers.update(self._skip_auto_headers)
+            if self._skip_auto_headers is not None:
+                skip_headers.update(self._skip_auto_headers)
         elif self._skip_auto_headers is not None:
             skip_headers = self._skip_auto_headers
 

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -490,10 +490,10 @@ class ClientSession:
         if url.scheme not in self._connector.allowed_protocol_schema_set:
             raise NonHttpUrlClientError(url)
 
-        skip_headers = set(self._skip_auto_headers)
-        if skip_auto_headers is not None:
-            for i in skip_auto_headers:
-                skip_headers.add(istr(i))
+        skip_headers: Optional[set[str]] = None
+        skip_headers = (
+            None if skip_auto_headers is None else {istr(i) for i in skip_auto_headers}
+        )
 
         if proxy is None:
             proxy = self._default_proxy
@@ -613,7 +613,7 @@ class ClientSession:
                         url,
                         params=params,
                         headers=headers,
-                        skip_auto_headers=skip_headers if skip_headers else None,
+                        skip_auto_headers=skip_headers,
                         data=data,
                         cookies=all_cookies,
                         auth=auth,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -490,13 +490,15 @@ class ClientSession:
         if url.scheme not in self._connector.allowed_protocol_schema_set:
             raise NonHttpUrlClientError(url)
 
-        skip_headers: Optional[Union[frozenset[istr], set[istr]]] = None
+        skip_headers: Optional[Union[frozenset[istr], set[istr]]]
         if skip_auto_headers is not None:
-            skip_headers = {istr(i) for i in skip_auto_headers}
-            if self._skip_auto_headers:
-                skip_headers.update(self._skip_auto_headers)
+            skip_headers = {
+                istr(i) for i in skip_auto_headers
+            } | self._skip_auto_headers
         elif self._skip_auto_headers:
             skip_headers = self._skip_auto_headers
+        else:
+            skip_headers = None
 
         if proxy is None:
             proxy = self._default_proxy

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -490,7 +490,7 @@ class ClientSession:
         if url.scheme not in self._connector.allowed_protocol_schema_set:
             raise NonHttpUrlClientError(url)
 
-        skip_headers: Optional[Union[frozenset[istr], set[istr]]]
+        skip_headers: Optional[Iterable[istr]]
         if skip_auto_headers is not None:
             skip_headers = {
                 istr(i) for i in skip_auto_headers


### PR DESCRIPTION
There is a very good chance that we will build `skip_headers` and than throw it away as this option is not commonly passed.