### PR TITLE
Bump yarl to 1.19.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -42,5 +42,5 @@ typing-extensions==4.13.1
     # via multidict
 uvloop==0.21.0 ; platform_system != "Windows" and implementation_name == "cpython"
     # via -r requirements/base.in
-yarl==1.18.3
+yarl==1.19.0
     # via -r requirements/runtime-deps.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -282,7 +282,7 @@ wait-for-it==2.3.0
     # via -r requirements/test.in
 wheel==0.46.0
     # via pip-tools
-yarl==1.18.3
+yarl==1.19.0
     # via -r requirements/runtime-deps.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -273,7 +273,7 @@ wait-for-it==2.3.0
     # via -r requirements/test.in
 wheel==0.46.0
     # via pip-tools
-yarl==1.18.3
+yarl==1.19.0
     # via -r requirements/runtime-deps.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/runtime-deps.txt
+++ b/requirements/runtime-deps.txt
@@ -36,5 +36,5 @@ pycparser==2.22
     # via cffi
 typing-extensions==4.13.1
     # via multidict
-yarl==1.18.3
+yarl==1.19.0
     # via -r requirements/runtime-deps.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -132,5 +132,5 @@ uvloop==0.21.0 ; platform_system != "Windows" and implementation_name == "cpytho
     # via -r requirements/base.in
 wait-for-it==2.3.0
     # via -r requirements/test.in
-yarl==1.18.3
+yarl==1.19.0
     # via -r requirements/runtime-deps.in


### PR DESCRIPTION
Early bump to check performance

changelog: https://github.com/aio-libs/yarl/compare/v1.18.3...v1.19.0
