### PR TITLE
[PR #10043/5255cec backport][3.11] Avoid constructing headers mulitidict twice for ``web.Response``

### DIFF
--- a/CHANGES/10043.misc.rst
+++ b/CHANGES/10043.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of constructing :class:`aiohttp.web.Response` with headers -- by :user:`bdraco`.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -86,7 +86,15 @@ class StreamResponse(BaseClass, HeadersMixin):
         status: int = 200,
         reason: Optional[str] = None,
         headers: Optional[LooseHeaders] = None,
+        _real_headers: Optional[CIMultiDict[str]] = None,
     ) -> None:
+        """Initialize a new stream response object.
+
+        _real_headers is an internal parameter used to pass a pre-populated
+        headers object. It is used by the `Response` class to avoid copying
+        the headers when creating a new response object. It is not intended
+        to be used by external code.
+        """
         self._body = None
         self._keep_alive: Optional[bool] = None
         self._chunked = False
@@ -102,7 +110,9 @@ class StreamResponse(BaseClass, HeadersMixin):
         self._body_length = 0
         self._state: Dict[str, Any] = {}
 
-        if headers is not None:
+        if _real_headers is not None:
+            self._headers = _real_headers
+        elif headers is not None:
             self._headers: CIMultiDict[str] = CIMultiDict(headers)
         else:
             self._headers = CIMultiDict()
@@ -660,7 +670,7 @@ class Response(StreamResponse):
                 content_type += "; charset=" + charset
             real_headers[hdrs.CONTENT_TYPE] = content_type
 
-        super().__init__(status=status, reason=reason, headers=real_headers)
+        super().__init__(status=status, reason=reason, _real_headers=real_headers)
 
         if text is not None:
             self.text = text


### PR DESCRIPTION
(cherry picked from commit 5255cecfe73c2be59e7e207449783635f4b978a2)
