### PR TITLE
Log the remote that generates request errors

### DIFF
--- a/CHANGES/10332.feature.rst
+++ b/CHANGES/10332.feature.rst
@@ -1,0 +1,1 @@
+Improved logging of HTTP protocol errors to include the remote address -- by :user:`bdraco`.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -719,9 +719,13 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             # or encrypted traffic to an HTTP port. This is expected
             # to happen when connected to the public internet so we log
             # it at the debug level as to not fill logs with noise.
-            self.logger.debug("Error handling request", exc_info=exc)
+            self.logger.debug(
+                "Error handling request from %s", request.remote, exc_info=exc
+            )
         else:
-            self.log_exception("Error handling request", exc_info=exc)
+            self.log_exception(
+                "Error handling request from %s", request.remote, exc_info=exc
+            )
 
         # some data already got sent, connection is broken
         if request.writer.output_size > 0:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -67,7 +67,9 @@ async def test_raw_server_not_http_exception(
     assert txt.startswith("500 Internal Server Error")
     assert "Traceback" not in txt
 
-    logger.exception.assert_called_with("Error handling request", exc_info=exc)
+    logger.exception.assert_called_with(
+        "Error handling request from %s", cli.host, exc_info=exc
+    )
 
 
 async def test_raw_server_logs_invalid_method_with_loop_debug(
@@ -96,7 +98,9 @@ async def test_raw_server_logs_invalid_method_with_loop_debug(
     # on the first request since the client may
     # be probing for TLS/SSL support which is
     # expected to fail
-    logger.debug.assert_called_with("Error handling request", exc_info=exc)
+    logger.debug.assert_called_with(
+        "Error handling request from %s", cli.host, exc_info=exc
+    )
     logger.debug.reset_mock()
 
     # Now make another connection to the server
@@ -110,7 +114,9 @@ async def test_raw_server_logs_invalid_method_with_loop_debug(
     # on the first request since the client may
     # be probing for TLS/SSL support which is
     # expected to fail
-    logger.debug.assert_called_with("Error handling request", exc_info=exc)
+    logger.debug.assert_called_with(
+        "Error handling request from %s", cli.host, exc_info=exc
+    )
 
 
 async def test_raw_server_logs_invalid_method_without_loop_debug(
@@ -139,7 +145,9 @@ async def test_raw_server_logs_invalid_method_without_loop_debug(
     # on the first request since the client may
     # be probing for TLS/SSL support which is
     # expected to fail
-    logger.debug.assert_called_with("Error handling request", exc_info=exc)
+    logger.debug.assert_called_with(
+        "Error handling request from %s", cli.host, exc_info=exc
+    )
 
 
 async def test_raw_server_logs_invalid_method_second_request(
@@ -170,7 +178,9 @@ async def test_raw_server_logs_invalid_method_second_request(
     # BadHttpMethod should be logged as an exception
     # if its not the first request since we know
     # that the client already was speaking HTTP
-    logger.exception.assert_called_with("Error handling request", exc_info=exc)
+    logger.exception.assert_called_with(
+        "Error handling request from %s", cli.host, exc_info=exc
+    )
 
 
 async def test_raw_server_logs_bad_status_line_as_exception(
@@ -195,7 +205,9 @@ async def test_raw_server_logs_bad_status_line_as_exception(
     txt = await resp.text()
     assert "Traceback (most recent call last):\n" not in txt
 
-    logger.exception.assert_called_with("Error handling request", exc_info=exc)
+    logger.exception.assert_called_with(
+        "Error handling request from %s", cli.host, exc_info=exc
+    )
 
 
 async def test_raw_server_handler_timeout(
@@ -280,7 +292,9 @@ async def test_raw_server_not_http_exception_debug(
     txt = await resp.text()
     assert "Traceback (most recent call last):\n" in txt
 
-    logger.exception.assert_called_with("Error handling request", exc_info=exc)
+    logger.exception.assert_called_with(
+        "Error handling request from %s", cli.host, exc_info=exc
+    )
 
 
 async def test_raw_server_html_exception(
@@ -311,7 +325,9 @@ async def test_raw_server_html_exception(
         "</body></html>\n"
     )
 
-    logger.exception.assert_called_with("Error handling request", exc_info=exc)
+    logger.exception.assert_called_with(
+        "Error handling request from %s", cli.host, exc_info=exc
+    )
 
 
 async def test_raw_server_html_exception_debug(
@@ -339,7 +355,9 @@ async def test_raw_server_html_exception_debug(
         "<pre>Traceback (most recent call last):\n"
     )
 
-    logger.exception.assert_called_with("Error handling request", exc_info=exc)
+    logger.exception.assert_called_with(
+        "Error handling request from %s", cli.host, exc_info=exc
+    )
 
 
 async def test_handler_cancellation(unused_port_socket: socket.socket) -> None:


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

Currently we only log that a request error occurred with no information about which remote the error
came from. This made it quite difficult to find
the offending remote

## Are there changes in behavior for the user?

The remote address is now found in the logs

## Is it a substantial burden for the maintainers to support this?

no

## Related issue number

#10331
