### PR TITLE
Add host parameter to aiohttp_server fixture (#10120)

### DIFF
--- a/CHANGES/10120.feature.rst
+++ b/CHANGES/10120.feature.rst
@@ -1,0 +1,1 @@
+Added ``host`` parameter to ``aiohttp_server`` fixture -- by :user:`christianwbrock`.

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -304,9 +304,9 @@ def aiohttp_server(loop: asyncio.AbstractEventLoop) -> Iterator[AiohttpServer]:
     servers = []
 
     async def go(
-        app: Application, *, port: Optional[int] = None, **kwargs: Any
+        app: Application, *, host: str = "127.0.0.1", port: Optional[int] = None, **kwargs: Any
     ) -> TestServer:
-        server = TestServer(app, port=port)
+        server = TestServer(app, host=host, port=port)
         await server.start_server(**kwargs)
         servers.append(server)
         return server

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -304,7 +304,11 @@ def aiohttp_server(loop: asyncio.AbstractEventLoop) -> Iterator[AiohttpServer]:
     servers = []
 
     async def go(
-        app: Application, *, host: str = "127.0.0.1", port: Optional[int] = None, **kwargs: Any
+        app: Application,
+        *,
+        host: str = "127.0.0.1",
+        port: Optional[int] = None,
+        **kwargs: Any,
     ) -> TestServer:
         server = TestServer(app, host=host, port=port)
         await server.start_server(**kwargs)


### PR DESCRIPTION
Fixes #10120 

It adds a host parameter to the aiohttp_server fixture to allow access
from non local clients, e.g. running in docker containers.
