### PR TITLE
Add sphinx configuration for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,6 +5,10 @@
 ---
 version: 2
 
+sphinx:
+  # Path to your Sphinx configuration file.
+  configuration: docs/conf.py
+
 submodules:
   include: all
   exclude: []


### PR DESCRIPTION
This is now required https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
