### PR TITLE
Close the socket if there's a failure in start_connection()

### DIFF
--- a/CHANGES/10464.bugfix.rst
+++ b/CHANGES/10464.bugfix.rst
@@ -1,1 +1,1 @@
-Changed connection creation to explicitly close sockets if an exception is raised in the event loop's ``create_connection`` method.
+Changed connection creation to explicitly close sockets if an exception is raised in the event loop's ``create_connection`` method -- by :user:`top-oai`.

--- a/CHANGES/10464.bugfix.rst
+++ b/CHANGES/10464.bugfix.rst
@@ -1,0 +1,1 @@
+Changed connection creation to explicitly close sockets if an exception is raised in the event loop's ``create_connection`` method.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -43,6 +43,7 @@ Andrej Antonov
 Andrew Leech
 Andrew Lytvyn
 Andrew Svetlov
+Andrew Top
 Andrew Zhou
 Andrii Soldatenko
 Anes Abismail

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1128,6 +1128,9 @@ class TCPConnector(BaseConnector):
             raise client_error(req.connection_key, exc) from exc
         finally:
             if sock is not None:
+                # Will be hit if an exception is thrown before the event loop takes the socket.
+                # In that case, proactively close the socket to guard against event loop leaks.
+                # For example, see https://github.com/MagicStack/uvloop/issues/653.
                 sock.close()
 
     def _warn_about_tls_in_tls(

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1101,7 +1101,7 @@ class TCPConnector(BaseConnector):
         client_error: Type[Exception] = ClientConnectorError,
         **kwargs: Any,
     ) -> Tuple[asyncio.Transport, ResponseHandler]:
-        sock = None
+        sock: Union[socket.socket, None] = None
         try:
             async with ceil_timeout(
                 timeout.sock_connect, ceil_threshold=timeout.ceil_threshold

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1101,6 +1101,7 @@ class TCPConnector(BaseConnector):
         client_error: Type[Exception] = ClientConnectorError,
         **kwargs: Any,
     ) -> Tuple[asyncio.Transport, ResponseHandler]:
+        sock = None
         try:
             async with ceil_timeout(
                 timeout.sock_connect, ceil_threshold=timeout.ceil_threshold
@@ -1112,7 +1113,11 @@ class TCPConnector(BaseConnector):
                     interleave=self._interleave,
                     loop=self._loop,
                 )
-                return await self._loop.create_connection(*args, **kwargs, sock=sock)
+                connection = await self._loop.create_connection(
+                    *args, **kwargs, sock=sock
+                )
+                sock = None
+                return connection
         except cert_errors as exc:
             raise ClientConnectorCertificateError(req.connection_key, exc) from exc
         except ssl_errors as exc:
@@ -1121,6 +1126,9 @@ class TCPConnector(BaseConnector):
             if exc.errno is None and isinstance(exc, asyncio.TimeoutError):
                 raise
             raise client_error(req.connection_key, exc) from exc
+        finally:
+            if sock is not None:
+                sock.close()
 
     def _warn_about_tls_in_tls(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,6 +222,7 @@ def start_connection() -> Iterator[mock.Mock]:
         "aiohttp.connector.aiohappyeyeballs.start_connection",
         autospec=True,
         spec_set=True,
+        return_value=mock.create_autospec(socket.socket, spec_set=True, instance=True),
     ) as start_connection_mock:
         yield start_connection_mock
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -646,6 +646,27 @@ async def test_tcp_connector_certificate_error(
     await conn.close()
 
 
+async def test_tcp_connector_closes_socket_on_error(
+    loop: asyncio.AbstractEventLoop, start_connection: mock.AsyncMock
+) -> None:
+    req = ClientRequest("GET", URL("https://127.0.0.1:443"), loop=loop)
+
+    conn = aiohttp.TCPConnector()
+    with mock.patch.object(
+        conn._loop,
+        "create_connection",
+        autospec=True,
+        spec_set=True,
+        side_effect=ValueError,
+    ):
+        with pytest.raises(ValueError):
+            await conn.connect(req, [], ClientTimeout())
+
+        assert start_connection.return_value.close.called
+
+    await conn.close()
+
+
 async def test_tcp_connector_server_hostname_default(
     loop: asyncio.AbstractEventLoop, start_connection: mock.AsyncMock
 ) -> None:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -652,17 +652,19 @@ async def test_tcp_connector_closes_socket_on_error(
     req = ClientRequest("GET", URL("https://127.0.0.1:443"), loop=loop)
 
     conn = aiohttp.TCPConnector()
-    with mock.patch.object(
-        conn._loop,
-        "create_connection",
-        autospec=True,
-        spec_set=True,
-        side_effect=ValueError,
+    with (
+        mock.patch.object(
+            conn._loop,
+            "create_connection",
+            autospec=True,
+            spec_set=True,
+            side_effect=ValueError,
+        ),
+        pytest.raises(ValueError),
     ):
-        with pytest.raises(ValueError):
-            await conn.connect(req, [], ClientTimeout())
+        await conn.connect(req, [], ClientTimeout())
 
-        assert start_connection.return_value.close.called
+    assert start_connection.return_value.close.called
 
     await conn.close()
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -216,6 +216,7 @@ class TestProxy(unittest.TestCase):
         "aiohttp.connector.aiohappyeyeballs.start_connection",
         autospec=True,
         spec_set=True,
+        return_value=mock.create_autospec(socket.socket, spec_set=True, instance=True),
     )
     def test_proxy_connection_error(self, start_connection: mock.Mock) -> None:
         async def make_conn() -> aiohttp.TCPConnector:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Over in https://github.com/MagicStack/uvloop/issues/653 in issue is described where after upgrading from aiohttp 3.9.5 -> 3.10.5 (but same thing on 3.11.11), under certain conditions where exceptions are raised at the right/wrong time, continued use of `aiohttp` can result in `File descriptor 2877 is used by transport` errors.

I've been able to repro with a small script ([gist](https://gist.github.com/top-oai/9c9769e92f65fcc7e4139c170a14cc2f)) that starts/stops/cancels many connections repeatedly. I can repro on at least Ubuntu 24 x86, aiohttp 3.11.11 and uvloop 0.21.0. This fix resolves the errors in my repro script.

I was unable to produce a detailed end-to-end explanation for what's happening here, but I do know that we enter the error state when an exception is thrown while inside of uvloop's `create_connection` function, here:

https://github.com/MagicStack/uvloop/blob/7bb12a174884b2ec8b3162a08564e5fb8a5c6b39/uvloop/loop.pyx#L2066

In that case, if `sock.close()` is not called (this pr changes that), uvloop seems to erroneously hold on to a ref to the transport when the underlying file descriptor has been relinquished to the os.

It feels like at its core a bug in uvloop, however this at least works around it in `aiohttp`.

## Are there changes in behavior for the user?

No... Aside from this error not reproducing.

## Is it a substantial burden for the maintainers to support this?

Unless I've made a mistake (it is a very small change though), I think this is a pure bug fix.

## Related issue number

https://github.com/MagicStack/uvloop/issues/653

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
