### PR TITLE
Add support for switching the zlib implementation

### DIFF
--- a/CHANGES/9798.feature.rst
+++ b/CHANGES/9798.feature.rst
@@ -1,0 +1,5 @@
+Allow user setting zlib compression backend -- by :user:`TimMenninger`
+
+This change allows the user to call :func:`aiohttp.set_zlib_backend()` with the
+zlib compression module of their choice. Default behavior continues to use
+the builtin ``zlib`` library.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -47,6 +47,7 @@ from .client import (
     WSServerHandshakeError,
     request,
 )
+from .compression_utils import set_zlib_backend
 from .connector import AddrInfoType, SocketFactoryType
 from .cookiejar import CookieJar, DummyCookieJar
 from .formdata import FormData
@@ -165,6 +166,7 @@ __all__: Tuple[str, ...] = (
     "BasicAuth",
     "ChainMapProxy",
     "ETag",
+    "set_zlib_backend",
     # http
     "HttpVersion",
     "HttpVersion10",

--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -2,13 +2,12 @@
 
 import asyncio
 import random
-import zlib
 from functools import partial
 from typing import Any, Final, Optional, Union
 
 from ..base_protocol import BaseProtocol
 from ..client_exceptions import ClientConnectionResetError
-from ..compression_utils import ZLibCompressor
+from ..compression_utils import ZLibBackend, ZLibCompressor
 from .helpers import (
     MASK_LEN,
     MSG_SIZE,
@@ -95,7 +94,9 @@ class WebSocketWriter:
             message = (
                 await compressobj.compress(message)
                 + compressobj.flush(
-                    zlib.Z_FULL_FLUSH if self.notakeover else zlib.Z_SYNC_FLUSH
+                    ZLibBackend.Z_FULL_FLUSH
+                    if self.notakeover
+                    else ZLibBackend.Z_SYNC_FLUSH
                 )
             ).removesuffix(WS_DEFLATE_TRAILING)
             # Its critical that we do not return control to the event
@@ -160,7 +161,7 @@ class WebSocketWriter:
 
     def _make_compress_obj(self, compress: int) -> ZLibCompressor:
         return ZLibCompressor(
-            level=zlib.Z_BEST_SPEED,
+            level=ZLibBackend.Z_BEST_SPEED,
             wbits=-compress,
             max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
         )

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -1,6 +1,5 @@
 import logging
 import socket
-import zlib
 from abc import ABC, abstractmethod
 from collections.abc import Sized
 from http.cookies import BaseCookie, Morsel
@@ -217,7 +216,7 @@ class AbstractStreamWriter(ABC):
 
     @abstractmethod
     def enable_compression(
-        self, encoding: str = "deflate", strategy: int = zlib.Z_DEFAULT_STRATEGY
+        self, encoding: str = "deflate", strategy: Optional[int] = None
     ) -> None:
         """Enable HTTP body compression"""
 

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import sys
-import zlib
 from typing import (  # noqa
     Any,
     Awaitable,
@@ -85,7 +84,7 @@ class StreamWriter(AbstractStreamWriter):
         self.chunked = True
 
     def enable_compression(
-        self, encoding: str = "deflate", strategy: int = zlib.Z_DEFAULT_STRATEGY
+        self, encoding: str = "deflate", strategy: Optional[int] = None
     ) -> None:
         self._compress = ZLibCompressor(encoding=encoding, strategy=strategy)
 

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -5,7 +5,6 @@ import re
 import sys
 import uuid
 import warnings
-import zlib
 from collections import deque
 from types import TracebackType
 from typing import (
@@ -1032,7 +1031,7 @@ class MultipartPayloadWriter:
             self._encoding = "quoted-printable"
 
     def enable_compression(
-        self, encoding: str = "deflate", strategy: int = zlib.Z_DEFAULT_STRATEGY
+        self, encoding: str = "deflate", strategy: Optional[int] = None
     ) -> None:
         self._compress = ZLibCompressor(
             encoding=encoding,

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -6,7 +6,6 @@ import json
 import math
 import time
 import warnings
-import zlib
 from concurrent.futures import Executor
 from http import HTTPStatus
 from typing import (
@@ -83,7 +82,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
     _keep_alive: Optional[bool] = None
     _chunked: bool = False
     _compression: bool = False
-    _compression_strategy: int = zlib.Z_DEFAULT_STRATEGY
+    _compression_strategy: Optional[int] = None
     _compression_force: Optional[ContentCoding] = None
     _req: Optional["BaseRequest"] = None
     _payload_writer: Optional[AbstractStreamWriter] = None
@@ -184,7 +183,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
     def enable_compression(
         self,
         force: Optional[ContentCoding] = None,
-        strategy: int = zlib.Z_DEFAULT_STRATEGY,
+        strategy: Optional[int] = None,
     ) -> None:
         """Enables response compression encoding."""
         self._compression = True

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2145,6 +2145,30 @@ Utilities
 
    .. versionadded:: 3.0
 
+.. function:: set_zlib_backend(lib)
+
+   Sets the compression backend for zlib-based operations.
+
+   This function allows you to override the default zlib backend
+   used internally by passing a module that implements the standard
+   compression interface.
+
+   The module should implement at minimum the exact interface offered by the
+   latest version of zlib.
+
+   :param types.ModuleType lib: A module that implements the zlib-compatible compression API.
+
+   Example usage::
+
+      import zlib_ng.zlib_ng as zng
+      import aiohttp
+
+      aiohttp.set_zlib_backend(zng)
+
+   .. note:: aiohttp has been tested internally with :mod:`zlib`, :mod:`zlib_ng.zlib_ng`, and :mod:`isal.isal_zlib`.
+
+   .. versionadded:: 3.12
+
 FormData
 ^^^^^^^^
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,6 +84,8 @@ intersphinx_mapping = {
     "aiohttpdemos": ("https://aiohttp-demos.readthedocs.io/en/latest/", None),
     "aiojobs": ("https://aiojobs.readthedocs.io/en/stable/", None),
     "aiohappyeyeballs": ("https://aiohappyeyeballs.readthedocs.io/en/latest/", None),
+    "isal": ("https://python-isal.readthedocs.io/en/stable/", None),
+    "zlib_ng": ("https://python-zlib-ng.readthedocs.io/en/stable/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -374,3 +374,4 @@ wss
 www
 xxx
 yarl
+zlib

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -649,7 +649,7 @@ and :ref:`aiohttp-web-signals` handlers::
 
       .. seealso:: :meth:`enable_compression`
 
-   .. method:: enable_compression(force=None, strategy=zlib.Z_DEFAULT_STRATEGY)
+   .. method:: enable_compression(force=None, strategy=None)
 
       Enable compression.
 
@@ -660,7 +660,10 @@ and :ref:`aiohttp-web-signals` handlers::
       :class:`ContentCoding`.
 
       *strategy* accepts a :mod:`zlib` compression strategy.
-      See :func:`zlib.compressobj` for possible values.
+      See :func:`zlib.compressobj` for possible values, or refer to the
+      docs for the zlib of your using, should you use :func:`aiohttp.set_zlib_backend`
+      to change zlib backend. If ``None``, the default value adopted by
+      your zlib backend will be used where applicable.
 
       .. seealso:: :attr:`compression`
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -97,6 +97,8 @@ incremental==24.7.2
     # via towncrier
 iniconfig==2.1.0
     # via pytest
+isal==1.7.2
+    # via -r requirements/test.in
 jinja2==3.1.6
     # via
     #   sphinx
@@ -275,6 +277,8 @@ wheel==0.46.0
     # via pip-tools
 yarl==1.19.0
     # via -r requirements/runtime-deps.in
+zlib_ng==0.5.1
+    # via -r requirements/test.in
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==25.0.1

--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -1,6 +1,7 @@
 aiodns
 blockbuster
 freezegun
+isal
 mypy; implementation_name == "cpython"
 pre-commit
 proxy.py
@@ -12,3 +13,4 @@ slotscheck
 trustme
 uvloop; platform_system != "Windows"
 valkey
+zlib_ng

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -39,6 +39,8 @@ idna==3.7
     # via trustme
 iniconfig==2.1.0
     # via pytest
+isal==1.7.2
+    # via -r requirements/lint.in
 markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
@@ -113,3 +115,5 @@ valkey==6.1.0
     # via -r requirements/lint.in
 virtualenv==20.30.0
     # via pre-commit
+zlib-ng==0.5.1
+    # via -r requirements/lint.in

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,6 +3,7 @@
 blockbuster
 coverage
 freezegun
+isal
 mypy; implementation_name == "cpython"
 proxy.py >= 2.4.4rc5
 pytest
@@ -14,3 +15,4 @@ python-on-whales
 setuptools-git
 trustme; platform_machine != "i686"  # no 32-bit wheels
 wait-for-it
+zlib_ng

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -51,6 +51,8 @@ idna==3.6
     #   yarl
 iniconfig==2.1.0
     # via pytest
+isal==1.7.2
+    # via -r requirements/test.in
 markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
@@ -134,3 +136,5 @@ wait-for-it==2.3.0
     # via -r requirements/test.in
 yarl==1.19.0
     # via -r requirements/runtime-deps.in
+zlib_ng==0.5.1
+    # via -r requirements/test.in

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 import socket
 import ssl
 import sys
+import zlib
 from hashlib import md5, sha1, sha256
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -11,10 +12,13 @@ from typing import Any, Callable, Generator, Iterator
 from unittest import mock
 from uuid import uuid4
 
+import isal.isal_zlib
 import pytest
+import zlib_ng.zlib_ng
 from blockbuster import blockbuster_ctx
 
 from aiohttp.client_proto import ResponseHandler
+from aiohttp.compression_utils import ZLibBackend, ZLibBackendProtocol, set_zlib_backend
 from aiohttp.http import WS_KEY
 from aiohttp.test_utils import get_unused_port_socket, loop_context
 
@@ -296,3 +300,15 @@ def unused_port_socket() -> Generator[socket.socket, None, None]:
         yield s
     finally:
         s.close()
+
+
+@pytest.fixture(params=[zlib, zlib_ng.zlib_ng, isal.isal_zlib])
+def parametrize_zlib_backend(
+    request: pytest.FixtureRequest,
+) -> Generator[None, None, None]:
+    original_backend: ZLibBackendProtocol = ZLibBackend._zlib_backend
+    set_zlib_backend(request.param)
+
+    yield
+
+    set_zlib_backend(original_backend)

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2071,7 +2071,10 @@ async def test_expect_continue(aiohttp_client: AiohttpClient) -> None:
     assert expect_called
 
 
-async def test_encoding_deflate(aiohttp_client: AiohttpClient) -> None:
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_encoding_deflate(
+    aiohttp_client: AiohttpClient,
+) -> None:
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(text="text")
         resp.enable_chunked_encoding()
@@ -2089,7 +2092,10 @@ async def test_encoding_deflate(aiohttp_client: AiohttpClient) -> None:
     resp.close()
 
 
-async def test_encoding_deflate_nochunk(aiohttp_client: AiohttpClient) -> None:
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_encoding_deflate_nochunk(
+    aiohttp_client: AiohttpClient,
+) -> None:
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(text="text")
         resp.enable_compression(web.ContentCoding.deflate)
@@ -2106,7 +2112,10 @@ async def test_encoding_deflate_nochunk(aiohttp_client: AiohttpClient) -> None:
     resp.close()
 
 
-async def test_encoding_gzip(aiohttp_client: AiohttpClient) -> None:
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_encoding_gzip(
+    aiohttp_client: AiohttpClient,
+) -> None:
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(text="text")
         resp.enable_chunked_encoding()
@@ -2124,7 +2133,10 @@ async def test_encoding_gzip(aiohttp_client: AiohttpClient) -> None:
     resp.close()
 
 
-async def test_encoding_gzip_write_by_chunks(aiohttp_client: AiohttpClient) -> None:
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_encoding_gzip_write_by_chunks(
+    aiohttp_client: AiohttpClient,
+) -> None:
     async def handler(request: web.Request) -> web.StreamResponse:
         resp = web.StreamResponse()
         resp.enable_compression(web.ContentCoding.gzip)
@@ -2144,7 +2156,10 @@ async def test_encoding_gzip_write_by_chunks(aiohttp_client: AiohttpClient) -> N
     resp.close()
 
 
-async def test_encoding_gzip_nochunk(aiohttp_client: AiohttpClient) -> None:
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_encoding_gzip_nochunk(
+    aiohttp_client: AiohttpClient,
+) -> None:
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(text="text")
         resp.enable_compression(web.ContentCoding.gzip)

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -3,7 +3,6 @@ import hashlib
 import io
 import pathlib
 import sys
-import zlib
 from http.cookies import BaseCookie, Morsel, SimpleCookie
 from typing import (
     Any,
@@ -32,6 +31,7 @@ from aiohttp.client_reqrep import (
     Fingerprint,
     _gen_default_accept_encoding,
 )
+from aiohttp.compression_utils import ZLibBackend
 from aiohttp.connector import Connection
 from aiohttp.http import HttpVersion10, HttpVersion11
 from aiohttp.test_utils import make_mocked_coro
@@ -822,8 +822,10 @@ async def test_bytes_data(loop: asyncio.AbstractEventLoop, conn: mock.Mock) -> N
         resp.close()
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_content_encoding(
-    loop: asyncio.AbstractEventLoop, conn: mock.Mock
+    loop: asyncio.AbstractEventLoop,
+    conn: mock.Mock,
 ) -> None:
     req = ClientRequest(
         "post", URL("http://python.org/"), data="foo", compress="deflate", loop=loop
@@ -852,8 +854,10 @@ async def test_content_encoding_dont_set_headers_if_no_body(
     resp.close()
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_content_encoding_header(
-    loop: asyncio.AbstractEventLoop, conn: mock.Mock
+    loop: asyncio.AbstractEventLoop,
+    conn: mock.Mock,
 ) -> None:
     req = ClientRequest(
         "post",
@@ -978,8 +982,11 @@ async def test_file_upload_not_chunked(loop: asyncio.AbstractEventLoop) -> None:
         await req.close()
 
 
-async def test_precompressed_data_stays_intact(loop: asyncio.AbstractEventLoop) -> None:
-    data = zlib.compress(b"foobar")
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_precompressed_data_stays_intact(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    data = ZLibBackend.compress(b"foobar")
     req = ClientRequest(
         "post",
         URL("http://python.org/"),

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -977,6 +977,7 @@ async def test_close_websocket_while_ping_inflight(
     assert cancelled is True
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_send_recv_compress(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.WebSocketResponse:
         ws = web.WebSocketResponse()
@@ -1002,6 +1003,7 @@ async def test_send_recv_compress(aiohttp_client: AiohttpClient) -> None:
     assert resp.get_extra_info("socket") is None
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_send_recv_compress_wbits(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.WebSocketResponse:
         ws = web.WebSocketResponse()

--- a/tests/test_compression_utils.py
+++ b/tests/test_compression_utils.py
@@ -1,22 +1,34 @@
 """Tests for compression utils."""
 
-from aiohttp.compression_utils import ZLibCompressor, ZLibDecompressor
+import pytest
+
+from aiohttp.compression_utils import ZLibBackend, ZLibCompressor, ZLibDecompressor
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_compression_round_trip_in_executor() -> None:
     """Ensure that compression and decompression work correctly in the executor."""
-    compressor = ZLibCompressor(max_sync_chunk_size=1)
+    compressor = ZLibCompressor(
+        strategy=ZLibBackend.Z_DEFAULT_STRATEGY, max_sync_chunk_size=1
+    )
+    assert type(compressor._compressor) is type(ZLibBackend.compressobj())
     decompressor = ZLibDecompressor(max_sync_chunk_size=1)
+    assert type(decompressor._decompressor) is type(ZLibBackend.decompressobj())
     data = b"Hi" * 100
     compressed_data = await compressor.compress(data) + compressor.flush()
     decompressed_data = await decompressor.decompress(compressed_data)
     assert data == decompressed_data
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_compression_round_trip_in_event_loop() -> None:
     """Ensure that compression and decompression work correctly in the event loop."""
-    compressor = ZLibCompressor(max_sync_chunk_size=10000)
+    compressor = ZLibCompressor(
+        strategy=ZLibBackend.Z_DEFAULT_STRATEGY, max_sync_chunk_size=10000
+    )
+    assert type(compressor._compressor) is type(ZLibBackend.compressobj())
     decompressor = ZLibDecompressor(max_sync_chunk_size=10000)
+    assert type(decompressor._decompressor) is type(ZLibBackend.decompressobj())
     data = b"Hi" * 100
     compressed_data = await compressor.compress(data) + compressor.flush()
     decompressed_data = await decompressor.decompress(compressed_data)

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -3,7 +3,6 @@ import io
 import json
 import pathlib
 import sys
-import zlib
 from types import TracebackType
 from typing import Dict, Optional, Tuple, Type
 from unittest import mock
@@ -13,6 +12,7 @@ from multidict import CIMultiDict, CIMultiDictProxy
 
 import aiohttp
 from aiohttp import payload
+from aiohttp.compression_utils import ZLibBackend
 from aiohttp.hdrs import (
     CONTENT_DISPOSITION,
     CONTENT_ENCODING,
@@ -1104,8 +1104,11 @@ async def test_writer_write_no_parts(
     assert b"--:--\r\n" == bytes(buf)
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_writer_serialize_with_content_encoding_gzip(
-    buf: bytearray, stream: Stream, writer: aiohttp.MultipartWriter
+    buf: bytearray,
+    stream: Stream,
+    writer: aiohttp.MultipartWriter,
 ) -> None:
     writer.append("Time to Relax!", {CONTENT_ENCODING: "gzip"})
     await writer.write(stream)
@@ -1116,7 +1119,7 @@ async def test_writer_serialize_with_content_encoding_gzip(
         b"Content-Encoding: gzip" == headers
     )
 
-    decompressor = zlib.decompressobj(wbits=16 + zlib.MAX_WBITS)
+    decompressor = ZLibBackend.decompressobj(wbits=16 + ZLibBackend.MAX_WBITS)
     data = decompressor.decompress(message.split(b"\r\n")[0])
     data += decompressor.flush()
     assert b"Time to Relax!" == data

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -4,8 +4,17 @@ import json
 import pathlib
 import socket
 import sys
-import zlib
-from typing import AsyncIterator, Awaitable, Callable, Dict, List, NoReturn, Optional
+from typing import (
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Dict,
+    Generator,
+    List,
+    NoReturn,
+    Optional,
+    Tuple,
+)
 from unittest import mock
 
 import pytest
@@ -24,6 +33,7 @@ from aiohttp import (
     web,
 )
 from aiohttp.abc import AbstractResolver, ResolveResult
+from aiohttp.compression_utils import ZLibBackend, ZLibCompressObjProtocol
 from aiohttp.hdrs import CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING
 from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
 from aiohttp.test_utils import make_mocked_coro
@@ -1090,19 +1100,30 @@ async def test_response_with_payload_stringio(
     resp.release()
 
 
-@pytest.mark.parametrize(
-    "compressor,encoding",
-    [
-        (zlib.compressobj(wbits=16 + zlib.MAX_WBITS), "gzip"),
-        (zlib.compressobj(wbits=zlib.MAX_WBITS), "deflate"),
-        # Actually, wrong compression format, but
-        # should be supported for some legacy cases.
-        (zlib.compressobj(wbits=-zlib.MAX_WBITS), "deflate"),
-    ],
-)
+@pytest.fixture(params=["gzip", "deflate", "deflate-raw"])
+def compressor_case(
+    request: pytest.FixtureRequest,
+    parametrize_zlib_backend: None,
+) -> Generator[Tuple[ZLibCompressObjProtocol, str], None, None]:
+    encoding: str = request.param
+    max_wbits: int = ZLibBackend.MAX_WBITS
+
+    encoding_to_wbits: Dict[str, int] = {
+        "deflate": max_wbits,
+        "deflate-raw": -max_wbits,
+        "gzip": 16 + max_wbits,
+    }
+
+    compressor = ZLibBackend.compressobj(wbits=encoding_to_wbits[encoding])
+    yield (compressor, "deflate" if encoding.startswith("deflate") else encoding)
+
+
 async def test_response_with_precompressed_body(
-    aiohttp_client: AiohttpClient, compressor: "zlib._Compress", encoding: str
+    aiohttp_client: AiohttpClient,
+    compressor_case: Tuple[ZLibCompressObjProtocol, str],
 ) -> None:
+    compressor, encoding = compressor_case
+
     async def handler(request: web.Request) -> web.Response:
         headers = {"Content-Encoding": encoding}
         data = compressor.compress(b"mydata") + compressor.flush()
@@ -2179,6 +2200,7 @@ async def test_read_bufsize(aiohttp_client: AiohttpClient) -> None:
 @pytest.mark.parametrize(
     "auto_decompress,len_of", [(True, "uncompressed"), (False, "compressed")]
 )
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_auto_decompress(
     aiohttp_client: AiohttpClient,
     auto_decompress: bool,
@@ -2193,7 +2215,7 @@ async def test_auto_decompress(
 
     client = await aiohttp_client(app)
     uncompressed = b"dataaaaaaaaaaaaaaaaaaaaaaaaa"
-    compressor = zlib.compressobj(wbits=16 + zlib.MAX_WBITS)
+    compressor = ZLibBackend.compressobj(wbits=16 + ZLibBackend.MAX_WBITS)
     compressed = compressor.compress(uncompressed) + compressor.flush()
     assert len(compressed) != len(uncompressed)
     headers = {"content-encoding": "gzip"}

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -3,7 +3,6 @@ import bz2
 import gzip
 import pathlib
 import socket
-import zlib
 from typing import Iterable, Iterator, NoReturn, Optional, Protocol, Tuple
 from unittest import mock
 
@@ -12,6 +11,7 @@ from _pytest.fixtures import SubRequest
 
 import aiohttp
 from aiohttp import web
+from aiohttp.compression_utils import ZLibBackend
 from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
 from aiohttp.typedefs import PathLike
 
@@ -313,6 +313,7 @@ async def test_static_file_custom_content_type_compress(
     [("gzip, deflate", "gzip"), ("gzip, deflate, br", "br")],
 )
 @pytest.mark.parametrize("forced_compression", [None, web.ContentCoding.gzip])
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_static_file_with_encoding_and_enable_compression(
     hello_txt: pathlib.Path,
     aiohttp_client: AiohttpClient,
@@ -1062,8 +1063,10 @@ async def test_static_file_if_range_invalid_date(
     await client.close()
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_static_file_compression(
-    aiohttp_client: AiohttpClient, sender: _Sender
+    aiohttp_client: AiohttpClient,
+    sender: _Sender,
 ) -> None:
     filepath = pathlib.Path(__file__).parent / "data.unknown_mime_type"
 
@@ -1078,7 +1081,7 @@ async def test_static_file_compression(
 
     resp = await client.get("/")
     assert resp.status == 200
-    zcomp = zlib.compressobj(wbits=zlib.MAX_WBITS)
+    zcomp = ZLibBackend.compressobj(wbits=ZLibBackend.MAX_WBITS)
     expected_body = zcomp.compress(b"file content\n") + zcomp.flush()
     assert expected_body == await resp.read()
     assert "application/octet-stream" == resp.headers["Content-Type"]

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -127,6 +127,7 @@ async def test_send_compress_text_per_message(
         (32, lambda count: 64 + count if count % 2 else count),
     ),
 )
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_concurrent_messages(
     protocol: BaseProtocol,
     transport: asyncio.Transport,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These changes allow a user to arbitrarily set the zlib backend by calling `aiohttp.set_zlib_backend()` on the zlib module of their choice. For example:

```
import aiohttp
import zlib_ng.zlib_ng as zlib_ng

aiohttp.set_zlib_backend(zlib_ng)
```

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

The only changes for the user are opt-in.

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

The only burden that could arise is if for some reason `zlib_ng.zlib_ng` or `isal.isal_zlib` change their interface to differ from `zlib`.

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

Fixes #9798

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
