### PR TITLE
fix: include carriage return in multipartform.decode()

### DIFF
--- a/CHANGES/10270.bugfix.rst
+++ b/CHANGES/10270.bugfix.rst
@@ -1,0 +1,2 @@
+``MultipartForm.decode()`` must follow RFC1341 7.2.1 with a ``CRLF`` after the boundary
+-- by :user:`imnotjames`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -175,6 +175,7 @@ Jaesung Lee
 Jake Davis
 Jakob Ackermann
 Jakub Wilk
+James Ward
 Jan Buchar
 Jan Gosmann
 Jarno Elonen

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -983,7 +983,7 @@ class MultipartWriter(Payload):
         return "".join(
             "--"
             + self.boundary
-            + "\n"
+            + "\r\n"
             + part._binary_headers.decode(encoding, errors)
             + part.decode()
             for part, _e, _te in self._parts

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -1063,7 +1063,7 @@ class CustomIO(io.IOBase):
         (BodyPartReader(b"x", CIMultiDictProxy(CIMultiDict()), mock.Mock()), None),
         (
             mpwriter,
-            "--x\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 4\r\n\r\ntest",
+            "--x\r\nContent-Type: text/plain; charset=utf-8\r\nContent-Length: 4\r\n\r\ntest",
         ),
     ),
 )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The `MultipartForm.decode()` function has a bare newline follow the
initial boundary.  However, in [RFC1341 7.2.1](https://datatracker.ietf.org/doc/html/rfc1341#page-31)
a boundary is defined to be followed by a `CRLF`.

> The boundary must be followed immediately either by another CRLF
> and the header fields for the next part, or by two CRLFs

This updates the `decode` function to utilize a `CRLF` instead for the initial boundary.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No.

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
