### PR TITLE
[PR #10672/35c979b backport][3.12] Fix headers being mutated if passed to web.Response as a CIMultiDict

### DIFF
--- a/CHANGES/10672.bugfix.rst
+++ b/CHANGES/10672.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :class:`multidict.CIMultiDict` being mutated when passed to :class:`aiohttp.web.Response` -- by :user:`bdraco`.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -639,10 +639,8 @@ class Response(StreamResponse):
 
         if headers is None:
             real_headers: CIMultiDict[str] = CIMultiDict()
-        elif not isinstance(headers, CIMultiDict):
-            real_headers = CIMultiDict(headers)
         else:
-            real_headers = headers  # = cast('CIMultiDict[str]', headers)
+            real_headers = CIMultiDict(headers)
 
         if content_type is not None and "charset" in content_type:
             raise ValueError("charset must not be in content_type argument")

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -11,7 +11,7 @@ from unittest import mock
 
 import aiosignal
 import pytest
-from multidict import CIMultiDict, CIMultiDictProxy
+from multidict import CIMultiDict, CIMultiDictProxy, MultiDict
 from re_assert import Matches
 
 from aiohttp import HttpVersion, HttpVersion10, HttpVersion11, hdrs
@@ -1501,3 +1501,15 @@ class TestJSONResponse:
     def test_content_type_is_overrideable(self) -> None:
         resp = json_response({"foo": 42}, content_type="application/vnd.json+api")
         assert "application/vnd.json+api" == resp.content_type
+
+
+@pytest.mark.parametrize("loose_header_type", (MultiDict, CIMultiDict, dict))
+async def test_passing_cimultidict_to_web_response_not_mutated(
+    loose_header_type: type,
+) -> None:
+    req = make_request("GET", "/")
+    headers = loose_header_type({})
+    resp = Response(body=b"answer", headers=headers)
+    await resp.prepare(req)
+    assert resp.content_length == 6
+    assert not headers


### PR DESCRIPTION
If `CIMultiDict` is passed in we need to make a copy to avoid mutating it. In some cases we used to copy these twice which was fixed in #10045 but for this case that was the only copy being made and the source of this regression.

fixes #10670

(cherry picked from commit 35c979be79dcc75ecbf7270ccc9fde264e5e2948)
