### PR TITLE
Disable TLS in TLS warning for uvloop

### DIFF
--- a/CHANGES/7686.bugfix.rst
+++ b/CHANGES/7686.bugfix.rst
@@ -1,0 +1,1 @@
+Disabled TLS in TLS warning (when using HTTPS proxies) for uvloop and newer Python versions -- by :user:`lezgomatt`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -250,6 +250,7 @@ Martin Sucha
 Mathias Fröjdman
 Mathieu Dugré
 Matt VanEseltine
+Matthew Go
 Matthias Marquardt
 Matthieu Hauglustaine
 Matthieu Rigal

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1150,11 +1150,13 @@ class TCPConnector(BaseConnector):
         if req.request_info.url.scheme != "https":
             return
 
-        asyncio_supports_tls_in_tls = getattr(
-            underlying_transport,
-            "_start_tls_compatible",
-            False,
-        )
+        # Check if uvloop is being used, which supports TLS in TLS,
+        # otherwise assume that asyncio's native transport is being used.
+        if type(underlying_transport).__module__.startswith("uvloop"):
+            return
+
+        # Support in asyncio was added in Python 3.11 (bpo-44011)
+        asyncio_supports_tls_in_tls = sys.version_info >= (3, 11)
 
         if asyncio_supports_tls_in_tls:
             return

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1156,7 +1156,11 @@ class TCPConnector(BaseConnector):
             return
 
         # Support in asyncio was added in Python 3.11 (bpo-44011)
-        asyncio_supports_tls_in_tls = sys.version_info >= (3, 11)
+        asyncio_supports_tls_in_tls = sys.version_info >= (3, 11) or getattr(
+            underlying_transport,
+            "_start_tls_compatible",
+            False,
+        )
 
         if asyncio_supports_tls_in_tls:
             return

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,13 @@ try:
 except ImportError:
     TRUSTME = False
 
+
+try:
+    import uvloop
+except ImportError:
+    uvloop = None  # type: ignore[assignment]
+
+
 pytest_plugins = ("aiohttp.pytest_plugin", "pytester")
 
 IS_HPUX = sys.platform.startswith("hp-ux")
@@ -221,6 +228,16 @@ def unix_sockname(
 @pytest.fixture
 def selector_loop() -> Iterator[asyncio.AbstractEventLoop]:
     policy = asyncio.WindowsSelectorEventLoopPolicy()  # type: ignore[attr-defined]
+    asyncio.set_event_loop_policy(policy)
+
+    with loop_context(policy.new_event_loop) as _loop:
+        asyncio.set_event_loop(_loop)
+        yield _loop
+
+
+@pytest.fixture
+def uvloop_loop() -> Iterator[asyncio.AbstractEventLoop]:
+    policy = uvloop.EventLoopPolicy()  # type: ignore[attr-defined]
     asyncio.set_event_loop_policy(policy)
 
     with loop_context(policy.new_event_loop) as _loop:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,7 +237,7 @@ def selector_loop() -> Iterator[asyncio.AbstractEventLoop]:
 
 @pytest.fixture
 def uvloop_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    policy = uvloop.EventLoopPolicy()  # type: ignore[attr-defined]
+    policy = uvloop.EventLoopPolicy()
     asyncio.set_event_loop_policy(policy)
 
     with loop_context(policy.new_event_loop) as _loop:


### PR DESCRIPTION
## What do these changes do?

- Disables the TLS in TLS warning (when using HTTPS proxies) for uvloop and newer Python versions (3.11 and up)
    - Asyncio support was added in 3.11, see: bpo-44011
    - For older versions of Python, we still fallback to the original check

## Are there changes in behavior for the user?

Not really. Users using uvloop or newer versions of Python will no longer see a warning when sending an HTTPS request through an HTTPS proxy.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Fixes #7686

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
