### PR TITLE
[PR #10093/7b5d54a backport][3.11] Use `quote_cookie` setting from ClientSession's cookiejar in `tmp_cookie_jar`

### DIFF
--- a/CHANGES/10093.bugfix.rst
+++ b/CHANGES/10093.bugfix.rst
@@ -1,0 +1,2 @@
+Update :py:meth:`~aiohttp.ClientSession.request` to reuse the ``quote_cookie`` setting from ``ClientSession._cookie_jar`` when processing cookies parameter.
+-- by :user:`Cycloctane`.

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -176,6 +176,11 @@ class AbstractCookieJar(Sized, IterableBase):
     def __init__(self, *, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
         self._loop = loop or asyncio.get_running_loop()
 
+    @property
+    @abstractmethod
+    def quote_cookie(self) -> bool:
+        """Return True if cookies should be quoted."""
+
     @abstractmethod
     def clear(self, predicate: Optional[ClearCookiePredicate] = None) -> None:
         """Clear all cookies if no predicate is passed."""

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -658,7 +658,9 @@ class ClientSession:
                     all_cookies = self._cookie_jar.filter_cookies(url)
 
                     if cookies is not None:
-                        tmp_cookie_jar = CookieJar()
+                        tmp_cookie_jar = CookieJar(
+                            quote_cookie=self._cookie_jar.quote_cookie
+                        )
                         tmp_cookie_jar.update_cookies(cookies)
                         req_cookies = tmp_cookie_jar.filter_cookies(url)
                         if req_cookies:

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -117,6 +117,10 @@ class CookieJar(AbstractCookieJar):
         self._expire_heap: List[Tuple[float, Tuple[str, str, str]]] = []
         self._expirations: Dict[Tuple[str, str, str], float] = {}
 
+    @property
+    def quote_cookie(self) -> bool:
+        return self._quote_cookie
+
     def save(self, file_path: PathLike) -> None:
         file_path = pathlib.Path(file_path)
         with file_path.open(mode="wb") as f:
@@ -473,6 +477,10 @@ class DummyCookieJar(AbstractCookieJar):
 
     def __len__(self) -> int:
         return 0
+
+    @property
+    def quote_cookie(self) -> bool:
+        return True
 
     def clear(self, predicate: Optional[ClearCookiePredicate] = None) -> None:
         pass

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -807,6 +807,7 @@ class TestCookieJarSafe(TestCookieJarBase):
 async def test_dummy_cookie_jar() -> None:
     cookie = SimpleCookie("foo=bar; Domain=example.com;")
     dummy_jar = DummyCookieJar()
+    assert dummy_jar.quote_cookie is True
     assert len(dummy_jar) == 0
     dummy_jar.update_cookies(cookie)
     assert len(dummy_jar) == 0


### PR DESCRIPTION
Co-authored-by: pre-commit-ci[bot] <66853113+pre-commit-ci[bot]@users.noreply.github.com>
Co-authored-by: Sam Bull <git@sambull.org>
(cherry picked from commit 7b5d54a96c1dd1282e9a79f9fc8056c02ca91c6f)
