### PR TITLE
Break cyclic references when a MatchInfoError occurs

### DIFF
--- a/tests/isolated/check_for_system_route_leak.py
+++ b/tests/isolated/check_for_system_route_leak.py
@@ -1,0 +1,41 @@
+import asyncio
+import gc
+import sys
+from typing import NoReturn
+
+from aiohttp import ClientSession, web
+from aiohttp.test_utils import get_unused_port_socket
+
+gc.set_debug(gc.DEBUG_LEAK)
+
+
+async def main() -> None:
+    app = web.Application()
+
+    async def handler(request: web.Request) -> NoReturn:
+        """Handler will never be called."""
+
+    app.router.add_route("POST", "/json", handler)
+    sock = get_unused_port_socket("127.0.0.1")
+    port = sock.getsockname()[1]
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.SockSite(runner, sock)
+    await site.start()
+
+    async with ClientSession() as session:
+        # Make a GET request to the server, which expects a POST request
+        async with session.get(f"http://127.0.0.1:{port}/json") as resp:
+            await resp.read()
+
+    # Give time for the cancelled task to be collected
+    await asyncio.sleep(0.5)
+    gc.collect()
+    request_present = any(type(obj).__name__ == "SystemRoute" for obj in gc.garbage)
+    await session.close()
+    await runner.cleanup()
+    sys.exit(1 if request_present else 0)
+
+
+asyncio.run(main())

--- a/tests/isolated/check_for_system_route_leak.py
+++ b/tests/isolated/check_for_system_route_leak.py
@@ -14,6 +14,7 @@ async def main() -> None:
 
     async def handler(request: web.Request) -> NoReturn:
         """Handler will never be called."""
+        assert False
 
     app.router.add_route("POST", "/json", handler)
     sock = get_unused_port_socket("127.0.0.1")

--- a/tests/test_leaks.py
+++ b/tests/test_leaks.py
@@ -40,3 +40,20 @@ def test_request_does_not_leak_when_request_handler_raises() -> None:
         stdout=subprocess.PIPE,
     ) as proc:
         assert proc.wait() == 0, "Request leaked"
+
+
+@pytest.mark.skipif(IS_PYPY, reason="gc.DEBUG_LEAK not available on PyPy")
+def test_system_route_does_not_leak() -> None:
+    """Test that the SystemRoute object is collected on MatchInfoError
+
+    https://github.com/aio-libs/aiohttp/issues/10548
+    """
+    leak_test_script = pathlib.Path(__file__).parent.joinpath(
+        "isolated", "check_for_system_route_leak.py"
+    )
+
+    with subprocess.Popen(
+        [sys.executable, "-u", str(leak_test_script)],
+        stdout=subprocess.PIPE,
+    ) as proc:
+        assert proc.wait() == 0, "SystemRoute leaked"


### PR DESCRIPTION
I haven't figure out how to fix this one yet.  If I can't, I'll merge the test as xfail
https://github.com/aio-libs/aiohttp/issues/10548#issuecomment-2727603670

<!-- Thank you for your contribution! -->

## What do these changes do?

Break cyclic references when a MatchInfoError occurs

## Are there changes in behavior for the user?

fixes a potential memory leak
## Is it a substantial burden for the maintainers to support this?
no