### PR TITLE
Add host parameter to aiohttp_server fixture (#10120) (#10121)

### DIFF
--- a/CHANGES/10120.feature.rst
+++ b/CHANGES/10120.feature.rst
@@ -1,0 +1,1 @@
+Added ``host`` parameter to ``aiohttp_server`` fixture -- by :user:`christianwbrock`.

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -301,9 +301,13 @@ def aiohttp_server(loop: asyncio.AbstractEventLoop) -> Iterator[AiohttpServer]:
     servers = []
 
     async def go(
-        app: Application, *, port: Optional[int] = None, **kwargs: Any
+        app: Application,
+        *,
+        host: str = "127.0.0.1",
+        port: Optional[int] = None,
+        **kwargs: Any,
     ) -> TestServer:
-        server = TestServer(app, port=port)
+        server = TestServer(app, host=host, port=port)
         await server.start_server(loop=loop, **kwargs)
         servers.append(server)
         return server


### PR DESCRIPTION
Co-authored-by: ChristianWBrock <christian.brock AT posteo.net>
(cherry picked from commit 7f8e2d35ad4d0d5fed82721060bafd1bafa264b8)