### PR TITLE
Revert "Start building riscv64 platform wheels in CI/CD"

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -378,8 +378,6 @@ jobs:
         - os: ubuntu
           qemu: ppc64le
         - os: ubuntu
-          qemu: riscv64
-        - os: ubuntu
           qemu: s390x
     steps:
     - name: Checkout

--- a/CHANGES/10330.packaging.rst
+++ b/CHANGES/10330.packaging.rst
@@ -1,1 +1,0 @@
-Started publishing ``riscv64`` wheels -- by :user:`eshattow`.


### PR DESCRIPTION
cibuildwheel does not support riscv64 yet so this PR made the release fail

`ValueError: 'riscv64' is not a valid Architecture`

https://github.com/aio-libs/aiohttp/actions/runs/13164143542/job/36740982377

Reverts aio-libs/aiohttp#10330