### PR TITLE
Ensure Response is True even when map is empty

### DIFF
--- a/CHANGES/10119.bugfix.rst
+++ b/CHANGES/10119.bugfix.rst
@@ -1,0 +1,1 @@
+Response is now always True, instead of using MutableMapping behaviour (False when map is empty)

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -504,6 +504,9 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
     def __eq__(self, other: object) -> bool:
         return self is other
 
+    def __bool__(self) -> bool:
+        return True
+
 
 class Response(StreamResponse):
 

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -287,6 +287,7 @@ def test_match_info() -> None:
 def test_request_is_mutable_mapping() -> None:
     req = make_mocked_request("GET", "/")
     assert isinstance(req, MutableMapping)
+    assert req # even when the MutableMapping is empty, request should always be True
     req["key"] = "value"
     assert "value" == req["key"]
 

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -287,7 +287,7 @@ def test_match_info() -> None:
 def test_request_is_mutable_mapping() -> None:
     req = make_mocked_request("GET", "/")
     assert isinstance(req, MutableMapping)
-    assert req # even when the MutableMapping is empty, request should always be True
+    assert req  # even when the MutableMapping is empty, request should always be True
     req["key"] = "value"
     assert "value" == req["key"]
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -93,7 +93,7 @@ def test_stream_response_eq() -> None:
 def test_stream_response_is_mutable_mapping() -> None:
     resp = web.StreamResponse()
     assert isinstance(resp, collections.abc.MutableMapping)
-    assert resp # even when the MutableMapping is empty, response should always be True
+    assert resp  # even when the MutableMapping is empty, response should always be True
     resp["key"] = "value"
     assert "value" == resp["key"]
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -93,6 +93,7 @@ def test_stream_response_eq() -> None:
 def test_stream_response_is_mutable_mapping() -> None:
     resp = web.StreamResponse()
     assert isinstance(resp, collections.abc.MutableMapping)
+    assert resp # even when the MutableMapping is empty, response should always be True
     resp["key"] = "value"
     assert "value" == resp["key"]
 


### PR DESCRIPTION
Fixes #10119

Technically a breaking change, but I can't imagine anyone depending on this. Still, it should probably not go in a patch release.

I can't get the entire test suite to pass, probably an issue with my development environment. test_web_request and test_web_response do pass.
<!-- Thank you for your contribution! -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
