### PR TITLE
Fixed bug that lead to infinite wait for dns futures

### DIFF
--- a/CHANGES/10529.bugfix.rst
+++ b/CHANGES/10529.bugfix.rst
@@ -1,2 +1,2 @@
-Fixed an issue where dns queries were delayed indefinitely when an exception occurred in a ``tracer.send_dns_cache_miss``
+Fixed an issue where dns queries were delayed indefinitely when an exception occurred in a ``trace.send_dns_cache_miss``
 -- by :user:`logioniz`.

--- a/CHANGES/10529.bugfix.rst
+++ b/CHANGES/10529.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed an issue where dns queries were delayed indefinitely when an exception occurred in a ``tracer.send_dns_cache_miss``
+-- by :user:`logioniz`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -31,6 +31,7 @@ Alexandru Mihai
 Alexey Firsov
 Alexey Nikitin
 Alexey Popravka
+Alexey Stavrov
 Alexey Stepanov
 Almaz Salakhov
 Amin Etesamian

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1023,7 +1023,6 @@ class TCPConnector(BaseConnector):
                 for trace in traces:
                     await trace.send_dns_cache_miss(host)
 
-            if traces:
                 for trace in traces:
                     await trace.send_dns_resolvehost_start(host)
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1018,10 +1018,11 @@ class TCPConnector(BaseConnector):
         This method must be run in a task and shielded from cancellation
         to avoid cancelling the underlying lookup.
         """
-        if traces:
-            for trace in traces:
-                await trace.send_dns_cache_miss(host)
         try:
+            if traces:
+                for trace in traces:
+                    await trace.send_dns_cache_miss(host)
+
             if traces:
                 for trace in traces:
                     await trace.send_dns_resolvehost_start(host)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3720,7 +3720,7 @@ async def test_connector_resolve_in_case_of_trace_cache_miss_exception(
             if request_count <= 1:
                 raise Exception("first attempt")
 
-    async def resolve_response():
+    async def resolve_response() -> List[ResolveResult]:
         await asyncio.sleep(0)
         return [token]
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3702,17 +3702,17 @@ async def test_connector_resolve_in_case_of_trace_cache_miss_exception(
             """Dummy"""
 
         async def send_dns_cache_hit(self, *args: object, **kwargs: object) -> None:
-            pass
+            """Dummy send_dns_cache_hit"""
 
         async def send_dns_resolvehost_start(
             self, *args: object, **kwargs: object
         ) -> None:
-            pass
+            """Dummy send_dns_resolvehost_start"""
 
         async def send_dns_resolvehost_end(
             self, *args: object, **kwargs: object
         ) -> None:
-            pass
+            """Dummy send_dns_resolvehost_end"""
 
         async def send_dns_cache_miss(self, *args: object, **kwargs: object) -> None:
             nonlocal request_count


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixed bug that lead to infinite wait for dns futures when exception occured in trace.send_dns_cache_miss call.

## Are there changes in behavior for the user?

No

## Is it a substantial burden for the maintainers to support this?

No

## Related issue number

No issue. 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```


