### PR TITLE
Improve performance of parsing headers

### DIFF
--- a/CHANGES/10073.misc.rst
+++ b/CHANGES/10073.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of parsing headers when using the C parser -- by :user:`bdraco`.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -394,7 +394,7 @@ cdef class HttpParser:
         if self._has_value:
             self._process_header()
 
-        if not self._raw_name:
+        if self._raw_name:
             self._raw_name += at[:length]
         else:
             self._raw_name = at[:length]

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -387,16 +387,24 @@ cdef class HttpParser:
 
             self._has_value = False
             self._raw_headers.append((self._raw_name, self._raw_value))
+            self._raw_name = b""
+            self._raw_value = b""
 
     cdef _on_header_field(self, char* at, size_t length):
         if self._has_value:
             self._process_header()
 
-        self._raw_name = at[:length]
+        if not self._raw_name:
+            self._raw_name += at[:length]
+        else:
+            self._raw_name = at[:length]
         self._name = find_header(at, length, self._raw_name)
 
     cdef _on_header_value(self, char* at, size_t length):
-        self._raw_value = at[:length]
+        if self._raw_value:
+            self._raw_value += at[:length]
+        else:
+            self._raw_value = at[:length]
         self._has_value = True
 
     cdef _on_headers_complete(self):

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -71,7 +71,7 @@ cdef object CONTENT_ENCODING = hdrs.CONTENT_ENCODING
 cdef object EMPTY_PAYLOAD = _EMPTY_PAYLOAD
 cdef object StreamReader = _StreamReader
 cdef object DeflateBuffer = _DeflateBuffer
-
+cdef bytes EMPTY_BYTES = b""
 
 cdef inline object extend(object buf, const char* at, size_t length):
     cdef Py_ssize_t s
@@ -348,9 +348,9 @@ cdef class HttpParser:
         self._payload_exception = payload_exception
         self._messages = []
 
-        self._raw_name = b""
+        self._raw_name = EMPTY_BYTES
         self._name = None
-        self._raw_value = b""
+        self._raw_value = EMPTY_BYTES
         self._has_value = False
 
         self._max_line_size = max_line_size
@@ -387,24 +387,24 @@ cdef class HttpParser:
 
             self._has_value = False
             self._raw_headers.append((self._raw_name, self._raw_value))
-            self._raw_name = b""
-            self._raw_value = b""
+            self._raw_name = EMPTY_BYTES
+            self._raw_value = EMPTY_BYTES
 
     cdef _on_header_field(self, char* at, size_t length):
         if self._has_value:
             self._process_header()
 
-        if self._raw_name:
-            self._raw_name += at[:length]
-        else:
+        if self._raw_name is EMPTY_BYTES:
             self._raw_name = at[:length]
+        else:
+            self._raw_name += at[:length]
         self._name = find_header(at, length, self._raw_name)
 
     cdef _on_header_value(self, char* at, size_t length):
-        if self._raw_value:
-            self._raw_value += at[:length]
-        else:
+        if self._raw_value is EMPTY_BYTES:
             self._raw_value = at[:length]
+        else:
+            self._raw_value += at[:length]
         self._has_value = True
 
     cdef _on_headers_complete(self):

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -294,7 +294,7 @@ cdef class HttpParser:
         bytearray   _buf
         str     _path
         str     _reason
-        object  _headers
+        list    _headers
         list    _raw_headers
         bint    _upgraded
         list    _messages
@@ -380,7 +380,7 @@ cdef class HttpParser:
         if self._raw_name:
             value = self._raw_value.decode('utf-8', 'surrogateescape')
 
-            self._headers.add(self._name, value)
+            self._headers.append((self._name, value))
 
             if self._name is CONTENT_ENCODING:
                 self._content_encoding = value
@@ -415,7 +415,7 @@ cdef class HttpParser:
         chunked = self._cparser.flags & cparser.F_CHUNKED
 
         raw_headers = tuple(self._raw_headers)
-        headers = CIMultiDictProxy(self._headers)
+        headers = CIMultiDictProxy(CIMultiDict(self._headers))
 
         if self._cparser.type == cparser.HTTP_REQUEST:
             allowed = upgrade and headers.get("upgrade", "").lower() in ALLOWED_UPGRADES

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -663,7 +663,7 @@ cdef int cb_on_message_begin(cparser.llhttp_t* parser) except -1:
     cdef HttpParser pyparser = <HttpParser>parser.data
 
     pyparser._started = True
-    pyparser._headers = CIMultiDict()
+    pyparser._headers = []
     pyparser._raw_headers = []
     PyByteArray_Resize(pyparser._buf, 0)
     pyparser._path = None


### PR DESCRIPTION
After we have a complete header we always have to convert it to a new bytes object. For almost every case we get the header in a single read. In this case its much faster to convert to bytes once. If the header gets split across multiple reads it will be a bit slower but this is the uncommon case.


<img width="338" alt="Screenshot 2024-12-01 at 3 13 50 PM" src="https://github.com/user-attachments/assets/14d3f952-547e-490e-87b0-fb5d95db1d52">
