### PR TITLE
[3.11] Bump setuptools to 75.8.0

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -316,7 +316,7 @@ zipp==3.20.2
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.3.1
     # via pip-tools
-setuptools==75.2.0
+setuptools==75.8.0
     # via
     #   incremental
     #   pip-tools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -287,7 +287,7 @@ zipp==3.20.2
 # The following packages are considered to be unsafe in a requirements file:
 pip==24.3.1
     # via pip-tools
-setuptools==75.2.0
+setuptools==75.8.0
     # via
     #   incremental
     #   pip-tools

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -83,5 +83,5 @@ zipp==3.20.2
     #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.2.0
+setuptools==75.8.0
     # via incremental

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -78,5 +78,5 @@ zipp==3.20.2
     #   importlib-resources
 
 # The following packages are considered to be unsafe in a requirements file:
-setuptools==75.2.0
+setuptools==75.8.0
     # via incremental


### PR DESCRIPTION
changelog: https://github.com/pypa/setuptools/compare/v75.2.0...v75.8.0

I am hoping this fixes the twine check failures we see on 3.11
