### PR TITLE
Disable zero copy writes in the ``StreamWriter``

### DIFF
--- a/CHANGES/10125.bugfix.rst
+++ b/CHANGES/10125.bugfix.rst
@@ -1,0 +1,1 @@
+Disabled zero copy writes in the ``StreamWriter`` -- by :user:`bdraco`.

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -90,7 +90,7 @@ class StreamWriter(AbstractStreamWriter):
         transport = self._protocol.transport
         if transport is None or transport.is_closing():
             raise ClientConnectionResetError("Cannot write to closing transport")
-        transport.writelines(chunks)
+        transport.write(b"".join(chunks))
 
     async def write(
         self, chunk: bytes, *, drain: bool = True, LIMIT: int = 0x10000


### PR DESCRIPTION
https://github.com/python/cpython/pull/127656

Zero copy writes will return in a future version once a new cpython version is released. https://github.com/aio-libs/aiohttp/pull/10137 will restore them in the future.