### PR TITLE
Bump yarl to 1.18.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,5 +42,5 @@ typing-extensions==4.12.2
     # via multidict
 uvloop==0.21.0 ; platform_system != "Windows" and implementation_name == "cpython"
     # via -r requirements/base.in
-yarl==1.17.2
+yarl==1.18.0
     # via -r requirements/runtime-deps.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -300,7 +300,7 @@ wait-for-it==2.2.2
     # via -r requirements/test.in
 wheel==0.44.0
     # via pip-tools
-yarl==1.17.2
+yarl==1.18.0
     # via -r requirements/runtime-deps.in
 zipp==3.20.2
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -273,7 +273,7 @@ wait-for-it==2.2.2
     # via -r requirements/test.in
 wheel==0.44.0
     # via pip-tools
-yarl==1.17.2
+yarl==1.18.0
     # via -r requirements/runtime-deps.in
 zipp==3.20.2
     # via

--- a/requirements/runtime-deps.txt
+++ b/requirements/runtime-deps.txt
@@ -36,5 +36,5 @@ pycparser==2.22
     # via cffi
 typing-extensions==4.12.2
     # via multidict
-yarl==1.17.2
+yarl==1.18.0
     # via -r requirements/runtime-deps.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -149,5 +149,5 @@ uvloop==0.21.0 ; platform_system != "Windows" and implementation_name == "cpytho
     # via -r requirements/base.in
 wait-for-it==2.2.2
     # via -r requirements/test.in
-yarl==1.17.2
+yarl==1.18.0
     # via -r requirements/runtime-deps.in


### PR DESCRIPTION
changelog: https://github.com/aio-libs/yarl/compare/v1.17.2...v1.18.0

Doing this ahead of dependabot so the benchmarks get re-run
