### PR TITLE
Downgrade logging of invalid HTTP methods on first request to debug level

### DIFF
--- a/CHANGES/10055.misc.rst
+++ b/CHANGES/10055.misc.rst
@@ -1,0 +1,3 @@
+Downgrade logging of ``BadStatusLine`` exceptions to debug level -- by :user:`bdraco`.
+
+``BadStatusLine`` exceptions are relatively common, especially when connected to the public internet, because browsers or other clients may try to speak SSL to a plaintext server or vice-versa. These exceptions can quickly fill the log with noise when nothing is wrong.

--- a/CHANGES/10055.misc.rst
+++ b/CHANGES/10055.misc.rst
@@ -1,3 +1,3 @@
-Downgraded logging of invalid HTTP method exceptions to debug level -- by :user:`bdraco`.
+Downgraded logging of invalid HTTP method exceptions on the first request to debug level -- by :user:`bdraco`.
 
 HTTP requests starting with an invalid method are relatively common, especially when connected to the public internet, because browsers or other clients may try to speak SSL to a plain-text server or vice-versa. These exceptions can quickly fill the log with noise when nothing is wrong.

--- a/CHANGES/10055.misc.rst
+++ b/CHANGES/10055.misc.rst
@@ -1,3 +1,3 @@
 Downgraded logging of ``BadStatusLine`` exceptions to debug level -- by :user:`bdraco`.
 
-``BadStatusLine`` exceptions are relatively common, especially when connected to the public internet, because browsers or other clients may try to speak SSL to a plaintext server or vice-versa. These exceptions can quickly fill the log with noise when nothing is wrong.
+``BadStatusLine`` exceptions are relatively common, especially when connected to the public internet, because browsers or other clients may try to speak SSL to a plain-text server or vice-versa. These exceptions can quickly fill the log with noise when nothing is wrong.

--- a/CHANGES/10055.misc.rst
+++ b/CHANGES/10055.misc.rst
@@ -1,3 +1,3 @@
-Downgraded logging of ``BadStatusLine`` exceptions to debug level -- by :user:`bdraco`.
+Downgraded logging of invalid HTTP method exceptions to debug level -- by :user:`bdraco`.
 
-``BadStatusLine`` exceptions are relatively common, especially when connected to the public internet, because browsers or other clients may try to speak SSL to a plain-text server or vice-versa. These exceptions can quickly fill the log with noise when nothing is wrong.
+HTTP requests starting with an invalid method are relatively common, especially when connected to the public internet, because browsers or other clients may try to speak SSL to a plain-text server or vice-versa. These exceptions can quickly fill the log with noise when nothing is wrong.

--- a/CHANGES/10055.misc.rst
+++ b/CHANGES/10055.misc.rst
@@ -1,3 +1,3 @@
-Downgrade logging of ``BadStatusLine`` exceptions to debug level -- by :user:`bdraco`.
+Downgraded logging of ``BadStatusLine`` exceptions to debug level -- by :user:`bdraco`.
 
 ``BadStatusLine`` exceptions are relatively common, especially when connected to the public internet, because browsers or other clients may try to speak SSL to a plaintext server or vice-versa. These exceptions can quickly fill the log with noise when nothing is wrong.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -23,6 +23,7 @@ from aiohttp.helpers import DEBUG, set_exception
 
 from .http_exceptions import (
     BadHttpMessage,
+    BadHttpMethod,
     BadStatusLine,
     ContentLengthError,
     InvalidHeader,
@@ -831,8 +832,9 @@ cdef parser_error_from_errno(cparser.llhttp_t* parser, data, pointer):
                  cparser.HPE_INVALID_EOF_STATE,
                  cparser.HPE_INVALID_TRANSFER_ENCODING}:
         return BadHttpMessage(err_msg)
-    elif errno in {cparser.HPE_INVALID_STATUS,
-                   cparser.HPE_INVALID_METHOD,
+    elif errno == cparser.HPE_INVALID_METHOD:
+        return BadHttpMethod(error=err_msg)
+    elif errno in {cparser.HPE_INVALID_METHOD,
                    cparser.HPE_INVALID_VERSION}:
         return BadStatusLine(error=err_msg)
     elif errno == cparser.HPE_INVALID_URL:

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -834,7 +834,7 @@ cdef parser_error_from_errno(cparser.llhttp_t* parser, data, pointer):
         return BadHttpMessage(err_msg)
     elif errno == cparser.HPE_INVALID_METHOD:
         return BadHttpMethod(error=err_msg)
-    elif errno in {cparser.HPE_INVALID_METHOD,
+    elif errno in {cparser.HPE_INVALID_STATUS,
                    cparser.HPE_INVALID_VERSION}:
         return BadStatusLine(error=err_msg)
     elif errno == cparser.HPE_INVALID_URL:

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -97,5 +97,14 @@ class BadStatusLine(BadHttpMessage):
         self.line = line
 
 
+class BadHttpMethod(BadStatusLine):
+    """Invalid HTTP method in status line."""
+
+    def __init__(self, line: str = "", error: Optional[str] = None) -> None:
+        super().__init__(
+            error or f"Bad HTTP method in status line {line!r}", line, error
+        )
+
+
 class InvalidURLError(BadHttpMessage):
     pass

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -101,9 +101,7 @@ class BadHttpMethod(BadStatusLine):
     """Invalid HTTP method in status line."""
 
     def __init__(self, line: str = "", error: Optional[str] = None) -> None:
-        super().__init__(
-            error or f"Bad HTTP method in status line {line!r}", line, error
-        )
+        super().__init__(line, error or f"Bad HTTP method in status line {line!r}")
 
 
 class InvalidURLError(BadHttpMessage):

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -38,6 +38,7 @@ from .helpers import (
 )
 from .http_exceptions import (
     BadHttpMessage,
+    BadHttpMethod,
     BadStatusLine,
     ContentEncodingError,
     ContentLengthError,
@@ -564,7 +565,7 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
         try:
             method, path, version = line.split(" ", maxsplit=2)
         except ValueError:
-            raise BadStatusLine(line) from None
+            raise BadHttpMethod(line) from None
 
         if len(path) > self.max_line_size:
             raise LineTooLong(
@@ -573,7 +574,7 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
 
         # method
         if not TOKENRE.fullmatch(method):
-            raise BadStatusLine(method)
+            raise BadHttpMethod(method)
 
         # version
         match = VERSRE.fullmatch(version)

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -35,7 +35,7 @@ from .http import (
     RawRequestMessage,
     StreamWriter,
 )
-from .http_exceptions import BadStatusLine
+from .http_exceptions import BadHttpMethod
 from .log import access_logger, server_logger
 from .streams import EMPTY_PAYLOAD, StreamReader
 from .tcp_helpers import tcp_keepalive
@@ -713,8 +713,8 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         Returns HTTP response with specific status code. Logs additional
         information. It always closes current connection.
         """
-        if isinstance(exc, BadStatusLine):
-            # BadStatusLine is common when a client sends non-HTTP
+        if isinstance(exc, BadHttpMethod):
+            # BadHttpMethod is common when a client sends non-HTTP
             # or encrypted traffic to an HTTP port. This is expected
             # to happen when connected to the public internet so we log
             # it at the debug level as to not fill logs with noise.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -35,6 +35,7 @@ from .http import (
     RawRequestMessage,
     StreamWriter,
 )
+from .http_exceptions import BadStatusLine
 from .log import access_logger, server_logger
 from .streams import EMPTY_PAYLOAD, StreamReader
 from .tcp_helpers import tcp_keepalive
@@ -712,7 +713,14 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         Returns HTTP response with specific status code. Logs additional
         information. It always closes current connection.
         """
-        self.log_exception("Error handling request", exc_info=exc)
+        if isinstance(exc, BadStatusLine):
+            # BadStatusLine is common when a client sends non-HTTP
+            # or encrypted traffic to an HTTP port. This is expected
+            # to happen when connected to the public internet so we log
+            # it at the debug level as to not fill logs with noise.
+            self.logger.debug("Error handling request", exc_info=exc)
+        else:
+            self.log_exception("Error handling request", exc_info=exc)
 
         # some data already got sent, connection is broken
         if request.writer.output_size > 0:

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -713,7 +713,11 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         Returns HTTP response with specific status code. Logs additional
         information. It always closes current connection.
         """
-        if isinstance(exc, BadHttpMethod):
+        if (
+            self._manager
+            and self._manager.requests_count == 1
+            and isinstance(exc, BadHttpMethod)
+        ):
             # BadHttpMethod is common when a client sends non-HTTP
             # or encrypted traffic to an HTTP port. This is expected
             # to happen when connected to the public internet so we log

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -988,7 +988,7 @@ def test_http_request_parser_two_slashes(parser: HttpRequestParser) -> None:
 def test_http_request_parser_bad_method(
     parser: HttpRequestParser, rfc9110_5_6_2_token_delim: bytes
 ) -> None:
-    with pytest.raises(http_exceptions.BadStatusLine):
+    with pytest.raises(http_exceptions.BadHttpMethod):
         parser.feed_data(rfc9110_5_6_2_token_delim + b'ET" /get HTTP/1.1\r\n\r\n')
 
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -92,7 +92,7 @@ async def test_raw_server_logs_invalid_method_with_loop_debug(
     txt = await resp.text()
     assert "Traceback (most recent call last):\n" in txt
 
-    # BadHttpMethod should be logged as an debug
+    # BadHttpMethod should be logged as debug
     # on the first request since the client may
     # be probing for TLS/SSL support which is
     # expected to fail
@@ -121,7 +121,7 @@ async def test_raw_server_logs_invalid_method_without_loop_debug(
     txt = await resp.text()
     assert "Traceback (most recent call last):\n" not in txt
 
-    # BadHttpMethod should be logged as an debug
+    # BadHttpMethod should be logged as debug
     # on the first request since the client may
     # be probing for TLS/SSL support which is
     # expected to fail

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -92,6 +92,10 @@ async def test_raw_server_logs_invalid_method_with_loop_debug(
     txt = await resp.text()
     assert "Traceback (most recent call last):\n" in txt
 
+    # BadHttpMethod should be logged as an debug
+    # on the first request since the client may
+    # be probing for TLS/SSL support which is
+    # expected to fail
     logger.debug.assert_called_with("Error handling request", exc_info=exc)
 
 
@@ -117,6 +121,10 @@ async def test_raw_server_logs_invalid_method_without_loop_debug(
     txt = await resp.text()
     assert "Traceback (most recent call last):\n" not in txt
 
+    # BadHttpMethod should be logged as an debug
+    # on the first request since the client may
+    # be probing for TLS/SSL support which is
+    # expected to fail
     logger.debug.assert_called_with("Error handling request", exc_info=exc)
 
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -7,6 +7,7 @@ from unittest import mock
 import pytest
 
 from aiohttp import client, web
+from aiohttp.http_exceptions import BadStatusLine
 from aiohttp.pytest_plugin import AiohttpClient, AiohttpRawServer
 
 
@@ -67,6 +68,56 @@ async def test_raw_server_not_http_exception(
     assert "Traceback" not in txt
 
     logger.exception.assert_called_with("Error handling request", exc_info=exc)
+
+
+async def test_raw_server_logs_invalid_request_with_loop_debug(
+    aiohttp_raw_server: AiohttpRawServer,
+    aiohttp_client: AiohttpClient,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    exc = BadStatusLine(b"\x16\x03\x03\x01F\x01", "error")
+
+    async def handler(request: web.BaseRequest) -> NoReturn:
+        raise exc
+
+    loop = asyncio.get_event_loop()
+    loop.set_debug(True)
+    logger = mock.Mock()
+    server = await aiohttp_raw_server(handler, logger=logger)
+    cli = await aiohttp_client(server)
+    resp = await cli.get("/path/to")
+    assert resp.status == 500
+    assert resp.headers["Content-Type"].startswith("text/plain")
+
+    txt = await resp.text()
+    assert "Traceback (most recent call last):\n" in txt
+
+    logger.debug.assert_called_with("Error handling request", exc_info=exc)
+
+
+async def test_raw_server_logs_invalid_request_without_loop_debug(
+    aiohttp_raw_server: AiohttpRawServer,
+    aiohttp_client: AiohttpClient,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    exc = BadStatusLine(b"\x16\x03\x03\x01F\x01", "error")
+
+    async def handler(request: web.BaseRequest) -> NoReturn:
+        raise exc
+
+    loop = asyncio.get_event_loop()
+    loop.set_debug(False)
+    logger = mock.Mock()
+    server = await aiohttp_raw_server(handler, logger=logger)
+    cli = await aiohttp_client(server)
+    resp = await cli.get("/path/to")
+    assert resp.status == 500
+    assert resp.headers["Content-Type"].startswith("text/plain")
+
+    txt = await resp.text()
+    assert "Traceback (most recent call last):\n" not in txt
+
+    logger.debug.assert_called_with("Error handling request", exc_info=exc)
 
 
 async def test_raw_server_handler_timeout(

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -75,7 +75,7 @@ async def test_raw_server_logs_invalid_request_with_loop_debug(
     aiohttp_client: AiohttpClient,
     loop: asyncio.AbstractEventLoop,
 ) -> None:
-    exc = BadStatusLine(b"\x16\x03\x03\x01F\x01", "error")
+    exc = BadStatusLine(b"\x16\x03\x03\x01F\x01".decode(), "error")
 
     async def handler(request: web.BaseRequest) -> NoReturn:
         raise exc
@@ -100,7 +100,7 @@ async def test_raw_server_logs_invalid_request_without_loop_debug(
     aiohttp_client: AiohttpClient,
     loop: asyncio.AbstractEventLoop,
 ) -> None:
-    exc = BadStatusLine(b"\x16\x03\x03\x01F\x01", "error")
+    exc = BadStatusLine(b"\x16\x03\x03\x01F\x01".decode(), "error")
 
     async def handler(request: web.BaseRequest) -> NoReturn:
         raise exc


### PR DESCRIPTION
Its common when a client sends non-HTTP or encrypted traffic to an HTTP port for the server to encounter an error parsing the request. This is expected to happen when connected to the public internet (rather frequently) as browsers may try to speak SSL before plain-text. There are a variety of other reasons as well, such users mis-typing the port, bad redirects, etc which generates non HTTP traffic on the first request.

To avoid fill logs with noise, a new exception `BadHttpMethod`, which inherits from `BadStatusLine` is now raised internally to distinguish between status lines with invalid versions or status and ones one that start with garbage or an invalid method.

The new exception is logged at debug level on the first request only to avoid filling the log with noise when nothing is actually wrong as the vast majority of these are noise. Bad methods received on keep alive requests will continue to be logged at exception level.

Example of how common spurious errors are downstream: https://github.com/home-assistant/core/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aclosed+BadStatusLine https://github.com/home-assistant/core/issues?q=sort%3Aupdated-desc+is%3Aissue+is%3Aopen+BadStatusLine

fixes #8065
fixes #8442
fixes #3287