### PR TITLE
[PR #10003/78d1be5 backport][3.12] Fix client connection header not reflecting connector `force_close` value

### DIFF
--- a/CHANGES/10003.bugfix.rst
+++ b/CHANGES/10003.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the HTTP client not considering the connector's ``force_close`` value when setting the ``Connection`` header -- by :user:`bdraco`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -634,15 +634,6 @@ class ClientRequest:
             proxy_headers = CIMultiDict(proxy_headers)
         self.proxy_headers = proxy_headers
 
-    def keep_alive(self) -> bool:
-        if self.version >= HttpVersion11:
-            return self.headers.get(hdrs.CONNECTION) != "close"
-        if self.version == HttpVersion10:
-            # no headers means we close for Http 1.0
-            return self.headers.get(hdrs.CONNECTION) == "keep-alive"
-        # keep alive not supported at all
-        return False
-
     async def write_bytes(
         self, writer: AbstractStreamWriter, conn: "Connection"
     ) -> None:
@@ -737,21 +728,15 @@ class ClientRequest:
         ):
             self.headers[hdrs.CONTENT_TYPE] = "application/octet-stream"
 
-        # set the connection header
-        connection = self.headers.get(hdrs.CONNECTION)
-        if not connection:
-            if self.keep_alive():
-                if self.version == HttpVersion10:
-                    connection = "keep-alive"
-            else:
-                if self.version == HttpVersion11:
-                    connection = "close"
-
-        if connection is not None:
-            self.headers[hdrs.CONNECTION] = connection
+        v = self.version
+        if hdrs.CONNECTION not in self.headers:
+            if conn._connector.force_close:
+                if v == HttpVersion11:
+                    self.headers[hdrs.CONNECTION] = "close"
+            elif v == HttpVersion10:
+                self.headers[hdrs.CONNECTION] = "keep-alive"
 
         # status + headers
-        v = self.version
         status_line = f"{self.method} {path} HTTP/{v.major}.{v.minor}"
         await writer.write_headers(status_line, self.headers)
         task: Optional["asyncio.Task[None]"]

--- a/tests/test_benchmarks_client_request.py
+++ b/tests/test_benchmarks_client_request.py
@@ -100,10 +100,16 @@ def test_send_client_request_one_hundred(
         def start_timeout(self) -> None:
             """Swallow start_timeout."""
 
+    class MockConnector:
+
+        def __init__(self) -> None:
+            self.force_close = False
+
     class MockConnection:
         def __init__(self) -> None:
             self.transport = None
             self.protocol = MockProtocol()
+            self._connector = MockConnector()
 
     conn = MockConnection()
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -696,9 +696,8 @@ async def test_http11_keep_alive_default(aiohttp_client) -> None:
     await resp.release()
 
 
-@pytest.mark.xfail
-async def test_http10_keep_alive_default(aiohttp_client) -> None:
-    async def handler(request):
+async def test_http10_keep_alive_default(aiohttp_client: AiohttpClient) -> None:
+    async def handler(request: web.Request) -> web.Response:
         return web.Response()
 
     app = web.Application()


### PR DESCRIPTION
(cherry picked from commit 78d1be5d79f67597313354646eec200ff603fd9d)
