### PR TITLE
Improve performance of serializing headers

### DIFF
--- a/CHANGES/10625.misc.rst
+++ b/CHANGES/10625.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of serializing headers -- by :user:`bdraco`.

--- a/aiohttp/_http_writer.pyx
+++ b/aiohttp/_http_writer.pyx
@@ -125,7 +125,6 @@ def _serialize_headers(str status_line, headers):
     cdef Writer writer
     cdef object key
     cdef object val
-    cdef bytes ret
 
     _init_writer(&writer)
 

--- a/aiohttp/_http_writer.pyx
+++ b/aiohttp/_http_writer.pyx
@@ -126,8 +126,6 @@ def _serialize_headers(str status_line, headers):
     cdef object key
     cdef object val
     cdef bytes ret
-    cdef str key_str
-    cdef str val_str
 
     _init_writer(&writer)
 

--- a/aiohttp/_http_writer.pyx
+++ b/aiohttp/_http_writer.pyx
@@ -111,7 +111,9 @@ cdef inline int _write_str_raise_nlcr(Writer* writer, str s):
 
 # --------------- _serialize_headers ----------------------
 
-cdef str to_str(object s):
+cdef inline str to_str(object s):
+    if type(s) is str:
+        return <str>s
     if type(s) is _istr:
         return PyObject_Str(s)
     elif not isinstance(s, str):
@@ -140,19 +142,13 @@ def _serialize_headers(str status_line, headers):
             raise
 
         for key, val in headers.items():
-            if _write_str_raise_nlcr(
-                &writer,
-                <str>key if type(key) is str else to_str(key)
-            ) < 0:
+            if _write_str_raise_nlcr(&writer, to_str(key)) < 0:
                 raise
             if _write_byte(&writer, b':') < 0:
                 raise
             if _write_byte(&writer, b' ') < 0:
                 raise
-            if _write_str_raise_nlcr(
-                &writer,
-                <str>val if type(val) is str else to_str(val)
-            ) < 0:
+            if _write_str_raise_nlcr(&writer, to_str(val)) < 0:
                 raise
             if _write_byte(&writer, b'\r') < 0:
                 raise

--- a/aiohttp/_http_writer.pyx
+++ b/aiohttp/_http_writer.pyx
@@ -112,8 +112,8 @@ cdef inline int _write_str_raise_on_nlcr(Writer* writer, object s):
     for ch in out_str:
         if ch == 0x0D or ch == 0x0A:
             raise ValueError(
-                "Newline or carriage return character detected in HTTP status message or "
-                "header. This is a potential security issue."
+                "Newline or carriage return detected in headers. "
+                "Potential header injection attack."
             )
         if _write_utf8(writer, ch) < 0:
             return -1

--- a/aiohttp/_http_writer.pyx
+++ b/aiohttp/_http_writer.pyx
@@ -97,7 +97,7 @@ cdef inline int _write_str(Writer* writer, str s):
             return -1
 
 
-cdef inline int _write_or_raise_nlcr(Writer* writer, object s):
+cdef inline int _write_str_raise_on_nlcr(Writer* writer, object s):
     cdef Py_UCS4 ch
     cdef str out_str
     if type(s) is str:
@@ -137,13 +137,13 @@ def _serialize_headers(str status_line, headers):
             raise
 
         for key, val in headers.items():
-            if _write_or_raise_nlcr(&writer, key) < 0:
+            if _write_str_raise_on_nlcr(&writer, key) < 0:
                 raise
             if _write_byte(&writer, b':') < 0:
                 raise
             if _write_byte(&writer, b' ') < 0:
                 raise
-            if _write_or_raise_nlcr(&writer, val) < 0:
+            if _write_str_raise_on_nlcr(&writer, val) < 0:
                 raise
             if _write_byte(&writer, b'\r') < 0:
                 raise

--- a/aiohttp/_http_writer.pyx
+++ b/aiohttp/_http_writer.pyx
@@ -97,19 +97,19 @@ cdef inline int _write_str(Writer* writer, str s):
             return -1
 
 
-cdef inline int _write_or_raise_nlcr(Writer* writer, object in_str):
+cdef inline int _write_or_raise_nlcr(Writer* writer, object s):
     cdef Py_UCS4 ch
-    cdef str s
-    if type(in_str) is str:
-        s = <str>in_str
-    elif type(in_str) is _istr:
-        s = PyObject_Str(in_str)
-    elif not isinstance(in_str, str):
-        raise TypeError("Cannot serialize non-str key {!r}".format(in_str))
+    cdef str out_str
+    if type(s) is str:
+        out_str = <str>s
+    elif type(s) is _istr:
+        out_str = PyObject_Str(s)
+    elif not isinstance(s, str):
+        raise TypeError("Cannot serialize non-str key {!r}".format(s))
     else:
-        s = str(in_str)
+        out_str = str(s)
 
-    for ch in s:
+    for ch in out_str:
         if ch == 0x0D or ch == 0x0A:
             raise ValueError(
                 "Newline or carriage return character detected in HTTP status message or "

--- a/aiohttp/_http_writer.pyx
+++ b/aiohttp/_http_writer.pyx
@@ -112,9 +112,7 @@ cdef inline int _write_str_raise_nlcr(Writer* writer, str s):
 # --------------- _serialize_headers ----------------------
 
 cdef str to_str(object s):
-    if type(s) is str:
-        return <str>s
-    elif type(s) is _istr:
+    if type(s) is _istr:
         return PyObject_Str(s)
     elif not isinstance(s, str):
         raise TypeError("Cannot serialize non-str key {!r}".format(s))
@@ -142,16 +140,19 @@ def _serialize_headers(str status_line, headers):
             raise
 
         for key, val in headers.items():
-            key_str = to_str(key)
-            val_str = to_str(val)
-
-            if _write_str_raise_nlcr(&writer, key_str) < 0:
+            if _write_str_raise_nlcr(
+                &writer,
+                <str>key if type(key) is str else to_str(key)
+            ) < 0:
                 raise
             if _write_byte(&writer, b':') < 0:
                 raise
             if _write_byte(&writer, b' ') < 0:
                 raise
-            if _write_str_raise_nlcr(&writer, val_str) < 0:
+            if _write_str_raise_nlcr(
+                &writer,
+                <str>val if type(val) is str else to_str(val)
+            ) < 0:
                 raise
             if _write_byte(&writer, b'\r') < 0:
                 raise

--- a/aiohttp/_http_writer.pyx
+++ b/aiohttp/_http_writer.pyx
@@ -102,7 +102,7 @@ cdef inline int _write_or_raise_nlcr(Writer* writer, object in_str):
     cdef str s
     if type(in_str) is str:
         s = <str>in_str
-    if type(in_str) is _istr:
+    elif type(in_str) is _istr:
         s = PyObject_Str(in_str)
     elif not isinstance(in_str, str):
         raise TypeError("Cannot serialize non-str key {!r}".format(in_str))

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -8,8 +8,9 @@ from unittest import mock
 import pytest
 from multidict import CIMultiDict
 
-from aiohttp import ClientConnectionResetError, http
+from aiohttp import ClientConnectionResetError, hdrs, http
 from aiohttp.base_protocol import BaseProtocol
+from aiohttp.http_writer import _serialize_headers
 from aiohttp.test_utils import make_mocked_coro
 
 
@@ -603,3 +604,29 @@ async def test_set_eof_after_write_headers(
     msg.set_eof()
     await msg.write_eof()
     assert not transport.write.called
+
+
+@pytest.mark.parametrize(
+    "char",
+    [
+        "\n",
+        "\r",
+    ],
+)
+def test_serialize_headers_raises_on_new_line_or_carriage_return(char: str) -> None:
+    """Verify serialize_headers raises on cr or nl in the headers."""
+    status_line = "HTTP/1.1 200 OK"
+    headers = CIMultiDict(
+        {
+            hdrs.CONTENT_TYPE: f"text/plain{char}",
+        }
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "Newline or carriage return character detected in HTTP status message or "
+            "header. This is a potential security issue."
+        ),
+    ):
+        _serialize_headers(status_line, headers)

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -625,8 +625,8 @@ def test_serialize_headers_raises_on_new_line_or_carriage_return(char: str) -> N
     with pytest.raises(
         ValueError,
         match=(
-            "Newline or carriage return character detected in HTTP status message or "
-            "header. This is a potential security issue."
+            "Newline or carriage return detected in headers. "
+            "Potential header injection attack."
         ),
     ):
         _serialize_headers(status_line, headers)


### PR DESCRIPTION
Improve performance of serializing headers by moving the check for `\r` and `\n` into the write loop instead of making a separate call to check each disallowed character in the Python string.