### PR TITLE
Stream unpauses protocol before releasing connection

### DIFF
--- a/CHANGES/10169.bugfix.rst
+++ b/CHANGES/10169.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a hang where a connection previously used for a streaming
+download could be returned to the pool in a paused state.
+-- by :user:`javitonino`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -179,6 +179,7 @@ Jan Buchar
 Jan Gosmann
 Jarno Elonen
 Jashandeep Sohi
+Javier Torres
 Jean-Baptiste Estival
 Jens Steinhauser
 Jeonghun Lee

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -220,6 +220,9 @@ class StreamReader(AsyncStreamReaderMixin):
             self._eof_waiter = None
             set_result(waiter, None)
 
+        if self._protocol._reading_paused:
+            self._protocol.resume_reading()
+
         for cb in self._eof_callbacks:
             try:
                 cb()

--- a/tests/test_flowcontrol_streams.py
+++ b/tests/test_flowcontrol_streams.py
@@ -107,3 +107,25 @@ class TestFlowControlStreamReader:
         res = stream.read_nowait(5)
         assert res == b""
         assert stream._protocol.resume_reading.call_count == 1  # type: ignore[attr-defined]
+
+    async def test_resumed_on_eof(self, stream: streams.StreamReader) -> None:
+        stream.feed_data(b"data")
+        assert stream._protocol.pause_reading.call_count == 1
+        assert stream._protocol.resume_reading.call_count == 0
+        stream._protocol._reading_paused = True
+
+        stream.feed_eof()
+        assert stream._protocol.resume_reading.call_count == 1
+
+
+async def test_stream_reader_eof_when_full() -> None:
+    loop = asyncio.get_event_loop()
+    protocol = BaseProtocol(loop=loop)
+    protocol.transport = asyncio.Transport()
+    stream = streams.StreamReader(protocol, 1024, loop=loop)
+
+    data_len = stream._high_water + 1
+    stream.feed_data(b"0" * data_len)
+    assert protocol._reading_paused
+    stream.feed_eof()
+    assert not protocol._reading_paused

--- a/tests/test_flowcontrol_streams.py
+++ b/tests/test_flowcontrol_streams.py
@@ -110,12 +110,12 @@ class TestFlowControlStreamReader:
 
     async def test_resumed_on_eof(self, stream: streams.StreamReader) -> None:
         stream.feed_data(b"data")
-        assert stream._protocol.pause_reading.call_count == 1
-        assert stream._protocol.resume_reading.call_count == 0
+        assert stream._protocol.pause_reading.call_count == 1  # type: ignore[attr-defined]
+        assert stream._protocol.resume_reading.call_count == 0  # type: ignore[attr-defined]
         stream._protocol._reading_paused = True
 
         stream.feed_eof()
-        assert stream._protocol.resume_reading.call_count == 1
+        assert stream._protocol.resume_reading.call_count == 1  # type: ignore[attr-defined]
 
 
 async def test_stream_reader_eof_when_full() -> None:


### PR DESCRIPTION
## What do these changes do?

Fixes a hang when reusing a connection that was previously used for a streaming download and returned to the pool in paused state.

## Are there changes in behavior for the user?

No, aside from the bugfix.

## Is it a substantial burden for the maintainers to support this?

No. This adds bit of extra code to ensure correctness in this case. It's covered by tests to ensure the behaviour stays through code changes.

## Related issue number

Fixes https://github.com/aio-libs/aiohttp/issues/10169

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder