### PR TITLE
[PR #10700/ceeca6a backport][3.12] Add support for switching the zlib implementation

### DIFF
--- a/CHANGES/9798.feature.rst
+++ b/CHANGES/9798.feature.rst
@@ -1,0 +1,5 @@
+Allow user setting zlib compression backend -- by :user:`TimMenninger`
+
+This change allows the user to call :func:`aiohttp.set_zlib_backend()` with the
+zlib compression module of their choice. Default behavior continues to use
+the builtin ``zlib`` library.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -47,12 +47,19 @@ from .client import (
     WSServerHandshakeError,
     request,
 )
+<<<<<<< HEAD
 from .connector import (
     AddrInfoType as AddrInfoType,
     SocketFactoryType as SocketFactoryType,
 )
 from .cookiejar import CookieJar as CookieJar, DummyCookieJar as DummyCookieJar
 from .formdata import FormData as FormData
+=======
+from .compression_utils import set_zlib_backend
+from .connector import AddrInfoType, SocketFactoryType
+from .cookiejar import CookieJar, DummyCookieJar
+from .formdata import FormData
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from .helpers import BasicAuth, ChainMapProxy, ETag
 from .http import (
     HttpVersion as HttpVersion,
@@ -183,6 +190,7 @@ __all__: Tuple[str, ...] = (
     "BasicAuth",
     "ChainMapProxy",
     "ETag",
+    "set_zlib_backend",
     # http
     "HttpVersion",
     "HttpVersion10",

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -47,19 +47,13 @@ from .client import (
     WSServerHandshakeError,
     request,
 )
-<<<<<<< HEAD
+from .compression_utils import set_zlib_backend
 from .connector import (
     AddrInfoType as AddrInfoType,
     SocketFactoryType as SocketFactoryType,
 )
 from .cookiejar import CookieJar as CookieJar, DummyCookieJar as DummyCookieJar
 from .formdata import FormData as FormData
-=======
-from .compression_utils import set_zlib_backend
-from .connector import AddrInfoType, SocketFactoryType
-from .cookiejar import CookieJar, DummyCookieJar
-from .formdata import FormData
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from .helpers import BasicAuth, ChainMapProxy, ETag
 from .http import (
     HttpVersion as HttpVersion,

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -238,15 +238,23 @@ class WebSocketReader:
                         self._decompressobj = ZLibDecompressor(
                             suppress_deflate_header=True
                         )
+                    # XXX: It's possible that the zlib backend (isal is known to
+                    # do this, maybe others too?) will return max_length bytes,
+                    # but internally buffer more data such that the payload is
+                    # >max_length, so we return one extra byte and if we're able
+                    # to do that, then the message is too big.
                     payload_merged = self._decompressobj.decompress_sync(
-                        assembled_payload + WS_DEFLATE_TRAILING, self._max_msg_size
+                        assembled_payload + WS_DEFLATE_TRAILING,
+                        (
+                            self._max_msg_size + 1
+                            if self._max_msg_size
+                            else self._max_msg_size
+                        ),
                     )
-                    if self._decompressobj.unconsumed_tail:
-                        left = len(self._decompressobj.unconsumed_tail)
+                    if self._max_msg_size and len(payload_merged) > self._max_msg_size:
                         raise WebSocketError(
                             WSCloseCode.MESSAGE_TOO_BIG,
-                            f"Decompressed message size {self._max_msg_size + left}"
-                            f" exceeds limit {self._max_msg_size}",
+                            f"Decompressed message exceeds size limit {self._max_msg_size}",
                         )
                 elif type(assembled_payload) is bytes:
                     payload_merged = assembled_payload

--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -2,13 +2,12 @@
 
 import asyncio
 import random
-import zlib
 from functools import partial
 from typing import Any, Final, Optional, Union
 
 from ..base_protocol import BaseProtocol
 from ..client_exceptions import ClientConnectionResetError
-from ..compression_utils import ZLibCompressor
+from ..compression_utils import ZLibBackend, ZLibCompressor
 from .helpers import (
     MASK_LEN,
     MSG_SIZE,
@@ -95,7 +94,9 @@ class WebSocketWriter:
             message = (
                 await compressobj.compress(message)
                 + compressobj.flush(
-                    zlib.Z_FULL_FLUSH if self.notakeover else zlib.Z_SYNC_FLUSH
+                    ZLibBackend.Z_FULL_FLUSH
+                    if self.notakeover
+                    else ZLibBackend.Z_SYNC_FLUSH
                 )
             ).removesuffix(WS_DEFLATE_TRAILING)
             # Its critical that we do not return control to the event
@@ -160,7 +161,7 @@ class WebSocketWriter:
 
     def _make_compress_obj(self, compress: int) -> ZLibCompressor:
         return ZLibCompressor(
-            level=zlib.Z_BEST_SPEED,
+            level=ZLibBackend.Z_BEST_SPEED,
             wbits=-compress,
             max_sync_chunk_size=WEBSOCKET_MAX_SYNC_CHUNK_SIZE,
         )

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import socket
-import zlib
 from abc import ABC, abstractmethod
 from collections.abc import Sized
 from http.cookies import BaseCookie, Morsel
@@ -219,7 +218,7 @@ class AbstractStreamWriter(ABC):
 
     @abstractmethod
     def enable_compression(
-        self, encoding: str = "deflate", strategy: int = zlib.Z_DEFAULT_STRATEGY
+        self, encoding: str = "deflate", strategy: Optional[int] = None
     ) -> None:
         """Enable HTTP body compression"""
 

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import zlib
 from concurrent.futures import Executor
-from typing import Optional, cast
+from typing import Any, Final, Optional, Protocol, TypedDict, cast
 
 try:
     try:
@@ -16,14 +16,113 @@ except ImportError:  # pragma: no cover
 MAX_SYNC_CHUNK_SIZE = 1024
 
 
+class ZLibCompressObjProtocol(Protocol):
+    def compress(self, data: Buffer) -> bytes: ...
+    def flush(self, mode: int = ..., /) -> bytes: ...
+
+
+class ZLibDecompressObjProtocol(Protocol):
+    def decompress(self, data: Buffer, max_length: int = ...) -> bytes: ...
+    def flush(self, length: int = ..., /) -> bytes: ...
+
+    @property
+    def eof(self) -> bool: ...
+
+
+class ZLibBackendProtocol(Protocol):
+    MAX_WBITS: int
+    Z_FULL_FLUSH: int
+    Z_SYNC_FLUSH: int
+    Z_BEST_SPEED: int
+    Z_FINISH: int
+
+    def compressobj(
+        self,
+        level: int = ...,
+        method: int = ...,
+        wbits: int = ...,
+        memLevel: int = ...,
+        strategy: int = ...,
+        zdict: Optional[Buffer] = ...,
+    ) -> ZLibCompressObjProtocol: ...
+    def decompressobj(
+        self, wbits: int = ..., zdict: Buffer = ...
+    ) -> ZLibDecompressObjProtocol: ...
+
+    def compress(
+        self, data: Buffer, /, level: int = ..., wbits: int = ...
+    ) -> bytes: ...
+    def decompress(
+        self, data: Buffer, /, wbits: int = ..., bufsize: int = ...
+    ) -> bytes: ...
+
+
+class CompressObjArgs(TypedDict, total=False):
+    wbits: int
+    strategy: int
+    level: int
+
+
+class ZLibBackendWrapper:
+    def __init__(self, _zlib_backend: ZLibBackendProtocol):
+        self._zlib_backend: ZLibBackendProtocol = _zlib_backend
+
+    @property
+    def name(self) -> str:
+        return getattr(self._zlib_backend, "__name__", "undefined")
+
+    @property
+    def MAX_WBITS(self) -> int:
+        return self._zlib_backend.MAX_WBITS
+
+    @property
+    def Z_FULL_FLUSH(self) -> int:
+        return self._zlib_backend.Z_FULL_FLUSH
+
+    @property
+    def Z_SYNC_FLUSH(self) -> int:
+        return self._zlib_backend.Z_SYNC_FLUSH
+
+    @property
+    def Z_BEST_SPEED(self) -> int:
+        return self._zlib_backend.Z_BEST_SPEED
+
+    @property
+    def Z_FINISH(self) -> int:
+        return self._zlib_backend.Z_FINISH
+
+    def compressobj(self, *args: Any, **kwargs: Any) -> ZLibCompressObjProtocol:
+        return self._zlib_backend.compressobj(*args, **kwargs)
+
+    def decompressobj(self, *args: Any, **kwargs: Any) -> ZLibDecompressObjProtocol:
+        return self._zlib_backend.decompressobj(*args, **kwargs)
+
+    def compress(self, data: Buffer, *args: Any, **kwargs: Any) -> bytes:
+        return self._zlib_backend.compress(data, *args, **kwargs)
+
+    def decompress(self, data: Buffer, *args: Any, **kwargs: Any) -> bytes:
+        return self._zlib_backend.decompress(data, *args, **kwargs)
+
+    # Everything not explicitly listed in the Protocol we just pass through
+    def __getattr__(self, attrname: str) -> Any:
+        return getattr(self._zlib_backend, attrname)
+
+
+ZLibBackend: ZLibBackendWrapper = ZLibBackendWrapper(zlib)
+
+
+def set_zlib_backend(new_zlib_backend: ZLibBackendProtocol) -> None:
+    ZLibBackend._zlib_backend = new_zlib_backend
+
+
 def encoding_to_mode(
     encoding: Optional[str] = None,
     suppress_deflate_header: bool = False,
 ) -> int:
     if encoding == "gzip":
-        return 16 + zlib.MAX_WBITS
+        return 16 + ZLibBackend.MAX_WBITS
 
-    return -zlib.MAX_WBITS if suppress_deflate_header else zlib.MAX_WBITS
+    return -ZLibBackend.MAX_WBITS if suppress_deflate_header else ZLibBackend.MAX_WBITS
 
 
 class ZlibBaseHandler:
@@ -45,7 +144,7 @@ class ZLibCompressor(ZlibBaseHandler):
         suppress_deflate_header: bool = False,
         level: Optional[int] = None,
         wbits: Optional[int] = None,
-        strategy: int = zlib.Z_DEFAULT_STRATEGY,
+        strategy: Optional[int] = None,
         executor: Optional[Executor] = None,
         max_sync_chunk_size: Optional[int] = MAX_SYNC_CHUNK_SIZE,
     ):
@@ -58,12 +157,15 @@ class ZLibCompressor(ZlibBaseHandler):
             executor=executor,
             max_sync_chunk_size=max_sync_chunk_size,
         )
-        if level is None:
-            self._compressor = zlib.compressobj(wbits=self._mode, strategy=strategy)
-        else:
-            self._compressor = zlib.compressobj(
-                wbits=self._mode, strategy=strategy, level=level
-            )
+        self._zlib_backend: Final = ZLibBackendWrapper(ZLibBackend._zlib_backend)
+
+        kwargs: CompressObjArgs = {}
+        kwargs["wbits"] = self._mode
+        if strategy is not None:
+            kwargs["strategy"] = strategy
+        if level is not None:
+            kwargs["level"] = level
+        self._compressor = self._zlib_backend.compressobj(**kwargs)
         self._compress_lock = asyncio.Lock()
 
     def compress_sync(self, data: bytes) -> bytes:
@@ -92,8 +194,10 @@ class ZLibCompressor(ZlibBaseHandler):
                 )
             return self.compress_sync(data)
 
-    def flush(self, mode: int = zlib.Z_FINISH) -> bytes:
-        return self._compressor.flush(mode)
+    def flush(self, mode: Optional[int] = None) -> bytes:
+        return self._compressor.flush(
+            mode if mode is not None else self._zlib_backend.Z_FINISH
+        )
 
 
 class ZLibDecompressor(ZlibBaseHandler):
@@ -109,7 +213,8 @@ class ZLibDecompressor(ZlibBaseHandler):
             executor=executor,
             max_sync_chunk_size=max_sync_chunk_size,
         )
-        self._decompressor = zlib.decompressobj(wbits=self._mode)
+        self._zlib_backend: Final = ZLibBackendWrapper(ZLibBackend._zlib_backend)
+        self._decompressor = self._zlib_backend.decompressobj(wbits=self._mode)
 
     def decompress_sync(self, data: bytes, max_length: int = 0) -> bytes:
         return self._decompressor.decompress(data, max_length)
@@ -140,14 +245,6 @@ class ZLibDecompressor(ZlibBaseHandler):
     @property
     def eof(self) -> bool:
         return self._decompressor.eof
-
-    @property
-    def unconsumed_tail(self) -> bytes:
-        return self._decompressor.unconsumed_tail
-
-    @property
-    def unused_data(self) -> bytes:
-        return self._decompressor.unused_data
 
 
 class BrotliDecompressor:

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -1,7 +1,15 @@
 import asyncio
+import sys
 import zlib
 from concurrent.futures import Executor
 from typing import Any, Final, Optional, Protocol, TypedDict, cast
+
+if sys.version_info >= (3, 12):
+    from collections.abc import Buffer
+else:
+    from typing import Union
+
+    Buffer = Union[bytes, bytearray, "memoryview[int]", "memoryview[bytes]"]
 
 try:
     try:

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import sys
-import zlib
 from typing import (  # noqa
     Any,
     Awaitable,
@@ -80,7 +79,7 @@ class StreamWriter(AbstractStreamWriter):
         self.chunked = True
 
     def enable_compression(
-        self, encoding: str = "deflate", strategy: int = zlib.Z_DEFAULT_STRATEGY
+        self, encoding: str = "deflate", strategy: Optional[int] = None
     ) -> None:
         self._compress = ZLibCompressor(encoding=encoding, strategy=strategy)
 

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -5,7 +5,6 @@ import re
 import sys
 import uuid
 import warnings
-import zlib
 from collections import deque
 from types import TracebackType
 from typing import (
@@ -1028,7 +1027,7 @@ class MultipartPayloadWriter:
             self._encoding = "quoted-printable"
 
     def enable_compression(
-        self, encoding: str = "deflate", strategy: int = zlib.Z_DEFAULT_STRATEGY
+        self, encoding: str = "deflate", strategy: Optional[int] = None
     ) -> None:
         self._compress = ZLibCompressor(
             encoding=encoding,

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -6,7 +6,6 @@ import json
 import math
 import time
 import warnings
-import zlib
 from concurrent.futures import Executor
 from http import HTTPStatus
 from http.cookies import SimpleCookie
@@ -82,7 +81,7 @@ class StreamResponse(BaseClass, HeadersMixin):
     _keep_alive: Optional[bool] = None
     _chunked: bool = False
     _compression: bool = False
-    _compression_strategy: int = zlib.Z_DEFAULT_STRATEGY
+    _compression_strategy: Optional[int] = None
     _compression_force: Optional[ContentCoding] = None
     _req: Optional["BaseRequest"] = None
     _payload_writer: Optional[AbstractStreamWriter] = None
@@ -191,8 +190,13 @@ class StreamResponse(BaseClass, HeadersMixin):
 
     def enable_compression(
         self,
+<<<<<<< HEAD
         force: Optional[Union[bool, ContentCoding]] = None,
         strategy: int = zlib.Z_DEFAULT_STRATEGY,
+=======
+        force: Optional[ContentCoding] = None,
+        strategy: Optional[int] = None,
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     ) -> None:
         """Enables response compression encoding."""
         # Backwards compatibility for when force was a bool <0.17.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -190,13 +190,8 @@ class StreamResponse(BaseClass, HeadersMixin):
 
     def enable_compression(
         self,
-<<<<<<< HEAD
         force: Optional[Union[bool, ContentCoding]] = None,
-        strategy: int = zlib.Z_DEFAULT_STRATEGY,
-=======
-        force: Optional[ContentCoding] = None,
         strategy: Optional[int] = None,
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     ) -> None:
         """Enables response compression encoding."""
         # Backwards compatibility for when force was a bool <0.17.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2163,6 +2163,30 @@ Utilities
 
    .. versionadded:: 3.0
 
+.. function:: set_zlib_backend(lib)
+
+   Sets the compression backend for zlib-based operations.
+
+   This function allows you to override the default zlib backend
+   used internally by passing a module that implements the standard
+   compression interface.
+
+   The module should implement at minimum the exact interface offered by the
+   latest version of zlib.
+
+   :param types.ModuleType lib: A module that implements the zlib-compatible compression API.
+
+   Example usage::
+
+      import zlib_ng.zlib_ng as zng
+      import aiohttp
+
+      aiohttp.set_zlib_backend(zng)
+
+   .. note:: aiohttp has been tested internally with :mod:`zlib`, :mod:`zlib_ng.zlib_ng`, and :mod:`isal.isal_zlib`.
+
+   .. versionadded:: 3.12
+
 FormData
 ^^^^^^^^
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,8 @@ intersphinx_mapping = {
     "aiohttpdemos": ("https://aiohttp-demos.readthedocs.io/en/latest/", None),
     "aiojobs": ("https://aiojobs.readthedocs.io/en/stable/", None),
     "aiohappyeyeballs": ("https://aiohappyeyeballs.readthedocs.io/en/latest/", None),
+    "isal": ("https://python-isal.readthedocs.io/en/stable/", None),
+    "zlib_ng": ("https://python-zlib-ng.readthedocs.io/en/stable/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -375,3 +375,4 @@ wss
 www
 xxx
 yarl
+zlib

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -669,7 +669,7 @@ and :ref:`aiohttp-web-signals` handlers::
 
       .. seealso:: :meth:`enable_compression`
 
-   .. method:: enable_compression(force=None, strategy=zlib.Z_DEFAULT_STRATEGY)
+   .. method:: enable_compression(force=None, strategy=None)
 
       Enable compression.
 
@@ -680,7 +680,10 @@ and :ref:`aiohttp-web-signals` handlers::
       :class:`ContentCoding`.
 
       *strategy* accepts a :mod:`zlib` compression strategy.
-      See :func:`zlib.compressobj` for possible values.
+      See :func:`zlib.compressobj` for possible values, or refer to the
+      docs for the zlib of your using, should you use :func:`aiohttp.set_zlib_backend`
+      to change zlib backend. If ``None``, the default value adopted by
+      your zlib backend will be used where applicable.
 
       .. seealso:: :attr:`compression`
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -99,6 +99,8 @@ incremental==24.7.2
     # via towncrier
 iniconfig==2.1.0
     # via pytest
+isal==1.7.2
+    # via -r requirements/test.in
 jinja2==3.1.6
     # via
     #   sphinx
@@ -278,6 +280,8 @@ wheel==0.45.1
     # via pip-tools
 yarl==1.19.0
     # via -r requirements/runtime-deps.in
+zlib_ng==0.5.1
+    # via -r requirements/test.in
 
 # The following packages are considered to be unsafe in a requirements file:
 pip==25.0.1

--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -1,6 +1,7 @@
 aiodns
 blockbuster
 freezegun
+isal
 mypy; implementation_name == "cpython"
 pre-commit
 pytest
@@ -11,3 +12,4 @@ slotscheck
 trustme
 uvloop; platform_system != "Windows"
 valkey
+zlib_ng

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -39,6 +39,8 @@ idna==3.7
     # via trustme
 iniconfig==2.1.0
     # via pytest
+isal==1.7.2
+    # via -r requirements/lint.in
 markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
@@ -111,3 +113,5 @@ valkey==6.1.0
     # via -r requirements/lint.in
 virtualenv==20.30.0
     # via pre-commit
+zlib-ng==0.5.1
+    # via -r requirements/lint.in

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -3,6 +3,7 @@
 blockbuster
 coverage
 freezegun
+isal
 mypy; implementation_name == "cpython"
 proxy.py >= 2.4.4rc5
 pytest
@@ -15,3 +16,4 @@ re-assert
 setuptools-git
 trustme; platform_machine != "i686"  # no 32-bit wheels
 wait-for-it
+zlib_ng

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -53,6 +53,8 @@ idna==3.4
     #   yarl
 iniconfig==2.1.0
     # via pytest
+isal==1.7.2
+    # via -r requirements/test.in
 markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
@@ -140,3 +142,5 @@ wait-for-it==2.3.0
     # via -r requirements/test.in
 yarl==1.19.0
     # via -r requirements/runtime-deps.in
+zlib_ng==0.5.1
+    # via -r requirements/test.in

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2040,16 +2040,9 @@ async def test_expect_continue(aiohttp_client) -> None:
     assert expect_called
 
 
-<<<<<<< HEAD
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_encoding_deflate(aiohttp_client) -> None:
     async def handler(request):
-=======
-@pytest.mark.usefixtures("parametrize_zlib_backend")
-async def test_encoding_deflate(
-    aiohttp_client: AiohttpClient,
-) -> None:
-    async def handler(request: web.Request) -> web.Response:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
         resp = web.Response(text="text")
         resp.enable_chunked_encoding()
         resp.enable_compression(web.ContentCoding.deflate)
@@ -2066,16 +2059,9 @@ async def test_encoding_deflate(
     resp.close()
 
 
-<<<<<<< HEAD
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_encoding_deflate_nochunk(aiohttp_client) -> None:
     async def handler(request):
-=======
-@pytest.mark.usefixtures("parametrize_zlib_backend")
-async def test_encoding_deflate_nochunk(
-    aiohttp_client: AiohttpClient,
-) -> None:
-    async def handler(request: web.Request) -> web.Response:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
         resp = web.Response(text="text")
         resp.enable_compression(web.ContentCoding.deflate)
         return resp
@@ -2091,16 +2077,9 @@ async def test_encoding_deflate_nochunk(
     resp.close()
 
 
-<<<<<<< HEAD
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_encoding_gzip(aiohttp_client) -> None:
     async def handler(request):
-=======
-@pytest.mark.usefixtures("parametrize_zlib_backend")
-async def test_encoding_gzip(
-    aiohttp_client: AiohttpClient,
-) -> None:
-    async def handler(request: web.Request) -> web.Response:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
         resp = web.Response(text="text")
         resp.enable_chunked_encoding()
         resp.enable_compression(web.ContentCoding.gzip)
@@ -2117,16 +2096,9 @@ async def test_encoding_gzip(
     resp.close()
 
 
-<<<<<<< HEAD
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_encoding_gzip_write_by_chunks(aiohttp_client) -> None:
     async def handler(request):
-=======
-@pytest.mark.usefixtures("parametrize_zlib_backend")
-async def test_encoding_gzip_write_by_chunks(
-    aiohttp_client: AiohttpClient,
-) -> None:
-    async def handler(request: web.Request) -> web.StreamResponse:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
         resp = web.StreamResponse()
         resp.enable_compression(web.ContentCoding.gzip)
         await resp.prepare(request)
@@ -2145,16 +2117,9 @@ async def test_encoding_gzip_write_by_chunks(
     resp.close()
 
 
-<<<<<<< HEAD
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_encoding_gzip_nochunk(aiohttp_client) -> None:
     async def handler(request):
-=======
-@pytest.mark.usefixtures("parametrize_zlib_backend")
-async def test_encoding_gzip_nochunk(
-    aiohttp_client: AiohttpClient,
-) -> None:
-    async def handler(request: web.Request) -> web.Response:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
         resp = web.Response(text="text")
         resp.enable_compression(web.ContentCoding.gzip)
         return resp

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2040,8 +2040,16 @@ async def test_expect_continue(aiohttp_client) -> None:
     assert expect_called
 
 
+<<<<<<< HEAD
 async def test_encoding_deflate(aiohttp_client) -> None:
     async def handler(request):
+=======
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_encoding_deflate(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    async def handler(request: web.Request) -> web.Response:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
         resp = web.Response(text="text")
         resp.enable_chunked_encoding()
         resp.enable_compression(web.ContentCoding.deflate)
@@ -2058,8 +2066,16 @@ async def test_encoding_deflate(aiohttp_client) -> None:
     resp.close()
 
 
+<<<<<<< HEAD
 async def test_encoding_deflate_nochunk(aiohttp_client) -> None:
     async def handler(request):
+=======
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_encoding_deflate_nochunk(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    async def handler(request: web.Request) -> web.Response:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
         resp = web.Response(text="text")
         resp.enable_compression(web.ContentCoding.deflate)
         return resp
@@ -2075,8 +2091,16 @@ async def test_encoding_deflate_nochunk(aiohttp_client) -> None:
     resp.close()
 
 
+<<<<<<< HEAD
 async def test_encoding_gzip(aiohttp_client) -> None:
     async def handler(request):
+=======
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_encoding_gzip(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    async def handler(request: web.Request) -> web.Response:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
         resp = web.Response(text="text")
         resp.enable_chunked_encoding()
         resp.enable_compression(web.ContentCoding.gzip)
@@ -2093,8 +2117,16 @@ async def test_encoding_gzip(aiohttp_client) -> None:
     resp.close()
 
 
+<<<<<<< HEAD
 async def test_encoding_gzip_write_by_chunks(aiohttp_client) -> None:
     async def handler(request):
+=======
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_encoding_gzip_write_by_chunks(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    async def handler(request: web.Request) -> web.StreamResponse:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
         resp = web.StreamResponse()
         resp.enable_compression(web.ContentCoding.gzip)
         await resp.prepare(request)
@@ -2113,8 +2145,16 @@ async def test_encoding_gzip_write_by_chunks(aiohttp_client) -> None:
     resp.close()
 
 
+<<<<<<< HEAD
 async def test_encoding_gzip_nochunk(aiohttp_client) -> None:
     async def handler(request):
+=======
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_encoding_gzip_nochunk(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    async def handler(request: web.Request) -> web.Response:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
         resp = web.Response(text="text")
         resp.enable_compression(web.ContentCoding.gzip)
         return resp

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -3,11 +3,7 @@ import hashlib
 import io
 import pathlib
 import sys
-<<<<<<< HEAD
 import urllib.parse
-import zlib
-=======
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from http.cookies import BaseCookie, Morsel, SimpleCookie
 from typing import Any, Callable, Dict, Iterable, Optional
 from unittest import mock
@@ -26,11 +22,7 @@ from aiohttp.client_reqrep import (
     _gen_default_accept_encoding,
     _merge_ssl_params,
 )
-<<<<<<< HEAD
-=======
 from aiohttp.compression_utils import ZLibBackend
-from aiohttp.connector import Connection
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from aiohttp.http import HttpVersion10, HttpVersion11
 from aiohttp.test_utils import make_mocked_coro
 
@@ -808,15 +800,8 @@ async def test_bytes_data(loop, conn) -> None:
         resp.close()
 
 
-<<<<<<< HEAD
-async def test_content_encoding(loop, conn) -> None:
-=======
 @pytest.mark.usefixtures("parametrize_zlib_backend")
-async def test_content_encoding(
-    loop: asyncio.AbstractEventLoop,
-    conn: mock.Mock,
-) -> None:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
+async def test_content_encoding(loop, conn) -> None:
     req = ClientRequest(
         "post", URL("http://python.org/"), data="foo", compress="deflate", loop=loop
     )
@@ -842,15 +827,8 @@ async def test_content_encoding_dont_set_headers_if_no_body(loop, conn) -> None:
     resp.close()
 
 
-<<<<<<< HEAD
-async def test_content_encoding_header(loop, conn) -> None:
-=======
 @pytest.mark.usefixtures("parametrize_zlib_backend")
-async def test_content_encoding_header(
-    loop: asyncio.AbstractEventLoop,
-    conn: mock.Mock,
-) -> None:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
+async def test_content_encoding_header(loop, conn) -> None:
     req = ClientRequest(
         "post",
         URL("http://python.org/"),
@@ -949,16 +927,9 @@ async def test_file_upload_not_chunked(loop) -> None:
         await req.close()
 
 
-<<<<<<< HEAD
-async def test_precompressed_data_stays_intact(loop) -> None:
-    data = zlib.compress(b"foobar")
-=======
 @pytest.mark.usefixtures("parametrize_zlib_backend")
-async def test_precompressed_data_stays_intact(
-    loop: asyncio.AbstractEventLoop,
-) -> None:
+async def test_precompressed_data_stays_intact(loop) -> None:
     data = ZLibBackend.compress(b"foobar")
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     req = ClientRequest(
         "post",
         URL("http://python.org/"),

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -3,8 +3,11 @@ import hashlib
 import io
 import pathlib
 import sys
+<<<<<<< HEAD
 import urllib.parse
 import zlib
+=======
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from http.cookies import BaseCookie, Morsel, SimpleCookie
 from typing import Any, Callable, Dict, Iterable, Optional
 from unittest import mock
@@ -23,6 +26,11 @@ from aiohttp.client_reqrep import (
     _gen_default_accept_encoding,
     _merge_ssl_params,
 )
+<<<<<<< HEAD
+=======
+from aiohttp.compression_utils import ZLibBackend
+from aiohttp.connector import Connection
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from aiohttp.http import HttpVersion10, HttpVersion11
 from aiohttp.test_utils import make_mocked_coro
 
@@ -800,7 +808,15 @@ async def test_bytes_data(loop, conn) -> None:
         resp.close()
 
 
+<<<<<<< HEAD
 async def test_content_encoding(loop, conn) -> None:
+=======
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_content_encoding(
+    loop: asyncio.AbstractEventLoop,
+    conn: mock.Mock,
+) -> None:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     req = ClientRequest(
         "post", URL("http://python.org/"), data="foo", compress="deflate", loop=loop
     )
@@ -826,7 +842,15 @@ async def test_content_encoding_dont_set_headers_if_no_body(loop, conn) -> None:
     resp.close()
 
 
+<<<<<<< HEAD
 async def test_content_encoding_header(loop, conn) -> None:
+=======
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_content_encoding_header(
+    loop: asyncio.AbstractEventLoop,
+    conn: mock.Mock,
+) -> None:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     req = ClientRequest(
         "post",
         URL("http://python.org/"),
@@ -925,8 +949,16 @@ async def test_file_upload_not_chunked(loop) -> None:
         await req.close()
 
 
+<<<<<<< HEAD
 async def test_precompressed_data_stays_intact(loop) -> None:
     data = zlib.compress(b"foobar")
+=======
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_precompressed_data_stays_intact(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    data = ZLibBackend.compress(b"foobar")
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     req = ClientRequest(
         "post",
         URL("http://python.org/"),

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -953,6 +953,7 @@ async def test_close_websocket_while_ping_inflight(
     assert cancelled is True
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_send_recv_compress(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.WebSocketResponse:
         ws = web.WebSocketResponse()
@@ -978,8 +979,14 @@ async def test_send_recv_compress(aiohttp_client: AiohttpClient) -> None:
     assert resp.get_extra_info("socket") is None
 
 
+<<<<<<< HEAD
 async def test_send_recv_compress_wbits(aiohttp_client) -> None:
     async def handler(request):
+=======
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_send_recv_compress_wbits(aiohttp_client: AiohttpClient) -> None:
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
         ws = web.WebSocketResponse()
         await ws.prepare(request)
 

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -979,14 +979,9 @@ async def test_send_recv_compress(aiohttp_client: AiohttpClient) -> None:
     assert resp.get_extra_info("socket") is None
 
 
-<<<<<<< HEAD
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_send_recv_compress_wbits(aiohttp_client) -> None:
     async def handler(request):
-=======
-@pytest.mark.usefixtures("parametrize_zlib_backend")
-async def test_send_recv_compress_wbits(aiohttp_client: AiohttpClient) -> None:
-    async def handler(request: web.Request) -> web.WebSocketResponse:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
         ws = web.WebSocketResponse()
         await ws.prepare(request)
 

--- a/tests/test_compression_utils.py
+++ b/tests/test_compression_utils.py
@@ -1,22 +1,34 @@
 """Tests for compression utils."""
 
-from aiohttp.compression_utils import ZLibCompressor, ZLibDecompressor
+import pytest
+
+from aiohttp.compression_utils import ZLibBackend, ZLibCompressor, ZLibDecompressor
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_compression_round_trip_in_executor() -> None:
     """Ensure that compression and decompression work correctly in the executor."""
-    compressor = ZLibCompressor(max_sync_chunk_size=1)
+    compressor = ZLibCompressor(
+        strategy=ZLibBackend.Z_DEFAULT_STRATEGY, max_sync_chunk_size=1
+    )
+    assert type(compressor._compressor) is type(ZLibBackend.compressobj())
     decompressor = ZLibDecompressor(max_sync_chunk_size=1)
+    assert type(decompressor._decompressor) is type(ZLibBackend.decompressobj())
     data = b"Hi" * 100
     compressed_data = await compressor.compress(data) + compressor.flush()
     decompressed_data = await decompressor.decompress(compressed_data)
     assert data == decompressed_data
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_compression_round_trip_in_event_loop() -> None:
     """Ensure that compression and decompression work correctly in the event loop."""
-    compressor = ZLibCompressor(max_sync_chunk_size=10000)
+    compressor = ZLibCompressor(
+        strategy=ZLibBackend.Z_DEFAULT_STRATEGY, max_sync_chunk_size=10000
+    )
+    assert type(compressor._compressor) is type(ZLibBackend.compressobj())
     decompressor = ZLibDecompressor(max_sync_chunk_size=10000)
+    assert type(decompressor._decompressor) is type(ZLibBackend.decompressobj())
     data = b"Hi" * 100
     compressed_data = await compressor.compress(data) + compressor.flush()
     decompressed_data = await decompressor.decompress(compressed_data)

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -2,7 +2,11 @@
 import array
 import asyncio
 import zlib
+<<<<<<< HEAD
 from typing import Generator, Iterable
+=======
+from typing import Any, Generator, Iterable, Union
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from unittest import mock
 
 import pytest
@@ -10,6 +14,7 @@ from multidict import CIMultiDict
 
 from aiohttp import ClientConnectionResetError, hdrs, http
 from aiohttp.base_protocol import BaseProtocol
+from aiohttp.compression_utils import ZLibBackend
 from aiohttp.http_writer import _serialize_headers
 from aiohttp.test_utils import make_mocked_coro
 
@@ -61,7 +66,35 @@ def protocol(loop, transport):
     return protocol
 
 
+<<<<<<< HEAD
 def test_payloadwriter_properties(transport, protocol, loop) -> None:
+=======
+def decompress(data: bytes) -> bytes:
+    d = ZLibBackend.decompressobj()
+    return d.decompress(data)
+
+
+def decode_chunked(chunked: Union[bytes, bytearray]) -> bytes:
+    i = 0
+    out = b""
+    while i < len(chunked):
+        j = chunked.find(b"\r\n", i)
+        assert j != -1, "Malformed chunk"
+        size = int(chunked[i:j], 16)
+        if size == 0:
+            break
+        i = j + 2
+        out += chunked[i : i + size]
+        i += size + 2  # skip \r\n after the chunk
+    return out
+
+
+def test_payloadwriter_properties(
+    transport: asyncio.Transport,
+    protocol: BaseProtocol,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     writer = http.StreamWriter(protocol, loop)
     assert writer.protocol == protocol
     assert writer.transport == transport
@@ -112,6 +145,7 @@ async def test_write_payload_length(protocol, transport, loop) -> None:
 
 
 @pytest.mark.usefixtures("disable_writelines")
+@pytest.mark.internal  # Used for performance benchmarking
 async def test_write_large_payload_deflate_compression_data_in_eof(
     protocol: BaseProtocol,
     transport: asyncio.Transport,
@@ -137,7 +171,42 @@ async def test_write_large_payload_deflate_compression_data_in_eof(
     assert zlib.decompress(content) == (b"data" * 4096) + payload
 
 
+@pytest.mark.usefixtures("disable_writelines")
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_write_large_payload_deflate_compression_data_in_eof_all_zlib(
+    protocol: BaseProtocol,
+    transport: asyncio.Transport,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    msg = http.StreamWriter(protocol, loop)
+    msg.enable_compression("deflate")
+
+    await msg.write(b"data" * 4096)
+    # Behavior depends on zlib backend, isal compress() returns b'' initially
+    # and the entire compressed bytes at flush() for this data
+    backend_to_write_called = {
+        "isal.isal_zlib": False,
+        "zlib": True,
+        "zlib_ng.zlib_ng": True,
+    }
+    assert transport.write.called == backend_to_write_called[ZLibBackend.name]  # type: ignore[attr-defined]
+    chunks = [c[1][0] for c in list(transport.write.mock_calls)]  # type: ignore[attr-defined]
+    transport.write.reset_mock()  # type: ignore[attr-defined]
+
+    # This payload compresses to 20447 bytes
+    payload = b"".join(
+        [bytes((*range(0, i), *range(i, 0, -1))) for i in range(255) for _ in range(64)]
+    )
+    await msg.write_eof(payload)
+    chunks.extend([c[1][0] for c in list(transport.write.mock_calls)])  # type: ignore[attr-defined]
+
+    assert all(chunks)
+    content = b"".join(chunks)
+    assert ZLibBackend.decompress(content) == (b"data" * 4096) + payload
+
+
 @pytest.mark.usefixtures("enable_writelines")
+@pytest.mark.internal  # Used for performance benchmarking
 async def test_write_large_payload_deflate_compression_data_in_eof_writelines(
     protocol: BaseProtocol,
     transport: asyncio.Transport,
@@ -162,6 +231,43 @@ async def test_write_large_payload_deflate_compression_data_in_eof_writelines(
     chunks.extend(transport.writelines.mock_calls[0][1][0])  # type: ignore[attr-defined]
     content = b"".join(chunks)
     assert zlib.decompress(content) == (b"data" * 4096) + payload
+
+
+@pytest.mark.usefixtures("enable_writelines")
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_write_large_payload_deflate_compression_data_in_eof_writelines_all_zlib(
+    protocol: BaseProtocol,
+    transport: asyncio.Transport,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    msg = http.StreamWriter(protocol, loop)
+    msg.enable_compression("deflate")
+
+    await msg.write(b"data" * 4096)
+    # Behavior depends on zlib backend, isal compress() returns b'' initially
+    # and the entire compressed bytes at flush() for this data
+    backend_to_write_called = {
+        "isal.isal_zlib": False,
+        "zlib": True,
+        "zlib_ng.zlib_ng": True,
+    }
+    assert transport.write.called == backend_to_write_called[ZLibBackend.name]  # type: ignore[attr-defined]
+    chunks = [c[1][0] for c in list(transport.write.mock_calls)]  # type: ignore[attr-defined]
+    transport.write.reset_mock()  # type: ignore[attr-defined]
+    assert not transport.writelines.called  # type: ignore[attr-defined]
+
+    # This payload compresses to 20447 bytes
+    payload = b"".join(
+        [bytes((*range(0, i), *range(i, 0, -1))) for i in range(255) for _ in range(64)]
+    )
+    await msg.write_eof(payload)
+    assert transport.writelines.called != transport.write.called  # type: ignore[attr-defined]
+    if transport.writelines.called:  # type: ignore[attr-defined]
+        chunks.extend(transport.writelines.mock_calls[0][1][0])  # type: ignore[attr-defined]
+    else:  # transport.write.called:  # type: ignore[attr-defined]
+        chunks.extend([c[1][0] for c in list(transport.write.mock_calls)])  # type: ignore[attr-defined]
+    content = b"".join(chunks)
+    assert ZLibBackend.decompress(content) == (b"data" * 4096) + payload
 
 
 async def test_write_payload_chunked_filter(
@@ -200,7 +306,16 @@ async def test_write_payload_chunked_filter_multiple_chunks(
     )
 
 
+<<<<<<< HEAD
 async def test_write_payload_deflate_compression(protocol, transport, loop) -> None:
+=======
+@pytest.mark.internal  # Used for performance benchmarking
+async def test_write_payload_deflate_compression(
+    protocol: BaseProtocol,
+    transport: asyncio.Transport,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     COMPRESSED = b"x\x9cKI,I\x04\x00\x04\x00\x01\x9b"
     write = transport.write = mock.Mock()
     msg = http.StreamWriter(protocol, loop)
@@ -214,6 +329,24 @@ async def test_write_payload_deflate_compression(protocol, transport, loop) -> N
     assert COMPRESSED == content.split(b"\r\n\r\n", 1)[-1]
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_write_payload_deflate_compression_all_zlib(
+    protocol: BaseProtocol,
+    transport: asyncio.Transport,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    msg = http.StreamWriter(protocol, loop)
+    msg.enable_compression("deflate")
+    await msg.write(b"data")
+    await msg.write_eof()
+
+    chunks = [c[1][0] for c in list(transport.write.mock_calls)]  # type: ignore[attr-defined]
+    assert all(chunks)
+    content = b"".join(chunks)
+    assert b"data" == decompress(content)
+
+
+@pytest.mark.internal  # Used for performance benchmarking
 async def test_write_payload_deflate_compression_chunked(
     protocol: BaseProtocol,
     transport: asyncio.Transport,
@@ -232,8 +365,27 @@ async def test_write_payload_deflate_compression_chunked(
     assert content == expected
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_write_payload_deflate_compression_chunked_all_zlib(
+    protocol: BaseProtocol,
+    transport: asyncio.Transport,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    msg = http.StreamWriter(protocol, loop)
+    msg.enable_compression("deflate")
+    msg.enable_chunking()
+    await msg.write(b"data")
+    await msg.write_eof()
+
+    chunks = [c[1][0] for c in list(transport.write.mock_calls)]  # type: ignore[attr-defined]
+    assert all(chunks)
+    content = b"".join(chunks)
+    assert b"data" == decompress(decode_chunked(content))
+
+
 @pytest.mark.usefixtures("enable_writelines")
 @pytest.mark.usefixtures("force_writelines_small_payloads")
+@pytest.mark.internal  # Used for performance benchmarking
 async def test_write_payload_deflate_compression_chunked_writelines(
     protocol: BaseProtocol,
     transport: asyncio.Transport,
@@ -252,6 +404,27 @@ async def test_write_payload_deflate_compression_chunked_writelines(
     assert content == expected
 
 
+@pytest.mark.usefixtures("enable_writelines")
+@pytest.mark.usefixtures("force_writelines_small_payloads")
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_write_payload_deflate_compression_chunked_writelines_all_zlib(
+    protocol: BaseProtocol,
+    transport: asyncio.Transport,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    msg = http.StreamWriter(protocol, loop)
+    msg.enable_compression("deflate")
+    msg.enable_chunking()
+    await msg.write(b"data")
+    await msg.write_eof()
+
+    chunks = [b"".join(c[1][0]) for c in list(transport.writelines.mock_calls)]  # type: ignore[attr-defined]
+    assert all(chunks)
+    content = b"".join(chunks)
+    assert b"data" == decompress(decode_chunked(content))
+
+
+@pytest.mark.internal  # Used for performance benchmarking
 async def test_write_payload_deflate_and_chunked(
     buf: bytearray,
     protocol: BaseProtocol,
@@ -270,6 +443,25 @@ async def test_write_payload_deflate_and_chunked(
     assert thing == buf
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_write_payload_deflate_and_chunked_all_zlib(
+    buf: bytearray,
+    protocol: BaseProtocol,
+    transport: asyncio.Transport,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    msg = http.StreamWriter(protocol, loop)
+    msg.enable_compression("deflate")
+    msg.enable_chunking()
+
+    await msg.write(b"da")
+    await msg.write(b"ta")
+    await msg.write_eof()
+
+    assert b"data" == decompress(decode_chunked(buf))
+
+
+@pytest.mark.internal  # Used for performance benchmarking
 async def test_write_payload_deflate_compression_chunked_data_in_eof(
     protocol: BaseProtocol,
     transport: asyncio.Transport,
@@ -288,8 +480,27 @@ async def test_write_payload_deflate_compression_chunked_data_in_eof(
     assert content == expected
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_write_payload_deflate_compression_chunked_data_in_eof_all_zlib(
+    protocol: BaseProtocol,
+    transport: asyncio.Transport,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    msg = http.StreamWriter(protocol, loop)
+    msg.enable_compression("deflate")
+    msg.enable_chunking()
+    await msg.write(b"data")
+    await msg.write_eof(b"end")
+
+    chunks = [c[1][0] for c in list(transport.write.mock_calls)]  # type: ignore[attr-defined]
+    assert all(chunks)
+    content = b"".join(chunks)
+    assert b"dataend" == decompress(decode_chunked(content))
+
+
 @pytest.mark.usefixtures("enable_writelines")
 @pytest.mark.usefixtures("force_writelines_small_payloads")
+@pytest.mark.internal  # Used for performance benchmarking
 async def test_write_payload_deflate_compression_chunked_data_in_eof_writelines(
     protocol: BaseProtocol,
     transport: asyncio.Transport,
@@ -308,6 +519,27 @@ async def test_write_payload_deflate_compression_chunked_data_in_eof_writelines(
     assert content == expected
 
 
+@pytest.mark.usefixtures("enable_writelines")
+@pytest.mark.usefixtures("force_writelines_small_payloads")
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_write_payload_deflate_compression_chunked_data_in_eof_writelines_all_zlib(
+    protocol: BaseProtocol,
+    transport: asyncio.Transport,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    msg = http.StreamWriter(protocol, loop)
+    msg.enable_compression("deflate")
+    msg.enable_chunking()
+    await msg.write(b"data")
+    await msg.write_eof(b"end")
+
+    chunks = [b"".join(c[1][0]) for c in list(transport.writelines.mock_calls)]  # type: ignore[attr-defined]
+    assert all(chunks)
+    content = b"".join(chunks)
+    assert b"dataend" == decompress(decode_chunked(content))
+
+
+@pytest.mark.internal  # Used for performance benchmarking
 async def test_write_large_payload_deflate_compression_chunked_data_in_eof(
     protocol: BaseProtocol,
     transport: asyncio.Transport,
@@ -334,8 +566,36 @@ async def test_write_large_payload_deflate_compression_chunked_data_in_eof(
     assert zlib.decompress(content) == (b"data" * 4096) + payload
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_write_large_payload_deflate_compression_chunked_data_in_eof_all_zlib(
+    protocol: BaseProtocol,
+    transport: asyncio.Transport,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    msg = http.StreamWriter(protocol, loop)
+    msg.enable_compression("deflate")
+    msg.enable_chunking()
+
+    await msg.write(b"data" * 4096)
+    # This payload compresses to 1111 bytes
+    payload = b"".join([bytes((*range(0, i), *range(i, 0, -1))) for i in range(255)])
+    await msg.write_eof(payload)
+
+    compressed = []
+    chunks = [c[1][0] for c in list(transport.write.mock_calls)]  # type: ignore[attr-defined]
+    chunked_body = b"".join(chunks)
+    split_body = chunked_body.split(b"\r\n")
+    while split_body:
+        if split_body.pop(0):
+            compressed.append(split_body.pop(0))
+
+    content = b"".join(compressed)
+    assert ZLibBackend.decompress(content) == (b"data" * 4096) + payload
+
+
 @pytest.mark.usefixtures("enable_writelines")
 @pytest.mark.usefixtures("force_writelines_small_payloads")
+@pytest.mark.internal  # Used for performance benchmarking
 async def test_write_large_payload_deflate_compression_chunked_data_in_eof_writelines(
     protocol: BaseProtocol,
     transport: asyncio.Transport,
@@ -362,7 +622,56 @@ async def test_write_large_payload_deflate_compression_chunked_data_in_eof_write
     assert zlib.decompress(content) == (b"data" * 4096) + payload
 
 
+@pytest.mark.usefixtures("enable_writelines")
+@pytest.mark.usefixtures("force_writelines_small_payloads")
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_write_large_payload_deflate_compression_chunked_data_in_eof_writelines_all_zlib(
+    protocol: BaseProtocol,
+    transport: asyncio.Transport,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    msg = http.StreamWriter(protocol, loop)
+    msg.enable_compression("deflate")
+    msg.enable_chunking()
+
+    await msg.write(b"data" * 4096)
+    # This payload compresses to 1111 bytes
+    payload = b"".join([bytes((*range(0, i), *range(i, 0, -1))) for i in range(255)])
+    await msg.write_eof(payload)
+    assert not transport.write.called  # type: ignore[attr-defined]
+
+    chunks = []
+    for write_lines_call in transport.writelines.mock_calls:  # type: ignore[attr-defined]
+        chunked_payload = list(write_lines_call[1][0])[1:]
+        chunked_payload.pop()
+        chunks.extend(chunked_payload)
+
+    assert all(chunks)
+    content = b"".join(chunks)
+    assert ZLibBackend.decompress(content) == (b"data" * 4096) + payload
+
+
+@pytest.mark.internal  # Used for performance benchmarking
 async def test_write_payload_deflate_compression_chunked_connection_lost(
+    protocol: BaseProtocol,
+    transport: asyncio.Transport,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    msg = http.StreamWriter(protocol, loop)
+    msg.enable_compression("deflate")
+    msg.enable_chunking()
+    await msg.write(b"data")
+    with (
+        pytest.raises(
+            ClientConnectionResetError, match="Cannot write to closing transport"
+        ),
+        mock.patch.object(transport, "is_closing", return_value=True),
+    ):
+        await msg.write_eof(b"end")
+
+
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_write_payload_deflate_compression_chunked_connection_lost_all_zlib(
     protocol: BaseProtocol,
     transport: asyncio.Transport,
     loop: asyncio.AbstractEventLoop,

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -2,11 +2,7 @@
 import array
 import asyncio
 import zlib
-<<<<<<< HEAD
-from typing import Generator, Iterable
-=======
-from typing import Any, Generator, Iterable, Union
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
+from typing import Generator, Iterable, Union
 from unittest import mock
 
 import pytest
@@ -66,9 +62,6 @@ def protocol(loop, transport):
     return protocol
 
 
-<<<<<<< HEAD
-def test_payloadwriter_properties(transport, protocol, loop) -> None:
-=======
 def decompress(data: bytes) -> bytes:
     d = ZLibBackend.decompressobj()
     return d.decompress(data)
@@ -89,12 +82,7 @@ def decode_chunked(chunked: Union[bytes, bytearray]) -> bytes:
     return out
 
 
-def test_payloadwriter_properties(
-    transport: asyncio.Transport,
-    protocol: BaseProtocol,
-    loop: asyncio.AbstractEventLoop,
-) -> None:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
+def test_payloadwriter_properties(transport, protocol, loop) -> None:
     writer = http.StreamWriter(protocol, loop)
     assert writer.protocol == protocol
     assert writer.transport == transport
@@ -306,16 +294,8 @@ async def test_write_payload_chunked_filter_multiple_chunks(
     )
 
 
-<<<<<<< HEAD
-async def test_write_payload_deflate_compression(protocol, transport, loop) -> None:
-=======
 @pytest.mark.internal  # Used for performance benchmarking
-async def test_write_payload_deflate_compression(
-    protocol: BaseProtocol,
-    transport: asyncio.Transport,
-    loop: asyncio.AbstractEventLoop,
-) -> None:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
+async def test_write_payload_deflate_compression(protocol, transport, loop) -> None:
     COMPRESSED = b"x\x9cKI,I\x04\x00\x04\x00\x01\x9b"
     write = transport.write = mock.Mock()
     msg = http.StreamWriter(protocol, loop)

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -3,12 +3,6 @@ import io
 import json
 import pathlib
 import sys
-<<<<<<< HEAD
-import zlib
-=======
-from types import TracebackType
-from typing import Dict, Optional, Tuple, Type
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from unittest import mock
 
 import pytest
@@ -1196,16 +1190,8 @@ async def test_writer_write_no_parts(buf, stream, writer) -> None:
     assert b"--:--\r\n" == bytes(buf)
 
 
-<<<<<<< HEAD
-async def test_writer_serialize_with_content_encoding_gzip(buf, stream, writer):
-=======
 @pytest.mark.usefixtures("parametrize_zlib_backend")
-async def test_writer_serialize_with_content_encoding_gzip(
-    buf: bytearray,
-    stream: Stream,
-    writer: aiohttp.MultipartWriter,
-) -> None:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
+async def test_writer_serialize_with_content_encoding_gzip(buf, stream, writer):
     writer.append("Time to Relax!", {CONTENT_ENCODING: "gzip"})
     await writer.write(stream)
     headers, message = bytes(buf).split(b"\r\n\r\n", 1)

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -3,13 +3,19 @@ import io
 import json
 import pathlib
 import sys
+<<<<<<< HEAD
 import zlib
+=======
+from types import TracebackType
+from typing import Dict, Optional, Tuple, Type
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from unittest import mock
 
 import pytest
 
 import aiohttp
 from aiohttp import payload
+from aiohttp.compression_utils import ZLibBackend
 from aiohttp.hdrs import (
     CONTENT_DISPOSITION,
     CONTENT_ENCODING,
@@ -1190,7 +1196,16 @@ async def test_writer_write_no_parts(buf, stream, writer) -> None:
     assert b"--:--\r\n" == bytes(buf)
 
 
+<<<<<<< HEAD
 async def test_writer_serialize_with_content_encoding_gzip(buf, stream, writer):
+=======
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_writer_serialize_with_content_encoding_gzip(
+    buf: bytearray,
+    stream: Stream,
+    writer: aiohttp.MultipartWriter,
+) -> None:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     writer.append("Time to Relax!", {CONTENT_ENCODING: "gzip"})
     await writer.write(stream)
     headers, message = bytes(buf).split(b"\r\n\r\n", 1)
@@ -1200,7 +1215,7 @@ async def test_writer_serialize_with_content_encoding_gzip(buf, stream, writer):
         b"Content-Encoding: gzip" == headers
     )
 
-    decompressor = zlib.decompressobj(wbits=16 + zlib.MAX_WBITS)
+    decompressor = ZLibBackend.decompressobj(wbits=16 + ZLibBackend.MAX_WBITS)
     data = decompressor.decompress(message.split(b"\r\n")[0])
     data += decompressor.flush()
     assert b"Time to Relax!" == data

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -4,22 +4,7 @@ import json
 import pathlib
 import socket
 import sys
-<<<<<<< HEAD
-import zlib
-from typing import Any, NoReturn, Optional
-=======
-from typing import (
-    AsyncIterator,
-    Awaitable,
-    Callable,
-    Dict,
-    Generator,
-    List,
-    NoReturn,
-    Optional,
-    Tuple,
-)
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
+from typing import Any, Dict, Generator, NoReturn, Optional, Tuple
 from unittest import mock
 
 import pytest
@@ -36,11 +21,7 @@ from aiohttp import (
     multipart,
     web,
 )
-<<<<<<< HEAD
-=======
-from aiohttp.abc import AbstractResolver, ResolveResult
 from aiohttp.compression_utils import ZLibBackend, ZLibCompressObjProtocol
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from aiohttp.hdrs import CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING
 from aiohttp.pytest_plugin import AiohttpClient
 from aiohttp.test_utils import make_mocked_coro
@@ -1172,18 +1153,12 @@ def compressor_case(
 
 
 async def test_response_with_precompressed_body(
-<<<<<<< HEAD
-    aiohttp_client, compressor, encoding
-) -> None:
-    async def handler(request):
-=======
     aiohttp_client: AiohttpClient,
     compressor_case: Tuple[ZLibCompressObjProtocol, str],
 ) -> None:
     compressor, encoding = compressor_case
 
-    async def handler(request: web.Request) -> web.Response:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
+    async def handler(request):
         headers = {"Content-Encoding": encoding}
         data = compressor.compress(b"mydata") + compressor.flush()
         return web.Response(body=data, headers=headers)

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -3,8 +3,13 @@ import datetime
 import gzip
 import io
 import json
+<<<<<<< HEAD
 import sys
 import zlib
+=======
+import re
+import weakref
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from concurrent.futures import ThreadPoolExecutor
 from typing import AsyncIterator, Optional
 from unittest import mock
@@ -417,6 +422,7 @@ async def test_chunked_encoding_forbidden_for_http_10() -> None:
     assert Matches("Using chunked encoding is forbidden for HTTP/1.0") == str(ctx.value)
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_compression_no_accept() -> None:
     req = make_request("GET", "/")
     resp = StreamResponse()
@@ -458,6 +464,7 @@ async def test_force_compression_false_backwards_compat() -> None:
     assert not msg.enable_compression.called
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_compression_default_coding() -> None:
     req = make_request(
         "GET", "/", headers=CIMultiDict({hdrs.ACCEPT_ENCODING: "gzip, deflate"})
@@ -471,11 +478,12 @@ async def test_compression_default_coding() -> None:
 
     msg = await resp.prepare(req)
 
-    msg.enable_compression.assert_called_with("deflate", zlib.Z_DEFAULT_STRATEGY)
+    msg.enable_compression.assert_called_with("deflate", None)
     assert "deflate" == resp.headers.get(hdrs.CONTENT_ENCODING)
     assert msg.filter is not None
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_force_compression_deflate() -> None:
     req = make_request(
         "GET", "/", headers=CIMultiDict({hdrs.ACCEPT_ENCODING: "gzip, deflate"})
@@ -486,10 +494,16 @@ async def test_force_compression_deflate() -> None:
     assert resp.compression
 
     msg = await resp.prepare(req)
+<<<<<<< HEAD
     msg.enable_compression.assert_called_with("deflate", zlib.Z_DEFAULT_STRATEGY)
+=======
+    assert msg is not None
+    msg.enable_compression.assert_called_with("deflate", None)  # type: ignore[attr-defined]
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     assert "deflate" == resp.headers.get(hdrs.CONTENT_ENCODING)
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_force_compression_deflate_large_payload() -> None:
     """Make sure a warning is thrown for large payloads compressed in the event loop."""
     req = make_request(
@@ -509,6 +523,7 @@ async def test_force_compression_deflate_large_payload() -> None:
     assert "deflate" == resp.headers.get(hdrs.CONTENT_ENCODING)
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_force_compression_no_accept_deflate() -> None:
     req = make_request("GET", "/")
     resp = StreamResponse()
@@ -517,10 +532,16 @@ async def test_force_compression_no_accept_deflate() -> None:
     assert resp.compression
 
     msg = await resp.prepare(req)
+<<<<<<< HEAD
     msg.enable_compression.assert_called_with("deflate", zlib.Z_DEFAULT_STRATEGY)
+=======
+    assert msg is not None
+    msg.enable_compression.assert_called_with("deflate", None)  # type: ignore[attr-defined]
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     assert "deflate" == resp.headers.get(hdrs.CONTENT_ENCODING)
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_force_compression_gzip() -> None:
     req = make_request(
         "GET", "/", headers=CIMultiDict({hdrs.ACCEPT_ENCODING: "gzip, deflate"})
@@ -531,10 +552,16 @@ async def test_force_compression_gzip() -> None:
     assert resp.compression
 
     msg = await resp.prepare(req)
+<<<<<<< HEAD
     msg.enable_compression.assert_called_with("gzip", zlib.Z_DEFAULT_STRATEGY)
+=======
+    assert msg is not None
+    msg.enable_compression.assert_called_with("gzip", None)  # type: ignore[attr-defined]
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     assert "gzip" == resp.headers.get(hdrs.CONTENT_ENCODING)
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_force_compression_no_accept_gzip() -> None:
     req = make_request("GET", "/")
     resp = StreamResponse()
@@ -543,10 +570,16 @@ async def test_force_compression_no_accept_gzip() -> None:
     assert resp.compression
 
     msg = await resp.prepare(req)
+<<<<<<< HEAD
     msg.enable_compression.assert_called_with("gzip", zlib.Z_DEFAULT_STRATEGY)
+=======
+    assert msg is not None
+    msg.enable_compression.assert_called_with("gzip", None)  # type: ignore[attr-defined]
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     assert "gzip" == resp.headers.get(hdrs.CONTENT_ENCODING)
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_change_content_threaded_compression_enabled() -> None:
     req = make_request("GET", "/")
     body_thread_size = 1024
@@ -558,6 +591,7 @@ async def test_change_content_threaded_compression_enabled() -> None:
     assert gzip.decompress(resp._compressed_body) == body
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_change_content_threaded_compression_enabled_explicit() -> None:
     req = make_request("GET", "/")
     body_thread_size = 1024
@@ -572,6 +606,7 @@ async def test_change_content_threaded_compression_enabled_explicit() -> None:
         assert gzip.decompress(resp._compressed_body) == body
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_change_content_length_if_compression_enabled() -> None:
     req = make_request("GET", "/")
     resp = Response(body=b"answer")
@@ -581,6 +616,7 @@ async def test_change_content_length_if_compression_enabled() -> None:
     assert resp.content_length is not None and resp.content_length != len(b"answer")
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_set_content_length_if_compression_enabled() -> None:
     writer = mock.Mock()
 
@@ -600,6 +636,7 @@ async def test_set_content_length_if_compression_enabled() -> None:
     assert resp.content_length == 26
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_remove_content_length_if_compression_enabled_http11() -> None:
     writer = mock.Mock()
 
@@ -616,6 +653,7 @@ async def test_remove_content_length_if_compression_enabled_http11() -> None:
     assert resp.content_length is None
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_remove_content_length_if_compression_enabled_http10() -> None:
     writer = mock.Mock()
 
@@ -632,6 +670,7 @@ async def test_remove_content_length_if_compression_enabled_http10() -> None:
     assert resp.content_length is None
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_force_compression_identity() -> None:
     writer = mock.Mock()
 
@@ -648,6 +687,7 @@ async def test_force_compression_identity() -> None:
     assert resp.content_length == 123
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_force_compression_identity_response() -> None:
     writer = mock.Mock()
 
@@ -663,6 +703,7 @@ async def test_force_compression_identity_response() -> None:
     assert resp.content_length == 6
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_rm_content_length_if_compression_http11() -> None:
     writer = mock.Mock()
 
@@ -680,6 +721,7 @@ async def test_rm_content_length_if_compression_http11() -> None:
     assert resp.content_length is None
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_rm_content_length_if_compression_http10() -> None:
     writer = mock.Mock()
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -3,13 +3,7 @@ import datetime
 import gzip
 import io
 import json
-<<<<<<< HEAD
 import sys
-import zlib
-=======
-import re
-import weakref
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from concurrent.futures import ThreadPoolExecutor
 from typing import AsyncIterator, Optional
 from unittest import mock
@@ -494,12 +488,8 @@ async def test_force_compression_deflate() -> None:
     assert resp.compression
 
     msg = await resp.prepare(req)
-<<<<<<< HEAD
-    msg.enable_compression.assert_called_with("deflate", zlib.Z_DEFAULT_STRATEGY)
-=======
     assert msg is not None
-    msg.enable_compression.assert_called_with("deflate", None)  # type: ignore[attr-defined]
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
+    msg.enable_compression.assert_called_with("deflate", None)
     assert "deflate" == resp.headers.get(hdrs.CONTENT_ENCODING)
 
 
@@ -532,12 +522,8 @@ async def test_force_compression_no_accept_deflate() -> None:
     assert resp.compression
 
     msg = await resp.prepare(req)
-<<<<<<< HEAD
-    msg.enable_compression.assert_called_with("deflate", zlib.Z_DEFAULT_STRATEGY)
-=======
     assert msg is not None
-    msg.enable_compression.assert_called_with("deflate", None)  # type: ignore[attr-defined]
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
+    msg.enable_compression.assert_called_with("deflate", None)
     assert "deflate" == resp.headers.get(hdrs.CONTENT_ENCODING)
 
 
@@ -552,12 +538,8 @@ async def test_force_compression_gzip() -> None:
     assert resp.compression
 
     msg = await resp.prepare(req)
-<<<<<<< HEAD
-    msg.enable_compression.assert_called_with("gzip", zlib.Z_DEFAULT_STRATEGY)
-=======
     assert msg is not None
-    msg.enable_compression.assert_called_with("gzip", None)  # type: ignore[attr-defined]
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
+    msg.enable_compression.assert_called_with("gzip", None)
     assert "gzip" == resp.headers.get(hdrs.CONTENT_ENCODING)
 
 
@@ -570,12 +552,8 @@ async def test_force_compression_no_accept_gzip() -> None:
     assert resp.compression
 
     msg = await resp.prepare(req)
-<<<<<<< HEAD
-    msg.enable_compression.assert_called_with("gzip", zlib.Z_DEFAULT_STRATEGY)
-=======
     assert msg is not None
-    msg.enable_compression.assert_called_with("gzip", None)  # type: ignore[attr-defined]
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
+    msg.enable_compression.assert_called_with("gzip", None)
     assert "gzip" == resp.headers.get(hdrs.CONTENT_ENCODING)
 
 

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -3,14 +3,24 @@ import bz2
 import gzip
 import pathlib
 import socket
+<<<<<<< HEAD
 import zlib
 from typing import Any, Iterable, Optional
+=======
+from typing import Iterable, Iterator, NoReturn, Optional, Protocol, Tuple
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from unittest import mock
 
 import pytest
 
 import aiohttp
 from aiohttp import web
+<<<<<<< HEAD
+=======
+from aiohttp.compression_utils import ZLibBackend
+from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
+from aiohttp.typedefs import PathLike
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 
 try:
     import brotlicffi as brotli
@@ -300,6 +310,7 @@ async def test_static_file_custom_content_type_compress(
     [("gzip, deflate", "gzip"), ("gzip, deflate, br", "br")],
 )
 @pytest.mark.parametrize("forced_compression", [None, web.ContentCoding.gzip])
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_static_file_with_encoding_and_enable_compression(
     hello_txt: pathlib.Path,
     aiohttp_client: Any,
@@ -1047,7 +1058,15 @@ async def test_static_file_if_range_invalid_date(
     await client.close()
 
 
+<<<<<<< HEAD
 async def test_static_file_compression(aiohttp_client, sender) -> None:
+=======
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_static_file_compression(
+    aiohttp_client: AiohttpClient,
+    sender: _Sender,
+) -> None:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     filepath = pathlib.Path(__file__).parent / "data.unknown_mime_type"
 
     async def handler(request):
@@ -1061,7 +1080,7 @@ async def test_static_file_compression(aiohttp_client, sender) -> None:
 
     resp = await client.get("/")
     assert resp.status == 200
-    zcomp = zlib.compressobj(wbits=zlib.MAX_WBITS)
+    zcomp = ZLibBackend.compressobj(wbits=ZLibBackend.MAX_WBITS)
     expected_body = zcomp.compress(b"file content\n") + zcomp.flush()
     assert expected_body == await resp.read()
     assert "application/octet-stream" == resp.headers["Content-Type"]

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -3,24 +3,14 @@ import bz2
 import gzip
 import pathlib
 import socket
-<<<<<<< HEAD
-import zlib
 from typing import Any, Iterable, Optional
-=======
-from typing import Iterable, Iterator, NoReturn, Optional, Protocol, Tuple
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 from unittest import mock
 
 import pytest
 
 import aiohttp
 from aiohttp import web
-<<<<<<< HEAD
-=======
 from aiohttp.compression_utils import ZLibBackend
-from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
-from aiohttp.typedefs import PathLike
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 
 try:
     import brotlicffi as brotli
@@ -1058,15 +1048,8 @@ async def test_static_file_if_range_invalid_date(
     await client.close()
 
 
-<<<<<<< HEAD
-async def test_static_file_compression(aiohttp_client, sender) -> None:
-=======
 @pytest.mark.usefixtures("parametrize_zlib_backend")
-async def test_static_file_compression(
-    aiohttp_client: AiohttpClient,
-    sender: _Sender,
-) -> None:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
+async def test_static_file_compression(aiohttp_client, sender) -> None:
     filepath = pathlib.Path(__file__).parent / "data.unknown_mime_type"
 
     async def handler(request):

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -2,8 +2,7 @@ import asyncio
 import pickle
 import random
 import struct
-import zlib
-from typing import Union
+from typing import Optional, Union
 from unittest import mock
 
 import pytest
@@ -20,8 +19,21 @@ from aiohttp._websocket.helpers import (
 from aiohttp._websocket.models import WS_DEFLATE_TRAILING
 from aiohttp._websocket.reader import WebSocketDataQueue
 from aiohttp.base_protocol import BaseProtocol
+<<<<<<< HEAD
 from aiohttp.http import WebSocketError, WSCloseCode, WSMessage, WSMsgType
 from aiohttp.http_websocket import WebSocketReader
+=======
+from aiohttp.compression_utils import ZLibBackend, ZLibBackendWrapper
+from aiohttp.http import WebSocketError, WSCloseCode, WSMsgType
+from aiohttp.http_websocket import (
+    WebSocketReader,
+    WSMessageBinary,
+    WSMessageClose,
+    WSMessagePing,
+    WSMessagePong,
+    WSMessageText,
+)
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 
 
 class PatchableWebSocketReader(WebSocketReader):
@@ -29,13 +41,24 @@ class PatchableWebSocketReader(WebSocketReader):
 
 
 def build_frame(
+<<<<<<< HEAD
     message, opcode, use_mask=False, noheader=False, is_fin=True, compress=False
 ):
+=======
+    message: bytes,
+    opcode: int,
+    noheader: bool = False,
+    is_fin: bool = True,
+    ZLibBackend: Optional[ZLibBackendWrapper] = None,
+) -> bytes:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     # Send a frame over the websocket with message as its payload.
-    if compress:
-        compressobj = zlib.compressobj(wbits=-9)
+    compress = False
+    if ZLibBackend:
+        compress = True
+        compressobj = ZLibBackend.compressobj(wbits=-9)
         message = compressobj.compress(message)
-        message = message + compressobj.flush(zlib.Z_SYNC_FLUSH)
+        message = message + compressobj.flush(ZLibBackend.Z_SYNC_FLUSH)
         if message.endswith(WS_DEFLATE_TRAILING):
             message = message[:-4]
     msg_length = len(message)
@@ -572,9 +595,14 @@ def test_msg_too_large_not_fin(out) -> None:
     assert ctx.value.code == WSCloseCode.MESSAGE_TOO_BIG
 
 
+<<<<<<< HEAD
 def test_compressed_msg_too_large(out) -> None:
+=======
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+def test_compressed_msg_too_large(out: WebSocketDataQueue) -> None:
+>>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     parser = WebSocketReader(out, 256, compress=True)
-    data = build_frame(b"aaa" * 256, WSMsgType.TEXT, compress=True)
+    data = build_frame(b"aaa" * 256, WSMsgType.TEXT, ZLibBackend=ZLibBackend)
     with pytest.raises(WebSocketError) as ctx:
         parser._feed_data(data)
     assert ctx.value.code == WSCloseCode.MESSAGE_TOO_BIG

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -2,7 +2,7 @@ import asyncio
 import pickle
 import random
 import struct
-from typing import Optional, Union
+from typing import Union
 from unittest import mock
 
 import pytest
@@ -19,21 +19,9 @@ from aiohttp._websocket.helpers import (
 from aiohttp._websocket.models import WS_DEFLATE_TRAILING
 from aiohttp._websocket.reader import WebSocketDataQueue
 from aiohttp.base_protocol import BaseProtocol
-<<<<<<< HEAD
+from aiohttp.compression_utils import ZLibBackend
 from aiohttp.http import WebSocketError, WSCloseCode, WSMessage, WSMsgType
 from aiohttp.http_websocket import WebSocketReader
-=======
-from aiohttp.compression_utils import ZLibBackend, ZLibBackendWrapper
-from aiohttp.http import WebSocketError, WSCloseCode, WSMsgType
-from aiohttp.http_websocket import (
-    WebSocketReader,
-    WSMessageBinary,
-    WSMessageClose,
-    WSMessagePing,
-    WSMessagePong,
-    WSMessageText,
-)
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
 
 
 class PatchableWebSocketReader(WebSocketReader):
@@ -41,17 +29,8 @@ class PatchableWebSocketReader(WebSocketReader):
 
 
 def build_frame(
-<<<<<<< HEAD
-    message, opcode, use_mask=False, noheader=False, is_fin=True, compress=False
+    message, opcode, use_mask=False, noheader=False, is_fin=True, ZLibBackend=None
 ):
-=======
-    message: bytes,
-    opcode: int,
-    noheader: bool = False,
-    is_fin: bool = True,
-    ZLibBackend: Optional[ZLibBackendWrapper] = None,
-) -> bytes:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     # Send a frame over the websocket with message as its payload.
     compress = False
     if ZLibBackend:
@@ -568,6 +547,7 @@ def test_parse_compress_error_frame(parser) -> None:
     assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_parse_no_compress_frame_single(
     loop: asyncio.AbstractEventLoop, out: WebSocketDataQueue
 ) -> None:
@@ -595,12 +575,7 @@ def test_msg_too_large_not_fin(out) -> None:
     assert ctx.value.code == WSCloseCode.MESSAGE_TOO_BIG
 
 
-<<<<<<< HEAD
 def test_compressed_msg_too_large(out) -> None:
-=======
-@pytest.mark.usefixtures("parametrize_zlib_backend")
-def test_compressed_msg_too_large(out: WebSocketDataQueue) -> None:
->>>>>>> ceeca6a9b (Add support for switching the zlib implementation (#10700))
     parser = WebSocketReader(out, 256, compress=True)
     data = build_frame(b"aaa" * 256, WSMsgType.TEXT, ZLibBackend=ZLibBackend)
     with pytest.raises(WebSocketError) as ctx:

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -118,6 +118,7 @@ async def test_send_compress_text_per_message(protocol, transport) -> None:
         (32, lambda count: 64 + count if count % 2 else count),
     ),
 )
+@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_concurrent_messages(
     protocol: Any,
     transport: Any,


### PR DESCRIPTION
# backport #10700 to 3.12

<!-- Thank you for your contribution! -->

## What do these changes do?

These changes allow a user to arbitrarily set the zlib backend by calling `aiohttp.set_zlib_backend()` on the zlib module of their choice. For example:

```
import aiohttp
import zlib_ng.zlib_ng as zlib_ng

aiohttp.set_zlib_backend(zlib_ng)
```

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

The only changes for the user are opt-in.

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

The only burden that could arise is if for some reason `zlib_ng.zlib_ng` or `isal.isal_zlib` change their interface to differ from `zlib`.

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

Fixes #9798

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
