### PR TITLE
Avoid calling len on the same data in the stream reader twice

### DIFF
--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -502,8 +502,9 @@ class StreamReader(AsyncStreamReaderMixin):
         else:
             data = self._buffer.popleft()
 
-        self._size -= len(data)
-        self._cursor += len(data)
+        data_len = len(data)
+        self._size -= data_len
+        self._cursor += data_len
 
         chunk_splits = self._http_chunk_splits
         # Prevent memory leak: drop useless chunk splits


### PR DESCRIPTION
This is trivial but it is noticeable in the profile.

before
![before](https://github.com/user-attachments/assets/97c0dcf3-f038-4d33-8c83-7b8c8336f0f2)

after
![after](https://github.com/user-attachments/assets/e8b5eed4-e427-4fa2-b6bf-229f7969a33d)
