### PR TITLE
Bump sphinx to 8.1.3 along with required dependencies

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -237,7 +237,7 @@ sphinx==8.1.3
     #   sphinxcontrib-towncrier
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.1
     # via sphinx

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -230,7 +230,7 @@ slotscheck==0.19.1
     # via -r requirements/lint.in
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.1.2
+sphinx==8.1.3
     # via
     #   -r requirements/doc.in
     #   sphinxcontrib-spelling

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -239,7 +239,7 @@ sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -243,7 +243,7 @@ sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -14,7 +14,7 @@ aiohttp-theme==0.1.7
     # via -r requirements/doc.in
 aiosignal==1.3.1
     # via -r requirements/runtime-deps.in
-alabaster==0.7.13
+alabaster==1.0.0
     # via sphinx
 annotated-types==0.7.0
     # via pydantic

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -245,7 +245,7 @@ sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxcontrib-spelling==8.0.0 ; platform_system != "Windows"
     # via -r requirements/doc-spelling.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -235,7 +235,7 @@ sphinx==8.1.3
     #   -r requirements/doc.in
     #   sphinxcontrib-spelling
     #   sphinxcontrib-towncrier
-sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -218,7 +218,7 @@ sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -14,7 +14,7 @@ aiohttp-theme==0.1.7
     # via -r requirements/doc.in
 aiosignal==1.3.1
     # via -r requirements/runtime-deps.in
-alabaster==0.7.13
+alabaster==1.0.0
     # via sphinx
 annotated-types==0.7.0
     # via pydantic

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -210,7 +210,7 @@ sphinx==8.1.3
     # via
     #   -r requirements/doc.in
     #   sphinxcontrib-towncrier
-sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -206,7 +206,7 @@ slotscheck==0.19.1
     # via -r requirements/lint.in
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.1.2
+sphinx==8.1.3
     # via
     #   -r requirements/doc.in
     #   sphinxcontrib-towncrier

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -220,7 +220,7 @@ sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxcontrib-towncrier==0.4.0a0
     # via -r requirements/doc.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -214,7 +214,7 @@ sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -212,7 +212,7 @@ sphinx==8.1.3
     #   sphinxcontrib-towncrier
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.1
     # via sphinx

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -59,7 +59,7 @@ sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -46,7 +46,7 @@ requests==2.32.3
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.1.2
+sphinx==8.1.3
     # via
     #   -r requirements/doc.in
     #   sphinxcontrib-spelling

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -53,7 +53,7 @@ sphinx==8.1.3
     #   sphinxcontrib-towncrier
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.1
     # via sphinx

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -51,7 +51,7 @@ sphinx==8.1.3
     #   -r requirements/doc.in
     #   sphinxcontrib-spelling
     #   sphinxcontrib-towncrier
-sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -6,7 +6,7 @@
 #
 aiohttp-theme==0.1.7
     # via -r requirements/doc.in
-alabaster==0.7.13
+alabaster==1.0.0
     # via sphinx
 babel==2.16.0
     # via sphinx

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -55,7 +55,7 @@ sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -61,7 +61,7 @@ sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxcontrib-spelling==8.0.0 ; platform_system != "Windows"
     # via -r requirements/doc-spelling.in

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -44,7 +44,7 @@ requests==2.32.3
     # via sphinx
 snowballstemmer==2.2.0
     # via sphinx
-sphinx==7.1.2
+sphinx==8.1.3
     # via
     #   -r requirements/doc.in
     #   sphinxcontrib-towncrier

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -52,7 +52,7 @@ sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==2.0.0
     # via sphinx
-sphinxcontrib-htmlhelp==2.0.1
+sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -48,7 +48,7 @@ sphinx==8.1.3
     # via
     #   -r requirements/doc.in
     #   sphinxcontrib-towncrier
-sphinxcontrib-applehelp==1.0.4
+sphinxcontrib-applehelp==2.0.0
     # via sphinx
 sphinxcontrib-devhelp==1.0.2
     # via sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -50,7 +50,7 @@ sphinx==8.1.3
     #   sphinxcontrib-towncrier
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
-sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-devhelp==2.0.0
     # via sphinx
 sphinxcontrib-htmlhelp==2.0.1
     # via sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -56,7 +56,7 @@ sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
-sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,7 +6,7 @@
 #
 aiohttp-theme==0.1.7
     # via -r requirements/doc.in
-alabaster==0.7.13
+alabaster==1.0.0
     # via sphinx
 babel==2.16.0
     # via sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -58,7 +58,7 @@ sphinxcontrib-jsmath==1.0.1
     # via sphinx
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
-sphinxcontrib-serializinghtml==1.1.5
+sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxcontrib-towncrier==0.4.0a0
     # via -r requirements/doc.in


### PR DESCRIPTION
sphinx changelog: https://github.com/sphinx-doc/sphinx/compare/v7.1.2...v8.1.3
sphinxcontrib-applehelp changelog: https://github.com/sphinx-doc/sphinxcontrib-applehelp/compare/1.0.4...2.0.0
sphinxcontrib-devhelp changelog: https://github.com/sphinx-doc/sphinxcontrib-devhelp/compare/1.0.2...2.0.0
sphinxcontrib-htmlhelp changelog: https://github.com/sphinx-doc/sphinxcontrib-htmlhelp/compare/2.0.1...2.1.0
sphinxcontrib-qthelp changelog: https://github.com/sphinx-doc/sphinxcontrib-qthelp/compare/1.0.3...2.0.0
sphinxcontrib-serializinghtml changelog: https://github.com/sphinx-doc/sphinxcontrib-serializinghtml/compare/1.1.5...2.0.0
alabaster changelog: https://github.com/sphinx-doc/alabaster/compare/0.7.13...1.0.0