### PR TITLE
Disable writelines for test_write_large_payload_deflate_compression_data_in_eof

### DIFF
--- a/CHANGES/10423.packaging.rst
+++ b/CHANGES/10423.packaging.rst
@@ -1,0 +1,1 @@
+Fixed test ``test_write_large_payload_deflate_compression_data_in_eof_writelines`` failing with Python 3.12.9+ or 3.13.2+ -- by :user:`bdraco`.

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -20,6 +20,12 @@ def enable_writelines() -> Generator[None, None, None]:
 
 
 @pytest.fixture
+def disable_writelines() -> Generator[None, None, None]:
+    with mock.patch("aiohttp.http_writer.SKIP_WRITELINES", True):
+        yield
+
+
+@pytest.fixture
 def force_writelines_small_payloads() -> Generator[None, None, None]:
     with mock.patch("aiohttp.http_writer.MIN_PAYLOAD_FOR_WRITELINES", 1):
         yield
@@ -123,6 +129,7 @@ async def test_write_payload_length(
     assert b"da" == content.split(b"\r\n\r\n", 1)[-1]
 
 
+@pytest.mark.usefixtures("disable_writelines")
 async def test_write_large_payload_deflate_compression_data_in_eof(
     protocol: BaseProtocol,
     transport: asyncio.Transport,


### PR DESCRIPTION


We have a `writelines` version of this test, `test_write_large_payload_deflate_compression_data_in_eof_writelines`, which should have `writelines` enabled, but for this version, `writelines` should always be disabled

This test would fail with CPython 3.12.9+ or 3.13.2+

fixes #10421