### PR TITLE
Add benchmark for JSON post requests that check the content type

### DIFF
--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -319,3 +319,30 @@ def test_one_hundred_simple_post_requests(
     @benchmark
     def _run() -> None:
         loop.run_until_complete(run_client_benchmark())
+
+
+def test_one_hundred_json_post_requests(
+    loop: asyncio.AbstractEventLoop,
+    aiohttp_client: AiohttpClient,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark 100 JSON POST requests that check the content-type."""
+    message_count = 100
+
+    async def handler(request: web.Request) -> web.Response:
+        _ = request.content_type
+        _ = request.charset
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_route("POST", "/", handler)
+
+    async def run_client_benchmark() -> None:
+        client = await aiohttp_client(app)
+        for _ in range(message_count):
+            await client.post("/", json={"key": "value"})
+        await client.close()
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_client_benchmark())


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add benchmark for JSON post requests that check the content type

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no