### PR TITLE
Defer creation of cookies for client responses until needed

### DIFF
--- a/CHANGES/10029.misc.rst
+++ b/CHANGES/10029.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of creating :class:`aiohttp.ClientResponse` objects when there are no cookies -- by :user:`bdraco`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -687,7 +687,7 @@ class ClientSession:
                             raise
                         raise ClientOSError(*exc.args) from exc
 
-                    if cookies := resp.cookies:
+                    if cookies := resp._cookies:
                         self._cookie_jar.update_cookies(cookies, resp.url)
 
                     # redirects

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -764,6 +764,7 @@ class ClientResponse(HeadersMixin):
     _raw_headers: RawHeaders = None  # type: ignore[assignment]
 
     _connection: Optional["Connection"] = None  # current connection
+    _cookies: Optional[SimpleCookie] = None
     _source_traceback: Optional[traceback.StackSummary] = None
     # set up by ClientRequest after ClientResponse object creation
     # post-init stage allows to not change ctor signature
@@ -789,7 +790,6 @@ class ClientResponse(HeadersMixin):
         super().__init__()
 
         self.method = method
-        self.cookies = SimpleCookie()
 
         self._real_url = url
         self._url = url.with_fragment(None) if url.raw_fragment else url
@@ -843,6 +843,16 @@ class ClientResponse(HeadersMixin):
             self.__writer = None
         else:
             writer.add_done_callback(self.__reset_writer)
+
+    @property
+    def cookies(self) -> SimpleCookie:
+        if self._cookies is None:
+            self._cookies = SimpleCookie()
+        return self._cookies
+
+    @cookies.setter
+    def cookies(self, cookies: SimpleCookie) -> None:
+        self._cookies = cookies
 
     @reify
     def url(self) -> URL:
@@ -1003,11 +1013,14 @@ class ClientResponse(HeadersMixin):
         self.content = payload
 
         # cookies
-        for hdr in self.headers.getall(hdrs.SET_COOKIE, ()):
-            try:
-                self.cookies.load(hdr)
-            except CookieError as exc:
-                client_logger.warning("Can not load response cookies: %s", exc)
+        if cookie_hdrs := self.headers.getall(hdrs.SET_COOKIE, ()):
+            cookies = SimpleCookie()
+            for hdr in cookie_hdrs:
+                try:
+                    cookies.load(hdr)
+                except CookieError as exc:
+                    client_logger.warning("Can not load response cookies: %s", exc)
+            self._cookies = cookies
         return self
 
     def _response_eof(self) -> None:

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -1161,6 +1161,25 @@ async def test_response_read_triggers_callback(
     )
 
 
+def test_response_cookies(
+    loop: asyncio.AbstractEventLoop, session: ClientSession
+) -> None:
+    response = ClientResponse(
+        "get",
+        URL("http://python.org"),
+        request_info=mock.Mock(),
+        writer=WriterMock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[],
+        loop=loop,
+        session=session,
+    )
+    cookies = response.cookies
+    # Ensure the same cookies object is returned each time
+    assert response.cookies is cookies
+
+
 def test_response_real_url(
     loop: asyncio.AbstractEventLoop, session: ClientSession
 ) -> None:


### PR DESCRIPTION
Defer creation of cookies for client responses until needed

Looks to be a bit faster if there are no cookies and saves some RAM if there are not
<img width="709" alt="Screenshot 2024-11-23 at 7 51 58 PM" src="https://github.com/user-attachments/assets/655b3805-bf6e-492b-87cd-3d95959dd77d">
<img width="250" alt="Screenshot 2024-11-23 at 7 51 55 PM" src="https://github.com/user-attachments/assets/d8cad625-3055-4aeb-904a-22a3b97d8199">
