### PR TITLE
Add a benchmark for web.FileResponse

### DIFF
--- a/tests/test_benchmarks_web_fileresponse.py
+++ b/tests/test_benchmarks_web_fileresponse.py
@@ -9,12 +9,12 @@ from aiohttp import web
 from aiohttp.pytest_plugin import AiohttpClient
 
 
-def test_simple_web_response(
+def test_simple_web_file_response(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark creating 100 simple web.Response."""
+    """Benchmark creating 100 simple web.FileResponse."""
     response_count = 100
     filepath = pathlib.Path(__file__).parent / "sample.txt"
 

--- a/tests/test_benchmarks_web_fileresponse.py
+++ b/tests/test_benchmarks_web_fileresponse.py
@@ -46,7 +46,8 @@ def test_simple_web_file_sendfile_fallback_response(
 
     async def handler(request: web.Request) -> web.FileResponse:
         transport = request.transport
-        transport._sendfile_compatible = False
+        assert transport is not None
+        transport._sendfile_compatible = False  # type: ignore
         return web.FileResponse(path=filepath)
 
     app = web.Application()

--- a/tests/test_benchmarks_web_fileresponse.py
+++ b/tests/test_benchmarks_web_fileresponse.py
@@ -1,4 +1,4 @@
-"""codspeed benchmarks for the web responses."""
+"""codspeed benchmarks for the web file responses."""
 
 import asyncio
 import pathlib

--- a/tests/test_benchmarks_web_fileresponse.py
+++ b/tests/test_benchmarks_web_fileresponse.py
@@ -1,0 +1,35 @@
+"""codspeed benchmarks for the web responses."""
+
+import asyncio
+import pathlib
+
+from pytest_codspeed import BenchmarkFixture
+
+from aiohttp import web
+from aiohttp.pytest_plugin import AiohttpClient
+
+
+def test_simple_web_response(
+    loop: asyncio.AbstractEventLoop,
+    aiohttp_client: AiohttpClient,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark creating 100 simple web.Response."""
+    response_count = 100
+    filepath = pathlib.Path(__file__).parent / "sample.txt"
+
+    async def handler(request: web.Request) -> web.FileResponse:
+        return web.FileResponse(path=filepath)
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+
+    async def run_file_resonse_benchmark() -> None:
+        client = await aiohttp_client(app)
+        for _ in range(response_count):
+            await client.get("/")
+        await client.close()
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_file_resonse_benchmark())

--- a/tests/test_benchmarks_web_fileresponse.py
+++ b/tests/test_benchmarks_web_fileresponse.py
@@ -33,3 +33,31 @@ def test_simple_web_file_response(
     @benchmark
     def _run() -> None:
         loop.run_until_complete(run_file_resonse_benchmark())
+
+
+def test_simple_web_file_sendfile_fallback_response(
+    loop: asyncio.AbstractEventLoop,
+    aiohttp_client: AiohttpClient,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark creating 100 simple web.FileResponse without sendfile."""
+    response_count = 100
+    filepath = pathlib.Path(__file__).parent / "sample.txt"
+
+    async def handler(request: web.Request) -> web.FileResponse:
+        transport = request.transport
+        transport._sendfile_compatible = False
+        return web.FileResponse(path=filepath)
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+
+    async def run_file_resonse_benchmark() -> None:
+        client = await aiohttp_client(app)
+        for _ in range(response_count):
+            await client.get("/")
+        await client.close()
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_file_resonse_benchmark())

--- a/tests/test_benchmarks_web_fileresponse.py
+++ b/tests/test_benchmarks_web_fileresponse.py
@@ -47,7 +47,7 @@ def test_simple_web_file_sendfile_fallback_response(
     async def handler(request: web.Request) -> web.FileResponse:
         transport = request.transport
         assert transport is not None
-        transport._sendfile_compatible = False  # type: ignore
+        transport._sendfile_compatible = False  # type: ignore[attr-defined]
         return web.FileResponse(path=filepath)
 
     app = web.Application()


### PR DESCRIPTION
We didn't have any benchmarks for file responses. From the benchmarks it turns out most of the time is creating and processing the executor jobs.

If we combine the stat into a job that returns the open fileobj it will likely be faster and solve https://github.com/aio-libs/aiohttp/issues/8013
