### PR TITLE
Remove useless nonlocal statements in tests

### DIFF
--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -363,7 +363,6 @@ async def test_concurrent_close(aiohttp_client: AiohttpClient) -> None:
     client_ws: Optional[aiohttp.ClientWebSocketResponse] = None
 
     async def handler(request: web.Request) -> web.WebSocketResponse:
-        nonlocal client_ws
         ws = web.WebSocketResponse()
         await ws.prepare(request)
 
@@ -960,7 +959,7 @@ async def test_close_websocket_while_ping_inflight(
         message: bytes, opcode: int, compress: Optional[int] = None
     ) -> None:
         assert opcode == WSMsgType.PING
-        nonlocal cancelled, ping_started
+        nonlocal cancelled
         ping_started.set_result(None)
         try:
             await asyncio.sleep(1)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -378,7 +378,6 @@ async def test_timer_context_timeout_does_swallow_cancellation() -> None:
     ctx = helpers.TimerContext(loop)
 
     async def task_with_timeout() -> None:
-        nonlocal ctx
         new_task = asyncio.current_task()
         assert new_task is not None
         with pytest.raises(asyncio.TimeoutError):

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -384,7 +384,6 @@ async def test_handler_cancellation(unused_port_socket: socket.socket) -> None:
     port = sock.getsockname()[1]
 
     async def on_request(request: web.Request) -> web.Response:
-        nonlocal event
         try:
             await asyncio.sleep(10)
         except asyncio.CancelledError:
@@ -427,7 +426,7 @@ async def test_no_handler_cancellation(unused_port_socket: socket.socket) -> Non
     started = False
 
     async def on_request(request: web.Request) -> web.Response:
-        nonlocal done_event, started, timeout_event
+        nonlocal started
         started = True
         await asyncio.wait_for(timeout_event.wait(), timeout=5)
         done_event.set()


### PR DESCRIPTION
discovered by new flake8 in https://github.com/aio-libs/aiohttp/pull/10653
