### PR TITLE
Release 3.11.12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,113 @@
 
 .. towncrier release notes start
 
+3.11.12 (2025-02-05)
+====================
+
+Bug fixes
+---------
+
+- ``MultipartForm.decode()`` must follow RFC1341 7.2.1 with a ``CRLF`` after the boundary
+  -- by :user:`imnotjames`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`10270`.
+
+
+
+- Restored the missing ``total_bytes`` attribute to ``EmptyStreamReader`` -- by :user:`bdraco`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`10387`.
+
+
+
+
+Features
+--------
+
+- Update :py:func:`~aiohttp.request` to make it accept ``_RequestOptions`` kwargs.
+  -- by :user:`Cycloctane`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`10300`.
+
+
+
+- Improved logging of HTTP protocol errors to include the remote address -- by :user:`bdraco`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`10332`.
+
+
+
+
+Improved documentation
+----------------------
+
+- Added ``aiohttp-openmetrics`` to list of third-party libraries -- by :user:`jelmer`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`10304`.
+
+
+
+
+Packaging updates and notes for downstreams
+-------------------------------------------
+
+- Started publishing ``riscv64`` wheels -- by :user:`eshattow`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`10330`.
+
+
+
+- Added missing files to the source distribution to fix ``Makefile`` targets.
+  Added a ``cythonize-nodeps`` target to run Cython without invoking pip to install dependencies.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`10366`.
+
+
+
+
+Contributor-facing changes
+--------------------------
+
+- The CI/CD workflow has been updated to use `upload-artifact` v4 and `download-artifact` v4 GitHub Actions -- by :user:`silamon`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`10281`.
+
+
+
+
+Miscellaneous internal changes
+------------------------------
+
+- Restored support for zero copy writes when using Python 3.12 versions 3.12.9 and later or Python 3.13.2+ -- by :user:`bdraco`.
+
+  Zero copy writes were previously disabled due to :cve:`2024-12254` which is resolved in these Python versions.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`10137`.
+
+
+
+
+----
+
+
 3.11.11 (2024-12-18)
 ====================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,7 +16,7 @@
 Bug fixes
 ---------
 
-- ``MultipartForm.decode()`` must follow RFC1341 7.2.1 with a ``CRLF`` after the boundary
+- ``MultipartForm.decode()`` now follows RFC1341 7.2.1 with a ``CRLF`` after the boundary
   -- by :user:`imnotjames`.
 
 
@@ -37,7 +37,7 @@ Bug fixes
 Features
 --------
 
-- Update :py:func:`~aiohttp.request` to make it accept ``_RequestOptions`` kwargs.
+- Updated :py:func:`~aiohttp.request` to make it accept ``_RequestOptions`` kwargs.
   -- by :user:`Cycloctane`.
 
 

--- a/CHANGES/10137.misc.rst
+++ b/CHANGES/10137.misc.rst
@@ -1,3 +1,0 @@
-Restored support for zero copy writes when using Python 3.12 versions 3.12.9 and later or Python 3.13.2+ -- by :user:`bdraco`.
-
-Zero copy writes were previously disabled due to :cve:`2024-12254` which is resolved in these Python versions.

--- a/CHANGES/10270.bugfix.rst
+++ b/CHANGES/10270.bugfix.rst
@@ -1,2 +1,0 @@
-``MultipartForm.decode()`` must follow RFC1341 7.2.1 with a ``CRLF`` after the boundary
--- by :user:`imnotjames`.

--- a/CHANGES/10281.contrib.rst
+++ b/CHANGES/10281.contrib.rst
@@ -1,1 +1,0 @@
-The CI/CD workflow has been updated to use `upload-artifact` v4 and `download-artifact` v4 GitHub Actions -- by :user:`silamon`.

--- a/CHANGES/10300.feature.rst
+++ b/CHANGES/10300.feature.rst
@@ -1,2 +1,0 @@
-Update :py:func:`~aiohttp.request` to make it accept ``_RequestOptions`` kwargs.
--- by :user:`Cycloctane`.

--- a/CHANGES/10304.doc.rst
+++ b/CHANGES/10304.doc.rst
@@ -1,1 +1,0 @@
-Added ``aiohttp-openmetrics`` to list of third-party libraries -- by :user:`jelmer`.

--- a/CHANGES/10330.packaging.rst
+++ b/CHANGES/10330.packaging.rst
@@ -1,1 +1,0 @@
-Started publishing ``riscv64`` wheels -- by :user:`eshattow`.

--- a/CHANGES/10332.feature.rst
+++ b/CHANGES/10332.feature.rst
@@ -1,1 +1,0 @@
-Improved logging of HTTP protocol errors to include the remote address -- by :user:`bdraco`.

--- a/CHANGES/10366.packaging
+++ b/CHANGES/10366.packaging
@@ -1,2 +1,0 @@
-Added missing files to the source distribution to fix ``Makefile`` targets.
-Added a ``cythonize-nodeps`` target to run Cython without invoking pip to install dependencies.

--- a/CHANGES/10387.bugfix.rst
+++ b/CHANGES/10387.bugfix.rst
@@ -1,1 +1,0 @@
-Restored the missing ``total_bytes`` attribute to ``EmptyStreamReader`` -- by :user:`bdraco`.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.11.12.dev0"
+__version__ = "3.11.12"
 
 from typing import TYPE_CHECKING, Tuple
 


### PR DESCRIPTION
~~attempt 1 https://github.com/aio-libs/aiohttp/actions/runs/13164143542~~ failed due to riscv64 not being supported in cibuildwheel
~~attempt 2 https://github.com/aio-libs/aiohttp/actions/runs/13165188071~~ failed due to https://github.com/pypa/cibuildwheel/issues/2257
~~attempt 3 https://github.com/aio-libs/aiohttp/actions/runs/13165870727~~ failed due to https://github.com/pypa/cibuildwheel/issues/2257
~~attempt 4 https://github.com/aio-libs/aiohttp/actions/runs/13166666172~~ failed to due mistake in the name of the arm runners
~~attempt 5 https://github.com/aio-libs/aiohttp/actions/runs/13167116126~~ aborted due to missing ppc64le musllinux wheels (refactoring error)
~~attempt 6 https://github.com/aio-libs/aiohttp/actions/runs/13167811054~~ failed due to download-artifact v4 breaking changes
attempt 7 https://github.com/aio-libs/aiohttp/actions/runs/13168676877

<img width="375" alt="Screenshot 2025-02-05 at 3 11 36 PM" src="https://github.com/user-attachments/assets/5cd7c518-9a8b-4479-99a5-ca2a2c6f8d5b" />
