### PR TITLE
Fix race in `FileResponse` if file is replaced during `prepare`

### DIFF
--- a/CHANGES/10101.bugfix.rst
+++ b/CHANGES/10101.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed race condition in :class:`aiohttp.web.FileResponse` that could result in an incorrect response if the file was replaced on the filesystem during ``prepare`` -- by :user:`bdraco`.
+Fixed race condition in :class:`aiohttp.web.FileResponse` that could have resulted in an incorrect response if the file was replaced on the filesystem during :meth:`aiohttp.web.FileResponse.prepare` -- by :user:`bdraco`.

--- a/CHANGES/10101.bugfix.rst
+++ b/CHANGES/10101.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed race condition in :class:`aiohttp.web.FileResponse` that could result in an incorrect response if the file was replaced on the filesystem during ``prepare`` -- by :user:`bdraco`.

--- a/CHANGES/10101.bugfix.rst
+++ b/CHANGES/10101.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed race condition in :class:`aiohttp.web.FileResponse` that could have resulted in an incorrect response if the file was replaced on the filesystem during ``prepare`` -- by :user:`bdraco`.
+Fixed race condition in :class:`aiohttp.web.FileResponse` that could have resulted in an incorrect response if the file was replaced on the file system during ``prepare`` -- by :user:`bdraco`.

--- a/CHANGES/10101.bugfix.rst
+++ b/CHANGES/10101.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed race condition in :class:`aiohttp.web.FileResponse` that could have resulted in an incorrect response if the file was replaced on the filesystem during :meth:`aiohttp.web.FileResponse.prepare` -- by :user:`bdraco`.
+Fixed race condition in :class:`aiohttp.web.FileResponse` that could have resulted in an incorrect response if the file was replaced on the filesystem during ``prepare`` -- by :user:`bdraco`.

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -184,9 +184,8 @@ class FileResponse(StreamResponse):
                 st = compressed_path.lstat()
                 if S_ISREG(st.st_mode):
                     fobj = compressed_path.open("rb")
-                    with suppress(
-                        OSError
-                    ):  # fstat() may not be available on all platforms
+                    with suppress(OSError):
+                        # fstat() may not be available on all platforms
                         # Once we open the file, we want the fstat() to ensure
                         # the file has not changed between the first stat()
                         # and the open().
@@ -198,7 +197,8 @@ class FileResponse(StreamResponse):
         if not S_ISREG(st.st_mode):
             return None, st, None
         fobj = file_path.open("rb")
-        with suppress(OSError):  # fstat() may not be available on all platforms
+        with suppress(OSError):
+            # fstat() may not be available on all platforms
             # Once we open the file, we want the fstat() to ensure
             # the file has not changed between the first stat()
             # and the open().

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -390,7 +390,9 @@ class FileResponse(StreamResponse):
             return await self._sendfile(request, fobj, offset, count)
         finally:
             # We do not await here because we do not want to wait
-            # for the executor to finish before returning the response.
+            # for the executor to finish before returning the response
+            # so the connection can begin servicing another request
+            # as soon as possible.
             close_future = loop.run_in_executor(None, fobj.close)
             # Hold a strong reference to the future to prevent it from being
             # garbage collected before it completes.

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -208,7 +208,7 @@ class FileResponse(StreamResponse):
         except OSError as e:
             if e.errno == 102:  # Operation not supported on socket
                 # This will also be checked in prepare() but we want
-                # to preserve backwards compatibility and give
+                # to preserve backwards compatibility and handle
                 # as 403 Forbidden.
                 raise PermissionError("File is a socket")
             raise

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -184,7 +184,9 @@ class FileResponse(StreamResponse):
                 st = compressed_path.lstat()
                 if S_ISREG(st.st_mode):
                     fobj = compressed_path.open("rb")
-                    with suppress(OSError):
+                    with suppress(
+                        OSError
+                    ):  # fstat() may not be available on all platforms
                         # Once we open the file, we want the fstat() to ensure
                         # the file has not changed between the first stat()
                         # and the open().
@@ -196,7 +198,7 @@ class FileResponse(StreamResponse):
         if not S_ISREG(st.st_mode):
             return None, st, None
         fobj = file_path.open("rb")
-        with suppress(OSError):
+        with suppress(OSError):  # fstat() may not be available on all platforms
             # Once we open the file, we want the fstat() to ensure
             # the file has not changed between the first stat()
             # and the open().

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -1,4 +1,5 @@
 import asyncio
+import io
 import os
 import pathlib
 from contextlib import suppress
@@ -13,6 +14,7 @@ from typing import (
     Callable,
     Final,
     Optional,
+    Set,
     Tuple,
     cast,
 )
@@ -67,6 +69,24 @@ ADDITIONAL_CONTENT_TYPES = MappingProxyType(
 CONTENT_TYPES.encodings_map.clear()
 for content_type, extension in ADDITIONAL_CONTENT_TYPES.items():
     CONTENT_TYPES.add_type(content_type, extension)
+
+
+_CLOSE_FUTURES: Set[asyncio.Future[None]] = set()
+
+
+def _stat_open_file(
+    file_path: pathlib.Path, fobj: io.BufferedReader, st: Optional[os.stat_result]
+) -> os.stat_result:
+    """Return the stat result of the file or the fallback stat result.
+
+    Ideally we can use fstat() to get the stat result of the file object,
+    to ensure we are returning the correct length of the open file,
+    but it is not possible to get the file descriptor from the file object
+    on some operating systems, so we have to use the stat result of the file path.
+    """
+    with suppress(OSError):  # May not work on Windows
+        st = os.stat(fobj.fileno())
+    return st or file_path.stat()
 
 
 class FileResponse(StreamResponse):
@@ -157,10 +177,10 @@ class FileResponse(StreamResponse):
         self.content_length = 0
         return await super().prepare(request)
 
-    def _get_file_path_stat_encoding(
+    def _open_file_path_stat_encoding(
         self, accept_encoding: str
-    ) -> Tuple[pathlib.Path, os.stat_result, Optional[str]]:
-        """Return the file path, stat result, and encoding.
+    ) -> Tuple[io.BufferedReader, os.stat_result, Optional[str]]:
+        """Return the io object, stat result, and encoding.
 
         If an uncompressed file is returned, the encoding is set to
         :py:data:`None`.
@@ -178,10 +198,14 @@ class FileResponse(StreamResponse):
                 # Do not follow symlinks and ignore any non-regular files.
                 st = compressed_path.lstat()
                 if S_ISREG(st.st_mode):
-                    return compressed_path, st, file_encoding
+                    fobj = compressed_path.open("rb")
+                    st = _stat_open_file(compressed_path, fobj, st)
+                    return fobj, st, file_encoding
 
         # Fallback to the uncompressed file
-        return file_path, file_path.stat(), None
+        fobj = file_path.open("rb")
+        st = _stat_open_file(file_path, fobj, None)
+        return fobj, st, None
 
     async def prepare(self, request: "BaseRequest") -> Optional[AbstractStreamWriter]:
         loop = asyncio.get_running_loop()
@@ -189,172 +213,176 @@ class FileResponse(StreamResponse):
         # https://www.rfc-editor.org/rfc/rfc9110#section-8.4.1
         accept_encoding = request.headers.get(hdrs.ACCEPT_ENCODING, "").lower()
         try:
-            file_path, st, file_encoding = await loop.run_in_executor(
-                None, self._get_file_path_stat_encoding, accept_encoding
+            fobj, st, file_encoding = await loop.run_in_executor(
+                None, self._open_file_path_stat_encoding, accept_encoding
             )
+        except PermissionError:
+            self.set_status(HTTPForbidden.status_code)
+            return await super().prepare(request)
         except OSError:
             # Most likely to be FileNotFoundError or OSError for circular
             # symlinks in python >= 3.13, so respond with 404.
             self.set_status(HTTPNotFound.status_code)
             return await super().prepare(request)
 
-        # Forbid special files like sockets, pipes, devices, etc.
-        if not S_ISREG(st.st_mode):
-            self.set_status(HTTPForbidden.status_code)
-            return await super().prepare(request)
-
-        etag_value = f"{st.st_mtime_ns:x}-{st.st_size:x}"
-        last_modified = st.st_mtime
-
-        # https://www.rfc-editor.org/rfc/rfc9110#section-13.1.1-2
-        ifmatch = request.if_match
-        if ifmatch is not None and not self._etag_match(
-            etag_value, ifmatch, weak=False
-        ):
-            return await self._precondition_failed(request)
-
-        unmodsince = request.if_unmodified_since
-        if (
-            unmodsince is not None
-            and ifmatch is None
-            and st.st_mtime > unmodsince.timestamp()
-        ):
-            return await self._precondition_failed(request)
-
-        # https://www.rfc-editor.org/rfc/rfc9110#section-13.1.2-2
-        ifnonematch = request.if_none_match
-        if ifnonematch is not None and self._etag_match(
-            etag_value, ifnonematch, weak=True
-        ):
-            return await self._not_modified(request, etag_value, last_modified)
-
-        modsince = request.if_modified_since
-        if (
-            modsince is not None
-            and ifnonematch is None
-            and st.st_mtime <= modsince.timestamp()
-        ):
-            return await self._not_modified(request, etag_value, last_modified)
-
-        status = self._status
-        file_size = st.st_size
-        count = file_size
-
-        start = None
-
-        ifrange = request.if_range
-        if ifrange is None or st.st_mtime <= ifrange.timestamp():
-            # If-Range header check:
-            # condition = cached date >= last modification date
-            # return 206 if True else 200.
-            # if False:
-            #   Range header would not be processed, return 200
-            # if True but Range header missing
-            #   return 200
-            try:
-                rng = request.http_range
-                start = rng.start
-                end = rng.stop
-            except ValueError:
-                # https://tools.ietf.org/html/rfc7233:
-                # A server generating a 416 (Range Not Satisfiable) response to
-                # a byte-range request SHOULD send a Content-Range header field
-                # with an unsatisfied-range value.
-                # The complete-length in a 416 response indicates the current
-                # length of the selected representation.
-                #
-                # Will do the same below. Many servers ignore this and do not
-                # send a Content-Range header with HTTP 416
-                self.headers[hdrs.CONTENT_RANGE] = f"bytes */{file_size}"
-                self.set_status(HTTPRequestRangeNotSatisfiable.status_code)
+        try:
+            # Forbid special files like sockets, pipes, devices, etc.
+            if not S_ISREG(st.st_mode):
+                self.set_status(HTTPForbidden.status_code)
                 return await super().prepare(request)
 
-            # If a range request has been made, convert start, end slice
-            # notation into file pointer offset and count
-            if start is not None or end is not None:
-                if start < 0 and end is None:  # return tail of file
-                    start += file_size
-                    if start < 0:
-                        # if Range:bytes=-1000 in request header but file size
-                        # is only 200, there would be trouble without this
-                        start = 0
-                    count = file_size - start
-                else:
-                    # rfc7233:If the last-byte-pos value is
-                    # absent, or if the value is greater than or equal to
-                    # the current length of the representation data,
-                    # the byte range is interpreted as the remainder
-                    # of the representation (i.e., the server replaces the
-                    # value of last-byte-pos with a value that is one less than
-                    # the current length of the selected representation).
-                    count = (
-                        min(end if end is not None else file_size, file_size) - start
-                    )
+            etag_value = f"{st.st_mtime_ns:x}-{st.st_size:x}"
+            last_modified = st.st_mtime
 
-                if start >= file_size:
-                    # HTTP 416 should be returned in this case.
+            # https://www.rfc-editor.org/rfc/rfc9110#section-13.1.1-2
+            ifmatch = request.if_match
+            if ifmatch is not None and not self._etag_match(
+                etag_value, ifmatch, weak=False
+            ):
+                return await self._precondition_failed(request)
+
+            unmodsince = request.if_unmodified_since
+            if (
+                unmodsince is not None
+                and ifmatch is None
+                and st.st_mtime > unmodsince.timestamp()
+            ):
+                return await self._precondition_failed(request)
+
+            # https://www.rfc-editor.org/rfc/rfc9110#section-13.1.2-2
+            ifnonematch = request.if_none_match
+            if ifnonematch is not None and self._etag_match(
+                etag_value, ifnonematch, weak=True
+            ):
+                return await self._not_modified(request, etag_value, last_modified)
+
+            modsince = request.if_modified_since
+            if (
+                modsince is not None
+                and ifnonematch is None
+                and st.st_mtime <= modsince.timestamp()
+            ):
+                return await self._not_modified(request, etag_value, last_modified)
+
+            status = self._status
+            file_size = st.st_size
+            count = file_size
+
+            start = None
+
+            ifrange = request.if_range
+            if ifrange is None or st.st_mtime <= ifrange.timestamp():
+                # If-Range header check:
+                # condition = cached date >= last modification date
+                # return 206 if True else 200.
+                # if False:
+                #   Range header would not be processed, return 200
+                # if True but Range header missing
+                #   return 200
+                try:
+                    rng = request.http_range
+                    start = rng.start
+                    end = rng.stop
+                except ValueError:
+                    # https://tools.ietf.org/html/rfc7233:
+                    # A server generating a 416 (Range Not Satisfiable) response to
+                    # a byte-range request SHOULD send a Content-Range header field
+                    # with an unsatisfied-range value.
+                    # The complete-length in a 416 response indicates the current
+                    # length of the selected representation.
                     #
-                    # According to https://tools.ietf.org/html/rfc7233:
-                    # If a valid byte-range-set includes at least one
-                    # byte-range-spec with a first-byte-pos that is less than
-                    # the current length of the representation, or at least one
-                    # suffix-byte-range-spec with a non-zero suffix-length,
-                    # then the byte-range-set is satisfiable. Otherwise, the
-                    # byte-range-set is unsatisfiable.
+                    # Will do the same below. Many servers ignore this and do not
+                    # send a Content-Range header with HTTP 416
                     self.headers[hdrs.CONTENT_RANGE] = f"bytes */{file_size}"
                     self.set_status(HTTPRequestRangeNotSatisfiable.status_code)
                     return await super().prepare(request)
 
-                status = HTTPPartialContent.status_code
-                # Even though you are sending the whole file, you should still
-                # return a HTTP 206 for a Range request.
-                self.set_status(status)
+                # If a range request has been made, convert start, end slice
+                # notation into file pointer offset and count
+                if start is not None or end is not None:
+                    if start < 0 and end is None:  # return tail of file
+                        start += file_size
+                        if start < 0:
+                            # if Range:bytes=-1000 in request header but file size
+                            # is only 200, there would be trouble without this
+                            start = 0
+                        count = file_size - start
+                    else:
+                        # rfc7233:If the last-byte-pos value is
+                        # absent, or if the value is greater than or equal to
+                        # the current length of the representation data,
+                        # the byte range is interpreted as the remainder
+                        # of the representation (i.e., the server replaces the
+                        # value of last-byte-pos with a value that is one less than
+                        # the current length of the selected representation).
+                        count = (
+                            min(end if end is not None else file_size, file_size)
+                            - start
+                        )
 
-        # If the Content-Type header is not already set, guess it based on the
-        # extension of the request path. The encoding returned by guess_type
-        #  can be ignored since the map was cleared above.
-        if hdrs.CONTENT_TYPE not in self.headers:
-            self.content_type = (
-                CONTENT_TYPES.guess_type(self._path)[0] or FALLBACK_CONTENT_TYPE
-            )
+                    if start >= file_size:
+                        # HTTP 416 should be returned in this case.
+                        #
+                        # According to https://tools.ietf.org/html/rfc7233:
+                        # If a valid byte-range-set includes at least one
+                        # byte-range-spec with a first-byte-pos that is less than
+                        # the current length of the representation, or at least one
+                        # suffix-byte-range-spec with a non-zero suffix-length,
+                        # then the byte-range-set is satisfiable. Otherwise, the
+                        # byte-range-set is unsatisfiable.
+                        self.headers[hdrs.CONTENT_RANGE] = f"bytes */{file_size}"
+                        self.set_status(HTTPRequestRangeNotSatisfiable.status_code)
+                        return await super().prepare(request)
 
-        if file_encoding:
-            self.headers[hdrs.CONTENT_ENCODING] = file_encoding
-            self.headers[hdrs.VARY] = hdrs.ACCEPT_ENCODING
-            # Disable compression if we are already sending
-            # a compressed file since we don't want to double
-            # compress.
-            self._compression = False
+                    status = HTTPPartialContent.status_code
+                    # Even though you are sending the whole file, you should still
+                    # return a HTTP 206 for a Range request.
+                    self.set_status(status)
 
-        self.etag = etag_value  # type: ignore[assignment]
-        self.last_modified = st.st_mtime  # type: ignore[assignment]
-        self.content_length = count
+            # If the Content-Type header is not already set, guess it based on the
+            # extension of the request path. The encoding returned by guess_type
+            #  can be ignored since the map was cleared above.
+            if hdrs.CONTENT_TYPE not in self.headers:
+                self.content_type = (
+                    CONTENT_TYPES.guess_type(self._path)[0] or FALLBACK_CONTENT_TYPE
+                )
 
-        self.headers[hdrs.ACCEPT_RANGES] = "bytes"
+            if file_encoding:
+                self.headers[hdrs.CONTENT_ENCODING] = file_encoding
+                self.headers[hdrs.VARY] = hdrs.ACCEPT_ENCODING
+                # Disable compression if we are already sending
+                # a compressed file since we don't want to double
+                # compress.
+                self._compression = False
 
-        real_start = cast(int, start)
+            self.etag = etag_value  # type: ignore[assignment]
+            self.last_modified = st.st_mtime  # type: ignore[assignment]
+            self.content_length = count
 
-        if status == HTTPPartialContent.status_code:
-            self.headers[hdrs.CONTENT_RANGE] = "bytes {}-{}/{}".format(
-                real_start, real_start + count - 1, file_size
-            )
+            self.headers[hdrs.ACCEPT_RANGES] = "bytes"
 
-        # If we are sending 0 bytes calling sendfile() will throw a ValueError
-        if count == 0 or must_be_empty_body(request.method, self.status):
-            return await super().prepare(request)
+            real_start = cast(int, start)
 
-        try:
-            fobj = await loop.run_in_executor(None, file_path.open, "rb")
-        except PermissionError:
-            self.set_status(HTTPForbidden.status_code)
-            return await super().prepare(request)
+            if status == HTTPPartialContent.status_code:
+                self.headers[hdrs.CONTENT_RANGE] = "bytes {}-{}/{}".format(
+                    real_start, real_start + count - 1, file_size
+                )
 
-        if start:  # be aware that start could be None or int=0 here.
-            offset = start
-        else:
-            offset = 0
+            # If we are sending 0 bytes calling sendfile() will throw a ValueError
+            if count == 0 or must_be_empty_body(request.method, self.status):
+                return await super().prepare(request)
 
-        try:
+            if start:  # be aware that start could be None or int=0 here.
+                offset = start
+            else:
+                offset = 0
+
             return await self._sendfile(request, fobj, offset, count)
         finally:
-            await asyncio.shield(loop.run_in_executor(None, fobj.close))
+            # We do not await here because we do not want to wait
+            # for the executor to finish before returning the response.
+            close_future = loop.run_in_executor(None, fobj.close)
+            # Hold a strong reference to the future to prevent it from being
+            # garbage collected before it completes.
+            _CLOSE_FUTURES.add(close_future)
+            close_future.add_done_callback(_CLOSE_FUTURES.remove)

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -303,6 +303,8 @@ class FileResponse(StreamResponse):
             #   return 200
             try:
                 rng = request.http_range
+                start = rng.start
+                end = rng.stop
             except ValueError:
                 # https://tools.ietf.org/html/rfc7233:
                 # A server generating a 416 (Range Not Satisfiable) response to
@@ -317,10 +319,6 @@ class FileResponse(StreamResponse):
                 self.set_status(HTTPRequestRangeNotSatisfiable.status_code)
                 return await super().prepare(request)
 
-            if TYPE_CHECKING:
-                assert rng is not None
-            start = rng.start
-            end = rng.stop
             # If a range request has been made, convert start, end slice
             # notation into file pointer offset and count
             if start is not None or end is not None:

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -303,6 +303,8 @@ class FileResponse(StreamResponse):
                     self.set_status(HTTPRequestRangeNotSatisfiable.status_code)
                     return await super().prepare(request)
 
+                if TYPE_CHECKING:
+                    assert rng is not None
                 start = rng.start
                 end = rng.stop
                 # If a range request has been made, convert start, end slice

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -281,8 +281,6 @@ class FileResponse(StreamResponse):
                 #   return 200
                 try:
                     rng = request.http_range
-                    start = rng.start
-                    end = rng.stop
                 except ValueError:
                     # https://tools.ietf.org/html/rfc7233:
                     # A server generating a 416 (Range Not Satisfiable) response to
@@ -297,6 +295,8 @@ class FileResponse(StreamResponse):
                     self.set_status(HTTPRequestRangeNotSatisfiable.status_code)
                     return await super().prepare(request)
 
+                start = rng.start
+                end = rng.stop
                 # If a range request has been made, convert start, end slice
                 # notation into file pointer offset and count
                 if start is not None or end is not None:

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -579,16 +579,17 @@ async def test_access_mock_special_resource(
     my_special.touch()
 
     real_result = my_special.stat()
-    real_stat = pathlib.Path.stat
+    real_stat = os.stat
 
-    def mock_stat(self: pathlib.Path, **kwargs: Any) -> os.stat_result:
-        s = real_stat(self, **kwargs)
+    def mock_stat(path: Any, **kwargs: Any) -> os.stat_result:
+        s = real_stat(path, **kwargs)
         if os.path.samestat(s, real_result):
             mock_mode = S_IFIFO | S_IMODE(s.st_mode)
             s = os.stat_result([mock_mode] + list(s)[1:])
         return s
 
     monkeypatch.setattr("pathlib.Path.stat", mock_stat)
+    monkeypatch.setattr("os.stat", mock_stat)
 
     app = web.Application()
     app.router.add_static("/", str(tmp_path))


### PR DESCRIPTION
There was a race in ``FileResponse`` where the `stat` would be incorrect if the file was changed out between the `stat` and `open` syscalls. This would lead to various unexpected behaviors such as trying to read beyond the length of the file or sending a partial file. This problem is likely to occour when files are being renamed/linked into place.

An example of how this can happen with a system that provides weather data every 60s:

An external process writes `.weather.txt` at the top of each minute, and than renames it into place as `weather.txt`. In this case `FileResponse.prepare` may `stat` the old `weather.txt`, and than `open` the new `weather.txt`, and use the `os.stat_result` from the original file.

To fix this we now `fstat` the open file on operating systems where `fstat` is available.

This change looks much larger than it actually is because most of the function now needs to be wrapped in the `try`/`finally` to ensure that we close the file cleanly as we open it a lot sooner now.  Its best to compare without white space as well.

fixes #8013
