### PR TITLE
Update workflow to use upload-artifact v4 and download-artifact v4

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -421,6 +421,7 @@ jobs:
       uses: pypa/cibuildwheel@v2.22.0
       env:
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
+    - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
         name: >-  

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -424,11 +424,11 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: >-  
-          dist-${{ matrix.os }}-${{  
-            matrix.qemu  
-            && matrix.qemu  
-            || 'native'  
+        name: >-
+          dist-${{ matrix.os }}-${{
+            matrix.qemu
+            && matrix.qemu
+            || 'native'
           }}
         path: ./wheelhouse/*.whl
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  merge_group:
   push:
     branches:
       - 'master'
@@ -420,15 +421,14 @@ jobs:
       uses: pypa/cibuildwheel@v2.22.0
       env:
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
-    - if: ${{ matrix.qemu }}
       uses: actions/upload-artifact@v4
       with:
-        name: dist-${{ matrix.os }}-${{ matrix.qemu }}
-        path: ./wheelhouse/*.whl
-    - if: ${{ !matrix.qemu }}
-      uses: actions/upload-artifact@v4
-      with:
-        name: dist-${{ matrix.os }}
+        name: >-  
+          dist-${{ matrix.os }}-${{  
+            matrix.qemu  
+            && matrix.qemu  
+            || 'native'  
+          }}
         path: ./wheelhouse/*.whl
 
   deploy:
@@ -449,11 +449,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Merge distribution artifacts
-      uses: actions/upload-artifact/merge@v4
-      with:
-        name: dist
-        pattern: dist-*
     - name: Login
       run: |
         echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  merge_group:
   push:
     branches:
       - 'master'
@@ -127,7 +126,7 @@ jobs:
       run: |
         make generate-llhttp
     - name: Upload llhttp generated files
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: llhttp
         path: vendor/llhttp/build
@@ -193,7 +192,7 @@ jobs:
         python -m pip install -r requirements/test.in -c requirements/test.txt
     - name: Restore llhttp generated files
       if: ${{ matrix.no-extensions == '' }}
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: llhttp
         path: vendor/llhttp/build/
@@ -280,7 +279,7 @@ jobs:
       run: |
         python -m pip install -r requirements/test.in -c requirements/test.txt
     - name: Restore llhttp generated files
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: llhttp
         path: vendor/llhttp/build/
@@ -344,7 +343,7 @@ jobs:
         python -m
         pip install -r requirements/cython.in -c requirements/cython.txt
     - name: Restore llhttp generated files
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: llhttp
         path: vendor/llhttp/build/
@@ -355,9 +354,9 @@ jobs:
       run: |
         python -m build --sdist
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
-        name: dist
+        name: dist-sdist
         path: dist
 
   build-wheels:
@@ -410,7 +409,7 @@ jobs:
         python -m
         pip install -r requirements/cython.in -c requirements/cython.txt
     - name: Restore llhttp generated files
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: llhttp
         path: vendor/llhttp/build/
@@ -421,9 +420,15 @@ jobs:
       uses: pypa/cibuildwheel@v2.22.0
       env:
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
-    - uses: actions/upload-artifact@v3
+    - if: ${{ matrix.qemu }}
+      uses: actions/upload-artifact@v4
       with:
-        name: dist
+        name: dist-${{ matrix.os }}-${{ matrix.qemu }}
+        path: ./wheelhouse/*.whl
+    - if: ${{ !matrix.qemu }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-${{ matrix.os }}
         path: ./wheelhouse/*.whl
 
   deploy:
@@ -444,14 +449,19 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: true
+    - name: Merge distribution artifacts
+      uses: actions/upload-artifact/merge@v4
+      with:
+        name: dist
+        pattern: dist-*
     - name: Login
       run: |
         echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
     - name: Download distributions
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
-        name: dist
         path: dist
+        pattern: dist-*
     - name: Collected dists
       run: |
         tree dist

--- a/CHANGES/10281.contrib.rst
+++ b/CHANGES/10281.contrib.rst
@@ -1,0 +1,1 @@
+The CI/CD workflow has been updated to use upload-artifact v4 and download-artifact v4 Github actions. -- by :user:`silamon`.

--- a/CHANGES/10281.contrib.rst
+++ b/CHANGES/10281.contrib.rst
@@ -1,1 +1,1 @@
-The CI/CD workflow has been updated to use upload-artifact v4 and download-artifact v4 Github actions. -- by :user:`silamon`.
+The CI/CD workflow has been updated to use `upload-artifact` v4 and `download-artifact` v4 GitHub Actions -- by :user:`silamon`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This updates the ci/cd workflow to use the upload-artifact v4 and download-artifact v4 github actions. The currently used upload-artifact and download-artifact will no longer work at the end of next month. 
The changes are needed since v4 no longer has mutable artifacts, which was used to collect wheels from different architectures.  

Fix #8588, Fix #8589, Fix #9009, Fix #10189, Fix #10191 

## Are there changes in behavior for the user?

No, the ci/cd workflow has been tested although without publishing. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
