### PR TITLE
Fixes for strict-bytes

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -20,6 +20,7 @@ pretty = True
 show_column_numbers = True
 show_error_codes = True
 show_error_code_links = True
+strict_bytes = True
 strict_equality = True
 warn_incomplete_stub = True
 warn_redundant_casts = True

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -309,11 +309,11 @@ class WebSocketReader:
                 self.queue.feed_data(msg)
             elif opcode == OP_CODE_PING:
                 self.queue.feed_data(
-                    WSMessagePing(data=payload, size=len(payload), extra="")
+                    WSMessagePing(data=bytes(payload), size=len(payload), extra="")
                 )
             elif opcode == OP_CODE_PONG:
                 self.queue.feed_data(
-                    WSMessagePong(data=payload, size=len(payload), extra="")
+                    WSMessagePong(data=bytes(payload), size=len(payload), extra="")
                 )
             else:
                 raise WebSocketError(

--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -133,9 +133,9 @@ class WebSocketWriter:
         # when aiohttp is acting as a client. Servers do not use a mask.
         if use_mask:
             mask = PACK_RANDBITS(self.get_random_bits())
-            message = bytearray(message)
-            websocket_mask(mask, message)
-            self.transport.write(header + mask + message)
+            message_arr = bytearray(message)
+            websocket_mask(mask, message_arr)
+            self.transport.write(header + mask + message_arr)
             self._output_size += MASK_LEN
         elif msg_length > MSG_SIZE:
             self.transport.write(header)

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -202,7 +202,7 @@ class AbstractStreamWriter(ABC):
     length: Optional[int] = 0
 
     @abstractmethod
-    async def write(self, chunk: Union[bytes, bytearray, memoryview]) -> None:
+    async def write(self, chunk: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]) -> None:
         """Write chunk into stream."""
 
     @abstractmethod

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -203,7 +203,7 @@ class AbstractStreamWriter(ABC):
 
     @abstractmethod
     async def write(
-        self, chunk: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]
+        self, chunk: Union[bytes, bytearray, "memoryview[int]", "memoryview[bytes]"]
     ) -> None:
         """Write chunk into stream."""
 

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -202,7 +202,9 @@ class AbstractStreamWriter(ABC):
     length: Optional[int] = 0
 
     @abstractmethod
-    async def write(self, chunk: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]) -> None:
+    async def write(
+        self, chunk: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]
+    ) -> None:
         """Write chunk into stream."""
 
     @abstractmethod

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -9,7 +9,7 @@ if sys.version_info >= (3, 12):
 else:
     from typing import Union
 
-    Buffer = Union[bytes, bytearray, memoryview[int], memoryview[bytes]]
+    Buffer = Union[bytes, bytearray, "memoryview[int]", "memoryview[bytes]"]
 
 try:
     try:

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -45,7 +45,7 @@ HttpVersion10 = HttpVersion(1, 0)
 HttpVersion11 = HttpVersion(1, 1)
 
 
-_T_OnChunkSent = Optional[Callable[[bytes], Awaitable[None]]]
+_T_OnChunkSent = Optional[Callable[[Union[bytes, bytearray, memoryview[int], memoryview[bytes]]], Awaitable[None]]]
 _T_OnHeadersSent = Optional[Callable[["CIMultiDict[str]"], Awaitable[None]]]
 
 
@@ -84,7 +84,7 @@ class StreamWriter(AbstractStreamWriter):
     ) -> None:
         self._compress = ZLibCompressor(encoding=encoding, strategy=strategy)
 
-    def _write(self, chunk: Union[bytes, bytearray, memoryview]) -> None:
+    def _write(self, chunk: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]) -> None:
         size = len(chunk)
         self.buffer_size += size
         self.output_size += size
@@ -93,7 +93,7 @@ class StreamWriter(AbstractStreamWriter):
             raise ClientConnectionResetError("Cannot write to closing transport")
         transport.write(chunk)
 
-    def _writelines(self, chunks: Iterable[bytes]) -> None:
+    def _writelines(self, chunks: Iterable[Union[bytes, bytearray, memoryview[int], memoryview[bytes]]]) -> None:
         size = 0
         for chunk in chunks:
             size += len(chunk)
@@ -109,7 +109,7 @@ class StreamWriter(AbstractStreamWriter):
 
     async def write(
         self,
-        chunk: Union[bytes, bytearray, memoryview],
+        chunk: Union[bytes, bytearray, memoryview[int], memoryview[bytes]],
         *,
         drain: bool = True,
         LIMIT: int = 0x10000,

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -47,7 +47,7 @@ HttpVersion11 = HttpVersion(1, 1)
 
 _T_OnChunkSent = Optional[
     Callable[
-        [Union[bytes, bytearray, memoryview[int], memoryview[bytes]]], Awaitable[None]
+        [Union[bytes, bytearray, "memoryview[int]", "memoryview[bytes]"]], Awaitable[None]
     ]
 ]
 _T_OnHeadersSent = Optional[Callable[["CIMultiDict[str]"], Awaitable[None]]]
@@ -89,7 +89,7 @@ class StreamWriter(AbstractStreamWriter):
         self._compress = ZLibCompressor(encoding=encoding, strategy=strategy)
 
     def _write(
-        self, chunk: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]
+        self, chunk: Union[bytes, bytearray, "memoryview[int]", "memoryview[bytes]"]
     ) -> None:
         size = len(chunk)
         self.buffer_size += size
@@ -101,7 +101,7 @@ class StreamWriter(AbstractStreamWriter):
 
     def _writelines(
         self,
-        chunks: Iterable[Union[bytes, bytearray, memoryview[int], memoryview[bytes]]],
+        chunks: Iterable[Union[bytes, bytearray, "memoryview[int]", "memoryview[bytes]"]],
     ) -> None:
         size = 0
         for chunk in chunks:
@@ -118,7 +118,7 @@ class StreamWriter(AbstractStreamWriter):
 
     async def write(
         self,
-        chunk: Union[bytes, bytearray, memoryview[int], memoryview[bytes]],
+        chunk: Union[bytes, bytearray, "memoryview[int]", "memoryview[bytes]"],
         *,
         drain: bool = True,
         LIMIT: int = 0x10000,

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -45,7 +45,11 @@ HttpVersion10 = HttpVersion(1, 0)
 HttpVersion11 = HttpVersion(1, 1)
 
 
-_T_OnChunkSent = Optional[Callable[[Union[bytes, bytearray, memoryview[int], memoryview[bytes]]], Awaitable[None]]]
+_T_OnChunkSent = Optional[
+    Callable[
+        [Union[bytes, bytearray, memoryview[int], memoryview[bytes]]], Awaitable[None]
+    ]
+]
 _T_OnHeadersSent = Optional[Callable[["CIMultiDict[str]"], Awaitable[None]]]
 
 
@@ -84,7 +88,9 @@ class StreamWriter(AbstractStreamWriter):
     ) -> None:
         self._compress = ZLibCompressor(encoding=encoding, strategy=strategy)
 
-    def _write(self, chunk: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]) -> None:
+    def _write(
+        self, chunk: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]
+    ) -> None:
         size = len(chunk)
         self.buffer_size += size
         self.output_size += size
@@ -93,7 +99,10 @@ class StreamWriter(AbstractStreamWriter):
             raise ClientConnectionResetError("Cannot write to closing transport")
         transport.write(chunk)
 
-    def _writelines(self, chunks: Iterable[Union[bytes, bytearray, memoryview[int], memoryview[bytes]]]) -> None:
+    def _writelines(
+        self,
+        chunks: Iterable[Union[bytes, bytearray, memoryview[int], memoryview[bytes]]],
+    ) -> None:
         size = 0
         for chunk in chunks:
             size += len(chunk)

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -47,7 +47,8 @@ HttpVersion11 = HttpVersion(1, 1)
 
 _T_OnChunkSent = Optional[
     Callable[
-        [Union[bytes, bytearray, "memoryview[int]", "memoryview[bytes]"]], Awaitable[None]
+        [Union[bytes, bytearray, "memoryview[int]", "memoryview[bytes]"]],
+        Awaitable[None],
     ]
 ]
 _T_OnHeadersSent = Optional[Callable[["CIMultiDict[str]"], Awaitable[None]]]
@@ -101,7 +102,9 @@ class StreamWriter(AbstractStreamWriter):
 
     def _writelines(
         self,
-        chunks: Iterable[Union[bytes, bytearray, "memoryview[int]", "memoryview[bytes]"]],
+        chunks: Iterable[
+            Union[bytes, bytearray, "memoryview[int]", "memoryview[bytes]"]
+        ],
     ) -> None:
         size = 0
         for chunk in chunks:

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -98,7 +98,7 @@ class StreamWriter(AbstractStreamWriter):
         transport = self._protocol.transport
         if transport is None or transport.is_closing():
             raise ClientConnectionResetError("Cannot write to closing transport")
-        transport.write(chunk)
+        transport.write(chunk)  # type: ignore[arg-type]
 
     def _writelines(
         self,
@@ -117,7 +117,7 @@ class StreamWriter(AbstractStreamWriter):
         if SKIP_WRITELINES or size < MIN_PAYLOAD_FOR_WRITELINES:
             transport.write(b"".join(chunks))
         else:
-            transport.writelines(chunks)
+            transport.writelines(chunks)  # type: ignore[arg-type]
 
     async def write(
         self,

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -656,7 +656,7 @@ class Response(StreamResponse):
         if self._eof_sent:
             return
         if self._compressed_body is None:
-            body: Optional[Union[bytes, bytearray, Payload]] = self._body
+            body = self._body
         else:
             body = self._compressed_body
         assert not data, f"data arg is not supported, got {data!r}"

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -435,7 +435,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         status_line = f"HTTP/{version[0]}.{version[1]} {self._status} {self._reason}"
         await writer.write_headers(status_line, self._headers)
 
-    async def write(self, data: Union[bytes, bytearray, memoryview]) -> None:
+    async def write(self, data: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]) -> None:
         assert isinstance(
             data, (bytes, bytearray, memoryview)
         ), "data argument must be byte-ish (%r)" % type(data)
@@ -580,7 +580,7 @@ class Response(StreamResponse):
         self._zlib_executor = zlib_executor
 
     @property
-    def body(self) -> Optional[Union[bytes, Payload]]:
+    def body(self) -> Optional[Union[bytes, bytearray, Payload]]:
         return self._body
 
     @body.setter
@@ -654,7 +654,7 @@ class Response(StreamResponse):
         if self._eof_sent:
             return
         if self._compressed_body is None:
-            body: Optional[Union[bytes, Payload]] = self._body
+            body: Optional[Union[bytes, bytearray, Payload]] = self._body
         else:
             body = self._compressed_body
         assert not data, f"data arg is not supported, got {data!r}"

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -436,7 +436,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         await writer.write_headers(status_line, self._headers)
 
     async def write(
-        self, data: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]
+        self, data: Union[bytes, bytearray, "memoryview[int]", "memoryview[bytes]"]
     ) -> None:
         assert isinstance(
             data, (bytes, bytearray, memoryview)

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -435,7 +435,9 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         status_line = f"HTTP/{version[0]}.{version[1]} {self._status} {self._reason}"
         await writer.write_headers(status_line, self._headers)
 
-    async def write(self, data: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]) -> None:
+    async def write(
+        self, data: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]
+    ) -> None:
         assert isinstance(
             data, (bytes, bytearray, memoryview)
         ), "data argument must be byte-ish (%r)" % type(data)

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -606,7 +606,7 @@ class WebSocketResponse(StreamResponse):
         data = await self.receive_str(timeout=timeout)
         return loads(data)
 
-    async def write(self, data: bytes) -> None:
+    async def write(self, data: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]) -> None:
         raise RuntimeError("Cannot call .write() for websocket")
 
     def __aiter__(self) -> "WebSocketResponse":

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -607,7 +607,7 @@ class WebSocketResponse(StreamResponse):
         return loads(data)
 
     async def write(
-        self, data: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]
+        self, data: Union[bytes, bytearray, "memoryview[int]", "memoryview[bytes]"]
     ) -> None:
         raise RuntimeError("Cannot call .write() for websocket")
 

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -606,7 +606,9 @@ class WebSocketResponse(StreamResponse):
         data = await self.receive_str(timeout=timeout)
         return loads(data)
 
-    async def write(self, data: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]) -> None:
+    async def write(
+        self, data: Union[bytes, bytearray, memoryview[int], memoryview[bytes]]
+    ) -> None:
         raise RuntimeError("Cannot call .write() for websocket")
 
     def __aiter__(self) -> "WebSocketResponse":


### PR DESCRIPTION
This will be default behaviour in mypy 2, so best to fix it early.

It would be good if anybody else can check over these, the existing code seems a little confused with when it wants bytes only or will allow bytes/bytearray/memoryview.