### PR TITLE
Fix deprecated calls to `guess_type` for paths with Python 3.13

### DIFF
--- a/CHANGES/10102.bugfix.rst
+++ b/CHANGES/10102.bugfix.rst
@@ -1,0 +1,1 @@
+Replaced deprecated call to :func:`mime_types.guess_type` with :func:`mime_types.guess_file_type` when using Python 3.13+ -- by :user:`bdraco`.

--- a/CHANGES/10102.bugfix.rst
+++ b/CHANGES/10102.bugfix.rst
@@ -1,1 +1,1 @@
-Replaced deprecated call to :func:`mime_types.guess_type` with :func:`mime_types.guess_file_type` when using Python 3.13+ -- by :user:`bdraco`.
+Replaced deprecated call to :func:`mimetypes.guess_type` with :func:`mimetypes.guess_file_type` when using Python 3.13+ -- by :user:`bdraco`.

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -4,6 +4,7 @@ import io
 import json
 import mimetypes
 import os
+import sys
 import warnings
 from abc import ABC, abstractmethod
 from itertools import chain
@@ -169,7 +170,11 @@ class Payload(ABC):
             assert isinstance(content_type, str)
             self._headers[hdrs.CONTENT_TYPE] = content_type
         elif self._filename is not None:
-            content_type = mimetypes.guess_type(self._filename)[0]
+            if sys.version_info >= (3, 13):
+                guesser = mimetypes.guess_file_type
+            else:
+                guesser = mimetypes.guess_type
+            content_type = guesser(self._filename)[0]
             if content_type is None:
                 content_type = self._default_content_type
             self._headers[hdrs.CONTENT_TYPE] = content_type

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import pathlib
+import sys
 from contextlib import suppress
 from mimetypes import MimeTypes
 from stat import S_ISREG
@@ -314,9 +315,11 @@ class FileResponse(StreamResponse):
         # extension of the request path. The encoding returned by guess_type
         #  can be ignored since the map was cleared above.
         if hdrs.CONTENT_TYPE not in self.headers:
-            self.content_type = (
-                CONTENT_TYPES.guess_file_type(self._path)[0] or FALLBACK_CONTENT_TYPE
-            )
+            if sys.version >= (3, 13):
+                guesser = CONTENT_TYPES.guess_file_type
+            else:
+                guesser = CONTENT_TYPES.guess_type
+            self.content_type = guesser(self._path)[0] or FALLBACK_CONTENT_TYPE
 
         if file_encoding:
             self.headers[hdrs.CONTENT_ENCODING] = file_encoding

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -315,7 +315,7 @@ class FileResponse(StreamResponse):
         #  can be ignored since the map was cleared above.
         if hdrs.CONTENT_TYPE not in self.headers:
             self.content_type = (
-                CONTENT_TYPES.guess_type(self._path)[0] or FALLBACK_CONTENT_TYPE
+                CONTENT_TYPES.guess_file_type(self._path)[0] or FALLBACK_CONTENT_TYPE
             )
 
         if file_encoding:

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -315,7 +315,7 @@ class FileResponse(StreamResponse):
         # extension of the request path. The encoding returned by guess_type
         #  can be ignored since the map was cleared above.
         if hdrs.CONTENT_TYPE not in self.headers:
-            if sys.version >= (3, 13):
+            if sys.version_info >= (3, 13):
                 guesser = CONTENT_TYPES.guess_file_type
             else:
                 guesser = CONTENT_TYPES.guess_type


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

https://docs.python.org/3/library/mimetypes.html#mimetypes.guess_type
> Deprecated since version 3.13: Passing a file path instead of URL is [soft deprecated](https://docs.python.org/3/glossary.html#term-soft-deprecated). Use [guess_file_type()](https://docs.python.org/3/library/mimetypes.html#mimetypes.guess_file_type) for this.

These should have been changed to `guess_file_type` on Python 3.13 as `guess_type` expects a URL and `guess_file_type` expects a path. Its a soft deprecation so they still work but that may change in the future.


## Are there changes in behavior for the user?
no

## Is it a substantial burden for the maintainers to support this?
no