### PR TITLE
Avoid constructing headers mulitidict twice for ``web.Response``

### DIFF
--- a/CHANGES/10043.misc.rst
+++ b/CHANGES/10043.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of constructing :class:`aiohttp.web.Response` with headers -- by :user:`bdraco`.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -105,7 +105,15 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         status: int = 200,
         reason: Optional[str] = None,
         headers: Optional[LooseHeaders] = None,
+        _real_headers: Optional[CIMultiDict[str]] = None,
     ) -> None:
+        """Initialize a new stream response object.
+
+        _real_headers is an internal parameter used to pass a pre-populated
+        headers object. It is used by the `Response` class to avoid copying
+        the headers when creating a new response object. It is not intended
+        to be used by external code.
+        """
         super().__init__()
         self._length_check = True
         self._body = None
@@ -122,7 +130,9 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         self._body_length = 0
         self._state: Dict[str, Any] = {}
 
-        if headers is not None:
+        if _real_headers is not None:
+            self._headers = _real_headers
+        elif headers is not None:
             self._headers: CIMultiDict[str] = CIMultiDict(headers)
         else:
             self._headers = CIMultiDict()
@@ -581,7 +591,7 @@ class Response(StreamResponse):
                 content_type += "; charset=" + charset
             real_headers[hdrs.CONTENT_TYPE] = content_type
 
-        super().__init__(status=status, reason=reason, headers=real_headers)
+        super().__init__(status=status, reason=reason, _real_headers=real_headers)
 
         if text is not None:
             self.text = text


### PR DESCRIPTION
`web.Response` constructed the headers `CIMultiDict`, and than passed it to `web.StreamResponse` which would construct a new `CIMultiDict` from the one that was just built in `web.Response` and than throw away the first constructed one.