### PR TITLE
Add aiohttp-openmetrics to list of third party aiohttp-related python…

### DIFF
--- a/CHANGES/10304.doc.rst
+++ b/CHANGES/10304.doc.rst
@@ -1,0 +1,1 @@
+Added ``aiohttp-openmetrics`` to list of third-party libraries -- by :user:`jelmer`.

--- a/docs/third_party.rst
+++ b/docs/third_party.rst
@@ -306,3 +306,6 @@ ask to raise the status.
 
 - `aiohttp-asgi-connector <https://github.com/thearchitector/aiohttp-asgi-connector>`_
   An aiohttp connector for using a ``ClientSession`` to interface directly with separate ASGI applications.
+
+- `aiohttp-openmetrics <https://github.com/jelmer/aiohttp-openmetrics>`_
+  An aiohttp middleware for exposing Prometheus metrics.


### PR DESCRIPTION
… modules

## What do these changes do?

Add [aiohttp-openmetrics](https://github.com/jelmer/aiohttp-openmetrics) to the list of third party aiohttp-related python modules.

## Are there changes in behavior for the user?

N/A

## Is it a substantial burden for the maintainers to support this?

No

## Related issue number

N/A

## Checklist

- [x] I think the code is well written (N/A)
- [x] Unit tests for the changes exist (N/A)
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (N/A)
- [x] Add a new news fragment into the `CHANGES/` folder