### PR TITLE
Fix missing ppc64le musllinux wheels

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -378,16 +378,16 @@ jobs:
           qemu: ppc64le
           musl: ""
         - os: ubuntu-latest
+          qemu: ppc64le
+          musl: musllinux
+        - os: ubuntu-latest
           qemu: s390x
           musl: ""
         - os: ubuntu-latest
+          qemu: s390x
+          musl: musllinux
+        - os: ubuntu-latest
           qemu: armv7l
-          musl: musllinux
-        - os: ubuntu-latest
-          qemu: s390x
-          musl: musllinux
-        - os: ubuntu-latest
-          qemu: s390x
           musl: musllinux
         - os: ubuntu-latest
           musl: musllinux


### PR DESCRIPTION
I had s390x twice instead of ppc64le. Seems like I could use a little more sleep or coffee today
