### PR TITLE
Disable wheel builds on PyPy

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -435,7 +435,7 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.22.0
       env:
-        CIBW_SKIP: ${{ matrix.musl == 'musllinux' && '*manylinux*' || '*musllinux*' }}
+        CIBW_SKIP: pp* ${{ matrix.musl == 'musllinux' && '*manylinux*' || '*musllinux*' }}
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2
     - name: Upload wheels
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
fixes failure seen in https://github.com/aio-libs/aiohttp/actions/runs/13165870727

When I split these, I forgot to turn these off as we have never tried to build extensions on PyPy