### PR TITLE
Fallback to ThreadedResolver if aiodns has no nameservers

### DIFF
--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -6,6 +6,7 @@ from .abc import AbstractResolver, ResolveResult
 
 __all__ = ("ThreadedResolver", "AsyncResolver", "DefaultResolver")
 
+
 try:
     import aiodns
     import pycares
@@ -18,6 +19,7 @@ try:
 except Exception:  # may raise ImportError or AresError
     aiodns = None  # type: ignore[assignment]
     aiodns_default = False
+
 
 _NUMERIC_SOCKET_FLAGS = socket.AI_NUMERICHOST | socket.AI_NUMERICSERV
 _NAME_SOCKET_FLAGS = socket.NI_NUMERICHOST | socket.NI_NUMERICSERV
@@ -146,5 +148,4 @@ class AsyncResolver(AbstractResolver):
 
 
 _DefaultType = Type[Union[AsyncResolver, ThreadedResolver]]
-
 DefaultResolver: _DefaultType = AsyncResolver if aiodns_default else ThreadedResolver

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -9,4 +9,5 @@ brotlicffi; platform_python_implementation != 'CPython'
 frozenlist >= 1.1.1
 multidict >=4.5, < 7.0
 propcache >= 0.2.0
+pycares >= 4.0.0; sys_platform=="linux" or sys_platform=="darwin"
 yarl >= 1.17.0, < 2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -68,6 +68,7 @@ install_requires =
 speedups =
   # required c-ares (aiodns' backend) will not build on windows
   aiodns >= 3.2.0; sys_platform=="linux" or sys_platform=="darwin"
+  pycares >= 4.0.0; sys_platform=="linux" or sys_platform=="darwin"
   Brotli; platform_python_implementation == 'CPython'
   brotlicffi; platform_python_implementation != 'CPython'
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fallback to ThreadedResolver if aiodns has no nameservers

## Are there changes in behavior for the user?

aiodns won't be used if there are no nameservers

## Is it a substantial burden for the maintainers to support this?

no
## Related issue number

fixes #10519
## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
