### PR TITLE
Fix inappropriate "break in finally"

### DIFF
--- a/CHANGES/10434.bugfix.rst
+++ b/CHANGES/10434.bugfix.rst
@@ -1,2 +1,2 @@
-Avoid break statement inside the finally block in :py:meth:`~aiohttp.web.RequestHandler.start`
+Avoid break statement inside the finally block in :py:class:`~aiohttp.web.RequestHandler`
 -- by :user:`Cycloctane`.

--- a/CHANGES/10434.bugfix.rst
+++ b/CHANGES/10434.bugfix.rst
@@ -1,0 +1,2 @@
+Avoid break statement inside the finally block in :py:meth:`~aiohttp.web.RequestHandler.start`
+-- by :user:`Cycloctane`.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -638,6 +638,9 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             except Exception as exc:
                 self.log_exception("Unhandled exception", exc_info=exc)
                 self.force_close()
+            except BaseException:
+                self.force_close()
+                raise
             else:
                 if self._keepalive and not self._close:
                     # start keep-alive timer

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -647,14 +647,13 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
 
             if self._keepalive and not self._close and not self._force_close:
                 # start keep-alive timer
-                if keepalive_timeout is not None:
-                    now = loop.time()
-                    close_time = now + keepalive_timeout
-                    self._next_keepalive_close_time = close_time
-                    if self._keepalive_handle is None:
-                        self._keepalive_handle = loop.call_at(
-                            close_time, self._process_keepalive
-                        )
+                now = loop.time()
+                close_time = now + keepalive_timeout
+                self._next_keepalive_close_time = close_time
+                if self._keepalive_handle is None:
+                    self._keepalive_handle = loop.call_at(
+                        close_time, self._process_keepalive
+                    )
             else:
                 break
 

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -647,8 +647,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
 
             if self._keepalive and not self._close and not self._force_close:
                 # start keep-alive timer
-                now = loop.time()
-                close_time = now + keepalive_timeout
+                close_time = loop.time() + keepalive_timeout
                 self._next_keepalive_close_time = close_time
                 if self._keepalive_handle is None:
                     self._keepalive_handle = loop.call_at(

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -633,26 +633,27 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
 
             except asyncio.CancelledError:
                 self.log_debug("Ignored premature client disconnection")
+                self.force_close()
                 raise
             except Exception as exc:
                 self.log_exception("Unhandled exception", exc_info=exc)
                 self.force_close()
+            else:
+                if self._keepalive and not self._close:
+                    # start keep-alive timer
+                    if keepalive_timeout is not None:
+                        now = loop.time()
+                        close_time = now + keepalive_timeout
+                        self._next_keepalive_close_time = close_time
+                        if self._keepalive_handle is None:
+                            self._keepalive_handle = loop.call_at(
+                                close_time, self._process_keepalive
+                            )
+                else:
+                    break
             finally:
                 if self.transport is None and resp is not None:
                     self.log_debug("Ignored premature client disconnection.")
-                elif not self._force_close:
-                    if self._keepalive and not self._close:
-                        # start keep-alive timer
-                        if keepalive_timeout is not None:
-                            now = loop.time()
-                            close_time = now + keepalive_timeout
-                            self._next_keepalive_close_time = close_time
-                            if self._keepalive_handle is None:
-                                self._keepalive_handle = loop.call_at(
-                                    close_time, self._process_keepalive
-                                )
-                    else:
-                        break
 
         # remove handler, close transport if no handlers left
         if not self._force_close:

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -641,22 +641,22 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             except BaseException:
                 self.force_close()
                 raise
-            else:
-                if self._keepalive and not self._close:
-                    # start keep-alive timer
-                    if keepalive_timeout is not None:
-                        now = loop.time()
-                        close_time = now + keepalive_timeout
-                        self._next_keepalive_close_time = close_time
-                        if self._keepalive_handle is None:
-                            self._keepalive_handle = loop.call_at(
-                                close_time, self._process_keepalive
-                            )
-                else:
-                    break
             finally:
                 if self.transport is None and resp is not None:
                     self.log_debug("Ignored premature client disconnection.")
+
+            if self._keepalive and not self._close and not self._force_close:
+                # start keep-alive timer
+                if keepalive_timeout is not None:
+                    now = loop.time()
+                    close_time = now + keepalive_timeout
+                    self._next_keepalive_close_time = close_time
+                    if self._keepalive_handle is None:
+                        self._keepalive_handle = loop.call_at(
+                            close_time, self._process_keepalive
+                        )
+            else:
+                break
 
         # remove handler, close transport if no handlers left
         if not self._force_close:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -248,6 +248,24 @@ async def test_raw_server_do_not_swallow_exceptions(
     logger.debug.assert_called_with("Ignored premature client disconnection")
 
 
+async def test_raw_server_do_not_swallow_base_exceptions(
+    aiohttp_raw_server: AiohttpRawServer, aiohttp_client: AiohttpClient
+) -> None:
+    class UnexpectedException(BaseException):
+        pass
+
+    async def handler(request: web.BaseRequest) -> NoReturn:
+        raise UnexpectedException()
+
+    loop = asyncio.get_event_loop()
+    loop.set_debug(True)
+    server = await aiohttp_raw_server(handler)
+    cli = await aiohttp_client(server)
+
+    with pytest.raises(client.ServerDisconnectedError):
+        await cli.get("/path/to", timeout=client.ClientTimeout(10))
+
+
 async def test_raw_server_cancelled_in_write_eof(
     aiohttp_raw_server: AiohttpRawServer, aiohttp_client: AiohttpClient
 ) -> None:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -248,11 +248,11 @@ async def test_raw_server_do_not_swallow_exceptions(
     logger.debug.assert_called_with("Ignored premature client disconnection")
 
 
-async def test_raw_server_do_not_swallow_base_exceptions(
+async def test_raw_server_does_not_swallow_base_exceptions(
     aiohttp_raw_server: AiohttpRawServer, aiohttp_client: AiohttpClient
 ) -> None:
     class UnexpectedException(BaseException):
-        pass
+        """Dummy base exception."""
 
     async def handler(request: web.BaseRequest) -> NoReturn:
         raise UnexpectedException()


### PR DESCRIPTION
## What do these changes do?

Remove break statement inside the finally block in file `aiohttp/webprotocol.py`.

## Are there changes in behavior for the user?

## Is it a substantial burden for the maintainers to support this?

## Related issue number

Fixes #9521 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
