### PR TITLE
Re-raise OSError as ClientConnectionError when failing to explicitly close connector socket

### DIFF
--- a/CHANGES/10551.bugfix.rst
+++ b/CHANGES/10551.bugfix.rst
@@ -1,1 +1,1 @@
-The connector now raises :exc:`aiohttp.ClientConnectionError` instead of :exc:`OSError` when failing to explicitly close the socket after ``loop.create_connection`` fails -- by :user:`bdraco`.
+The connector now raises :exc:`aiohttp.ClientConnectionError` instead of :exc:`OSError` when failing to explicitly close the socket after :py:func:`asyncio.loop.create_connection` fails -- by :user:`bdraco`.

--- a/CHANGES/10551.bugfix.rst
+++ b/CHANGES/10551.bugfix.rst
@@ -1,0 +1,1 @@
+The connector now raises :exc:`aiohttp.ClientConnectionError` instead of :exc:`OSError` when failing to explicitly close the socket after ``loop.create_connection`` fails -- by :user:`bdraco`.

--- a/CHANGES/10551.bugfix.rst
+++ b/CHANGES/10551.bugfix.rst
@@ -1,1 +1,1 @@
-The connector now raises :exc:`aiohttp.ClientConnectionError` instead of :exc:`OSError` when failing to explicitly close the socket after :py:func:`asyncio.loop.create_connection` fails -- by :user:`bdraco`.
+The connector now raises :exc:`aiohttp.ClientConnectionError` instead of :exc:`OSError` when failing to explicitly close the socket after :py:meth:`asyncio.loop.create_connection` fails -- by :user:`bdraco`.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1143,7 +1143,10 @@ class TCPConnector(BaseConnector):
                 # Will be hit if an exception is thrown before the event loop takes the socket.
                 # In that case, proactively close the socket to guard against event loop leaks.
                 # For example, see https://github.com/MagicStack/uvloop/issues/653.
-                sock.close()
+                try:
+                    sock.close()
+                except OSError as exc:
+                    raise client_error(req.connection_key, exc) from exc
 
     def _warn_about_tls_in_tls(
         self,

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -669,6 +669,33 @@ async def test_tcp_connector_closes_socket_on_error(
     await conn.close()
 
 
+async def test_tcp_connector_closes_socket_on_error_results_in_another_error(
+    loop: asyncio.AbstractEventLoop, start_connection: mock.AsyncMock
+) -> None:
+    """Test that when error occurs while closing the socket."""
+    req = ClientRequest("GET", URL("https://127.0.0.1:443"), loop=loop)
+    start_connection.return_value.close.side_effect = OSError(
+        1, "error from closing socket"
+    )
+
+    conn = aiohttp.TCPConnector()
+    with (
+        mock.patch.object(
+            conn._loop,
+            "create_connection",
+            autospec=True,
+            spec_set=True,
+            side_effect=ValueError,
+        ),
+        pytest.raises(aiohttp.ClientConnectionError, match="error from closing socket"),
+    ):
+        await conn.connect(req, [], ClientTimeout())
+
+    assert start_connection.return_value.close.called
+
+    await conn.close()
+
+
 async def test_tcp_connector_server_hostname_default(
     loop: asyncio.AbstractEventLoop, start_connection: mock.AsyncMock
 ) -> None:


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

This is a followup to #10464 to handle the case where `socket.close()` can also raise. This matches the logic we have in aiohappyeyeballs:

https://github.com/aio-libs/aiohappyeyeballs/blob/e3bd5bdf44f5d187802de6dcb08d27e1ca6da048/src/aiohappyeyeballs/impl.py#L227

We shouldn't raising `OSError` externally from this method as callers expect a `ClientError`


## Are there changes in behavior for the user?

bugfix

## Is it a substantial burden for the maintainers to support this?

no

## Related issue number

fixes #10506

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
