### PR TITLE
Improve client performance when there are no auto headers to skip

### DIFF
--- a/CHANGES/10049.misc.rst
+++ b/CHANGES/10049.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of making requests when there are no auto headers to skip -- by :user:`bdraco`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -209,7 +209,7 @@ class ClientRequest:
     __writer: Optional["asyncio.Task[None]"] = None  # async task for streaming data
     _continue = None  # waiter future for '100 Continue' response
 
-    skip_auto_headers: Optional["CIMultiDict[str]"] = None
+    skip_auto_headers: Optional["CIMultiDict[None]"] = None
 
     # N.B.
     # Adding __del__ method with self._writer closing doesn't make sense

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -524,11 +524,10 @@ class ClientRequest:
 
         # enable chunked encoding if needed
         if not self.chunked and hdrs.CONTENT_LENGTH not in self.headers:
-            size = body.size
-            if size is None:
-                self.chunked = True
-            else:
+            if (size := body.size) is not None:
                 self.headers[hdrs.CONTENT_LENGTH] = str(size)
+            else:
+                self.chunked = True
 
         # copy payload headers
         assert body.headers

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -531,12 +531,12 @@ class ClientRequest:
 
         # copy payload headers
         assert body.headers
+        headers = self.headers
+        skip_headers = self.skip_auto_headers
         for key, value in body.headers.items():
-            if key in self.headers or (
-                self.skip_auto_headers is not None and key in self.skip_auto_headers
-            ):
+            if key in headers or (skip_headers is not None and key in skip_headers):
                 continue
-            self.headers[key] = value
+            headers[key] = value
 
     def update_expect_continue(self, expect: bool = False) -> None:
         if expect:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -527,7 +527,7 @@ class ClientRequest:
             size = body.size
             if size is None:
                 self.chunked = True
-            elif hdrs.CONTENT_LENGTH not in self.headers:
+            else:
                 self.headers[hdrs.CONTENT_LENGTH] = str(size)
 
         # copy payload headers

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -687,6 +687,7 @@ async def test_content_type_skip_auto_header_bytes(
         skip_auto_headers={"Content-Type"},
         loop=loop,
     )
+    assert req.skip_auto_headers == CIMultiDict({"CONTENT-TYPE": None})
     resp = await req.send(conn)
     assert "CONTENT-TYPE" not in req.headers
     resp.close()


### PR DESCRIPTION
Skipping auto headers is a rarely used feature.

- Avoid making an empty `CIMultiDict` each request that we will throw away
- Avoid all the contains checks when there are no auto headers to skip
- Some unreachable branching has been removed from `update_body_from_data`

<img width="709" alt="Screenshot 2024-11-26 at 4 20 04 PM" src="https://github.com/user-attachments/assets/ae7bd728-14f8-4b4e-a352-5447ceb53839">

<img width="255" alt="Screenshot 2024-11-26 at 4 10 07 PM" src="https://github.com/user-attachments/assets/7134c083-b2d8-4d8a-8eb2-1907ce32be38">
