### PR TITLE
Fix headers being mutated if passed to web.Response as a CIMultiDict

### DIFF
--- a/CHANGES/10672.bugfix.rst
+++ b/CHANGES/10672.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :class:`multidict.CIMultiDict` being mutated when passed to :class:`aiohttp.web.Response` -- by :user:`bdraco`.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -532,10 +532,8 @@ class Response(StreamResponse):
 
         if headers is None:
             real_headers: CIMultiDict[str] = CIMultiDict()
-        elif not isinstance(headers, CIMultiDict):
-            real_headers = CIMultiDict(headers)
         else:
-            real_headers = headers  # = cast('CIMultiDict[str]', headers)
+            real_headers = CIMultiDict(headers)
 
         if content_type is not None and "charset" in content_type:
             raise ValueError("charset must not be in content_type argument")

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -1393,7 +1393,6 @@ async def test_passing_cimultidict_to_web_response_not_mutated(
     req = make_request("GET", "/")
     headers = loose_header_type({})
     resp = web.Response(body=b"answer", headers=headers)
-    resp.enable_compression(web.ContentCoding.identity)
     await resp.prepare(req)
     assert resp.content_length == 6
     assert not headers

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -12,7 +12,7 @@ from unittest import mock
 
 import aiosignal
 import pytest
-from multidict import CIMultiDict, CIMultiDictProxy
+from multidict import CIMultiDict, CIMultiDictProxy, MultiDict
 
 from aiohttp import HttpVersion, HttpVersion10, HttpVersion11, hdrs, web
 from aiohttp.abc import AbstractStreamWriter
@@ -1384,3 +1384,16 @@ async def test_warn_large_cookie(buf: bytearray, writer: AbstractStreamWriter) -
     assert match is not None
     cookie = match.group(1)
     assert len(cookie) == 4097
+
+
+@pytest.mark.parametrize("loose_header_type", (MultiDict, CIMultiDict, dict))
+async def test_passing_cimultidict_to_web_response_not_mutated(
+    loose_header_type: type,
+) -> None:
+    req = make_request("GET", "/")
+    headers = loose_header_type({})
+    resp = web.Response(body=b"answer", headers=headers)
+    resp.enable_compression(web.ContentCoding.identity)
+    await resp.prepare(req)
+    assert resp.content_length == 6
+    assert not headers


### PR DESCRIPTION
## What do these changes do?

If `CIMultiDict` is passed in we need to make a copy to avoid mutating it.   In some cases we used to copy these twice which was fixed in #10045 but for this case that was the only copy being made and the source of this regression.

fixes #10670
