### PR TITLE
--disallow-any-decorated

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -2,7 +2,7 @@
 files = aiohttp, examples, tests
 check_untyped_defs = True
 follow_imports_for_stubs = True
-#disallow_any_decorated = True
+disallow_any_decorated = True
 disallow_any_generics = True
 disallow_any_unimported = True
 disallow_incomplete_defs = True

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -12,6 +12,7 @@ from typing import (
     Dict,
     Generator,
     Iterable,
+    Iterator,
     List,
     Optional,
     Tuple,
@@ -81,7 +82,7 @@ class AbstractMatchInfo(ABC):
         """HTTPException instance raised on router's resolving, or None"""
 
     @abstractmethod  # pragma: no branch
-    def get_info(self) -> Dict[str, Any]:
+    def get_info(self) -> Dict[str, Any]:  # type: ignore[misc]
         """Return a dict with additional info useful for introspection"""
 
     @property  # pragma: no branch
@@ -120,7 +121,7 @@ class AbstractView(ABC):
         return self._request
 
     @abstractmethod
-    def __await__(self) -> Generator[Any, None, StreamResponse]:
+    def __await__(self) -> Generator[None, None, StreamResponse]:
         """Execute the view handler."""
 
 

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -12,7 +12,6 @@ from typing import (
     Dict,
     Generator,
     Iterable,
-    Iterator,
     List,
     Optional,
     Tuple,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1244,7 +1244,7 @@ class ClientSession:
         return self._skip_auto_headers
 
     @property
-    def auth(self) -> Optional[BasicAuth]:
+    def auth(self) -> Optional[BasicAuth]:  # type: ignore[misc]
         """An object that represents HTTP Basic Authorization"""
         return self._default_auth
 
@@ -1281,7 +1281,7 @@ class ClientSession:
         return self._trust_env
 
     @property
-    def trace_configs(self) -> List[TraceConfig[Any]]:
+    def trace_configs(self) -> List[TraceConfig[Any]]:  # type: ignore[misc]
         """A list of TraceConfig instances used for client tracing"""
         return self._trace_configs
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -322,7 +322,7 @@ class ClientRequest:
         return self._ssl
 
     @property
-    def connection_key(self) -> ConnectionKey:
+    def connection_key(self) -> ConnectionKey:  # type: ignore[misc]
         if proxy_headers := self.proxy_headers:
             h: Optional[int] = hash(tuple(proxy_headers.items()))
         else:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -145,7 +145,7 @@ class BasicAuth(namedtuple("BasicAuth", ["login", "password", "encoding"])):
         return super().__new__(cls, login, password, encoding)
 
     @classmethod
-    def decode(cls, auth_header: str, encoding: str = "latin1") -> "BasicAuth":
+    def decode(cls, auth_header: str, encoding: str = "latin1") -> "BasicAuth":  # type: ignore[misc]
         """Create a BasicAuth object from an Authorization HTTP header."""
         try:
             auth_type, encoded_credentials = auth_header.split(" ", 1)
@@ -174,7 +174,7 @@ class BasicAuth(namedtuple("BasicAuth", ["login", "password", "encoding"])):
         return cls(username, password, encoding=encoding)
 
     @classmethod
-    def from_url(cls, url: URL, *, encoding: str = "latin1") -> Optional["BasicAuth"]:
+    def from_url(cls, url: URL, *, encoding: str = "latin1") -> Optional["BasicAuth"]:  # type: ignore[misc]
         """Create BasicAuth from url."""
         if not isinstance(url, URL):
             raise TypeError("url should be yarl.URL instance")
@@ -245,7 +245,7 @@ def netrc_from_env() -> Optional[netrc.netrc]:
 
 
 @frozen_dataclass_decorator
-class ProxyInfo:
+class ProxyInfo:  # type: ignore[misc]
     proxy: URL
     proxy_auth: Optional[BasicAuth]
 
@@ -870,7 +870,7 @@ class ChainMapProxy(Mapping[Union[str, AppKey[Any]], Any]):
     def __getitem__(self, key: AppKey[_T]) -> _T: ...
 
     @overload
-    def __getitem__(self, key: str) -> Any: ...
+    def __getitem__(self, key: str) -> Any: ...  # type: ignore[misc]
 
     def __getitem__(self, key: Union[str, AppKey[_T]]) -> Any:
         for mapping in self._maps:
@@ -887,7 +887,7 @@ class ChainMapProxy(Mapping[Union[str, AppKey[Any]], Any]):
     def get(self, key: AppKey[_T], default: None = ...) -> Optional[_T]: ...
 
     @overload
-    def get(self, key: str, default: Any = ...) -> Any: ...
+    def get(self, key: str, default: Any = ...) -> Any: ...  # type: ignore[misc]
 
     def get(self, key: Union[str, AppKey[_T]], default: Any = None) -> Any:
         try:

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -40,8 +40,9 @@ _Request = TypeVar("_Request", bound=BaseRequest)
 
 
 class AiohttpClient(Protocol):
+    # TODO(PY311): Use Unpack to specify ClientSession kwargs.
     @overload
-    async def __call__(
+    async def __call__(  # type: ignore[misc]
         self,
         __param: Application,
         *,
@@ -49,7 +50,7 @@ class AiohttpClient(Protocol):
         **kwargs: Any,
     ) -> TestClient[Request, Application]: ...
     @overload
-    async def __call__(
+    async def __call__(  # type: ignore[misc]
         self,
         __param: BaseTestServer[_Request],
         *,
@@ -153,19 +154,19 @@ def pytest_fixture_setup(fixturedef):  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture
-def fast(request):  # type: ignore[no-untyped-def]
+def fast(request: pytest.FixtureRequest) -> bool:
     """--fast config option"""
-    return request.config.getoption("--aiohttp-fast")
+    return request.config.getoption("--aiohttp-fast")  # type: ignore[no-any-return]
 
 
 @pytest.fixture
-def loop_debug(request):  # type: ignore[no-untyped-def]
+def loop_debug(request: pytest.FixtureRequest) -> bool:
     """--enable-loop-debug config option"""
-    return request.config.getoption("--aiohttp-enable-loop-debug")
+    return request.config.getoption("--aiohttp-enable-loop-debug")  # type: ignore[no-any-return]
 
 
 @contextlib.contextmanager
-def _runtime_warning_context():  # type: ignore[no-untyped-def]
+def _runtime_warning_context() -> Iterator[None]:
     """Context manager which checks for RuntimeWarnings.
 
     This exists specifically to
@@ -195,7 +196,9 @@ def _runtime_warning_context():  # type: ignore[no-untyped-def]
 
 
 @contextlib.contextmanager
-def _passthrough_loop_context(loop, fast=False):  # type: ignore[no-untyped-def]
+def _passthrough_loop_context(
+    loop: Optional[asyncio.AbstractEventLoop], fast: bool = False
+) -> Iterator[asyncio.AbstractEventLoop]:
     """Passthrough loop context.
 
     Sets up and tears down a loop unless one is passed in via the loop
@@ -268,7 +271,11 @@ def pytest_generate_tests(metafunc):  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture
-def loop(loop_factory, fast, loop_debug):  # type: ignore[no-untyped-def]
+def loop(
+    loop_factory: Callable[[], asyncio.AbstractEventLoopPolicy],
+    fast: bool,
+    loop_debug: bool
+) -> Iterator[asyncio.AbstractEventLoop]:
     """Return an instance of the event loop."""
     policy = loop_factory()
     asyncio.set_event_loop_policy(policy)
@@ -280,7 +287,7 @@ def loop(loop_factory, fast, loop_debug):  # type: ignore[no-untyped-def]
 
 
 @pytest.fixture
-def proactor_loop():  # type: ignore[no-untyped-def]
+def proactor_loop() -> Iterator[asyncio.AbstractEventLoop]:
     policy = asyncio.WindowsProactorEventLoopPolicy()  # type: ignore[attr-defined]
     asyncio.set_event_loop_policy(policy)
 
@@ -353,7 +360,7 @@ def aiohttp_raw_server(loop: asyncio.AbstractEventLoop) -> Iterator[AiohttpRawSe
 
 
 @pytest.fixture
-def aiohttp_client_cls() -> Type[TestClient[Any, Any]]:
+def aiohttp_client_cls() -> Type[TestClient[Any, Any]]:  # type: ignore[misc]
     """
     Client class to use in ``aiohttp_client`` factory.
 
@@ -380,7 +387,7 @@ def aiohttp_client_cls() -> Type[TestClient[Any, Any]]:
 
 
 @pytest.fixture
-def aiohttp_client(
+def aiohttp_client(  # type: ignore[misc]
     loop: asyncio.AbstractEventLoop, aiohttp_client_cls: Type[TestClient[Any, Any]]
 ) -> Iterator[AiohttpClient]:
     """Factory to create a TestClient instance.
@@ -392,14 +399,14 @@ def aiohttp_client(
     clients = []
 
     @overload
-    async def go(
+    async def go(  # type: ignore[misc]
         __param: Application,
         *,
         server_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> TestClient[Request, Application]: ...
     @overload
-    async def go(
+    async def go(  # type: ignore[misc]
         __param: BaseTestServer[_Request],
         *,
         server_kwargs: Optional[Dict[str, Any]] = None,
@@ -411,6 +418,7 @@ def aiohttp_client(
         server_kwargs: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> TestClient[Any, Any]:
+        # TODO(PY311): Use Unpack to specify ClientSession kwargs and server_kwargs.
         if isinstance(__param, Application):
             server_kwargs = server_kwargs or {}
             server = TestServer(__param, **server_kwargs)

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -274,7 +274,7 @@ def pytest_generate_tests(metafunc):  # type: ignore[no-untyped-def]
 def loop(
     loop_factory: Callable[[], asyncio.AbstractEventLoopPolicy],
     fast: bool,
-    loop_debug: bool
+    loop_debug: bool,
 ) -> Iterator[asyncio.AbstractEventLoop]:
     """Return an instance of the event loop."""
     policy = loop_factory()

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -149,7 +149,7 @@ class BaseTestServer(ABC, Generic[_Request]):
         await site.start()
         server = site._server
         assert server is not None
-        sockets = server.sockets  # type: ignore[attr-defined]
+        sockets = server.sockets
         assert sockets is not None
         self.port = sockets[0].getsockname()[1]
         if not self.scheme:
@@ -157,7 +157,8 @@ class BaseTestServer(ABC, Generic[_Request]):
         self._root = URL(f"{self.scheme}://{absolute_host}:{self.port}")
 
     @abstractmethod  # pragma: no cover
-    async def _make_runner(self, **kwargs: Any) -> BaseRunner[_Request]:
+    async def _make_runner(self, **kwargs: Any) -> BaseRunner[_Request]:  # type: ignore[misc]
+        # TODO(PY311): Use Unpack to specify Server kwargs.
         pass
 
     def make_url(self, path: StrOrURL) -> URL:
@@ -232,6 +233,7 @@ class TestServer(BaseTestServer[Request]):
         super().__init__(scheme=scheme, host=host, port=port, **kwargs)
 
     async def _make_runner(self, **kwargs: Any) -> AppRunner:
+        # TODO(PY311): Use Unpack to specify Server kwargs.
         return AppRunner(self.app, **kwargs)
 
 
@@ -249,6 +251,7 @@ class RawTestServer(BaseTestServer[BaseRequest]):
         super().__init__(scheme=scheme, host=host, port=port, **kwargs)
 
     async def _make_runner(self, **kwargs: Any) -> ServerRunner:
+        # TODO(PY311): Use Unpack to specify Server kwargs.
         srv = Server(self._handler, **kwargs)
         return ServerRunner(srv, **kwargs)
 
@@ -264,7 +267,7 @@ class TestClient(Generic[_Request, _ApplicationNone]):
     __test__ = False
 
     @overload
-    def __init__(
+    def __init__(  # type: ignore[misc]
         self: "TestClient[Request, Application]",
         server: TestServer,
         *,
@@ -272,7 +275,7 @@ class TestClient(Generic[_Request, _ApplicationNone]):
         **kwargs: Any,
     ) -> None: ...
     @overload
-    def __init__(
+    def __init__(  # type: ignore[misc]
         self: "TestClient[_Request, None]",
         server: BaseTestServer[_Request],
         *,
@@ -286,6 +289,7 @@ class TestClient(Generic[_Request, _ApplicationNone]):
         cookie_jar: Optional[AbstractCookieJar] = None,
         **kwargs: Any,
     ) -> None:
+        # TODO(PY311): Use Unpack to specify ClientSession kwargs.
         if not isinstance(server, BaseTestServer):
             raise TypeError(
                 "server must be TestServer instance, found type: %r" % type(server)

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -164,7 +164,7 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
     def __getitem__(self, key: AppKey[_T]) -> _T: ...
 
     @overload
-    def __getitem__(self, key: str) -> Any: ...
+    def __getitem__(self, key: str) -> Any: ...  # type: ignore[misc]
 
     def __getitem__(self, key: Union[str, AppKey[_T]]) -> Any:
         return self._state[key]
@@ -179,7 +179,7 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
     def __setitem__(self, key: AppKey[_T], value: _T) -> None: ...
 
     @overload
-    def __setitem__(self, key: str, value: Any) -> None: ...
+    def __setitem__(self, key: str, value: Any) -> None: ...  # type: ignore[misc]
 
     def __setitem__(self, key: Union[str, AppKey[_T]], value: Any) -> None:
         self._check_frozen()
@@ -213,7 +213,7 @@ class Application(MutableMapping[Union[str, AppKey[Any]], Any]):
     def get(self, key: AppKey[_T], default: _U) -> Union[_T, _U]: ...
 
     @overload
-    def get(self, key: str, default: Any = ...) -> Any: ...
+    def get(self, key: str, default: Any = ...) -> Any: ...  # type: ignore[misc]
 
     def get(self, key: Union[str, AppKey[_T]], default: Any = None) -> Any:
         return self._state.get(key, default)

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -563,7 +563,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         return MappingProxyType({key: val.value for key, val in parsed.items()})
 
     @reify
-    def http_range(self) -> slice:
+    def http_range(self) -> "slice[int, int, int]":
         """The content of Range HTTP header.
 
         Return a slice instance.

--- a/aiohttp/web_routedef.py
+++ b/aiohttp/web_routedef.py
@@ -166,7 +166,9 @@ class RouteTableDef(Sequence[AbstractRouteDef]):
     @overload
     def __getitem__(self, index: slice[int, int, int]) -> List[AbstractRouteDef]: ...
 
-    def __getitem__(self, index: Union[int, slice[int, int, int]]) -> Union[AbstractRouteDef, List[AbstractRouteDef]]:
+    def __getitem__(
+        self, index: Union[int, slice[int, int, int]]
+    ) -> Union[AbstractRouteDef, List[AbstractRouteDef]]:
         return self._items[index]
 
     def __iter__(self) -> Iterator[AbstractRouteDef]:

--- a/aiohttp/web_routedef.py
+++ b/aiohttp/web_routedef.py
@@ -55,7 +55,7 @@ _HandlerType = Union[Type[AbstractView], Handler]
 
 
 @dataclasses.dataclass(frozen=True, repr=False)
-class RouteDef(AbstractRouteDef):
+class RouteDef(AbstractRouteDef):  # type: ignore[misc]
     method: str
     path: str
     handler: _HandlerType
@@ -80,7 +80,7 @@ class RouteDef(AbstractRouteDef):
 
 
 @dataclasses.dataclass(frozen=True, repr=False)
-class StaticDef(AbstractRouteDef):
+class StaticDef(AbstractRouteDef):  # type: ignore[misc]
     prefix: str
     path: PathLike
     kwargs: Dict[str, Any]
@@ -164,9 +164,9 @@ class RouteTableDef(Sequence[AbstractRouteDef]):
     def __getitem__(self, index: int) -> AbstractRouteDef: ...
 
     @overload
-    def __getitem__(self, index: slice) -> List[AbstractRouteDef]: ...
+    def __getitem__(self, index: slice[int, int, int]) -> List[AbstractRouteDef]: ...
 
-    def __getitem__(self, index):  # type: ignore[no-untyped-def]
+    def __getitem__(self, index: Union[int, slice[int, int, int]]) -> Union[AbstractRouteDef, List[AbstractRouteDef]]:
         return self._items[index]
 
     def __iter__(self) -> Iterator[AbstractRouteDef]:

--- a/aiohttp/web_routedef.py
+++ b/aiohttp/web_routedef.py
@@ -164,10 +164,10 @@ class RouteTableDef(Sequence[AbstractRouteDef]):
     def __getitem__(self, index: int) -> AbstractRouteDef: ...
 
     @overload
-    def __getitem__(self, index: slice[int, int, int]) -> List[AbstractRouteDef]: ...
+    def __getitem__(self, index: "slice[int, int, int]") -> List[AbstractRouteDef]: ...
 
     def __getitem__(
-        self, index: Union[int, slice[int, int, int]]
+        self, index: Union[int, "slice[int, int, int]"]
     ) -> Union[AbstractRouteDef, List[AbstractRouteDef]]:
         return self._items[index]
 

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -62,7 +62,7 @@ class BaseSite(ABC):
         self._runner = runner
         self._ssl_context = ssl_context
         self._backlog = backlog
-        self._server: Optional[asyncio.AbstractServer] = None
+        self._server: Optional[asyncio.Server] = None
 
     @property
     @abstractmethod
@@ -254,12 +254,12 @@ class BaseRunner(ABC, Generic[_Request]):
         return self._server
 
     @property
-    def addresses(self) -> List[Any]:
+    def addresses(self) -> List[Any]:  # type: ignore[misc]
         ret: List[Any] = []
         for site in self._sites:
             server = site._server
             if server is not None:
-                sockets = server.sockets  # type: ignore[attr-defined]
+                sockets = server.sockets
                 if sockets is not None:
                     for sock in sockets:
                         ret.append(sock.getsockname())

--- a/aiohttp/web_server.py
+++ b/aiohttp/web_server.py
@@ -40,16 +40,16 @@ class Server(Generic[_Request]):
     request_factory: _RequestFactory[_Request]
 
     @overload
-    def __init__(
+    def __init__(  # type: ignore[misc]
         self: "Server[BaseRequest]",
         handler: Callable[[_Request], Awaitable[StreamResponse]],
         *,
         debug: Optional[bool] = None,
         handler_cancellation: bool = False,
-        **kwargs: Any,
+        **kwargs: Any,  # TODO(PY311): Use Unpack to define kwargs from RequestHandler
     ) -> None: ...
     @overload
-    def __init__(
+    def __init__(  # type: ignore[misc]
         self,
         handler: Callable[[_Request], Awaitable[StreamResponse]],
         *,

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -949,7 +949,7 @@ class View(AbstractView):
             self._raise_allowed_methods()
         return await method()
 
-    def __await__(self) -> Generator[Any, None, StreamResponse]:
+    def __await__(self) -> Generator[None, None, StreamResponse]:
         return self._iter().__await__()
 
     def _raise_allowed_methods(self) -> NoReturn:

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -200,7 +200,7 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
         sys.exit(1)
 
     @staticmethod
-    def _create_ssl_context(cfg: Any) -> "SSLContext":
+    def _create_ssl_context(cfg: Any) -> "SSLContext":  # type: ignore[misc]
         """Creates SSLContext instance for usage in asyncio.create_server.
 
         See ssl.SSLSocket.__init__ for more details.

--- a/tests/autobahn/test_autobahn.py
+++ b/tests/autobahn/test_autobahn.py
@@ -47,7 +47,7 @@ def get_failed_tests(report_path: str, name: str) -> List[Dict[str, Any]]:
 
 @pytest.mark.skipif(sys.platform == "darwin", reason="Don't run on macOS")
 @pytest.mark.xfail
-def test_client(report_dir: Path, request: Any) -> None:
+def test_client(report_dir: Path, request: pytest.FixtureRequest) -> None:
     try:
         print("Starting autobahn-testsuite server")
         autobahn_container = docker.run(
@@ -57,7 +57,7 @@ def test_client(report_dir: Path, request: Any) -> None:
             publish=[(9001, 9001)],
             remove=True,
             volumes=[
-                (f"{request.fspath.dirname}/client", "/config"),
+                (f"{request.path.parent}/client", "/config"),
                 (f"{report_dir}", "/reports"),
             ],
         )
@@ -88,7 +88,7 @@ def test_client(report_dir: Path, request: Any) -> None:
 
 @pytest.mark.skipif(sys.platform == "darwin", reason="Don't run on macOS")
 @pytest.mark.xfail
-def test_server(report_dir: Path, request: Any) -> None:
+def test_server(report_dir: Path, request: pytest.FixtureRequest) -> None:
     try:
         print("Starting aiohttp test server")
         server = subprocess.Popen(
@@ -100,7 +100,7 @@ def test_server(report_dir: Path, request: Any) -> None:
             name="autobahn",
             remove=True,
             volumes=[
-                (f"{request.fspath.dirname}/server", "/config"),
+                (f"{request.path.parent}/server", "/config"),
                 (f"{report_dir}", "/reports"),
             ],
             networks=["host"],

--- a/tests/test_client_connection.py
+++ b/tests/test_client_connection.py
@@ -16,7 +16,7 @@ def key() -> object:
 
 
 @pytest.fixture
-def loop() -> Any:
+def loop() -> Any:  # type: ignore[misc]
     return mock.create_autospec(asyncio.AbstractEventLoop, spec_set=True, instance=True)
 
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1465,7 +1465,7 @@ def test_gen_default_accept_encoding(has_brotli: bool, expected: str) -> None:
     indirect=("netrc_contents",),
 )
 @pytest.mark.usefixtures("netrc_contents")
-def test_basicauth_from_netrc_present(
+def test_basicauth_from_netrc_present(  # type: ignore[misc]
     make_request: _RequestMaker,
     expected_auth: helpers.BasicAuth,
 ) -> None:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -62,7 +62,7 @@ def connector(
 
 
 @pytest.fixture
-def create_session(
+def create_session(  # type: ignore[misc]
     loop: asyncio.AbstractEventLoop,
 ) -> Iterator[Callable[..., Awaitable[ClientSession]]]:
     session = None
@@ -78,7 +78,7 @@ def create_session(
 
 
 @pytest.fixture
-def session(
+def session(  # type: ignore[misc]
     create_session: Callable[..., Awaitable[ClientSession]],
     loop: asyncio.AbstractEventLoop,
 ) -> ClientSession:
@@ -531,7 +531,7 @@ async def test_close_conn_on_error(
 
 
 @pytest.mark.parametrize("protocol", ["http", "https", "ws", "wss"])
-async def test_ws_connect_allowed_protocols(
+async def test_ws_connect_allowed_protocols(  # type: ignore[misc]
     create_session: Callable[..., Awaitable[ClientSession]],
     create_mocked_conn: Callable[[], ResponseHandler],
     protocol: str,
@@ -593,7 +593,7 @@ async def test_ws_connect_allowed_protocols(
 
 
 @pytest.mark.parametrize("protocol", ["http", "https", "ws", "wss", "unix"])
-async def test_ws_connect_unix_socket_allowed_protocols(
+async def test_ws_connect_unix_socket_allowed_protocols(  # type: ignore[misc]
     create_session: Callable[..., Awaitable[ClientSession]],
     create_mocked_conn: Callable[[], ResponseHandler],
     protocol: str,
@@ -1159,7 +1159,7 @@ async def test_requote_redirect_url_default_disable() -> None:
         ),
     ],
 )
-async def test_build_url_returns_expected_url(
+async def test_build_url_returns_expected_url(  # type: ignore[misc]
     create_session: Callable[..., Awaitable[ClientSession]],
     base_url: Union[URL, str, None],
     url: Union[URL, str],

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -53,26 +53,26 @@ from aiohttp.test_utils import make_mocked_coro, unused_port
 from aiohttp.tracing import Trace
 
 
-@pytest.fixture()
-def key() -> ConnectionKey:
+@pytest.fixture
+def key() -> ConnectionKey:  # type: ignore[misc]
     # Connection key
     return ConnectionKey("localhost", 80, False, True, None, None, None)
 
 
 @pytest.fixture
-def key2() -> ConnectionKey:
+def key2() -> ConnectionKey:  # type: ignore[misc]
     # Connection key
     return ConnectionKey("localhost", 80, False, True, None, None, None)
 
 
 @pytest.fixture
-def other_host_key2() -> ConnectionKey:
+def other_host_key2() -> ConnectionKey:  # type: ignore[misc]
     # Connection key
     return ConnectionKey("otherhost", 80, False, True, None, None, None)
 
 
 @pytest.fixture
-def ssl_key() -> ConnectionKey:
+def ssl_key() -> ConnectionKey:  # type: ignore[misc]
     # Connection key
     return ConnectionKey("localhost", 80, True, True, None, None, None)
 
@@ -221,7 +221,7 @@ async def test_del(loop: asyncio.AbstractEventLoop, key: ConnectionKey) -> None:
 
 
 @pytest.mark.xfail
-async def test_del_with_scheduled_cleanup(
+async def test_del_with_scheduled_cleanup(  # type: ignore[misc]
     loop: asyncio.AbstractEventLoop, key: ConnectionKey
 ) -> None:
     loop.set_debug(True)
@@ -251,7 +251,7 @@ async def test_del_with_scheduled_cleanup(
 @pytest.mark.skipif(
     sys.implementation.name != "cpython", reason="CPython GC is required for the test"
 )
-def test_del_with_closed_loop(
+def test_del_with_closed_loop(  # type: ignore[misc]
     loop: asyncio.AbstractEventLoop, key: ConnectionKey
 ) -> None:
     async def make_conn() -> aiohttp.BaseConnector:
@@ -444,7 +444,7 @@ async def test_release(loop: asyncio.AbstractEventLoop, key: ConnectionKey) -> N
 
 
 @pytest.mark.usefixtures("enable_cleanup_closed")
-async def test_release_ssl_transport(
+async def test_release_ssl_transport(  # type: ignore[misc]
     loop: asyncio.AbstractEventLoop, ssl_key: ConnectionKey
 ) -> None:
     conn = aiohttp.BaseConnector(enable_cleanup_closed=True)
@@ -1924,7 +1924,7 @@ async def test_cleanup(key: ConnectionKey) -> None:
 
 
 @pytest.mark.usefixtures("enable_cleanup_closed")
-async def test_cleanup_close_ssl_transport(
+async def test_cleanup_close_ssl_transport(  # type: ignore[misc]
     loop: asyncio.AbstractEventLoop, ssl_key: ConnectionKey
 ) -> None:
     proto = create_mocked_conn(loop)
@@ -3788,7 +3788,7 @@ async def test_available_connections_with_limit_per_host(
 
 
 @pytest.mark.parametrize("limit_per_host", [0, 10])
-async def test_available_connections_without_limit_per_host(
+async def test_available_connections_without_limit_per_host(  # type: ignore[misc]
     key: ConnectionKey, other_host_key2: ConnectionKey, limit_per_host: int
 ) -> None:
     """Verify expected values based on active connections with higher host limit."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -189,7 +189,7 @@ def test_basic_auth_decode_invalid_credentials() -> None:
         ),
     ),
 )
-def test_basic_auth_decode_blank_username(
+def test_basic_auth_decode_blank_username(  # type: ignore[misc]
     credentials: str, expected_auth: helpers.BasicAuth
 ) -> None:
     header = f"Basic {base64.b64encode(credentials.encode()).decode()}"
@@ -1106,7 +1106,7 @@ def test_netrc_from_home_does_not_raise_if_access_denied(
     indirect=("netrc_contents",),
 )
 @pytest.mark.usefixtures("netrc_contents")
-def test_basicauth_present_in_netrc(
+def test_basicauth_present_in_netrc(  # type: ignore[misc]
     expected_auth: helpers.BasicAuth,
 ) -> None:
     """Test that netrc file contents are properly parsed into BasicAuth tuples"""

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -46,7 +46,7 @@ except ImportError:  # pragma: no cover
 
 
 @pytest.fixture
-def protocol() -> Any:
+def protocol() -> Any:  # type: ignore[misc]
     return mock.create_autospec(BaseProtocol, spec_set=True, instance=True)
 
 

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -19,7 +19,7 @@ def buf() -> bytearray:
 
 
 @pytest.fixture
-def transport(buf: bytearray) -> Any:
+def transport(buf: bytearray) -> Any:  # type: ignore[misc]
     transport = mock.create_autospec(asyncio.Transport, spec_set=True, instance=True)
 
     def write(chunk: bytes) -> None:
@@ -36,7 +36,7 @@ def transport(buf: bytearray) -> Any:
 
 
 @pytest.fixture
-def protocol(loop: asyncio.AbstractEventLoop, transport: asyncio.Transport) -> Any:
+def protocol(loop: asyncio.AbstractEventLoop, transport: asyncio.Transport) -> Any:  # type: ignore[misc]
     return mock.create_autospec(
         BaseProtocol, spec_set=True, instance=True, transport=transport
     )

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -41,7 +41,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_connect(
+    def test_connect(  # type: ignore[misc]
         self, start_connection: mock.Mock, ClientRequestMock: mock.Mock
     ) -> None:
         req = ClientRequest(
@@ -104,7 +104,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_proxy_headers(
+    def test_proxy_headers(  # type: ignore[misc]
         self, start_connection: mock.Mock, ClientRequestMock: mock.Mock
     ) -> None:
         req = ClientRequest(
@@ -167,7 +167,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_proxy_auth(self, start_connection: mock.Mock) -> None:
+    def test_proxy_auth(self, start_connection: mock.Mock) -> None:  # type: ignore[misc]
         with self.assertRaises(ValueError) as ctx:
             ClientRequest(
                 "GET",
@@ -186,7 +186,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_proxy_dns_error(self, start_connection: mock.Mock) -> None:
+    def test_proxy_dns_error(self, start_connection: mock.Mock) -> None:  # type: ignore[misc]
         async def make_conn() -> aiohttp.TCPConnector:
             return aiohttp.TCPConnector()
 
@@ -217,7 +217,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_proxy_connection_error(self, start_connection: mock.Mock) -> None:
+    def test_proxy_connection_error(self, start_connection: mock.Mock) -> None:  # type: ignore[misc]
         async def make_conn() -> aiohttp.TCPConnector:
             return aiohttp.TCPConnector()
 
@@ -257,7 +257,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_proxy_server_hostname_default(
+    def test_proxy_server_hostname_default(  # type: ignore[misc]
         self, start_connection: mock.Mock, ClientRequestMock: mock.Mock
     ) -> None:
         proxy_req = ClientRequest(
@@ -338,7 +338,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_proxy_server_hostname_override(
+    def test_proxy_server_hostname_override(  # type: ignore[misc]
         self, start_connection: mock.Mock, ClientRequestMock: mock.Mock
     ) -> None:
         proxy_req = ClientRequest(
@@ -423,7 +423,7 @@ class TestProxy(unittest.TestCase):
         spec_set=True,
     )
     @pytest.mark.usefixtures("enable_cleanup_closed")
-    def test_https_connect_fingerprint_mismatch(
+    def test_https_connect_fingerprint_mismatch(  # type: ignore[misc]
         self, start_connection: mock.Mock, ClientRequestMock: mock.Mock
     ) -> None:
         async def make_conn() -> aiohttp.TCPConnector:
@@ -531,7 +531,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_https_connect(
+    def test_https_connect(  # type: ignore[misc]
         self, start_connection: mock.Mock, ClientRequestMock: mock.Mock
     ) -> None:
         proxy_req = ClientRequest(
@@ -613,7 +613,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_https_connect_certificate_error(
+    def test_https_connect_certificate_error(  # type: ignore[misc]
         self, start_connection: mock.Mock, ClientRequestMock: mock.Mock
     ) -> None:
         proxy_req = ClientRequest(
@@ -690,7 +690,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_https_connect_ssl_error(
+    def test_https_connect_ssl_error(  # type: ignore[misc]
         self, start_connection: mock.Mock, ClientRequestMock: mock.Mock
     ) -> None:
         proxy_req = ClientRequest(
@@ -765,7 +765,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_https_connect_http_proxy_error(
+    def test_https_connect_http_proxy_error(  # type: ignore[misc]
         self, start_connection: mock.Mock, ClientRequestMock: mock.Mock
     ) -> None:
         proxy_req = ClientRequest(
@@ -841,7 +841,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_https_connect_resp_start_error(
+    def test_https_connect_resp_start_error(  # type: ignore[misc]
         self, start_connection: mock.Mock, ClientRequestMock: mock.Mock
     ) -> None:
         proxy_req = ClientRequest(
@@ -911,7 +911,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_request_port(
+    def test_request_port(  # type: ignore[misc]
         self, start_connection: mock.Mock, ClientRequestMock: mock.Mock
     ) -> None:
         proxy_req = ClientRequest(
@@ -977,7 +977,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_https_connect_pass_ssl_context(
+    def test_https_connect_pass_ssl_context(  # type: ignore[misc]
         self, start_connection: mock.Mock, ClientRequestMock: mock.Mock
     ) -> None:
         proxy_req = ClientRequest(
@@ -1067,7 +1067,7 @@ class TestProxy(unittest.TestCase):
         autospec=True,
         spec_set=True,
     )
-    def test_https_auth(
+    def test_https_auth(  # type: ignore[misc]
         self, start_connection: mock.Mock, ClientRequestMock: mock.Mock
     ) -> None:
         proxy_req = ClientRequest(

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -442,7 +442,7 @@ mixed_bindings_test_params = [test[1:] for test in mixed_bindings_tests]
     mixed_bindings_test_params,
     ids=mixed_bindings_test_ids,
 )
-def test_run_app_mixed_bindings(
+def test_run_app_mixed_bindings(  # type: ignore[misc]
     run_app_kwargs: Dict[str, Any],
     expected_server_calls: List[mock._Call],
     expected_unix_server_calls: List[mock._Call],

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -102,7 +102,7 @@ class TestTrace:
             ("dns_cache_miss", (Mock(),), TraceDnsCacheMissParams),
         ],
     )
-    async def test_send(
+    async def test_send(  # type: ignore[misc]
         self, signal: str, params: Tuple[Mock, ...], param_obj: Any
     ) -> None:
         session = Mock()


### PR DESCRIPTION
Most of these ignores will also disappear once we remove BasicAuth (in favour of middlewares).