### PR TITLE
Raise `TypeError` when setting `StreamResponse.last_modified` to an unsupported type

### DIFF
--- a/CHANGES/10146.misc.rst
+++ b/CHANGES/10146.misc.rst
@@ -1,0 +1,1 @@
+Setting :attr:`aiohttp.web.StreamResponse.last_modified` to an unsupported type will now raise :exc:`ValueError` instead of silently failing -- by :user:`bdraco`.

--- a/CHANGES/10146.misc.rst
+++ b/CHANGES/10146.misc.rst
@@ -1,1 +1,1 @@
-Setting :attr:`aiohttp.web.StreamResponse.last_modified` to an unsupported type will now raise :exc:`ValueError` instead of silently failing -- by :user:`bdraco`.
+Setting :attr:`aiohttp.web.StreamResponse.last_modified` to an unsupported type will now raise :exc:`TypeError` instead of silently failing -- by :user:`bdraco`.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -269,7 +269,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             self._headers[hdrs.LAST_MODIFIED] = value
         else:
             msg = f"Unsupported type for last_modified: {type(value).__name__}"  # type: ignore[unreachable]
-            raise ValueError(msg)
+            raise TypeError(msg)
 
     @property
     def etag(self) -> Optional[ETag]:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -267,6 +267,9 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
             )
         elif isinstance(value, str):
             self._headers[hdrs.LAST_MODIFIED] = value
+        else:
+            msg = f"Unsupported type for last_modified: {type(value).__name__}"
+            raise ValueError(msg)
 
     @property
     def etag(self) -> Optional[ETag]:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -268,7 +268,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         elif isinstance(value, str):
             self._headers[hdrs.LAST_MODIFIED] = value
         else:
-            msg = f"Unsupported type for last_modified: {type(value).__name__}"
+            msg = f"Unsupported type for last_modified: {type(value).__name__}"  # type: ignore[unreachable]
             raise ValueError(msg)
 
     @property

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -242,6 +242,13 @@ def test_last_modified_reset() -> None:
     assert resp.last_modified is None
 
 
+def test_last_modified_invalid_type() -> None:
+    resp = web.StreamResponse()
+
+    with pytest.raises(ValueError, match="Unsupported type for last_modified: object"):
+        resp.last_modified = object()  # type: ignore[assignment]
+
+
 @pytest.mark.parametrize(
     "header_val",
     (

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -245,7 +245,7 @@ def test_last_modified_reset() -> None:
 def test_last_modified_invalid_type() -> None:
     resp = web.StreamResponse()
 
-    with pytest.raises(ValueError, match="Unsupported type for last_modified: object"):
+    with pytest.raises(TypeError, match="Unsupported type for last_modified: object"):
         resp.last_modified = object()  # type: ignore[assignment]
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?


closes #10143

## Are there changes in behavior for the user?

Currently this would silently fail and discard the new value.

<img width="685" alt="Screenshot 2024-12-08 at 12 32 49 PM" src="https://github.com/user-attachments/assets/b0cf00c3-cd2e-4be6-af94-d993491bd296">


