### PR TITLE
[PR #10481/60819de backport][3.12] Bump blockbuster to 1.5.22 (#10481)

### DIFF
--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -10,7 +10,7 @@ annotated-types==0.7.0
     # via pydantic
 async-timeout==5.0.1
     # via valkey
-blockbuster==1.5.21
+blockbuster==1.5.22
     # via -r requirements/lint.in
 cffi==1.17.1
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,7 +16,7 @@ async-timeout==5.0.1 ; python_version < "3.11"
     # via -r requirements/runtime-deps.in
 attrs==25.1.0
     # via -r requirements/runtime-deps.in
-blockbuster==1.5.21
+blockbuster==1.5.22
     # via -r requirements/test.in
 brotli==1.1.0 ; platform_python_implementation == "CPython"
     # via -r requirements/runtime-deps.in

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,6 @@ def blockbuster(request):
             bb.functions[func].can_block_in(
                 "aiohttp/web_urldispatcher.py", "add_static"
             )
-        bb.functions["os.getcwd"].can_block_in("coverage/control.py", "_should_trace")
         yield
 
 


### PR DESCRIPTION
Backport PR https://github.com/aio-libs/aiohttp/pull/10481

(cherry picked from commit 60819de0e383409cdf34244d14e80bc429819fdc)
