### PR TITLE
Only fetch SSLContext and peername once per connection

### DIFF
--- a/CHANGES/10714.misc.rst
+++ b/CHANGES/10714.misc.rst
@@ -1,0 +1,1 @@
+Improved web server performance when connection can be reused -- by :user:`bdraco`.

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -675,10 +675,10 @@ def make_mocked_request(
     if protocol is None:
         protocol = mock.Mock()
         protocol.transport = transport
-        protocol.peername = mock.PropertyMock(
+        type(protocol).peername = mock.PropertyMock(
             return_value=transport.get_extra_info("peername")
         )
-        protocol.ssl_context = mock.PropertyMock(return_value=sslcontext)
+        type(protocol).ssl_context = mock.PropertyMock(return_value=sslcontext)
 
     if writer is None:
         writer = mock.Mock()

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -675,6 +675,10 @@ def make_mocked_request(
     if protocol is None:
         protocol = mock.Mock()
         protocol.transport = transport
+        protocol.peername = mock.PropertyMock(
+            return_value=transport.get_extra_info("peername")
+        )
+        protocol.ssl_context = mock.PropertyMock(return_value=sslcontext)
 
     if writer is None:
         writer = mock.Mock()

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -24,6 +24,7 @@ from typing import (
 )
 
 import yarl
+from propcache import under_cached_property
 
 from .abc import AbstractAccessLogger, AbstractAsyncAccessLogger, AbstractStreamWriter
 from .base_protocol import BaseProtocol
@@ -47,6 +48,8 @@ from .web_response import Response, StreamResponse
 __all__ = ("RequestHandler", "RequestPayloadError", "PayloadAccessError")
 
 if TYPE_CHECKING:
+    import ssl
+
     from .web_server import Server
 
 
@@ -189,6 +192,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         "_current_request",
         "_timeout_ceil_threshold",
         "_request_in_progress",
+        "_cache",
     )
 
     def __init__(
@@ -275,11 +279,30 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         self._close = False
         self._force_close = False
         self._request_in_progress = False
+        self._cache = {}
 
     def __repr__(self) -> str:
         return "<{} {}>".format(
             self.__class__.__name__,
             "connected" if self.transport is not None else "disconnected",
+        )
+
+    @under_cached_property
+    def ssl_context(self) -> Optional["ssl.SSLContext"]:
+        """Return SSLContext if available."""
+        return (
+            None
+            if self.transport is None
+            else self.transport.get_extra_info("sslcontext")
+        )
+
+    @under_cached_property
+    def peername(self) -> Optional[Union[Tuple[str, int, int, int], Tuple[str, int]]]:
+        """Return peername if available."""
+        return (
+            None
+            if self.transport is None
+            else self.transport.get_extra_info("peername")
         )
 
     @property

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -279,7 +279,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         self._close = False
         self._force_close = False
         self._request_in_progress = False
-        self._cache = {}
+        self._cache: dict[str, Any] = {}
 
     def __repr__(self) -> str:
         return "<{} {}>".format(
@@ -297,7 +297,9 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         )
 
     @under_cached_property
-    def peername(self) -> Optional[Union[Tuple[str, int, int, int], Tuple[str, int]]]:
+    def peername(
+        self,
+    ) -> Optional[Union[str, Tuple[str, int, int, int], Tuple[str, int]]]:
         """Return peername if available."""
         return (
             None

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -179,10 +179,8 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         self._client_max_size = client_max_size
         self._loop = loop
 
-        transport = protocol.transport
-        assert transport is not None
-        self._transport_sslcontext = transport.get_extra_info("sslcontext")
-        self._transport_peername = transport.get_extra_info("peername")
+        self._transport_sslcontext = protocol.ssl_context
+        self._transport_peername = protocol.peername
 
         if remote is not None:
             self._cache["remote"] = remote


### PR DESCRIPTION
We were doing it on every request, and since its a property of the connection it will not change between requests.

<img width="254" alt="Screenshot 2025-04-09 at 3 30 45 PM" src="https://github.com/user-attachments/assets/2861baf3-2fde-4938-817d-beb64432d6da" />
