### PR TITLE
[PR #10030/cdc01cd backport][3.12] Reduce initialization overhead in `ClientResponse`

### DIFF
--- a/CHANGES/10030.misc.rst
+++ b/CHANGES/10030.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of creating :class:`aiohttp.ClientResponse` objects -- by :user:`bdraco`.

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -981,6 +981,24 @@ def test_content_disposition_no_header() -> None:
     assert response.content_disposition is None
 
 
+def test_default_encoding_is_utf8() -> None:
+    response = ClientResponse(
+        "get",
+        URL("http://def-cl-resp.org"),
+        request_info=mock.Mock(),
+        writer=WriterMock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[],
+        loop=mock.Mock(),
+        session=None,  # type: ignore[arg-type]
+    )
+    response._headers = CIMultiDictProxy(CIMultiDict({}))
+    response._body = b""
+
+    assert response.get_encoding() == "utf-8"
+
+
 def test_response_request_info() -> None:
     url = "http://def-cl-resp.org"
     headers = {"Content-Type": "application/json;charset=cp1251"}


### PR DESCRIPTION
(cherry picked from commit cdc01cde146fe4c38e6185b983747826cfbb0f6e)
