### PR TITLE
Replace deprecated `asyncio.iscoroutinefunction` with its counterpart from `inspect`

### DIFF
--- a/CHANGES/10634.bugfix.rst
+++ b/CHANGES/10634.bugfix.rst
@@ -1,0 +1,2 @@
+Replaced deprecated ``asyncio.iscoroutinefunction`` with its counterpart from ``inspect``
+-- by :user:`layday`.

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -106,7 +106,7 @@ def pytest_fixture_setup(fixturedef):  # type: ignore[no-untyped-def]
     if inspect.isasyncgenfunction(func):
         # async generator fixture
         is_async_gen = True
-    elif asyncio.iscoroutinefunction(func):
+    elif inspect.iscoroutinefunction(func):
         # regular async fixture
         is_async_gen = False
     else:
@@ -216,14 +216,14 @@ def _passthrough_loop_context(
 
 def pytest_pycollect_makeitem(collector, name, obj):  # type: ignore[no-untyped-def]
     """Fix pytest collecting for coroutines."""
-    if collector.funcnamefilter(name) and asyncio.iscoroutinefunction(obj):
+    if collector.funcnamefilter(name) and inspect.iscoroutinefunction(obj):
         return list(collector._genfunctions(name, obj))
 
 
 def pytest_pyfunc_call(pyfuncitem):  # type: ignore[no-untyped-def]
     """Run coroutines in an event loop instead of a normal function call."""
     fast = pyfuncitem.config.getoption("--aiohttp-fast")
-    if asyncio.iscoroutinefunction(pyfuncitem.function):
+    if inspect.iscoroutinefunction(pyfuncitem.function):
         existing_loop = pyfuncitem.funcargs.get(
             "proactor_loop"
         ) or pyfuncitem.funcargs.get("loop", None)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -175,13 +175,17 @@ class AbstractRoute(abc.ABC):
         if expect_handler is None:
             expect_handler = _default_expect_handler
 
-        assert inspect.iscoroutinefunction(expect_handler) or (sys.version_info < (3, 14) and asyncio.iscoroutinefunction(expect_handler)), f"Coroutine is expected, got {expect_handler!r}"
+        assert inspect.iscoroutinefunction(expect_handler) or (
+            sys.version_info < (3, 14) and asyncio.iscoroutinefunction(expect_handler)
+        ), f"Coroutine is expected, got {expect_handler!r}"
 
         method = method.upper()
         if not HTTP_METHOD_RE.match(method):
             raise ValueError(f"{method} is not allowed HTTP method")
 
-        if inspect.iscoroutinefunction(handler) or (sys.version_info < (3, 14) and asyncio.iscoroutinefunction(handler)):
+        if inspect.iscoroutinefunction(handler) or (
+            sys.version_info < (3, 14) and asyncio.iscoroutinefunction(handler)
+        ):
             pass
         elif isinstance(handler, type) and issubclass(handler, AbstractView):
             pass

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -175,15 +175,13 @@ class AbstractRoute(abc.ABC):
         if expect_handler is None:
             expect_handler = _default_expect_handler
 
-        assert inspect.iscoroutinefunction(
-            expect_handler
-        ), f"Coroutine is expected, got {expect_handler!r}"
+        assert inspect.iscoroutinefunction(expect_handler) or (sys.version_info < (3, 14) and asyncio.iscoroutinefunction(expect_handler)), f"Coroutine is expected, got {expect_handler!r}"
 
         method = method.upper()
         if not HTTP_METHOD_RE.match(method):
             raise ValueError(f"{method} is not allowed HTTP method")
 
-        if inspect.iscoroutinefunction(handler):
+        if inspect.iscoroutinefunction(handler) or (sys.version_info < (3, 14) and asyncio.iscoroutinefunction(handler)):
             pass
         elif isinstance(handler, type) and issubclass(handler, AbstractView):
             pass

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -4,6 +4,7 @@ import base64
 import functools
 import hashlib
 import html
+import inspect
 import keyword
 import os
 import re
@@ -174,7 +175,7 @@ class AbstractRoute(abc.ABC):
         if expect_handler is None:
             expect_handler = _default_expect_handler
 
-        assert asyncio.iscoroutinefunction(
+        assert inspect.iscoroutinefunction(
             expect_handler
         ), f"Coroutine is expected, got {expect_handler!r}"
 
@@ -182,7 +183,7 @@ class AbstractRoute(abc.ABC):
         if not HTTP_METHOD_RE.match(method):
             raise ValueError(f"{method} is not allowed HTTP method")
 
-        if asyncio.iscoroutinefunction(handler):
+        if inspect.iscoroutinefunction(handler):
             pass
         elif isinstance(handler, type) and issubclass(handler, AbstractView):
             pass

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -69,7 +69,7 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
         runner = None
         if isinstance(self.wsgi, Application):
             app = self.wsgi
-        elif inspect.iscoroutinefunction(self.wsgi):
+        elif inspect.iscoroutinefunction(self.wsgi)  or (sys.version_info < (3, 14) and asyncio.iscoroutinefunction(self.wsgi)):
             wsgi = await self.wsgi()
             if isinstance(wsgi, web.AppRunner):
                 runner = wsgi

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -1,6 +1,7 @@
 """Async gunicorn worker for aiohttp.web"""
 
 import asyncio
+import inspect
 import os
 import re
 import signal
@@ -68,7 +69,7 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
         runner = None
         if isinstance(self.wsgi, Application):
             app = self.wsgi
-        elif asyncio.iscoroutinefunction(self.wsgi):
+        elif inspect.iscoroutinefunction(self.wsgi):
             wsgi = await self.wsgi()
             if isinstance(wsgi, web.AppRunner):
                 runner = wsgi

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -69,7 +69,9 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
         runner = None
         if isinstance(self.wsgi, Application):
             app = self.wsgi
-        elif inspect.iscoroutinefunction(self.wsgi)  or (sys.version_info < (3, 14) and asyncio.iscoroutinefunction(self.wsgi)):
+        elif inspect.iscoroutinefunction(self.wsgi) or (
+            sys.version_info < (3, 14) and asyncio.iscoroutinefunction(self.wsgi)
+        ):
             wsgi = await self.wsgi()
             if isinstance(wsgi, web.AppRunner):
                 runner = wsgi


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Replace `asyncio.iscoroutinefunction` with `inspect.iscoroutinefunction`

`asyncio.iscoroutinefunction` was deprecated in https://github.com/python/cpython/pull/122875.

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
