### PR TITLE
[3.11] Bump packaging to 24.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -30,7 +30,7 @@ multidict==6.1.0
     # via
     #   -r requirements/runtime-deps.in
     #   yarl
-packaging==24.1
+packaging==24.2
     # via gunicorn
 propcache==0.2.0
     # via

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -129,7 +129,7 @@ mypy-extensions==1.0.0
     # via mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.1
+packaging==24.2
     # via
     #   build
     #   gunicorn

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -122,7 +122,7 @@ mypy-extensions==1.0.0
     # via mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.1
+packaging==24.2
     # via
     #   build
     #   gunicorn

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -34,7 +34,7 @@ jinja2==3.1.4
     #   towncrier
 markupsafe==2.1.5
     # via jinja2
-packaging==24.1
+packaging==24.2
     # via sphinx
 pyenchant==3.2.2
     # via sphinxcontrib-spelling

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -34,7 +34,7 @@ jinja2==3.1.4
     #   towncrier
 markupsafe==2.1.5
     # via jinja2
-packaging==24.1
+packaging==24.2
     # via sphinx
 pygments==2.18.0
     # via sphinx

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -55,7 +55,7 @@ mypy-extensions==1.0.0
     # via mypy
 nodeenv==1.9.1
     # via pre-commit
-packaging==24.1
+packaging==24.2
     # via pytest
 platformdirs==4.3.6
     # via virtualenv

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -70,7 +70,7 @@ mypy==1.11.2 ; implementation_name == "cpython"
     # via -r requirements/test.in
 mypy-extensions==1.0.0
     # via mypy
-packaging==24.1
+packaging==24.2
     # via
     #   gunicorn
     #   pytest


### PR DESCRIPTION
changelog: https://github.com/pypa/packaging/compare/24.1...24.2

I am hoping this fixes the twine check failures we see on 3.11
