### PR TITLE
Small speed up to `StreamWriter.__init__`

### DIFF
--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -191,8 +191,8 @@ class AbstractCookieJar(Sized, IterableBase):
 class AbstractStreamWriter(ABC):
     """Abstract stream writer."""
 
-    buffer_size = 0
-    output_size = 0
+    buffer_size: int = 0
+    output_size: int = 0
     length: Optional[int] = 0
 
     @abstractmethod

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -38,6 +38,15 @@ _T_OnHeadersSent = Optional[Callable[["CIMultiDict[str]"], Awaitable[None]]]
 
 
 class StreamWriter(AbstractStreamWriter):
+
+    length: Optional[int] = None
+    chunked: bool = False
+    buffer_size: int = 0
+    output_size: int = 0
+    _eof: bool = False
+    _compress: Optional[ZLibCompressor] = None
+    _drain_waiter: Optional[asyncio.Future[None]] = None
+
     def __init__(
         self,
         protocol: BaseProtocol,
@@ -46,17 +55,7 @@ class StreamWriter(AbstractStreamWriter):
         on_headers_sent: _T_OnHeadersSent = None,
     ) -> None:
         self._protocol = protocol
-
         self.loop = loop
-        self.length = None
-        self.chunked = False
-        self.buffer_size = 0
-        self.output_size = 0
-
-        self._eof = False
-        self._compress: Optional[ZLibCompressor] = None
-        self._drain_waiter = None
-
         self._on_chunk_sent: _T_OnChunkSent = on_chunk_sent
         self._on_headers_sent: _T_OnHeadersSent = on_headers_sent
 

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -39,7 +39,7 @@ _T_OnHeadersSent = Optional[Callable[["CIMultiDict[str]"], Awaitable[None]]]
 
 class StreamWriter(AbstractStreamWriter):
 
-    length: Optional[int] = None
+    length = None
     chunked: bool = False
     _eof: bool = False
     _compress: Optional[ZLibCompressor] = None

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -39,7 +39,7 @@ _T_OnHeadersSent = Optional[Callable[["CIMultiDict[str]"], Awaitable[None]]]
 
 class StreamWriter(AbstractStreamWriter):
 
-    length = None
+    length: Optional[int] = None
     chunked: bool = False
     _eof: bool = False
     _compress: Optional[ZLibCompressor] = None

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -41,8 +41,6 @@ class StreamWriter(AbstractStreamWriter):
 
     length: Optional[int] = None
     chunked: bool = False
-    buffer_size: int = 0
-    output_size: int = 0
     _eof: bool = False
     _compress: Optional[ZLibCompressor] = None
     _drain_waiter: Optional[asyncio.Future[None]] = None

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -43,7 +43,6 @@ class StreamWriter(AbstractStreamWriter):
     chunked: bool = False
     _eof: bool = False
     _compress: Optional[ZLibCompressor] = None
-    _drain_waiter: Optional[asyncio.Future[None]] = None
 
     def __init__(
         self,


### PR DESCRIPTION
Use classvar defaults to avoid `__init__` overhead. `AbstractStreamWriter` already does this so we can drop a few duplicates as well.

<img width="288" alt="Screenshot 2024-11-24 at 4 58 02 PM" src="https://github.com/user-attachments/assets/291b29cf-7cb7-4d44-9190-79e8b259c74a">
