### PR TITLE
Avoid fetching loop time on each request unless logging is enabled

### DIFF
--- a/CHANGES/10713.misc.rst
+++ b/CHANGES/10713.misc.rst
@@ -1,1 +1,1 @@
-Optimized web server performance when access logging is disabled -- by :user:`bdraco`.
+Optimized web server performance when access logging is disabled by reducing time syscalls -- by :user:`bdraco`.

--- a/CHANGES/10713.misc.rst
+++ b/CHANGES/10713.misc.rst
@@ -1,0 +1,1 @@
+Optimized web server performance when access logging is disabled -- by :user:`bdraco`.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -476,6 +476,8 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         request_start: Optional[float],
     ) -> None:
         if self._logging_enabled and self.access_logger is not None:
+            if TYPE_CHECKING:
+                assert request_start is not None
             await self.access_logger.log(request, response, request_start)
 
     def log_debug(self, *args: Any, **kw: Any) -> None:

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -470,9 +470,12 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             self.transport = None
 
     async def log_access(
-        self, request: BaseRequest, response: StreamResponse, request_start: float
+        self,
+        request: BaseRequest,
+        response: StreamResponse,
+        request_start: Optional[float],
     ) -> None:
-        if self._logging_enabled:
+        if self._logging_enabled and self.access_logger is not None:
             await self.access_logger.log(request, response, request_start)
 
     def log_debug(self, *args: Any, **kw: Any) -> None:

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -314,3 +314,29 @@ async def test_logger_does_not_log_when_not_enabled(
     resp = await client.get("/")
     assert 200 == resp.status
     assert "This should not be logged" not in caplog.text
+
+
+async def test_logger_set_to_none(
+    aiohttp_server: AiohttpServer,
+    aiohttp_client: AiohttpClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test logger does nothing when access_log is set to None."""
+
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response()
+
+    class Logger(AbstractAccessLogger):
+
+        def log(
+            self, request: web.BaseRequest, response: web.StreamResponse, time: float
+        ) -> None:
+            self.logger.critical("This should not be logged")  # pragma: no cover
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    server = await aiohttp_server(app, access_log=None, access_log_class=Logger)
+    client = await aiohttp_client(server)
+    resp = await client.get("/")
+    assert 200 == resp.status
+    assert "This should not be logged" not in caplog.text

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -196,6 +196,12 @@ async def test_app_make_handler_access_log_class2() -> None:
     assert runner._kwargs["access_log_class"] is Logger
 
 
+async def test_app_make_handler_no_access_log_class() -> None:
+    app = web.Application(handler_args={"access_log": None})
+    runner = web.AppRunner(app)
+    assert runner._kwargs["access_log"] is None
+
+
 async def test_addresses(make_runner: _RunnerMaker, unix_sockname: str) -> None:
     _sock = get_unused_port_socket("127.0.0.1")
     runner = make_runner()


### PR DESCRIPTION
We would call `loop.time()` and than throw it away most of the time because logging was not enabled by default.  This makes a syscall (or VDSO on more performant systems) and can be upwards of 8% of the request overhead on some ARM SBCs because of ARM errata that prevents VDSO from working (Cortex-A*3 and others)

Note that this will not show a performance difference with codspeed since it excludes syscalls.  It will need to be checked manually.

Looks to be ~2% speed up of request handling time on systems that support VDSO, and ~8% speed up on systems that don't
We still have one for the keep alive that we likely can't get rid of
<img width="363" alt="Screenshot 2025-04-09 at 3 34 36 PM" src="https://github.com/user-attachments/assets/9e61a864-73ad-4ce3-949d-59edb4c90747" />
<img width="246" alt="Screenshot 2025-04-09 at 3 34 27 PM" src="https://github.com/user-attachments/assets/81fbcb32-abea-4b45-b3af-fc2bd457107b" />

