### PR TITLE
DNM: Add a Cython implementation for ConnectionKey with hash caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@
 .tox
 .vimrc
 .vscode
+aiohttp/_client_reqrep.c
+aiohttp/_client_reqrep.html
 aiohttp/_find_header.c
 aiohttp/_headers.html
 aiohttp/_headers.pxi

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ clean:
 	@rm -f aiohttp/*.so
 	@rm -f aiohttp/*.pyd
 	@rm -f aiohttp/*.html
+	@rm -f aiohttp/_client_reqrep.c
 	@rm -f aiohttp/_frozenlist.c
 	@rm -f aiohttp/_find_header.c
 	@rm -f aiohttp/_http_parser.c

--- a/aiohttp/_client_reqrep.pyx
+++ b/aiohttp/_client_reqrep.pyx
@@ -1,0 +1,36 @@
+cdef class ConnectionKey:
+
+    cdef readonly str host
+    cdef readonly object port
+    cdef readonly bint is_ssl
+    cdef readonly object ssl
+    cdef readonly object proxy
+    cdef readonly object proxy_auth
+    cdef readonly object proxy_headers_hash
+    cdef readonly Py_hash_t _hash
+
+    def __init__(self, host, port, is_ssl, ssl, proxy, proxy_auth, proxy_headers_hash):
+        self.host = host
+        self.port = port
+        self.is_ssl = is_ssl
+        self.ssl = ssl
+        self.proxy = proxy
+        self.proxy_auth = proxy_auth
+        self.proxy_headers_hash = proxy_headers_hash
+        self._hash = hash((host, port, is_ssl, ssl, proxy, proxy_auth, proxy_headers_hash))
+
+    def __hash__(self):
+        return self._hash
+
+    def __eq__(self, other: ConnectionKey):
+        if not isinstance(other, ConnectionKey):
+            return NotImplemented
+        return (
+            self.host == other.host and
+            self.port == other.port and
+            self.is_ssl == other.is_ssl and
+            self.ssl == other.ssl and
+            self.proxy == other.proxy and
+            self.proxy_auth == other.proxy_auth and
+            self.proxy_headers_hash == other.proxy_headers_hash
+        )

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -43,6 +43,7 @@ from .formdata import FormData
 from .hdrs import CONTENT_TYPE
 from .helpers import (
     _SENTINEL,
+    NO_EXTENSIONS,
     BaseTimerContext,
     BasicAuth,
     HeadersMixin,
@@ -1239,3 +1240,16 @@ class ClientResponse(HeadersMixin):
         # if state is broken
         self.release()
         await self.wait_for_close()
+
+
+RawResponseMessagePy = ConnectionKey
+
+try:
+    if not NO_EXTENSIONS:
+        from ._client_repreq import (  # type: ignore[import-not-found,no-redef]
+            ConnectionKey,
+        )
+
+        ConnectionKeyC = ConnectionKey
+except ImportError:  # pragma: no cover
+    pass

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -325,17 +325,14 @@ class ClientRequest:
         else:
             h = None
         url = self.url
-        return tuple.__new__(
-            ConnectionKey,
-            (
-                url.raw_host or "",
-                url.port,
-                url.scheme in _SSL_SCHEMES,
-                self._ssl,
-                self.proxy,
-                self.proxy_auth,
-                h,
-            ),
+        return ConnectionKey(
+            url.raw_host or "",
+            url.port,
+            url.scheme in _SSL_SCHEMES,
+            self._ssl,
+            self.proxy,
+            self.proxy_auth,
+            h,
         )
 
     @property
@@ -1246,7 +1243,7 @@ ConnectionKeyPy = ConnectionKey
 
 try:
     if not NO_EXTENSIONS:
-        from ._client_repreq import (  # type: ignore[import-not-found,no-redef]
+        from ._client_reqrep import (  # type: ignore[import-not-found,no-redef]
             ConnectionKey,
         )
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1242,7 +1242,7 @@ class ClientResponse(HeadersMixin):
         await self.wait_for_close()
 
 
-RawResponseMessagePy = ConnectionKey
+ConnectionKeyPy = ConnectionKey
 
 try:
     if not NO_EXTENSIONS:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1241,11 +1241,6 @@ class ClientResponse(HeadersMixin):
 
 ConnectionKeyPy = ConnectionKey
 
-if not NO_EXTENSIONS:
-    from ._client_reqrep import ConnectionKey  # type: ignore[import-not-found,no-redef]
-
-    ConnectionKeyC = ConnectionKey
-
 try:
     if not NO_EXTENSIONS:
         from ._client_reqrep import (  # type: ignore[import-not-found,no-redef]

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1241,6 +1241,11 @@ class ClientResponse(HeadersMixin):
 
 ConnectionKeyPy = ConnectionKey
 
+if not NO_EXTENSIONS:
+    from ._client_reqrep import ConnectionKey  # type: ignore[import-not-found,no-redef]
+
+    ConnectionKeyC = ConnectionKey
+
 try:
     if not NO_EXTENSIONS:
         from ._client_reqrep import (  # type: ignore[import-not-found,no-redef]

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ if IS_GIT_REPO and not (HERE / "vendor/llhttp/README.md").exists():
 # NOTE: makefile cythonizes all Cython modules
 
 extensions = [
+    Extension("aiohttp._client_reqrep", ["aiohttp/_client_reqrep.c"]),
     Extension("aiohttp._websocket.mask", ["aiohttp/_websocket/mask.c"]),
     Extension(
         "aiohttp._http_parser",


### PR DESCRIPTION
I noticed on the profiles that we spend a lot of time in `connection.py` in functions that hash and compare the `ConnectionKey`.  We moved to a `NamedTuple` to speed up the hashing but its still looks like its taking up quite
a bit of overhead because we use it as a key in so many operations.

Add a Cython implementation which caches the hash to see if there is a measurable improvement.