### PR TITLE
Reduce initialization overhead in `ClientResponse`

### DIFF
--- a/CHANGES/10030.misc.rst
+++ b/CHANGES/10030.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of creating :class:`aiohttp.ClientResponse` objects -- by :user:`bdraco`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -794,7 +794,8 @@ class ClientResponse(HeadersMixin):
         loop: asyncio.AbstractEventLoop,
         session: "ClientSession",
     ) -> None:
-        assert type(url) is URL, f"url is a {url!r}, not a yarl.URL"
+        if type(url) is not URL:
+            raise AssertionError(f"url is a {url!r}, not a yarl.URL")
         super().__init__()
 
         self.method = method

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -775,6 +775,7 @@ class ClientResponse(HeadersMixin):
 
     # TODO: Fix session=None in tests (see ClientRequest.__init__).
     _resolve_charset: Callable[["ClientResponse", bytes], str] = lambda *_: "utf-8"
+    _timer: BaseTimerContext = TimerNoop()
 
     __writer: Optional["asyncio.Task[None]"] = None
 
@@ -803,7 +804,8 @@ class ClientResponse(HeadersMixin):
             self._writer = writer
         self._continue = continue100  # None by default
         self._request_info = request_info
-        self._timer = timer if timer is not None else TimerNoop()
+        if timer is not None:
+            self._timer = timer
         self._cache: Dict[str, Any] = {}
         self._traces = traces
         self._loop = loop

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -772,6 +772,10 @@ class ClientResponse(HeadersMixin):
     _closed = True  # to allow __del__ for non-initialized properly response
     _released = False
     _in_context = False
+
+    # TODO: Fix session=None in tests (see ClientRequest.__init__).
+    _resolve_charset: Callable[["ClientResponse", bytes], str] = lambda *_: "utf-8"
+
     __writer: Optional["asyncio.Task[None]"] = None
 
     def __init__(
@@ -807,12 +811,7 @@ class ClientResponse(HeadersMixin):
         self._session: Optional[ClientSession] = session
         # Save reference to _resolve_charset, so that get_encoding() will still
         # work after the response has finished reading the body.
-        if session is None:
-            # TODO: Fix session=None in tests (see ClientRequest.__init__).
-            self._resolve_charset: Callable[["ClientResponse", bytes], str] = (  # type: ignore[unreachable]
-                lambda *_: "utf-8"
-            )
-        else:
+        if session is not None:
             self._resolve_charset = session._resolve_charset
         if loop.get_debug():
             self._source_traceback = traceback.extract_stack(sys._getframe(1))

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -794,7 +794,7 @@ class ClientResponse(HeadersMixin):
         loop: asyncio.AbstractEventLoop,
         session: "ClientSession",
     ) -> None:
-        assert isinstance(url, URL)
+        assert type(url) is URL, f"url is a {url!r}, not a yarl.URL"
         super().__init__()
 
         self.method = method

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -777,7 +777,6 @@ class ClientResponse(HeadersMixin):
     _in_context = False
 
     _resolve_charset: Callable[["ClientResponse", bytes], str] = lambda *_: "utf-8"
-    _timer: BaseTimerContext = TimerNoop()
 
     __writer: Optional["asyncio.Task[None]"] = None
 
@@ -809,8 +808,7 @@ class ClientResponse(HeadersMixin):
         if continue100 is not None:
             self._continue = continue100
         self._request_info = request_info
-        if timer is not None:
-            self._timer = timer
+        self._timer = timer if timer is not None else TimerNoop()
         self._cache: Dict[str, Any] = {}
         if traces:
             self._traces = traces

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -793,9 +793,8 @@ class ClientResponse(HeadersMixin):
         loop: asyncio.AbstractEventLoop,
         session: "ClientSession",
     ) -> None:
-        if type(url) is not URL:
-            # URL forbids subclasses, so a simple type check is enough.
-            raise AssertionError(f"url is a {url!r}, not a yarl.URL")
+        # URL forbids subclasses, so a simple type check is enough.
+        assert type(url) is URL
         super().__init__()
 
         self.method = method

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1134,8 +1134,8 @@ class ClientResponse(HeadersMixin):
         if self._body is None:
             try:
                 self._body = await self.content.read()
-                if traces := self._traces:
-                    for trace in traces:
+                if self._traces:
+                    for trace in self._traces:
                         await trace.send_response_chunk_received(
                             self.method, self.url, self._body
                         )

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -773,7 +773,6 @@ class ClientResponse(HeadersMixin):
     _released = False
     _in_context = False
 
-    # TODO: Fix session=None in tests (see ClientRequest.__init__).
     _resolve_charset: Callable[["ClientResponse", bytes], str] = lambda *_: "utf-8"
     _timer: BaseTimerContext = TimerNoop()
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -760,7 +760,9 @@ class ClientResponse(HeadersMixin):
     reason: Optional[str] = None  # Reason-Phrase
 
     content: StreamReader = None  # type: ignore[assignment] # Payload stream
+    _body: Optional[bytes] = None
     _headers: CIMultiDictProxy[str] = None  # type: ignore[assignment]
+    _history: Tuple["ClientResponse", ...] = ()
     _raw_headers: RawHeaders = None  # type: ignore[assignment]
 
     _connection: Optional["Connection"] = None  # current connection
@@ -793,12 +795,9 @@ class ClientResponse(HeadersMixin):
 
         self._real_url = url
         self._url = url.with_fragment(None) if url.raw_fragment else url
-        self._body: Optional[bytes] = None
         if writer is not None:
             self._writer = writer
         self._continue = continue100  # None by default
-        self._closed = True
-        self._history: Tuple[ClientResponse, ...] = ()
         self._request_info = request_info
         self._timer = timer if timer is not None else TimerNoop()
         self._cache: Dict[str, Any] = {}

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -795,6 +795,7 @@ class ClientResponse(HeadersMixin):
         session: "ClientSession",
     ) -> None:
         if type(url) is not URL:
+            # URL forbids subclasses, so a simple type check is enough.
             raise AssertionError(f"url is a {url!r}, not a yarl.URL")
         super().__init__()
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -288,7 +288,7 @@ class ClientRequest:
         if data is not None or self.method not in self.GET_METHODS:
             self.update_transfer_encoding()
         self.update_expect_continue(expect100)
-        self._traces = [] if traces is None else traces
+        self._traces = traces
 
     def __reset_writer(self, _: object = None) -> None:
         self.__writer = None
@@ -789,7 +789,7 @@ class ClientResponse(HeadersMixin):
         continue100: Optional["asyncio.Future[bool]"],
         timer: Optional[BaseTimerContext],
         request_info: RequestInfo,
-        traces: List["Trace"],
+        traces: Optional[List["Trace"]],
         loop: asyncio.AbstractEventLoop,
         session: "ClientSession",
     ) -> None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -737,12 +737,14 @@ class ClientRequest:
             self.__writer = None
 
     async def _on_chunk_request_sent(self, method: str, url: URL, chunk: bytes) -> None:
+        assert self._traces is not None
         for trace in self._traces:
             await trace.send_request_chunk_sent(method, url, chunk)
 
     async def _on_headers_request_sent(
         self, method: str, url: URL, headers: "CIMultiDict[str]"
     ) -> None:
+        assert self._traces is not None
         for trace in self._traces:
             await trace.send_request_headers(method, url, headers)
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -764,7 +764,6 @@ class ClientResponse(HeadersMixin):
     _headers: CIMultiDictProxy[str] = None  # type: ignore[assignment]
     _history: Tuple["ClientResponse", ...] = ()
     _raw_headers: RawHeaders = None  # type: ignore[assignment]
-    _traces: Optional[List["Trace"]] = None
 
     _connection: Optional["Connection"] = None  # current connection
     _continue: Optional["asyncio.Future[bool]"] = None
@@ -809,8 +808,7 @@ class ClientResponse(HeadersMixin):
         self._request_info = request_info
         self._timer = timer if timer is not None else TimerNoop()
         self._cache: Dict[str, Any] = {}
-        if traces:
-            self._traces = traces
+        self._traces = traces
         self._loop = loop
         # Save reference to _resolve_charset, so that get_encoding() will still
         # work after the response has finished reading the body.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -812,6 +812,7 @@ class ClientResponse(HeadersMixin):
         self._session: Optional[ClientSession] = session
         # Save reference to _resolve_charset, so that get_encoding() will still
         # work after the response has finished reading the body.
+        # TODO: Fix session=None in tests (see ClientRequest.__init__).
         if session is not None:
             self._resolve_charset = session._resolve_charset
         if loop.get_debug():

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1131,7 +1131,7 @@ class ClientResponse(HeadersMixin):
         if self._body is None:
             try:
                 self._body = await self.content.read()
-                if self._traces:
+                if self._traces is not None:
                     for trace in self._traces:
                         await trace.send_response_chunk_received(
                             self.method, self.url, self._body

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -1013,6 +1013,23 @@ def test_content_disposition_no_header() -> None:
     assert response.content_disposition is None
 
 
+def test_default_encoding_is_utf8() -> None:
+    response = ClientResponse(
+        "get",
+        URL("http://def-cl-resp.org"),
+        request_info=mock.Mock(),
+        writer=WriterMock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[],
+        loop=mock.Mock(),
+        session=mock.Mock(),
+    )
+    response._headers = CIMultiDictProxy(CIMultiDict({}))
+
+    assert response.get_encoding() == "utf-8"
+
+
 def test_response_request_info() -> None:
     url = URL("http://def-cl-resp.org")
     h = {"Content-Type": "application/json;charset=cp1251"}

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -1023,7 +1023,7 @@ def test_default_encoding_is_utf8() -> None:
         timer=TimerNoop(),
         traces=[],
         loop=mock.Mock(),
-        session=None,
+        session=None,  # type: ignore[arg-type]
     )
     response._headers = CIMultiDictProxy(CIMultiDict({}))
     response._body = b""

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -1023,9 +1023,10 @@ def test_default_encoding_is_utf8() -> None:
         timer=TimerNoop(),
         traces=[],
         loop=mock.Mock(),
-        session=mock.Mock(),
+        session=None,
     )
     response._headers = CIMultiDictProxy(CIMultiDict({}))
+    response._body = b""
 
     assert response.get_encoding() == "utf-8"
 


### PR DESCRIPTION
Small speed up
<img width="320" alt="Screenshot 2024-11-23 at 8 37 12 PM" src="https://github.com/user-attachments/assets/4431f3a0-e209-40c6-b70b-425bd5324954">



When combined with https://github.com/aio-libs/aiohttp/pull/10029, its ~40% faster making `ClientResponse` objects