### PR TITLE
[PR #10003/78d1be5 backport][3.10] Fix client connection header not reflecting connector `force_close` value

### DIFF
--- a/CHANGES/10003.bugfix.rst
+++ b/CHANGES/10003.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the HTTP client not considering the connector's ``force_close`` value when setting the ``Connection`` header -- by :user:`bdraco`.

--- a/tests/test_benchmarks_client_request.py
+++ b/tests/test_benchmarks_client_request.py
@@ -95,10 +95,16 @@ def test_send_client_request_one_hundred(
         def start_timeout(self) -> None:
             """Swallow start_timeout."""
 
+    class MockConnector:
+
+        def __init__(self) -> None:
+            self.force_close = False
+
     class MockConnection:
         def __init__(self) -> None:
             self.transport = None
             self.protocol = MockProtocol()
+            self._connector = MockConnector()
 
     conn = MockConnection()
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -23,7 +23,7 @@ from aiohttp.client_reqrep import (
     _gen_default_accept_encoding,
     _merge_ssl_params,
 )
-from aiohttp.http import HttpVersion
+from aiohttp.http import HttpVersion10, HttpVersion11
 from aiohttp.test_utils import make_mocked_coro
 
 
@@ -138,30 +138,6 @@ def test_request_info_with_fragment(make_request) -> None:
 def test_version_err(make_request) -> None:
     with pytest.raises(ValueError):
         make_request("get", "http://python.org/", version="1.c")
-
-
-def test_keep_alive(make_request) -> None:
-    req = make_request("get", "http://python.org/", version=(0, 9))
-    assert not req.keep_alive()
-
-    req = make_request("get", "http://python.org/", version=(1, 0))
-    assert not req.keep_alive()
-
-    req = make_request(
-        "get",
-        "http://python.org/",
-        version=(1, 0),
-        headers={"connection": "keep-alive"},
-    )
-    assert req.keep_alive()
-
-    req = make_request("get", "http://python.org/", version=(1, 1))
-    assert req.keep_alive()
-
-    req = make_request(
-        "get", "http://python.org/", version=(1, 1), headers={"connection": "close"}
-    )
-    assert not req.keep_alive()
 
 
 def test_host_port_default_http(make_request) -> None:
@@ -634,32 +610,40 @@ def test_gen_netloc_no_port(make_request) -> None:
     )
 
 
-async def test_connection_header(loop, conn) -> None:
+async def test_connection_header(
+    loop: asyncio.AbstractEventLoop, conn: mock.Mock
+) -> None:
     req = ClientRequest("get", URL("http://python.org"), loop=loop)
-    req.keep_alive = mock.Mock()
     req.headers.clear()
 
-    req.keep_alive.return_value = True
-    req.version = HttpVersion(1, 1)
+    req.version = HttpVersion11
     req.headers.clear()
-    await req.send(conn)
+    with mock.patch.object(conn._connector, "force_close", False):
+        await req.send(conn)
     assert req.headers.get("CONNECTION") is None
 
-    req.version = HttpVersion(1, 0)
+    req.version = HttpVersion10
     req.headers.clear()
-    await req.send(conn)
+    with mock.patch.object(conn._connector, "force_close", False):
+        await req.send(conn)
     assert req.headers.get("CONNECTION") == "keep-alive"
 
-    req.keep_alive.return_value = False
-    req.version = HttpVersion(1, 1)
+    req.version = HttpVersion11
     req.headers.clear()
-    await req.send(conn)
+    with mock.patch.object(conn._connector, "force_close", True):
+        await req.send(conn)
     assert req.headers.get("CONNECTION") == "close"
 
-    await req.close()
+    req.version = HttpVersion10
+    req.headers.clear()
+    with mock.patch.object(conn._connector, "force_close", True):
+        await req.send(conn)
+    assert not req.headers.get("CONNECTION")
 
 
-async def test_no_content_length(loop, conn) -> None:
+async def test_no_content_length(
+    loop: asyncio.AbstractEventLoop, conn: mock.Mock
+) -> None:
     req = ClientRequest("get", URL("http://python.org"), loop=loop)
     resp = await req.send(conn)
     assert req.headers.get("CONTENT-LENGTH") is None

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -696,9 +696,8 @@ async def test_http11_keep_alive_default(aiohttp_client) -> None:
     await resp.release()
 
 
-@pytest.mark.xfail
-async def test_http10_keep_alive_default(aiohttp_client) -> None:
-    async def handler(request):
+async def test_http10_keep_alive_default(aiohttp_client: AiohttpClient) -> None:
+    async def handler(request: web.Request) -> web.Response:
         return web.Response()
 
     app = web.Application()


### PR DESCRIPTION
(cherry picked from commit 78d1be5d79f67597313354646eec200ff603fd9d)
