### PR TITLE
Add human readable error messages for WebSocket PING/PONG timeouts

### DIFF
--- a/CHANGES/10422.misc.rst
+++ b/CHANGES/10422.misc.rst
@@ -1,3 +1,3 @@
-Added human readable error messages to the exceptions for WebSocket disconnects due to PONG not being received -- by :user:`bdraco`.
+Added human-readable error messages to the exceptions for WebSocket disconnects due to PONG not being received -- by :user:`bdraco`.
 
-Previously the error messages were empty strings which made it hard to determine what went wrong.
+Previously, the error messages were empty strings, which made it hard to determine what went wrong.

--- a/CHANGES/10422.misc.rst
+++ b/CHANGES/10422.misc.rst
@@ -1,0 +1,3 @@
+Added human readable error messages to the exceptions for WebSocket disconnects due to PONG not being received -- by :user:`bdraco`.
+
+Previously the error messages were empty strings which made it hard to determine what went wrong.

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -163,7 +163,9 @@ class ClientWebSocketResponse:
         self._ping_task = None
 
     def _pong_not_received(self) -> None:
-        self._handle_ping_pong_exception(ServerTimeoutError())
+        self._handle_ping_pong_exception(
+            ServerTimeoutError(f"No PONG received after {self._pong_heartbeat} seconds")
+        )
 
     def _handle_ping_pong_exception(self, exc: BaseException) -> None:
         """Handle exceptions raised during ping/pong processing."""

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -186,7 +186,11 @@ class WebSocketResponse(StreamResponse):
 
     def _pong_not_received(self) -> None:
         if self._req is not None and self._req.transport is not None:
-            self._handle_ping_pong_exception(asyncio.TimeoutError())
+            self._handle_ping_pong_exception(
+                asyncio.TimeoutError(
+                    f"No PONG received after {self._pong_heartbeat} seconds"
+                )
+            )
 
     def _handle_ping_pong_exception(self, exc: BaseException) -> None:
         """Handle exceptions raised during ping/pong processing."""

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -926,6 +926,7 @@ async def test_heartbeat_no_pong_concurrent_receive(
         assert resp.close_code is WSCloseCode.ABNORMAL_CLOSURE
         assert msg.type is WSMsgType.ERROR
         assert isinstance(msg.data, ServerTimeoutError)
+        assert str(msg.data) == "No PONG received after 0.05 seconds"
 
 
 async def test_close_websocket_while_ping_inflight(

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -841,6 +841,7 @@ async def test_heartbeat_failure_ends_receive(
     assert ws.close_code == WSCloseCode.ABNORMAL_CLOSURE
     assert ws_server_close_code == WSCloseCode.ABNORMAL_CLOSURE
     assert isinstance(ws_server_exception, asyncio.TimeoutError)
+    assert str(ws_server_exception) == "No PONG received after 0.025 seconds"
     await ws.close()
 
 


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Currently the exception would stringify to an empty string which left the caller with no information about why the WebSocket disconnected in the log


## Are there changes in behavior for the user?

Human readable errors

## Is it a substantial burden for the maintainers to support this?

no