### PR TITLE
Support absolute url to override base url

### DIFF
--- a/CHANGES/10074.feature.rst
+++ b/CHANGES/10074.feature.rst
@@ -1,2 +1,2 @@
-Supported absolute url to override base url.
+Added support for overriding the base URL with an absolute one in client sessions
 -- by :user:`vivodi`.

--- a/CHANGES/10074.feature.rst
+++ b/CHANGES/10074.feature.rst
@@ -1,0 +1,2 @@
+Supported absolute url to override base url.
+-- by :user:`vivodi`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -394,3 +394,4 @@ Zlatan Sičanica
 Łukasz Setla
 Марк Коренберг
 Семён Марьясин
+Bai Haoran

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -54,6 +54,7 @@ Arseny Timoniq
 Artem Yushkovskiy
 Arthur Darcet
 Austin Scola
+Bai Haoran
 Ben Bader
 Ben Greiner
 Ben Kallus
@@ -394,4 +395,3 @@ Zlatan Sičanica
 Łukasz Setla
 Марк Коренберг
 Семён Марьясин
-Bai Haoran

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -414,9 +414,8 @@ class ClientSession:
 
     def _build_url(self, str_or_url: StrOrURL) -> URL:
         url = URL(str_or_url)
-        return (
-            url if self._base_url is None or url.absolute else self._base_url.join(url)
-        )
+        need_join = self._base_url and not url.absolute
+        return self._base_url.join(url) if need_join else url
 
     async def _request(
         self,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -414,7 +414,11 @@ class ClientSession:
 
     def _build_url(self, str_or_url: StrOrURL) -> URL:
         url = URL(str_or_url)
-        return self._base_url and not url.absolute if self._base_url and not url.absolute else url
+        return (
+            self._base_url and not url.absolute
+            if self._base_url and not url.absolute
+            else url
+        )
 
     async def _request(
         self,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -414,7 +414,9 @@ class ClientSession:
 
     def _build_url(self, str_or_url: StrOrURL) -> URL:
         url = URL(str_or_url)
-        return url if self._base_url is None or url.absolute else self._base_url.join(url)
+        return (
+            url if self._base_url is None or url.absolute else self._base_url.join(url)
+        )
 
     async def _request(
         self,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -414,8 +414,7 @@ class ClientSession:
 
     def _build_url(self, str_or_url: StrOrURL) -> URL:
         url = URL(str_or_url)
-        need_join = self._base_url and not url.absolute
-        return self._base_url.join(url) if need_join else url
+        return self._base_url and not url.absolute if self._base_url and not url.absolute else url
 
     async def _request(
         self,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -414,11 +414,7 @@ class ClientSession:
 
     def _build_url(self, str_or_url: StrOrURL) -> URL:
         url = URL(str_or_url)
-        if self._base_url is None:
-            return url
-        else:
-            assert not url.absolute
-            return self._base_url.join(url)
+        return url if self._base_url is None or url.absolute else self._base_url.join(url)
 
     async def _request(
         self,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -414,11 +414,7 @@ class ClientSession:
 
     def _build_url(self, str_or_url: StrOrURL) -> URL:
         url = URL(str_or_url)
-        return (
-            self._base_url and not url.absolute
-            if self._base_url and not url.absolute
-            else url
-        )
+        return self._base_url.join(url) if self._base_url and not url.absolute else url
 
     async def _request(
         self,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -414,10 +414,8 @@ class ClientSession:
 
     def _build_url(self, str_or_url: StrOrURL) -> URL:
         url = URL(str_or_url)
-        is_relative_path = self._base_url and not url.absolute
-        if is_relative_path:
+        if self._base_url and not url.absolute:
             return self._base_url.join(url)
-
         return url
 
     async def _request(

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -414,8 +414,11 @@ class ClientSession:
 
     def _build_url(self, str_or_url: StrOrURL) -> URL:
         url = URL(str_or_url)
-        need_join = self._base_url and not url.absolute
-        return self._base_url.join(url) if need_join else url
+        is_relative_path = self._base_url and not url.absolute
+        if is_relative_path:
+            return self._base_url.join(url)
+
+        return url
 
     async def _request(
         self,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -414,7 +414,8 @@ class ClientSession:
 
     def _build_url(self, str_or_url: StrOrURL) -> URL:
         url = URL(str_or_url)
-        return self._base_url.join(url) if self._base_url and not url.absolute else url
+        need_join = self._base_url and not url.absolute
+        return self._base_url.join(url) if need_join else url
 
     async def _request(
         self,

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -77,6 +77,9 @@ The client session supports the context manager protocol for self closing.
         await session.request("GET", "/bar")
         # request for http://example.com/bar
 
+        await session.request("GET", "http://foo.com/bar")
+        # request for http://foo.com/bar
+
       .. versionadded:: 3.8
 
    :param aiohttp.BaseConnector connector: BaseConnector

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -77,10 +77,11 @@ The client session supports the context manager protocol for self closing.
         await session.request("GET", "/bar")
         # request for http://example.com/bar
 
-        await session.request("GET", "http://foo.com/bar")
-        # request for http://foo.com/bar
-
       .. versionadded:: 3.8
+
+      .. versionchanged:: 3.12
+
+         Added support for overriding the base URL with an absolute one in client sessions.
 
    :param aiohttp.BaseConnector connector: BaseConnector
       sub-class instance to support connection pooling.

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -1157,7 +1157,7 @@ async def test_requote_redirect_url_default_disable() -> None:
             "http://foo.com",
             URL("http://foo.com"),
             id="base_url=URL('http://example.com/test1/') url='http://foo.com'",
-        )
+        ),
     ],
 )
 async def test_build_url_returns_expected_url(

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -1140,6 +1140,24 @@ async def test_requote_redirect_url_default_disable() -> None:
             URL("http://example.com/test1/test2?q=foo#bar"),
             id="base_url=URL('http://example.com/test1/') url='test2?q=foo#bar'",
         ),
+        pytest.param(
+            URL("http://example.com/test1/"),
+            "http://foo.com/bar",
+            URL("http://foo.com/bar"),
+            id="base_url=URL('http://example.com/test1/') url='http://foo.com/bar'",
+        ),
+        pytest.param(
+            URL("http://example.com"),
+            "http://foo.com/bar",
+            URL("http://foo.com/bar/"),
+            id="base_url=URL('http://example.com') url='http://foo.com/bar'",
+        ),
+        pytest.param(
+            URL("http://example.com/test1/"),
+            "http://foo.com",
+            URL("http://foo.com"),
+            id="base_url=URL('http://example.com/test1/') url='http://foo.com'",
+        )
     ],
 )
 async def test_build_url_returns_expected_url(

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -1140,6 +1140,24 @@ async def test_requote_redirect_url_default_disable() -> None:
             URL("http://example.com/test1/test2?q=foo#bar"),
             id="base_url=URL('http://example.com/test1/') url='test2?q=foo#bar'",
         ),
+        pytest.param(
+            URL("http://example.com/test1/"),
+            "http://foo.com/bar",
+            URL("http://foo.com/bar"),
+            id="base_url=URL('http://example.com/test1/') url='http://foo.com/bar'",
+        ),
+        pytest.param(
+            URL("http://example.com"),
+            "http://foo.com/bar",
+            URL("http://foo.com/bar"),
+            id="base_url=URL('http://example.com') url='http://foo.com/bar'",
+        ),
+        pytest.param(
+            URL("http://example.com/test1/"),
+            "http://foo.com",
+            URL("http://foo.com"),
+            id="base_url=URL('http://example.com/test1/') url='http://foo.com'",
+        )
     ],
 )
 async def test_build_url_returns_expected_url(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Support absolute url in request to override base url in session.
```py
session = ClientSession(base_url="http://example.com/foo/")

await session.request("GET", "http://abc.com/bar/")
```

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Yes

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->
No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->
Fixes #10027
## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
