### PR TITLE
Add benchmark for streaming API iter_chunks

### DIFF
--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -124,7 +124,7 @@ def test_one_hundred_get_requests_with_512kib_chunked_payload(
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 100 GET requests with a payload of 512KiB."""
+    """Benchmark 100 GET requests with a payload of 512KiB using read."""
     message_count = 100
     payload = b"a" * (2**19)
 
@@ -141,6 +141,36 @@ def test_one_hundred_get_requests_with_512kib_chunked_payload(
         for _ in range(message_count):
             resp = await client.get("/")
             await resp.read()
+        await client.close()
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_client_benchmark())
+
+
+def test_one_hundred_get_requests_iter_chunks_on_512kib_chunked_payload(
+    loop: asyncio.AbstractEventLoop,
+    aiohttp_client: AiohttpClient,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark 100 GET requests with a payload of 512KiB using iter_chunks."""
+    message_count = 100
+    payload = b"a" * (2**19)
+
+    async def handler(request: web.Request) -> web.Response:
+        resp = web.Response(body=payload)
+        resp.enable_chunked_encoding()
+        return resp
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+
+    async def run_client_benchmark() -> None:
+        client = await aiohttp_client(app)
+        for _ in range(message_count):
+            resp = await client.get("/")
+            async for _ in resp.content.iter_chunks():
+                pass
         await client.close()
 
     @benchmark


### PR DESCRIPTION
Benchmark to demo the benefit of `iter_chunks` over `read`

Most of the time is spent in getting the data from llhttp into python objects, but its still significantly faster to use `iter_chunks` vs `read` because it avoids another copy.
<img width="310" alt="Screenshot 2025-02-06 at 10 02 30 AM" src="https://github.com/user-attachments/assets/3e072456-65bd-453d-ba6a-8f30dc1bdad8" />

