### PR TITLE
Remove unreachable content length check for chunked encoding

### DIFF
--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -175,12 +175,11 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
 
     def enable_chunked_encoding(self) -> None:
         """Enables automatic chunked transfer encoding."""
-        self._chunked = True
-
         if hdrs.CONTENT_LENGTH in self._headers:
             raise RuntimeError(
                 "You can't enable chunked encoding when a content length is set"
             )
+        self._chunked = True
 
     def enable_compression(
         self,
@@ -388,8 +387,6 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             if not self._must_be_empty_body:
                 writer.enable_chunking()
                 headers[hdrs.TRANSFER_ENCODING] = "chunked"
-            if hdrs.CONTENT_LENGTH in headers:
-                del headers[hdrs.CONTENT_LENGTH]
         elif self._length_check:  # Disabled for WebSockets
             writer.length = self.content_length
             if writer.length is None:


### PR DESCRIPTION
`_prepare_headers` had a check to remove content-length if chunked encoding was set. This code was unreachable under normal circumstances because enabling chunked encoding checks to see if the content-length header is there and raises `RuntimeError`. It was still possible to reach this code if `RuntimeError` was suppressed because `enable_chunked_encoding` set `self._chunked = True` before checking if it needed to raise. To make it truly unreachable, the check is now done first in `enable_chunked_encoding`

<img width="710" alt="Screenshot 2024-11-26 at 10 26 22 PM" src="https://github.com/user-attachments/assets/d5f6fa7a-c6c5-4ba7-9e3b-2957bf2f2274">


