### PR TITLE
Bump yarl to 1.18.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,5 +42,5 @@ typing-extensions==4.12.2
     # via multidict
 uvloop==0.21.0 ; platform_system != "Windows" and implementation_name == "cpython"
     # via -r requirements/base.in
-yarl==1.18.0
+yarl==1.18.3
     # via -r requirements/runtime-deps.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -300,7 +300,7 @@ wait-for-it==2.2.2
     # via -r requirements/test.in
 wheel==0.44.0
     # via pip-tools
-yarl==1.18.0
+yarl==1.18.3
     # via -r requirements/runtime-deps.in
 zipp==3.20.2
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -273,7 +273,7 @@ wait-for-it==2.2.2
     # via -r requirements/test.in
 wheel==0.44.0
     # via pip-tools
-yarl==1.18.0
+yarl==1.18.3
     # via -r requirements/runtime-deps.in
 zipp==3.20.2
     # via

--- a/requirements/runtime-deps.txt
+++ b/requirements/runtime-deps.txt
@@ -36,5 +36,5 @@ pycparser==2.22
     # via cffi
 typing-extensions==4.12.2
     # via multidict
-yarl==1.18.0
+yarl==1.18.3
     # via -r requirements/runtime-deps.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -149,5 +149,5 @@ uvloop==0.21.0 ; platform_system != "Windows" and implementation_name == "cpytho
     # via -r requirements/base.in
 wait-for-it==2.2.2
     # via -r requirements/test.in
-yarl==1.18.0
+yarl==1.18.3
     # via -r requirements/runtime-deps.in


### PR DESCRIPTION
Bumping ahead of dependabot to get a new benchmark baseline as cache hit is a lot more likely with this version.


<img width="367" alt="Screenshot 2024-12-01 at 2 46 36 PM" src="https://github.com/user-attachments/assets/22d1c5d8-93b9-4b74-a0b5-e716d3d04a2d">
