### PR TITLE
Update StreamResponse.write annotation for strict-bytes

### DIFF
--- a/CHANGES/10154.bugfix.rst
+++ b/CHANGES/10154.bugfix.rst
@@ -1,0 +1,1 @@
+Updated ``StreamResponse.write`` annotation to also allow ``bytearray`` and ``memoryview`` as inputs.

--- a/CHANGES/10154.bugfix.rst
+++ b/CHANGES/10154.bugfix.rst
@@ -1,1 +1,1 @@
-Updated :meth:`aiohttp.web.StreamResponse.write` annotation to also allow ``bytearray`` and ``memoryview`` as inputs -- by :user:`cdce8p`.
+Updated :meth:`aiohttp.web.StreamResponse.write` annotation to also allow :class:`bytearray` and :class:`memoryview` as inputs -- by :user:`cdce8p`.

--- a/CHANGES/10154.bugfix.rst
+++ b/CHANGES/10154.bugfix.rst
@@ -1,1 +1,1 @@
-Updated ``StreamResponse.write`` annotation to also allow ``bytearray`` and ``memoryview`` as inputs.
+Updated :meth:`aiohttp.web.StreamResponse.write` annotation to also allow ``bytearray`` and ``memoryview`` as inputs -- by :user:`cdce8p`.

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -16,6 +16,7 @@ from typing import (
     Optional,
     Tuple,
     TypedDict,
+    Union,
 )
 
 from multidict import CIMultiDict
@@ -196,7 +197,7 @@ class AbstractStreamWriter(ABC):
     length: Optional[int] = 0
 
     @abstractmethod
-    async def write(self, chunk: bytes) -> None:
+    async def write(self, chunk: Union[bytes, bytearray, memoryview]) -> None:
         """Write chunk into stream."""
 
     @abstractmethod

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -72,7 +72,7 @@ class StreamWriter(AbstractStreamWriter):
     ) -> None:
         self._compress = ZLibCompressor(encoding=encoding, strategy=strategy)
 
-    def _write(self, chunk: bytes) -> None:
+    def _write(self, chunk: Union[bytes, bytearray, memoryview]) -> None:
         size = len(chunk)
         self.buffer_size += size
         self.output_size += size
@@ -93,7 +93,11 @@ class StreamWriter(AbstractStreamWriter):
         transport.write(b"".join(chunks))
 
     async def write(
-        self, chunk: bytes, *, drain: bool = True, LIMIT: int = 0x10000
+        self,
+        chunk: Union[bytes, bytearray, memoryview],
+        *,
+        drain: bool = True,
+        LIMIT: int = 0x10000,
     ) -> None:
         """Writes chunk of data to a stream.
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -432,7 +432,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         status_line = f"HTTP/{version[0]}.{version[1]} {self._status} {self._reason}"
         await writer.write_headers(status_line, self._headers)
 
-    async def write(self, data: bytes) -> None:
+    async def write(self, data: Union[bytes, bytearray, memoryview]) -> None:
         assert isinstance(
             data, (bytes, bytearray, memoryview)
         ), "data argument must be byte-ish (%r)" % type(data)


### PR DESCRIPTION
## What do these changes do?
Mypy will add a `--strict-bytes` flag. https://github.com/python/mypy/pull/18263

With that `bytearray` and `memoryview` are no longer subclasses of `bytes` and must be listed explicitly instead if they are supported.

## Are there changes in behavior for the user?
--

## Related issue number
--

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
