### PR TITLE
Cache parsing of the content-type

### DIFF
--- a/CHANGES/10552.misc.rst
+++ b/CHANGES/10552.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of parsing content types by adding a cache in the same manner currently done with mime types -- by :user:`bdraco`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -372,6 +372,9 @@ def parse_content_type(raw: str) -> Tuple[str, Dict[str, str]]:
     """Parse Content-Type header.
 
     Returns a tuple of the parsed content type and a dictionary of parameters.
+
+    Callers should be careful to make a copy of the returned dictionary if
+    they need to modify it, as the dictionary is shared between calls.
     """
     msg = HeaderParser().parsestr(f"Content-Type: {raw}")
     content_type = msg.get_content_type()

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -746,7 +746,11 @@ class HeadersMixin:
             self._content_type = "application/octet-stream"
             self._content_dict = {}
         else:
-            self._content_type, self._content_dict = parse_content_type(raw)
+            content_type, content_dict = parse_content_type(raw)
+            self._content_type = content_type
+            # _content_dict is mutable, so we need to copy it
+            # to avoid pollution of the original dict
+            self._content_dict = content_dict.copy()
 
     @property
     def content_type(self) -> str:


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

When profiling some frequent POST requests, I found the bulk of the time was spent parsing the content-type string. Use the same strategy as we do for `parse_mimetype` to cache the parsing.

## Are there changes in behavior for the user?

performance improvement

## Is it a substantial burden for the maintainers to support this?

no

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.

<img width="570" alt="Screenshot 2025-03-15 at 11 25 10 AM" src="https://github.com/user-attachments/assets/cabaaa7c-3a39-4f90-b450-a6a0559d22d6" />

