### PR TITLE
Add ALPN extension to client SSL Context

### DIFF
--- a/CHANGES/10156.feature.rst
+++ b/CHANGES/10156.feature.rst
@@ -1,1 +1,3 @@
-Add TLS ALPN extension to client SSL context -- by :user:`Cycloctane`.
+Enabled ALPN on default SSL contexts. This improves compatibility with some
+proxies which don't work without this extension.
+-- by :user:`Cycloctane`.

--- a/CHANGES/10156.feature.rst
+++ b/CHANGES/10156.feature.rst
@@ -1,0 +1,1 @@
+Add TLS ALPN extension to client SSL context -- by :user:`Cycloctane`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -376,6 +376,7 @@ William S.
 Wilson Ong
 wouter bolsterlee
 Xavier Halloran
+Xi Rui
 Xiang Li
 Yang Zhou
 Yannick Koechlin

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -772,14 +772,16 @@ def _make_ssl_context(verified: bool) -> SSLContext:
         # No ssl support
         return None  # type: ignore[unreachable]
     if verified:
-        return ssl.create_default_context()
-    sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
-    sslcontext.options |= ssl.OP_NO_SSLv2
-    sslcontext.options |= ssl.OP_NO_SSLv3
-    sslcontext.check_hostname = False
-    sslcontext.verify_mode = ssl.CERT_NONE
-    sslcontext.options |= ssl.OP_NO_COMPRESSION
-    sslcontext.set_default_verify_paths()
+        sslcontext = ssl.create_default_context()
+    else:
+        sslcontext = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        sslcontext.options |= ssl.OP_NO_SSLv2
+        sslcontext.options |= ssl.OP_NO_SSLv3
+        sslcontext.check_hostname = False
+        sslcontext.verify_mode = ssl.CERT_NONE
+        sslcontext.options |= ssl.OP_NO_COMPRESSION
+        sslcontext.set_default_verify_paths()
+    sslcontext.set_alpn_protocols(["http/1.1"])
     return sslcontext
 
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -781,7 +781,7 @@ def _make_ssl_context(verified: bool) -> SSLContext:
         sslcontext.verify_mode = ssl.CERT_NONE
         sslcontext.options |= ssl.OP_NO_COMPRESSION
         sslcontext.set_default_verify_paths()
-    sslcontext.set_alpn_protocols(["http/1.1"])
+    sslcontext.set_alpn_protocols(("http/1.1",))
     return sslcontext
 
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -633,10 +633,10 @@ async def test_ssl_client(
 
 
 async def test_ssl_client_alpn(
-        aiohttp_server: AiohttpServer,
-        aiohttp_client: AiohttpClient,
-        ssl_ctx: ssl.SSLContext,
-    ) -> None:
+    aiohttp_server: AiohttpServer,
+    aiohttp_client: AiohttpClient,
+    ssl_ctx: ssl.SSLContext,
+) -> None:
 
     async def handler(request: web.Request) -> web.Response:
         sslobj = request.transport.get_extra_info("ssl_object")

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -639,6 +639,7 @@ async def test_ssl_client_alpn(
 ) -> None:
 
     async def handler(request: web.Request) -> web.Response:
+        assert request.transport is not None
         sslobj = request.transport.get_extra_info("ssl_object")
         return web.Response(text=sslobj.selected_alpn_protocol())
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -640,18 +640,19 @@ async def test_ssl_client_alpn(
 
     async def handler(request: web.Request) -> web.Response:
         sslobj = request.transport.get_extra_info("ssl_object")
-        assert sslobj.selected_alpn_protocol() == "http/1.1"
-        return web.Response(text="Test message")
+        return web.Response(text=sslobj.selected_alpn_protocol())
 
     app = web.Application()
     app.router.add_route("GET", "/", handler)
-    ssl_ctx.set_alpn_protocols(["http/1.1"])
+    ssl_ctx.set_alpn_protocols(("http/1.1",))
     server = await aiohttp_server(app, ssl=ssl_ctx)
 
     connector = aiohttp.TCPConnector(ssl=False)
     client = await aiohttp_client(server, connector=connector)
     resp = await client.get("/")
     assert resp.status == 200
+    txt = await resp.text()
+    assert txt == "http/1.1"
 
 
 async def test_tcp_connector_fingerprint_ok(

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -632,6 +632,28 @@ async def test_ssl_client(
     assert txt == "Test message"
 
 
+async def test_ssl_client_alpn(
+        aiohttp_server: AiohttpServer,
+        aiohttp_client: AiohttpClient,
+        ssl_ctx: ssl.SSLContext,
+    ) -> None:
+
+    async def handler(request: web.Request) -> web.Response:
+        sslobj = request.transport.get_extra_info("ssl_object")
+        assert sslobj.selected_alpn_protocol() == "http/1.1"
+        return web.Response(text="Test message")
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    ssl_ctx.set_alpn_protocols(["http/1.1"])
+    server = await aiohttp_server(app, ssl=ssl_ctx)
+
+    connector = aiohttp.TCPConnector(ssl=False)
+    client = await aiohttp_client(server, connector=connector)
+    resp = await client.get("/")
+    assert resp.status == 200
+
+
 async def test_tcp_connector_fingerprint_ok(
     aiohttp_server: AiohttpServer,
     aiohttp_client: AiohttpClient,


### PR DESCRIPTION
## What do these changes do?

Add "http/1.1" ALPN extension to aiohttp client's SSL Context.

## Are there changes in behavior for the user?

## Is it a substantial burden for the maintainers to support this?

## Related issue number

Fixes #10152 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
