### PR TITLE
[PR #10029/5f5729d backport][3.11] Defer creation of cookies for client responses until needed

### DIFF
--- a/CHANGES/10029.misc.rst
+++ b/CHANGES/10029.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of creating :class:`aiohttp.ClientResponse` objects when there are no cookies -- by :user:`bdraco`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -744,7 +744,7 @@ class ClientSession:
                             raise
                         raise ClientOSError(*exc.args) from exc
 
-                    if cookies := resp.cookies:
+                    if cookies := resp._cookies:
                         self._cookie_jar.update_cookies(cookies, resp.url)
 
                     # redirects

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -826,6 +826,7 @@ class ClientResponse(HeadersMixin):
     _raw_headers: RawHeaders = None  # type: ignore[assignment]
 
     _connection: Optional["Connection"] = None  # current connection
+    _cookies: Optional[SimpleCookie] = None
     _continue: Optional["asyncio.Future[bool]"] = None
     _source_traceback: Optional[traceback.StackSummary] = None
     _session: Optional["ClientSession"] = None
@@ -856,7 +857,6 @@ class ClientResponse(HeadersMixin):
         assert type(url) is URL
 
         self.method = method
-        self.cookies = SimpleCookie()
 
         self._real_url = url
         self._url = url.with_fragment(None) if url.raw_fragment else url
@@ -904,6 +904,16 @@ class ClientResponse(HeadersMixin):
             self.__writer = None
         else:
             writer.add_done_callback(self.__reset_writer)
+
+    @property
+    def cookies(self) -> SimpleCookie:
+        if self._cookies is None:
+            self._cookies = SimpleCookie()
+        return self._cookies
+
+    @cookies.setter
+    def cookies(self, cookies: SimpleCookie) -> None:
+        self._cookies = cookies
 
     @reify
     def url(self) -> URL:
@@ -1068,11 +1078,14 @@ class ClientResponse(HeadersMixin):
         self.content = payload
 
         # cookies
-        for hdr in self.headers.getall(hdrs.SET_COOKIE, ()):
-            try:
-                self.cookies.load(hdr)
-            except CookieError as exc:
-                client_logger.warning("Can not load response cookies: %s", exc)
+        if cookie_hdrs := self.headers.getall(hdrs.SET_COOKIE, ()):
+            cookies = SimpleCookie()
+            for hdr in cookie_hdrs:
+                try:
+                    cookies.load(hdr)
+                except CookieError as exc:
+                    client_logger.warning("Can not load response cookies: %s", exc)
+            self._cookies = cookies
         return self
 
     def _response_eof(self) -> None:

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -1,5 +1,6 @@
 # Tests for aiohttp/client.py
 
+import asyncio
 import gc
 import sys
 from typing import Callable
@@ -10,7 +11,7 @@ from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 import aiohttp
-from aiohttp import http
+from aiohttp import ClientSession, http
 from aiohttp.client_reqrep import ClientResponse, RequestInfo
 from aiohttp.helpers import TimerNoop
 from aiohttp.test_utils import make_mocked_coro
@@ -1139,7 +1140,28 @@ async def test_response_read_triggers_callback(loop, session) -> None:
     )
 
 
-def test_response_real_url(loop, session) -> None:
+def test_response_cookies(
+    loop: asyncio.AbstractEventLoop, session: ClientSession
+) -> None:
+    response = ClientResponse(
+        "get",
+        URL("http://python.org"),
+        request_info=mock.Mock(),
+        writer=WriterMock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[],
+        loop=loop,
+        session=session,
+    )
+    cookies = response.cookies
+    # Ensure the same cookies object is returned each time
+    assert response.cookies is cookies
+
+
+def test_response_real_url(
+    loop: asyncio.AbstractEventLoop, session: ClientSession
+) -> None:
     url = URL("http://def-cl-resp.org/#urlfragment")
     response = ClientResponse(
         "get",


### PR DESCRIPTION
(cherry picked from commit 5f5729d2db02c5643e2e4e33d840b623a1af9c48)
