### PR TITLE
[3.11] Bump multidict to 6.4.3

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ gunicorn==23.0.0
     # via -r requirements/base.in
 idna==3.4
     # via yarl
-multidict==6.1.0
+multidict==6.4.3
     # via
     #   -r requirements/runtime-deps.in
     #   yarl

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -116,7 +116,7 @@ markupsafe==2.1.5
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.1.0
+multidict==6.4.3
     # via
     #   -r requirements/multidict.in
     #   -r requirements/runtime-deps.in

--- a/requirements/cython.txt
+++ b/requirements/cython.txt
@@ -6,7 +6,7 @@
 #
 cython==3.0.11
     # via -r requirements/cython.in
-multidict==6.1.0
+multidict==6.4.3
     # via -r requirements/multidict.in
 typing-extensions==4.12.2
     # via multidict

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -110,7 +110,7 @@ markupsafe==2.1.5
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.1.0
+multidict==6.4.3
     # via
     #   -r requirements/runtime-deps.in
     #   yarl

--- a/requirements/multidict.txt
+++ b/requirements/multidict.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements/multidict.txt --resolver=backtracking --strip-extras requirements/multidict.in
 #
-multidict==6.1.0
+multidict==6.4.3
     # via -r requirements/multidict.in
 typing-extensions==4.12.2
     # via multidict

--- a/requirements/runtime-deps.txt
+++ b/requirements/runtime-deps.txt
@@ -24,7 +24,7 @@ frozenlist==1.5.0
     #   aiosignal
 idna==3.4
     # via yarl
-multidict==6.1.0
+multidict==6.4.3
     # via
     #   -r requirements/runtime-deps.in
     #   yarl

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -62,7 +62,7 @@ markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-multidict==6.1.0
+multidict==6.4.3
     # via
     #   -r requirements/runtime-deps.in
     #   yarl


### PR DESCRIPTION
Since older versions have memory leaks, use 6.4.3 in the 3.11 CI

changelog: https://github.com/aio-libs/multidict/compare/v6.1.0...v6.4.3
