### PR TITLE
Fix sdist make

### DIFF
--- a/CHANGES/10366.packaging
+++ b/CHANGES/10366.packaging
@@ -1,0 +1,2 @@
+Added missing files to the source distribution to fix ``Makefile`` targets.
+Added a ``cythonize-nodeps`` target to run Cython without invoking pip to install dependencies.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ graft aiohttp
 graft docs
 graft examples
 graft tests
+graft tools
 graft requirements
 recursive-include vendor *
 global-include aiohttp *.pyi

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,9 @@ generate-llhttp: .llhttp-gen
 .PHONY: cythonize
 cythonize: .install-cython $(PYXS:.pyx=.c) aiohttp/_websocket/reader_c.c
 
+.PHONY: cythonize-nodeps
+cythonize-nodeps: $(PYXS:.pyx=.c) aiohttp/_websocket/reader_c.c
+
 .install-deps: .install-cython $(PYXS:.pyx=.c) aiohttp/_websocket/reader_c.c $(call to-hash,$(CYS) $(REQS))
 	@python -m pip install -r requirements/dev.in -c requirements/dev.txt
 	@touch .install-deps

--- a/tools/gen.py
+++ b/tools/gen.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 import multidict
 
 ROOT = pathlib.Path.cwd()
-while ROOT.parent != ROOT and not (ROOT / ".git").exists():
+while ROOT.parent != ROOT and not (ROOT / "pyproject.toml").exists():
     ROOT = ROOT.parent
 
 


### PR DESCRIPTION
## What do these changes do?

Three fixes related to use of source distribution to build `aiohttp`:

1. Add missing `tools` directory to sdist, as it is required by the `Makefile` targets.
2. Fix `tools/gen.py` to work outside a git checkout, by looking for `pyproject.toml` rather than `.git`.
3. Add a `cythonize-nodeps` target that can be used by downstream packagers to perform cythonization without calling `pip`.

## Are there changes in behavior for the user?

This fixes the ability to call `make` when working in an unpacked source distribution (currently it would fail due to missing `tools/gen.py`).

## Is it a substantial burden for the maintainers to support this?

Don't think so. Worst case, the extra Makefile rule would go out of sync.

## Related issue number

n/a

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder