### PR TITLE
[3.11] Amend changes to remove reverted riscv64 wheels

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,14 +70,6 @@ Improved documentation
 Packaging updates and notes for downstreams
 -------------------------------------------
 
-- Started publishing ``riscv64`` wheels -- by :user:`eshattow`.
-
-
-  *Related issues and pull requests on GitHub:*
-  :issue:`10330`.
-
-
-
 - Added missing files to the source distribution to fix ``Makefile`` targets.
   Added a ``cythonize-nodeps`` target to run Cython without invoking pip to install dependencies.
 


### PR DESCRIPTION
See https://github.com/aio-libs/aiohttp/pull/10393

Note that the release failed so this was never published

<img width="464" alt="Screenshot 2025-02-05 at 1 26 20 PM" src="https://github.com/user-attachments/assets/7e21a6ef-abc0-430f-afc8-99e2e4256276" />
