### PR TITLE
Bump Python version for benchmarks to 3.13

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -266,11 +266,11 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Setup Python 3.12
+    - name: Setup Python 3.13
       id: python-install
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.13
         cache: pip
         cache-dependency-path: requirements/*.txt
     - name: Update pip, wheel, setuptools, build, twine


### PR DESCRIPTION
Python 3.13.1 has been released. As its rare to see performance changes in Python versions after .0, and even more rare to see them after .1 its time to start benchmarking against 3.13.1

https://github.com/python/cpython/pull/106555
https://github.com/python/cpython/pull/106879
https://github.com/python/cpython/pull/106528

Showing some modest gains from the above
<img width="370" alt="Screenshot 2024-12-05 at 6 32 31 PM" src="https://github.com/user-attachments/assets/319811fd-80e0-400a-bcfd-bd19c57f8315">

