### PR TITLE
Refactor requests and responses to use classvar defaults to avoid multiple `__init__`s

### DIFF
--- a/CHANGES/10037.misc.rst
+++ b/CHANGES/10037.misc.rst
@@ -1,0 +1,1 @@
+Improved performances of creating objects during the HTTP request lifecycle -- by :user:`bdraco`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -795,7 +795,6 @@ class ClientResponse(HeadersMixin):
     ) -> None:
         # URL forbids subclasses, so a simple type check is enough.
         assert type(url) is URL
-        super().__init__()
 
         self.method = method
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -925,7 +925,7 @@ class CookieMixin:
     @property
     def cookies(self) -> SimpleCookie:
         if self._cookies is None:
-            self._cookies = SimpleCookie()  # type: ignore[misc]
+            self._cookies = SimpleCookie()
         return self._cookies
 
     def set_cookie(
@@ -947,7 +947,7 @@ class CookieMixin:
         Also updates only those params which are not None.
         """
         if self._cookies is None:
-            self._cookies = SimpleCookie()  # type: ignore[misc]
+            self._cookies = SimpleCookie()
 
         self._cookies[name] = value
         c = self._cookies[name]

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -719,15 +719,12 @@ def ceil_timeout(
 
 
 class HeadersMixin:
-    __slots__ = ("_content_type", "_content_dict", "_stored_content_type")
+    """Mixin for handling headers."""
 
     _headers: MultiMapping[str]
-
-    def __init__(self) -> None:
-        super().__init__()
-        self._content_type: Optional[str] = None
-        self._content_dict: Optional[Dict[str, str]] = None
-        self._stored_content_type: Union[str, None, _SENTINEL] = sentinel
+    _content_type: Optional[str] = None
+    _content_dict: Optional[Dict[str, str]] = None
+    _stored_content_type: Union[str, None, _SENTINEL] = sentinel
 
     def _parse_content_type(self, raw: Optional[str]) -> None:
         self._stored_content_type = raw
@@ -921,17 +918,9 @@ class ChainMapProxy(Mapping[Union[str, AppKey[Any]], Any]):
 
 
 class CookieMixin:
-    # The `_cookies` slots is not defined here because non-empty slots cannot
-    # be combined with an Exception base class, as is done in HTTPException.
-    # CookieMixin subclasses with slots should define the `_cookies`
-    # slot themselves.
-    __slots__ = ()
+    """Mixin for handling cookies."""
 
-    def __init__(self) -> None:
-        super().__init__()
-        # Mypy doesn't like that _cookies isn't in __slots__.
-        # See the comment on this class's __slots__ for why this is OK.
-        self._cookies: Optional[SimpleCookie] = None  # type: ignore[misc]
+    _cookies: Optional[SimpleCookie] = None
 
     @property
     def cookies(self) -> SimpleCookie:

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -96,7 +96,6 @@ class HTTPException(CookieMixin, Exception):
         text: Optional[str] = None,
         content_type: Optional[str] = None,
     ) -> None:
-        super().__init__()
         if reason is None:
             reason = self.default_reason
         elif "\n" in reason:

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -145,8 +145,6 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         host: Optional[str] = None,
         remote: Optional[str] = None,
     ) -> None:
-        if state is None:
-            state = {}
         self._message = message
         self._protocol = protocol
         self._payload_writer = payload_writer
@@ -170,18 +168,18 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
             self._cache["scheme"] = url.scheme
             self._rel_url = url.relative()
         else:
-            self._rel_url = message.url
+            self._rel_url = url
             if scheme is not None:
                 self._cache["scheme"] = scheme
             if host is not None:
                 self._cache["host"] = host
 
-        self._state = state
+        self._state = {} if state is None else state
         self._task = task
         self._client_max_size = client_max_size
         self._loop = loop
 
-        transport = self._protocol.transport
+        transport = protocol.transport
         assert transport is not None
         self._transport_sslcontext = transport.get_extra_info("sslcontext")
         self._transport_peername = transport.get_extra_info("peername")

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -817,14 +817,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
 
 class Request(BaseRequest):
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-
-        # matchdict, route_name, handler
-        # or information about traversal lookup
-
-        # initialized after route resolving
-        self._match_info: Optional[UrlMappingMatchInfo] = None
+    _match_info: Optional[UrlMappingMatchInfo] = None
 
     def clone(
         self,

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -127,6 +127,9 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         hdrs.METH_DELETE,
     }
 
+    _post: Optional[MultiDictProxy[Union[str, bytes, FileField]]] = None
+    _read_bytes: Optional[bytes] = None
+
     def __init__(
         self,
         message: RawRequestMessage,
@@ -172,8 +175,6 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
                 self._cache["scheme"] = scheme
             if host is not None:
                 self._cache["host"] = host
-        self._post: Optional[MultiDictProxy[Union[str, bytes, FileField]]] = None
-        self._read_bytes: Optional[bytes] = None
 
         self._state = state
         self._task = task

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -816,7 +816,6 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
 
 
 class Request(BaseRequest):
-    __slots__ = ("_match_info",)
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -127,27 +127,6 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         hdrs.METH_DELETE,
     }
 
-    __slots__ = (
-        "_message",
-        "_protocol",
-        "_payload_writer",
-        "_payload",
-        "_headers",
-        "_method",
-        "_version",
-        "_rel_url",
-        "_post",
-        "_read_bytes",
-        "_state",
-        "_cache",
-        "_task",
-        "_client_max_size",
-        "_loop",
-        "_transport_sslcontext",
-        "_transport_peername",
-        "__weakref__",
-    )
-
     def __init__(
         self,
         message: RawRequestMessage,

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -163,7 +163,6 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         host: Optional[str] = None,
         remote: Optional[str] = None,
     ) -> None:
-        super().__init__()
         if state is None:
             state = {}
         self._message = message

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -817,7 +817,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
 
 class Request(BaseRequest):
 
-    _match_info: Optional[UrlMappingMatchInfo] = None
+    _match_info: Optional["UrlMappingMatchInfo"] = None
 
     def clone(
         self,

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -105,7 +105,6 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         reason: Optional[str] = None,
         headers: Optional[LooseHeaders] = None,
     ) -> None:
-        super().__init__()
         self._length_check = True
         self._body = None
         self._keep_alive: Optional[bool] = None

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -497,11 +497,6 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
 
 
 class Response(StreamResponse):
-    __slots__ = (
-        "_compressed_body",
-        "_zlib_executor_size",
-        "_zlib_executor",
-    )
 
     def __init__(
         self,

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -93,7 +93,6 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         "_headers",
         "_status",
         "_reason",
-        "_cookies",
         "__weakref__",
     )
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -78,6 +78,18 @@ CONTENT_CODINGS = {coding.value: coding for coding in ContentCoding}
 class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
 
     _body: Union[None, bytes, bytearray, Payload]
+    _length_check = True
+    _body = None
+    _keep_alive: Optional[bool] = None
+    _chunked: bool = False
+    _compression: bool = False
+    _compression_strategy: int = zlib.Z_DEFAULT_STRATEGY
+    _compression_force: Optional[ContentCoding] = None
+    _req: Optional["BaseRequest"] = None
+    _payload_writer: Optional[AbstractStreamWriter] = None
+    _eof_sent: bool = False
+    _must_be_empty_body: Optional[bool] = None
+    _body_length = 0
 
     def __init__(
         self,
@@ -86,19 +98,6 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         reason: Optional[str] = None,
         headers: Optional[LooseHeaders] = None,
     ) -> None:
-        self._length_check = True
-        self._body = None
-        self._keep_alive: Optional[bool] = None
-        self._chunked = False
-        self._compression = False
-        self._compression_strategy: int = zlib.Z_DEFAULT_STRATEGY
-        self._compression_force: Optional[ContentCoding] = None
-
-        self._req: Optional[BaseRequest] = None
-        self._payload_writer: Optional[AbstractStreamWriter] = None
-        self._eof_sent = False
-        self._must_be_empty_body: Optional[bool] = None
-        self._body_length = 0
         self._state: Dict[str, Any] = {}
 
         if headers is not None:
@@ -498,6 +497,8 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
 
 class Response(StreamResponse):
 
+    _compressed_body: Optional[bytes] = None
+
     def __init__(
         self,
         *,
@@ -562,7 +563,6 @@ class Response(StreamResponse):
         else:
             self.body = body
 
-        self._compressed_body: Optional[bytes] = None
         self._zlib_executor_size = zlib_executor_size
         self._zlib_executor = zlib_executor
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -76,25 +76,6 @@ CONTENT_CODINGS = {coding.value: coding for coding in ContentCoding}
 
 
 class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
-    __slots__ = (
-        "_length_check",
-        "_body",
-        "_keep_alive",
-        "_chunked",
-        "_compression",
-        "_compression_force",
-        "_compression_strategy",
-        "_req",
-        "_payload_writer",
-        "_eof_sent",
-        "_must_be_empty_body",
-        "_body_length",
-        "_state",
-        "_headers",
-        "_status",
-        "_reason",
-        "__weakref__",
-    )
 
     _body: Union[None, bytes, bytearray, Payload]
 

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -64,33 +64,6 @@ class WebSocketReady:
 
 
 class WebSocketResponse(StreamResponse):
-    __slots__ = (
-        "_protocols",
-        "_ws_protocol",
-        "_writer",
-        "_reader",
-        "_closed",
-        "_closing",
-        "_conn_lost",
-        "_close_code",
-        "_loop",
-        "_waiting",
-        "_close_wait",
-        "_exception",
-        "_timeout",
-        "_receive_timeout",
-        "_autoclose",
-        "_autoping",
-        "_heartbeat",
-        "_heartbeat_when",
-        "_heartbeat_cb",
-        "_pong_heartbeat",
-        "_pong_response_cb",
-        "_compress",
-        "_max_msg_size",
-        "_ping_task",
-        "_writer_limit",
-    )
 
     def __init__(
         self,

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -65,6 +65,23 @@ class WebSocketReady:
 
 class WebSocketResponse(StreamResponse):
 
+    _length_check: bool = False
+    _ws_protocol: Optional[str] = None
+    _writer: Optional[WebSocketWriter] = None
+    _reader: Optional[WebSocketDataQueue] = None
+    _closed: bool = False
+    _closing: bool = False
+    _conn_lost: int = 0
+    _close_code: Optional[int] = None
+    _loop: Optional[asyncio.AbstractEventLoop] = None
+    _waiting: bool = False
+    _close_wait: Optional[asyncio.Future[None]] = None
+    _exception: Optional[BaseException] = None
+    _heartbeat_when: float = 0.0
+    _heartbeat_cb: Optional[asyncio.TimerHandle] = None
+    _pong_response_cb: Optional[asyncio.TimerHandle] = None
+    _ping_task: Optional[asyncio.Task[None]] = None
+
     def __init__(
         self,
         *,
@@ -79,32 +96,16 @@ class WebSocketResponse(StreamResponse):
         writer_limit: int = DEFAULT_LIMIT,
     ) -> None:
         super().__init__(status=101)
-        self._length_check = False
         self._protocols = protocols
-        self._ws_protocol: Optional[str] = None
-        self._writer: Optional[WebSocketWriter] = None
-        self._reader: Optional[WebSocketDataQueue] = None
-        self._closed = False
-        self._closing = False
-        self._conn_lost = 0
-        self._close_code: Optional[int] = None
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._waiting: bool = False
-        self._close_wait: Optional[asyncio.Future[None]] = None
-        self._exception: Optional[BaseException] = None
         self._timeout = timeout
         self._receive_timeout = receive_timeout
         self._autoclose = autoclose
         self._autoping = autoping
         self._heartbeat = heartbeat
-        self._heartbeat_when = 0.0
-        self._heartbeat_cb: Optional[asyncio.TimerHandle] = None
         if heartbeat is not None:
             self._pong_heartbeat = heartbeat / 2.0
-        self._pong_response_cb: Optional[asyncio.TimerHandle] = None
         self._compress: Union[bool, int] = compress
         self._max_msg_size = max_msg_size
-        self._ping_task: Optional[asyncio.Task[None]] = None
         self._writer_limit = writer_limit
 
     def _cancel_heartbeat(self) -> None:

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -61,8 +61,6 @@ def test_base_ctor() -> None:
 
     assert req.keep_alive
 
-    assert "__dict__" not in dir(req)
-
     assert req
 
 
@@ -108,8 +106,6 @@ def test_ctor() -> None:
     assert req.headers == headers
     assert req.raw_headers == ((b"FOO", b"bar"),)
     assert req.task is req._task
-
-    assert "__dict__" not in dir(req)
 
 
 def test_doubleslashes() -> None:


### PR DESCRIPTION
I was looking at the benchmarks and was wondering why 3.x was faster creating many objects. This PR re-aligns `master` to be similar to how these are implemented in 3.x as it was before https://github.com/aio-libs/aiohttp/pull/3942

Refactor mixins to avoid having to call `__init__` by using classvar defaults instead.

The downside is we have to drop `__slots__` but the trade-off seems worth it based on the benchmark.




