### PR TITLE
[PR #10037/2e369db backport][3.12] Refactor requests and responses to use classvar defaults to avoid multiple `__init__`s

### DIFF
--- a/CHANGES/10037.misc.rst
+++ b/CHANGES/10037.misc.rst
@@ -1,0 +1,1 @@
+Improved performances of creating objects during the HTTP request lifecycle -- by :user:`bdraco`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -694,10 +694,11 @@ def ceil_timeout(
 
 
 class HeadersMixin:
+    """Mixin for handling headers."""
+
     ATTRS = frozenset(["_content_type", "_content_dict", "_stored_content_type"])
 
     _headers: MultiMapping[str]
-
     _content_type: Optional[str] = None
     _content_dict: Optional[Dict[str, str]] = None
     _stored_content_type: Union[str, None, _SENTINEL] = sentinel

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -498,6 +498,8 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
         task: "asyncio.Task[None]",
         _cls: Type[Request] = Request,
     ) -> Request:
+        if TYPE_CHECKING:
+            assert self._loop is not None
         return _cls(
             message,
             payload,

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -89,6 +89,7 @@ class StreamResponse(BaseClass, HeadersMixin):
     _eof_sent: bool = False
     _must_be_empty_body: Optional[bool] = None
     _body_length = 0
+    _cookies: Optional[SimpleCookie] = None
 
     def __init__(
         self,

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -76,9 +76,19 @@ CONTENT_CODINGS = {coding.value: coding for coding in ContentCoding}
 
 class StreamResponse(BaseClass, HeadersMixin):
 
-    _length_check = True
-
     _body: Union[None, bytes, bytearray, Payload]
+    _length_check = True
+    _body = None
+    _keep_alive: Optional[bool] = None
+    _chunked: bool = False
+    _compression: bool = False
+    _compression_strategy: int = zlib.Z_DEFAULT_STRATEGY
+    _compression_force: Optional[ContentCoding] = None
+    _req: Optional["BaseRequest"] = None
+    _payload_writer: Optional[AbstractStreamWriter] = None
+    _eof_sent: bool = False
+    _must_be_empty_body: Optional[bool] = None
+    _body_length = 0
 
     def __init__(
         self,
@@ -95,19 +105,6 @@ class StreamResponse(BaseClass, HeadersMixin):
         the headers when creating a new response object. It is not intended
         to be used by external code.
         """
-        self._body = None
-        self._keep_alive: Optional[bool] = None
-        self._chunked = False
-        self._compression = False
-        self._compression_strategy: int = zlib.Z_DEFAULT_STRATEGY
-        self._compression_force: Optional[ContentCoding] = None
-        self._cookies: Optional[SimpleCookie] = None
-
-        self._req: Optional[BaseRequest] = None
-        self._payload_writer: Optional[AbstractStreamWriter] = None
-        self._eof_sent = False
-        self._must_be_empty_body: Optional[bool] = None
-        self._body_length = 0
         self._state: Dict[str, Any] = {}
 
         if _real_headers is not None:
@@ -613,6 +610,9 @@ class StreamResponse(BaseClass, HeadersMixin):
 
 
 class Response(StreamResponse):
+
+    _compressed_body: Optional[bytes] = None
+
     def __init__(
         self,
         *,
@@ -677,7 +677,6 @@ class Response(StreamResponse):
         else:
             self.body = body
 
-        self._compressed_body: Optional[bytes] = None
         self._zlib_executor_size = zlib_executor_size
         self._zlib_executor = zlib_executor
 

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -61,7 +61,22 @@ class WebSocketReady:
 
 class WebSocketResponse(StreamResponse):
 
-    _length_check = False
+    _length_check: bool = False
+    _ws_protocol: Optional[str] = None
+    _writer: Optional[WebSocketWriter] = None
+    _reader: Optional[WebSocketDataQueue] = None
+    _closed: bool = False
+    _closing: bool = False
+    _conn_lost: int = 0
+    _close_code: Optional[int] = None
+    _loop: Optional[asyncio.AbstractEventLoop] = None
+    _waiting: bool = False
+    _close_wait: Optional[asyncio.Future[None]] = None
+    _exception: Optional[BaseException] = None
+    _heartbeat_when: float = 0.0
+    _heartbeat_cb: Optional[asyncio.TimerHandle] = None
+    _pong_response_cb: Optional[asyncio.TimerHandle] = None
+    _ping_task: Optional[asyncio.Task[None]] = None
 
     def __init__(
         self,
@@ -78,30 +93,15 @@ class WebSocketResponse(StreamResponse):
     ) -> None:
         super().__init__(status=101)
         self._protocols = protocols
-        self._ws_protocol: Optional[str] = None
-        self._writer: Optional[WebSocketWriter] = None
-        self._reader: Optional[WebSocketDataQueue] = None
-        self._closed = False
-        self._closing = False
-        self._conn_lost = 0
-        self._close_code: Optional[int] = None
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-        self._waiting: bool = False
-        self._close_wait: Optional[asyncio.Future[None]] = None
-        self._exception: Optional[BaseException] = None
         self._timeout = timeout
         self._receive_timeout = receive_timeout
         self._autoclose = autoclose
         self._autoping = autoping
         self._heartbeat = heartbeat
-        self._heartbeat_when = 0.0
-        self._heartbeat_cb: Optional[asyncio.TimerHandle] = None
         if heartbeat is not None:
             self._pong_heartbeat = heartbeat / 2.0
-        self._pong_response_cb: Optional[asyncio.TimerHandle] = None
         self._compress: Union[bool, int] = compress
         self._max_msg_size = max_msg_size
-        self._ping_task: Optional[asyncio.Task[None]] = None
         self._writer_limit = writer_limit
 
     def _cancel_heartbeat(self) -> None:


### PR DESCRIPTION
(cherry picked from commit 2e369db2d9abcbef41031592b4f044adf5f89f59)
