### PR TITLE
Log offending websocket client address when no protocols overlap

### DIFF
--- a/CHANGES/10564.feature.rst
+++ b/CHANGES/10564.feature.rst
@@ -1,0 +1,1 @@
+Improved logging on non-overlapping WebSocket client protocols to include the remote address -- by :user:`bdraco`.

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -256,7 +256,8 @@ class WebSocketResponse(StreamResponse):
             else:
                 # No overlap found: Return no protocol as per spec
                 ws_logger.warning(
-                    "Client protocols %r don’t overlap server-known ones %r",
+                    "%s: Client protocols %r don’t overlap server-known ones %r",
+                    request.remote,
                     req_protocols,
                     self._protocols,
                 )

--- a/tests/test_websocket_handshake.py
+++ b/tests/test_websocket_handshake.py
@@ -175,7 +175,7 @@ async def test_handshake_protocol_unsupported(caplog: pytest.LogCaptureFixture) 
 
     assert (
         caplog.records[-1].msg
-        == "Client protocols %r don’t overlap server-known ones %r"
+        == "%s: Client protocols %r don’t overlap server-known ones %r"
     )
     assert ws.ws_protocol is None
 


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

Logs the remote address of a WebSocket client that has no overlapping protocols

## Are there changes in behavior for the user?

Which client has the problem should be a bit more discoverable

## Is it a substantial burden for the maintainers to support this?

no
## Related issue number
closes #10563
