### PR TITLE
Workaround race to remove writer in SelectorEventLoop sock_connect

### DIFF
--- a/CHANGES/10624.bugfix.rst
+++ b/CHANGES/10624.bugfix.rst
@@ -1,0 +1,1 @@
+Workaround a race in ``loop.sock_connect`` where the socket writer was not removed before the function returned if it was cancelled which could have resulted in attempting to reuse a file descriptor -- by :user:`bdraco`.

--- a/CHANGES/10624.bugfix.rst
+++ b/CHANGES/10624.bugfix.rst
@@ -1,1 +1,1 @@
-Worked around a race in ``loop.sock_connect`` where the socket writer was not removed before the function returned if it was canceled, which could have resulted in attempting to reuse a file descriptor -- by :user:`bdraco`.
+Worked around a race in :py:meth:`asyncio.loop.sock_connect` where the socket writer was not removed before the function returned if it was canceled, which could have resulted in attempting to reuse a file descriptor -- by :user:`bdraco`.

--- a/CHANGES/10624.bugfix.rst
+++ b/CHANGES/10624.bugfix.rst
@@ -1,1 +1,1 @@
-Workaround a race in ``loop.sock_connect`` where the socket writer was not removed before the function returned if it was cancelled which could have resulted in attempting to reuse a file descriptor -- by :user:`bdraco`.
+Worked around a race in ``loop.sock_connect`` where the socket writer was not removed before the function returned if it was canceled, which could have resulted in attempting to reuse a file descriptor -- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Workaround race to remove writer in SelectorEventLoop `sock_connect`
https://github.com/python/cpython/issues/131728

## Are there changes in behavior for the user?

bugfix

## Is it a substantial burden for the maintainers to support this?

This code path has been ripe with cancellation problems and race conditions.  However I don't see a way to do it better with asyncio.

## Related issue number

fixes https://github.com/aio-libs/aiohttp/issues/10617


## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
