### PR TITLE
Release 3.11.7

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,36 @@
 
 .. towncrier release notes start
 
+3.11.7 (2024-11-21)
+===================
+
+Bug fixes
+---------
+
+- Fixed the HTTP client not considering the connector's ``force_close`` value when setting the ``Connection`` header -- by :user:`bdraco`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`10003`.
+
+
+
+
+Miscellaneous internal changes
+------------------------------
+
+- Improved performance of serializing HTTP headers -- by :user:`bdraco`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`10014`.
+
+
+
+
+----
+
+
 3.11.6 (2024-11-19)
 ===================
 

--- a/CHANGES/10003.bugfix.rst
+++ b/CHANGES/10003.bugfix.rst
@@ -1,1 +1,0 @@
-Fixed the HTTP client not considering the connector's ``force_close`` value when setting the ``Connection`` header -- by :user:`bdraco`.

--- a/CHANGES/10014.misc.rst
+++ b/CHANGES/10014.misc.rst
@@ -1,1 +1,0 @@
-Improved performance of serializing HTTP headers -- by :user:`bdraco`.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.11.7.dev0"
+__version__ = "3.11.7"
 
 from typing import TYPE_CHECKING, Tuple
 


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/actions/runs/11955319325

I _think_ the initial feedback from 3.11.x has now been processed so I'm doing one last release to include #10003  before the Home Assistant beta coming up next week. We will get some "free" downstream testers to hit corner cases so any regressions can be discovered and fixes can be turned quickly before we start focusing on 3.12.

<img width="724" alt="Screenshot 2024-11-21 at 8 15 46 AM" src="https://github.com/user-attachments/assets/a387c0c9-4f1f-4c9b-bf90-db2fc77de66b">
