### PR TITLE
Refactor WebSocket reader to avoid creating lists

### DIFF
--- a/CHANGES/10740.misc.rst
+++ b/CHANGES/10740.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of the WebSocket reader -- by :user:`bdraco`.

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -8,12 +8,17 @@ cdef unsigned int READ_PAYLOAD_LENGTH
 cdef unsigned int READ_PAYLOAD_MASK
 cdef unsigned int READ_PAYLOAD
 
+cdef int OP_CODE_NOT_SET
 cdef int OP_CODE_CONTINUATION
 cdef int OP_CODE_TEXT
 cdef int OP_CODE_BINARY
 cdef int OP_CODE_CLOSE
 cdef int OP_CODE_PING
 cdef int OP_CODE_PONG
+
+cdef int COMPRESSED_NOT_SET
+cdef int COMPRESSED_FALSE
+cdef int COMPRESSED_TRUE
 
 cdef object UNPACK_LEN3
 cdef object UNPACK_CLOSE_CODE
@@ -89,7 +94,7 @@ cdef class WebSocketReader:
         has_partial=bint,
         payload_merged=bytes,
     )
-    cpdef void _handle_frame(self, bint fin, int opcode, object payload, bint compressed) except *
+    cpdef void _handle_frame(self, bint fin, int opcode, object payload, int compressed) except *
 
     @cython.locals(
         start_pos="unsigned int",

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -8,12 +8,12 @@ cdef unsigned int READ_PAYLOAD_LENGTH
 cdef unsigned int READ_PAYLOAD_MASK
 cdef unsigned int READ_PAYLOAD
 
-cdef unsigned int OP_CODE_CONTINUATION
-cdef unsigned int OP_CODE_TEXT
-cdef unsigned int OP_CODE_BINARY
-cdef unsigned int OP_CODE_CLOSE
-cdef unsigned int OP_CODE_PING
-cdef unsigned int OP_CODE_PONG
+cdef int OP_CODE_CONTINUATION
+cdef int OP_CODE_TEXT
+cdef int OP_CODE_BINARY
+cdef int OP_CODE_CLOSE
+cdef int OP_CODE_PING
+cdef int OP_CODE_PONG
 
 cdef object UNPACK_LEN3
 cdef object UNPACK_CLOSE_CODE
@@ -66,9 +66,9 @@ cdef class WebSocketReader:
     cdef bytearray _partial
     cdef unsigned int _state
 
-    cdef object _opcode
-    cdef object _frame_fin
-    cdef object _frame_opcode
+    cdef int _opcode
+    cdef bint _frame_fin
+    cdef int _frame_opcode
     cdef object _frame_payload
     cdef unsigned long long _frame_payload_len
 
@@ -77,7 +77,7 @@ cdef class WebSocketReader:
     cdef bytes _frame_mask
     cdef unsigned long long _payload_length
     cdef unsigned int _payload_length_flag
-    cdef object _compressed
+    cdef int _compressed
     cdef object _decompressobj
     cdef bint _compress
 
@@ -88,22 +88,21 @@ cdef class WebSocketReader:
         fin=bint,
         has_partial=bint,
         payload_merged=bytes,
-        opcode="unsigned int",
     )
-    cpdef void _feed_data(self, bytes data)
+    cpdef void _handle_frame(self, bint fin, int opcode, object payload, bint compressed) except *
 
     @cython.locals(
         start_pos="unsigned int",
-        buf_len="unsigned int",
+        data_len="unsigned int",
         length="unsigned int",
         chunk_size="unsigned int",
         chunk_len="unsigned int",
-        buf_length="unsigned int",
-        buf_cstr="const unsigned char *",
+        data_length="unsigned int",
+        data_cstr="const unsigned char *",
         first_byte="unsigned char",
         second_byte="unsigned char",
         end_pos="unsigned int",
         has_mask=bint,
         fin=bint,
     )
-    cpdef list parse_frame(self, bytes buf)
+    cpdef void _feed_data(self, bytes data) except *

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -323,9 +323,10 @@ class WebSocketReader:
             self.queue.feed_data(
                 WSMessagePong(data=bytes(payload), size=len(payload), extra="")
             )
-        raise WebSocketError(
-            WSCloseCode.PROTOCOL_ERROR, f"Unexpected opcode={opcode!r}"
-        )
+        else:
+            raise WebSocketError(
+                WSCloseCode.PROTOCOL_ERROR, f"Unexpected opcode={opcode!r}"
+            )
 
     def _feed_data(self, data: bytes) -> None:
         """Return the next frame from the socket."""

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -417,9 +417,8 @@ class WebSocketReader:
                 elif length_flag > 126:
                     if data_length - start_pos < 8:
                         break
-                    data = data_cstr[start_pos : start_pos + 8]
+                    self._payload_length = UNPACK_LEN3(data, start_pos)[0]
                     start_pos += 8
-                    self._payload_length = UNPACK_LEN3(data)[0]
                 else:
                     self._payload_length = length_flag
 

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -190,11 +190,9 @@ class WebSocketReader:
     def _handle_frame(
         self,
         fin: bool,
-        opcode: Union[int, cython_int],  # Union intended: Cython pxd converts to C int
+        opcode: Union[int, cython_int],  # Union intended: Cython pxd uses C int
         payload: Union[bytes, bytearray],
-        compressed: Union[
-            int, cython_int
-        ],  # Union intended: Cython pxd converts to C int
+        compressed: Union[int, cython_int],  # Union intended: Cython pxd uses C int
     ) -> None:
         msg: WSMessage
         if opcode in {OP_CODE_TEXT, OP_CODE_BINARY, OP_CODE_CONTINUATION}:

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -190,13 +190,11 @@ class WebSocketReader:
     def _handle_frame(
         self,
         fin: bool,
-        opcode: Union[
-            int, cython_int
-        ],  # Union intentional: Cython pxd converts to C int
+        opcode: Union[int, cython_int],  # Union intended: Cython pxd converts to C int
         payload: Union[bytes, bytearray],
         compressed: Union[
             int, cython_int
-        ],  # Union intentional: Cython pxd converts to C int
+        ],  # Union intended: Cython pxd converts to C int
     ) -> None:
         msg: WSMessage
         if opcode in {OP_CODE_TEXT, OP_CODE_BINARY, OP_CODE_CONTINUATION}:

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -53,6 +53,8 @@ COMPRESSED_TRUE = 1
 
 TUPLE_NEW = tuple.__new__
 
+cython_int = int  # Typed to int in Python, but cython with use a signed int in the pxd
+
 
 class WebSocketDataQueue:
     """WebSocketDataQueue resumes and pauses an underlying stream.
@@ -188,9 +190,13 @@ class WebSocketReader:
     def _handle_frame(
         self,
         fin: bool,
-        opcode: Union[int],  # Union is intentional so Cython will convert to C int
+        opcode: Union[
+            int, cython_int
+        ],  # Union intentional: Cython pxd converts to C int
         payload: Union[bytes, bytearray],
-        compressed: Union[int],  # Union is intentional so Cython will convert to C int
+        compressed: Union[
+            int, cython_int
+        ],  # Union intentional: Cython pxd converts to C int
     ) -> None:
         msg: WSMessage
         if opcode in {OP_CODE_TEXT, OP_CODE_BINARY, OP_CODE_CONTINUATION}:

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -585,7 +585,7 @@ def test_flow_control_binary(
 ) -> None:
     large_payload = b"b" * (1 + 16 * 2)
     large_payload_size = len(large_payload)
-    parser_low_limit._handle_frame(1, WSMsgType.BINARY, large_payload, 0)
+    parser_low_limit._handle_frame(True, WSMsgType.BINARY, large_payload, 0)
     res = out_low_limit._buffer[0]
     assert res == WSMessageBinary(data=large_payload, size=large_payload_size, extra="")
     assert protocol._reading_paused is True
@@ -599,7 +599,7 @@ def test_flow_control_multi_byte_text(
     large_payload_text = "𒀁" * (1 + 16 * 2)
     large_payload = large_payload_text.encode("utf-8")
     large_payload_size = len(large_payload)
-    parser_low_limit._handle_frame(1, WSMsgType.TEXT, large_payload, 0)
+    parser_low_limit._handle_frame(True, WSMsgType.TEXT, large_payload, 0)
     res = out_low_limit._buffer[0]
     assert res == WSMessageText(
         data=large_payload_text, size=large_payload_size, extra=""

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -28,12 +28,12 @@ class PatchableWebSocketReader(WebSocketReader):
 
     def parse_frame(
         self, data: bytes
-    ) -> list[tuple[int, int, Union[bytes, bytearray], bool]]:
+    ) -> list[tuple[bool, int, Union[bytes, bytearray], int]]:
         # This method is overridden to allow for patching in tests.
-        frames: list[tuple[int, int, Union[bytes, bytearray], int]] = []
+        frames: list[tuple[bool, int, Union[bytes, bytearray], int]] = []
 
         def _handle_frame(
-            fin: int,
+            fin: bool,
             opcode: int,
             payload: Union[bytes, bytearray],
             compressed: int,
@@ -141,7 +141,7 @@ def test_parse_frame(parser: PatchableWebSocketReader) -> None:
     res = parser.parse_frame(b"1")
     fin, opcode, payload, compress = res[0]
 
-    assert (0, 1, b"1", False) == (fin, opcode, payload, not not compress)
+    assert (0, 1, b"1", 0) == (fin, opcode, payload, not not compress)
 
 
 def test_parse_frame_length0(parser: PatchableWebSocketReader) -> None:
@@ -149,7 +149,7 @@ def test_parse_frame_length0(parser: PatchableWebSocketReader) -> None:
         struct.pack("!BB", 0b00000001, 0b00000000)
     )[0]
 
-    assert (0, 1, b"", False) == (fin, opcode, payload, not not compress)
+    assert (0, 1, b"", 0) == (fin, opcode, payload, not not compress)
 
 
 def test_parse_frame_length2(parser: PatchableWebSocketReader) -> None:
@@ -158,7 +158,7 @@ def test_parse_frame_length2(parser: PatchableWebSocketReader) -> None:
     res = parser.parse_frame(b"1234")
     fin, opcode, payload, compress = res[0]
 
-    assert (0, 1, b"1234", False) == (fin, opcode, payload, not not compress)
+    assert (0, 1, b"1234", 0) == (fin, opcode, payload, not not compress)
 
 
 def test_parse_frame_length2_multi_byte(parser: PatchableWebSocketReader) -> None:
@@ -169,7 +169,7 @@ def test_parse_frame_length2_multi_byte(parser: PatchableWebSocketReader) -> Non
     res = parser.parse_frame(b"1" * 32768)
     fin, opcode, payload, compress = res[0]
 
-    assert (0, 1, expected_payload, False) == (fin, opcode, payload, not not compress)
+    assert (0, 1, expected_payload, 0) == (fin, opcode, payload, not not compress)
 
 
 def test_parse_frame_length2_multi_byte_multi_packet(
@@ -185,7 +185,7 @@ def test_parse_frame_length2_multi_byte_multi_packet(
     res = parser.parse_frame(b"1" * 8192)
     fin, opcode, payload, compress = res[0]
     assert len(payload) == 32768
-    assert (0, 1, expected_payload, False) == (fin, opcode, payload, not not compress)
+    assert (0, 1, expected_payload, 0) == (fin, opcode, payload, not not compress)
 
 
 def test_parse_frame_length4(parser: PatchableWebSocketReader) -> None:
@@ -193,7 +193,7 @@ def test_parse_frame_length4(parser: PatchableWebSocketReader) -> None:
     parser.parse_frame(struct.pack("!Q", 4))
     fin, opcode, payload, compress = parser.parse_frame(b"1234")[0]
 
-    assert (0, 1, b"1234", False) == (fin, opcode, payload, not not compress)
+    assert (0, 1, b"1234", 0) == (fin, opcode, payload, compress)
 
 
 def test_parse_frame_mask(parser: PatchableWebSocketReader) -> None:
@@ -201,7 +201,7 @@ def test_parse_frame_mask(parser: PatchableWebSocketReader) -> None:
     parser.parse_frame(b"0001")
     fin, opcode, payload, compress = parser.parse_frame(b"1")[0]
 
-    assert (0, 1, b"\x01", False) == (fin, opcode, payload, not not compress)
+    assert (0, 1, b"\x01", 0) == (fin, opcode, payload, compress)
 
 
 def test_parse_frame_header_reversed_bits(
@@ -245,19 +245,19 @@ def test_ping_frame(
     parser: PatchableWebSocketReader,
     data: Union[bytes, bytearray, memoryview],
 ) -> None:
-    parser._handle_frame(1, WSMsgType.PING, b"data", 0)
+    parser._handle_frame(True, WSMsgType.PING, b"data", 0)
     res = out._buffer[0]
     assert res == WSMessagePing(data=b"data", size=4, extra="")
 
 
 def test_pong_frame(out: WebSocketDataQueue, parser: PatchableWebSocketReader) -> None:
-    parser._handle_frame(1, WSMsgType.PONG, b"data", 0)
+    parser._handle_frame(True, WSMsgType.PONG, b"data", 0)
     res = out._buffer[0]
     assert res == WSMessagePong(data=b"data", size=4, extra="")
 
 
 def test_close_frame(out: WebSocketDataQueue, parser: PatchableWebSocketReader) -> None:
-    parser._handle_frame(1, WSMsgType.CLOSE, b"", 0)
+    parser._handle_frame(True, WSMsgType.CLOSE, b"", 0)
     res = out._buffer[0]
     assert res == WSMessageClose(data=0, size=0, extra="")
 
@@ -265,7 +265,7 @@ def test_close_frame(out: WebSocketDataQueue, parser: PatchableWebSocketReader) 
 def test_close_frame_info(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
-    parser._handle_frame(1, WSMsgType.CLOSE, b"0112345", 0)
+    parser._handle_frame(True, WSMsgType.CLOSE, b"0112345", 0)
     res = out._buffer[0]
     assert res == WSMessageClose(data=12337, size=7, extra="12345")
 
@@ -274,7 +274,7 @@ def test_close_frame_invalid(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
     with pytest.raises(WebSocketError) as ctx:
-        parser._handle_frame(1, WSMsgType.CLOSE, b"1", 0)
+        parser._handle_frame(True, WSMsgType.CLOSE, b"1", 0)
     assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
 
 
@@ -302,7 +302,7 @@ def test_unknown_frame(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
     with pytest.raises(WebSocketError):
-        parser._handle_frame(1, WSMsgType.CONTINUATION, b"", 0)
+        parser._handle_frame(True, WSMsgType.CONTINUATION, b"", 0)
 
 
 def test_simple_text(out: WebSocketDataQueue, parser: PatchableWebSocketReader) -> None:
@@ -375,22 +375,22 @@ def test_continuation_with_ping(
 def test_continuation_err(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
-    parser._handle_frame(0, WSMsgType.TEXT, b"line1", 0)
+    parser._handle_frame(False, WSMsgType.TEXT, b"line1", 0)
     with pytest.raises(WebSocketError):
-        parser._handle_frame(1, WSMsgType.TEXT, b"line2", 0)
+        parser._handle_frame(True, WSMsgType.TEXT, b"line2", 0)
 
 
 def test_continuation_with_close(
     out: WebSocketDataQueue, parser: WebSocketReader
 ) -> None:
-    parser._handle_frame(0, WSMsgType.TEXT, b"line1", 0)
+    parser._handle_frame(False, WSMsgType.TEXT, b"line1", 0)
     parser._handle_frame(
-        0,
+        False,
         WSMsgType.CLOSE,
         build_close_frame(1002, b"test", noheader=True),
         False,
     )
-    parser._handle_frame(1, WSMsgType.CONTINUATION, b"line2", 0)
+    parser._handle_frame(True, WSMsgType.CONTINUATION, b"line2", 0)
     res = out._buffer[0]
     assert res == WSMessageClose(data=1002, size=6, extra="test")
     res = out._buffer[1]
@@ -403,44 +403,44 @@ def test_continuation_with_close_unicode_err(
     parser._handle_frame(False, WSMsgType.TEXT, b"line1", 0)
     with pytest.raises(WebSocketError) as ctx:
         parser._handle_frame(
-            0,
+            False,
             WSMsgType.CLOSE,
             build_close_frame(1000, b"\xf4\x90\x80\x80", noheader=True),
             0,
         )
-    parser._handle_frame(1, WSMsgType.CONTINUATION, b"line2", 0)
+    parser._handle_frame(True, WSMsgType.CONTINUATION, b"line2", 0)
     assert ctx.value.code == WSCloseCode.INVALID_TEXT
 
 
 def test_continuation_with_close_bad_code(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
-    parser._handle_frame(0, WSMsgType.TEXT, b"line1", 0)
+    parser._handle_frame(False, WSMsgType.TEXT, b"line1", 0)
     with pytest.raises(WebSocketError) as ctx:
 
         parser._handle_frame(
             0, WSMsgType.CLOSE, build_close_frame(1, b"test", noheader=True), 0
         )
     assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
-    parser._handle_frame(1, WSMsgType.CONTINUATION, b"line2", 0)
+    parser._handle_frame(True, WSMsgType.CONTINUATION, b"line2", 0)
 
 
 def test_continuation_with_close_bad_payload(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
-    parser._handle_frame(0, WSMsgType.TEXT, b"line1", 0)
+    parser._handle_frame(False, WSMsgType.TEXT, b"line1", 0)
     with pytest.raises(WebSocketError) as ctx:
-        parser._handle_frame(0, WSMsgType.CLOSE, b"1", 0)
+        parser._handle_frame(False, WSMsgType.CLOSE, b"1", 0)
     assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
-    parser._handle_frame(1, WSMsgType.CONTINUATION, b"line2", 0)
+    parser._handle_frame(True, WSMsgType.CONTINUATION, b"line2", 0)
 
 
 def test_continuation_with_close_empty(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
-    parser._handle_frame(0, WSMsgType.TEXT, b"line1", 0)
-    parser._handle_frame(0, WSMsgType.CLOSE, b"", 0)
-    parser._handle_frame(1, WSMsgType.CONTINUATION, b"line2", 0)
+    parser._handle_frame(False, WSMsgType.TEXT, b"line1", 0)
+    parser._handle_frame(False, WSMsgType.CLOSE, b"", 0)
+    parser._handle_frame(True, WSMsgType.CONTINUATION, b"line2", 0)
 
     res = out._buffer[0]
     assert res == WSMessageClose(data=0, size=0, extra="")

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -419,7 +419,7 @@ def test_continuation_with_close_bad_code(
     with pytest.raises(WebSocketError) as ctx:
 
         parser._handle_frame(
-            0, WSMsgType.CLOSE, build_close_frame(1, b"test", noheader=True), 0
+            False, WSMsgType.CLOSE, build_close_frame(1, b"test", noheader=True), 0
         )
     assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
     parser._handle_frame(True, WSMsgType.CONTINUATION, b"line2", 0)
@@ -527,7 +527,7 @@ def test_parse_compress_error_frame(parser: PatchableWebSocketReader) -> None:
     assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
 
 
-def test_parse_no_compress_frame_single(out: PatchableWebSocketReader) -> None:
+def test_parse_no_compress_frame_single(out: WebSocketDataQueue) -> None:
     parser_no_compress = PatchableWebSocketReader(out, 0, compress=False)
     with pytest.raises(WebSocketError) as ctx:
         parser_no_compress.parse_frame(struct.pack("!BB", 0b11000001, 0b00000001))
@@ -536,7 +536,7 @@ def test_parse_no_compress_frame_single(out: PatchableWebSocketReader) -> None:
     assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
 
 
-def test_msg_too_large(out: PatchableWebSocketReader) -> None:
+def test_msg_too_large(out: WebSocketDataQueue) -> None:
     parser = WebSocketReader(out, 256, compress=False)
     data = build_frame(b"text" * 256, WSMsgType.TEXT)
     with pytest.raises(WebSocketError) as ctx:
@@ -544,7 +544,7 @@ def test_msg_too_large(out: PatchableWebSocketReader) -> None:
     assert ctx.value.code == WSCloseCode.MESSAGE_TOO_BIG
 
 
-def test_msg_too_large_not_fin(out: PatchableWebSocketReader) -> None:
+def test_msg_too_large_not_fin(out: WebSocketDataQueue) -> None:
     parser = WebSocketReader(out, 256, compress=False)
     data = build_frame(b"text" * 256, WSMsgType.TEXT, is_fin=False)
     with pytest.raises(WebSocketError) as ctx:
@@ -553,7 +553,7 @@ def test_msg_too_large_not_fin(out: PatchableWebSocketReader) -> None:
 
 
 @pytest.mark.usefixtures("parametrize_zlib_backend")
-def test_compressed_msg_too_large(out: PatchableWebSocketReader) -> None:
+def test_compressed_msg_too_large(out: WebSocketDataQueue) -> None:
     parser = WebSocketReader(out, 256, compress=True)
     data = build_frame(b"aaa" * 256, WSMsgType.TEXT, ZLibBackend=ZLibBackend)
     with pytest.raises(WebSocketError) as ctx:

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -26,6 +26,23 @@ from aiohttp.http_websocket import (
 class PatchableWebSocketReader(WebSocketReader):
     """WebSocketReader subclass that allows for patching parse_frame."""
 
+    def parse_frame(self, data: bytes) -> list[tuple[int, int, bytes, bool]]:
+        # This method is overridden to allow for patching in tests.
+        frames: list[tuple[int, int, bytes, bool]] = []
+
+        def _handle_frame(
+            fin: bool,
+            opcode: int,
+            payload: Union[bytes, bytearray],
+            compressed: bool,
+        ) -> None:
+            # This method is overridden to allow for patching in tests.
+            frames.append((fin, opcode, payload, compressed))
+
+        with mock.patch.object(self, "_handle_frame", _handle_frame):
+            self._feed_data(data)
+        return frames
+
 
 def build_frame(
     message: bytes,
@@ -117,7 +134,7 @@ def test_feed_data_remembers_exception(parser: WebSocketReader) -> None:
     assert data == b""
 
 
-def test_parse_frame(parser: WebSocketReader) -> None:
+def test_parse_frame(parser: PatchableWebSocketReader) -> None:
     parser.parse_frame(struct.pack("!BB", 0b00000001, 0b00000001))
     res = parser.parse_frame(b"1")
     fin, opcode, payload, compress = res[0]
@@ -125,7 +142,7 @@ def test_parse_frame(parser: WebSocketReader) -> None:
     assert (0, 1, b"1", False) == (fin, opcode, payload, not not compress)
 
 
-def test_parse_frame_length0(parser: WebSocketReader) -> None:
+def test_parse_frame_length0(parser: PatchableWebSocketReader) -> None:
     fin, opcode, payload, compress = parser.parse_frame(
         struct.pack("!BB", 0b00000001, 0b00000000)
     )[0]
@@ -133,7 +150,7 @@ def test_parse_frame_length0(parser: WebSocketReader) -> None:
     assert (0, 1, b"", False) == (fin, opcode, payload, not not compress)
 
 
-def test_parse_frame_length2(parser: WebSocketReader) -> None:
+def test_parse_frame_length2(parser: PatchableWebSocketReader) -> None:
     parser.parse_frame(struct.pack("!BB", 0b00000001, 126))
     parser.parse_frame(struct.pack("!H", 4))
     res = parser.parse_frame(b"1234")
@@ -142,7 +159,7 @@ def test_parse_frame_length2(parser: WebSocketReader) -> None:
     assert (0, 1, b"1234", False) == (fin, opcode, payload, not not compress)
 
 
-def test_parse_frame_length2_multi_byte(parser: WebSocketReader) -> None:
+def test_parse_frame_length2_multi_byte(parser: PatchableWebSocketReader) -> None:
     """Ensure a multi-byte length is parsed correctly."""
     expected_payload = b"1" * 32768
     parser.parse_frame(struct.pack("!BB", 0b00000001, 126))
@@ -153,7 +170,9 @@ def test_parse_frame_length2_multi_byte(parser: WebSocketReader) -> None:
     assert (0, 1, expected_payload, False) == (fin, opcode, payload, not not compress)
 
 
-def test_parse_frame_length2_multi_byte_multi_packet(parser: WebSocketReader) -> None:
+def test_parse_frame_length2_multi_byte_multi_packet(
+    parser: PatchableWebSocketReader,
+) -> None:
     """Ensure a multi-byte length with multiple packets is parsed correctly."""
     expected_payload = b"1" * 32768
     assert parser.parse_frame(struct.pack("!BB", 0b00000001, 126)) == []
@@ -167,7 +186,7 @@ def test_parse_frame_length2_multi_byte_multi_packet(parser: WebSocketReader) ->
     assert (0, 1, expected_payload, False) == (fin, opcode, payload, not not compress)
 
 
-def test_parse_frame_length4(parser: WebSocketReader) -> None:
+def test_parse_frame_length4(parser: PatchableWebSocketReader) -> None:
     parser.parse_frame(struct.pack("!BB", 0b00000001, 127))
     parser.parse_frame(struct.pack("!Q", 4))
     fin, opcode, payload, compress = parser.parse_frame(b"1234")[0]
@@ -175,7 +194,7 @@ def test_parse_frame_length4(parser: WebSocketReader) -> None:
     assert (0, 1, b"1234", False) == (fin, opcode, payload, not not compress)
 
 
-def test_parse_frame_mask(parser: WebSocketReader) -> None:
+def test_parse_frame_mask(parser: PatchableWebSocketReader) -> None:
     parser.parse_frame(struct.pack("!BB", 0b00000001, 0b10000001))
     parser.parse_frame(b"0001")
     fin, opcode, payload, compress = parser.parse_frame(b"1")[0]
@@ -184,14 +203,14 @@ def test_parse_frame_mask(parser: WebSocketReader) -> None:
 
 
 def test_parse_frame_header_reversed_bits(
-    out: WebSocketDataQueue, parser: WebSocketReader
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
     with pytest.raises(WebSocketError):
         parser.parse_frame(struct.pack("!BB", 0b01100000, 0b00000000))
 
 
 def test_parse_frame_header_control_frame(
-    out: WebSocketDataQueue, parser: WebSocketReader
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
     with pytest.raises(WebSocketError):
         parser.parse_frame(struct.pack("!BB", 0b00001000, 0b00000000))
@@ -199,14 +218,14 @@ def test_parse_frame_header_control_frame(
 
 @pytest.mark.xfail()
 def test_parse_frame_header_new_data_err(
-    out: WebSocketDataQueue, parser: WebSocketReader
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
     with pytest.raises(WebSocketError):
         parser.parse_frame(struct.pack("!BB", 0b000000000, 0b00000000))
 
 
 def test_parse_frame_header_payload_size(
-    out: WebSocketDataQueue, parser: WebSocketReader
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
     with pytest.raises(WebSocketError):
         parser.parse_frame(struct.pack("!BB", 0b10001000, 0b01111110))
@@ -221,56 +240,44 @@ def test_parse_frame_header_payload_size(
 )
 def test_ping_frame(
     out: WebSocketDataQueue,
-    parser: WebSocketReader,
+    parser: PatchableWebSocketReader,
     data: Union[bytes, bytearray, memoryview],
 ) -> None:
-    with mock.patch.object(parser, "parse_frame", autospec=True) as m:
-        m.return_value = [(1, WSMsgType.PING, b"data", False)]
-
-        parser.feed_data(data)
-        res = out._buffer[0]
-        assert res == WSMessagePing(data=b"data", size=4, extra="")
+    parser._handle_frame(True, WSMsgType.PING, b"data", False)
+    res = out._buffer[0]
+    assert res == WSMessagePing(data=b"data", size=4, extra="")
 
 
-def test_pong_frame(out: WebSocketDataQueue, parser: WebSocketReader) -> None:
-    with mock.patch.object(parser, "parse_frame", autospec=True) as m:
-        m.return_value = [(1, WSMsgType.PONG, b"data", False)]
-
-        parser.feed_data(b"")
-        res = out._buffer[0]
-        assert res == WSMessagePong(data=b"data", size=4, extra="")
+def test_pong_frame(out: WebSocketDataQueue, parser: PatchableWebSocketReader) -> None:
+    parser._handle_frame(True, WSMsgType.PONG, b"data", False)
+    res = out._buffer[0]
+    assert res == WSMessagePong(data=b"data", size=4, extra="")
 
 
-def test_close_frame(out: WebSocketDataQueue, parser: WebSocketReader) -> None:
-    with mock.patch.object(parser, "parse_frame", autospec=True) as m:
-        m.return_value = [(1, WSMsgType.CLOSE, b"", False)]
-
-        parser.feed_data(b"")
-        res = out._buffer[0]
-        assert res == WSMessageClose(data=0, size=0, extra="")
+def test_close_frame(out: WebSocketDataQueue, parser: PatchableWebSocketReader) -> None:
+    parser._handle_frame(True, WSMsgType.CLOSE, b"", False)
+    res = out._buffer[0]
+    assert res == WSMessageClose(data=0, size=0, extra="")
 
 
-def test_close_frame_info(out: WebSocketDataQueue, parser: WebSocketReader) -> None:
-    with mock.patch.object(parser, "parse_frame", autospec=True) as m:
-        m.return_value = [(1, WSMsgType.CLOSE, b"0112345", False)]
+def test_close_frame_info(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
+    parser._handle_frame(True, WSMsgType.CLOSE, b"0112345", False)
+    res = out._buffer[0]
+    assert res == WSMessageClose(data=12337, size=7, extra="12345")
 
-        parser.feed_data(b"")
-        res = out._buffer[0]
-        assert res == WSMessageClose(data=12337, size=7, extra="12345")
 
-
-def test_close_frame_invalid(out: WebSocketDataQueue, parser: WebSocketReader) -> None:
-    with mock.patch.object(parser, "parse_frame", autospec=True) as m:
-        m.return_value = [(1, WSMsgType.CLOSE, b"1", False)]
-        parser.feed_data(b"")
-
-        exc = out.exception()
-        assert isinstance(exc, WebSocketError)
-        assert exc.code == WSCloseCode.PROTOCOL_ERROR
+def test_close_frame_invalid(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
+    with pytest.raises(WebSocketError) as ctx:
+        parser._handle_frame(True, WSMsgType.CLOSE, b"1", False)
+    assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
 
 
 def test_close_frame_invalid_2(
-    out: WebSocketDataQueue, parser: WebSocketReader
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
     data = build_close_frame(code=1)
 
@@ -280,7 +287,7 @@ def test_close_frame_invalid_2(
     assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
 
 
-def test_close_frame_unicode_err(parser: WebSocketReader) -> None:
+def test_close_frame_unicode_err(parser: PatchableWebSocketReader) -> None:
     data = build_close_frame(code=1000, message=b"\xf4\x90\x80\x80")
 
     with pytest.raises(WebSocketError) as ctx:
@@ -289,22 +296,21 @@ def test_close_frame_unicode_err(parser: WebSocketReader) -> None:
     assert ctx.value.code == WSCloseCode.INVALID_TEXT
 
 
-def test_unknown_frame(out: WebSocketDataQueue, parser: WebSocketReader) -> None:
-    with mock.patch.object(parser, "parse_frame", autospec=True) as m:
-        m.return_value = [(1, WSMsgType.CONTINUATION, b"", False)]
+def test_unknown_frame(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
+    with pytest.raises(WebSocketError):
+        parser._handle_frame(True, WSMsgType.CONTINUATION, b"", False)
 
-        parser.feed_data(b"")
-        assert isinstance(out.exception(), WebSocketError)
 
-
-def test_simple_text(out: WebSocketDataQueue, parser: WebSocketReader) -> None:
+def test_simple_text(out: WebSocketDataQueue, parser: PatchableWebSocketReader) -> None:
     data = build_frame(b"text", WSMsgType.TEXT)
     parser._feed_data(data)
     res = out._buffer[0]
     assert res == WSMessageText(data="text", size=4, extra="")
 
 
-def test_simple_text_unicode_err(parser: WebSocketReader) -> None:
+def test_simple_text_unicode_err(parser: PatchableWebSocketReader) -> None:
     data = build_frame(b"\xf4\x90\x80\x80", WSMsgType.TEXT)
 
     with pytest.raises(WebSocketError) as ctx:
@@ -313,16 +319,18 @@ def test_simple_text_unicode_err(parser: WebSocketReader) -> None:
     assert ctx.value.code == WSCloseCode.INVALID_TEXT
 
 
-def test_simple_binary(out: WebSocketDataQueue, parser: WebSocketReader) -> None:
-    with mock.patch.object(parser, "parse_frame", autospec=True) as m:
-        m.return_value = [(1, WSMsgType.BINARY, b"binary", False)]
+def test_simple_binary(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
+    data = build_frame(b"binary", WSMsgType.BINARY)
+    parser._feed_data(data)
+    res = out._buffer[0]
+    assert res == WSMessageBinary(data=b"binary", size=6, extra="")
 
-        parser.feed_data(b"")
-        res = out._buffer[0]
-        assert res == WSMessageBinary(data=b"binary", size=6, extra="")
 
-
-def test_fragmentation_header(out: WebSocketDataQueue, parser: WebSocketReader) -> None:
+def test_fragmentation_header(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
     data = build_frame(b"a", WSMsgType.TEXT)
     parser._feed_data(data[:1])
     parser._feed_data(data[1:])
@@ -331,7 +339,9 @@ def test_fragmentation_header(out: WebSocketDataQueue, parser: WebSocketReader) 
     assert res == WSMessageText(data="a", size=1, extra="")
 
 
-def test_continuation(out: WebSocketDataQueue, parser: WebSocketReader) -> None:
+def test_continuation(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
     data1 = build_frame(b"line1", WSMsgType.TEXT, is_fin=False)
     parser._feed_data(data1)
 
@@ -343,7 +353,7 @@ def test_continuation(out: WebSocketDataQueue, parser: WebSocketReader) -> None:
 
 
 def test_continuation_with_ping(
-    out: WebSocketDataQueue, parser: WebSocketReader
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
     with mock.patch.object(parser, "parse_frame", autospec=True) as m:
         m.return_value = [
@@ -367,107 +377,80 @@ def test_continuation_with_ping(
         assert res == WSMessageText(data="line1line2", size=10, extra="")
 
 
-def test_continuation_err(out: WebSocketDataQueue, parser: WebSocketReader) -> None:
-    with mock.patch.object(parser, "parse_frame", autospec=True) as m:
-        m.return_value = [
-            (0, WSMsgType.TEXT, b"line1", False),
-            (1, WSMsgType.TEXT, b"line2", False),
-        ]
-
-        with pytest.raises(WebSocketError):
-            parser._feed_data(b"")
+def test_continuation_err(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
+    parser._handle_frame(False, WSMsgType.TEXT, b"line1", False)
+    with pytest.raises(WebSocketError):
+        parser._handle_frame(True, WSMsgType.TEXT, b"line2", False)
 
 
 def test_continuation_with_close(
     out: WebSocketDataQueue, parser: WebSocketReader
 ) -> None:
-    with mock.patch.object(parser, "parse_frame", autospec=True) as m:
-        m.return_value = [
-            (0, WSMsgType.TEXT, b"line1", False),
-            (
-                0,
-                WSMsgType.CLOSE,
-                build_close_frame(1002, b"test", noheader=True),
-                False,
-            ),
-            (1, WSMsgType.CONTINUATION, b"line2", False),
-        ]
-
-        parser.feed_data(b"")
-        res = out._buffer[0]
-        assert res == WSMessageClose(data=1002, size=6, extra="test")
-        res = out._buffer[1]
-        assert res == WSMessageText(data="line1line2", size=10, extra="")
+    parser._handle_frame(False, WSMsgType.TEXT, b"line1", False)
+    parser._handle_frame(
+        0,
+        WSMsgType.CLOSE,
+        build_close_frame(1002, b"test", noheader=True),
+        False,
+    )
+    parser._handle_frame(True, WSMsgType.CONTINUATION, b"line2", False)
+    res = out._buffer[0]
+    assert res == WSMessageClose(data=1002, size=6, extra="test")
+    res = out._buffer[1]
+    assert res == WSMessageText(data="line1line2", size=10, extra="")
 
 
 def test_continuation_with_close_unicode_err(
-    out: WebSocketDataQueue, parser: WebSocketReader
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
-    with mock.patch.object(parser, "parse_frame", autospec=True) as m:
-        m.return_value = [
-            (0, WSMsgType.TEXT, b"line1", False),
-            (
-                0,
-                WSMsgType.CLOSE,
-                build_close_frame(1000, b"\xf4\x90\x80\x80", noheader=True),
-                False,
-            ),
-            (1, WSMsgType.CONTINUATION, b"line2", False),
-        ]
-
-        with pytest.raises(WebSocketError) as ctx:
-            parser._feed_data(b"")
-
-        assert ctx.value.code == WSCloseCode.INVALID_TEXT
+    parser._handle_frame(False, WSMsgType.TEXT, b"line1", False)
+    with pytest.raises(WebSocketError) as ctx:
+        parser._handle_frame(
+            0,
+            WSMsgType.CLOSE,
+            build_close_frame(1000, b"\xf4\x90\x80\x80", noheader=True),
+            False,
+        )
+    parser._handle_frame(True, WSMsgType.CONTINUATION, b"line2", False)
+    assert ctx.value.code == WSCloseCode.INVALID_TEXT
 
 
 def test_continuation_with_close_bad_code(
-    out: WebSocketDataQueue, parser: WebSocketReader
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
-    with mock.patch.object(parser, "parse_frame", autospec=True) as m:
-        m.return_value = [
-            (0, WSMsgType.TEXT, b"line1", False),
-            (0, WSMsgType.CLOSE, build_close_frame(1, b"test", noheader=True), False),
-            (1, WSMsgType.CONTINUATION, b"line2", False),
-        ]
+    parser._handle_frame(False, WSMsgType.TEXT, b"line1", False)
+    with pytest.raises(WebSocketError) as ctx:
 
-        with pytest.raises(WebSocketError) as ctx:
-            parser._feed_data(b"")
-
-        assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
+        parser._handle_frame(
+            0, WSMsgType.CLOSE, build_close_frame(1, b"test", noheader=True), False
+        )
+    assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
+    parser._handle_frame(True, WSMsgType.CONTINUATION, b"line2", False)
 
 
 def test_continuation_with_close_bad_payload(
-    out: WebSocketDataQueue, parser: WebSocketReader
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
-    with mock.patch.object(parser, "parse_frame", autospec=True) as m:
-        m.return_value = [
-            (0, WSMsgType.TEXT, b"line1", False),
-            (0, WSMsgType.CLOSE, b"1", False),
-            (1, WSMsgType.CONTINUATION, b"line2", False),
-        ]
-
-        with pytest.raises(WebSocketError) as ctx:
-            parser._feed_data(b"")
-
-        assert ctx.value.code, WSCloseCode.PROTOCOL_ERROR
+    parser._handle_frame(False, WSMsgType.TEXT, b"line1", False)
+    with pytest.raises(WebSocketError) as ctx:
+        parser._handle_frame(False, WSMsgType.CLOSE, b"1", False)
+    assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
+    parser._handle_frame(True, WSMsgType.CONTINUATION, b"line2", False)
 
 
 def test_continuation_with_close_empty(
-    out: WebSocketDataQueue, parser: WebSocketReader
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
-    with mock.patch.object(parser, "parse_frame", autospec=True) as m:
-        m.return_value = [
-            (0, WSMsgType.TEXT, b"line1", False),
-            (0, WSMsgType.CLOSE, b"", False),
-            (1, WSMsgType.CONTINUATION, b"line2", False),
-        ]
+    parser._handle_frame(False, WSMsgType.TEXT, b"line1", False)
+    parser._handle_frame(False, WSMsgType.CLOSE, b"", False)
+    parser._handle_frame(True, WSMsgType.CONTINUATION, b"line2", False)
 
-        parser.feed_data(b"")
-        res = out._buffer[0]
-        assert res == WSMessageClose(data=0, size=0, extra="")
-        res = out._buffer[1]
-        assert res == WSMessageText(data="line1line2", size=10, extra="")
+    res = out._buffer[0]
+    assert res == WSMessageClose(data=0, size=0, extra="")
+    res = out._buffer[1]
+    assert res == WSMessageText(data="line1line2", size=10, extra="")
 
 
 websocket_mask_data: bytes = b"some very long data for masking by websocket"
@@ -510,7 +493,7 @@ def test_websocket_mask_cython_empty() -> None:
     assert message == bytearray()
 
 
-def test_parse_compress_frame_single(parser: WebSocketReader) -> None:
+def test_parse_compress_frame_single(parser: PatchableWebSocketReader) -> None:
     parser.parse_frame(struct.pack("!BB", 0b11000001, 0b00000001))
     res = parser.parse_frame(b"1")
     fin, opcode, payload, compress = res[0]
@@ -518,7 +501,7 @@ def test_parse_compress_frame_single(parser: WebSocketReader) -> None:
     assert (1, 1, b"1", True) == (fin, opcode, payload, not not compress)
 
 
-def test_parse_compress_frame_multi(parser: WebSocketReader) -> None:
+def test_parse_compress_frame_multi(parser: PatchableWebSocketReader) -> None:
     parser.parse_frame(struct.pack("!BB", 0b01000001, 126))
     parser.parse_frame(struct.pack("!H", 4))
     res = parser.parse_frame(b"1234")
@@ -538,7 +521,7 @@ def test_parse_compress_frame_multi(parser: WebSocketReader) -> None:
     assert (1, 1, b"1234", False) == (fin, opcode, payload, not not compress)
 
 
-def test_parse_compress_error_frame(parser: WebSocketReader) -> None:
+def test_parse_compress_error_frame(parser: PatchableWebSocketReader) -> None:
     parser.parse_frame(struct.pack("!BB", 0b01000001, 0b00000001))
     parser.parse_frame(b"1")
 
@@ -549,8 +532,8 @@ def test_parse_compress_error_frame(parser: WebSocketReader) -> None:
     assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
 
 
-def test_parse_no_compress_frame_single(out: WebSocketDataQueue) -> None:
-    parser_no_compress = WebSocketReader(out, 0, compress=False)
+def test_parse_no_compress_frame_single(out: PatchableWebSocketReader) -> None:
+    parser_no_compress = PatchableWebSocketReader(out, 0, compress=False)
     with pytest.raises(WebSocketError) as ctx:
         parser_no_compress.parse_frame(struct.pack("!BB", 0b11000001, 0b00000001))
         parser_no_compress.parse_frame(b"1")
@@ -558,7 +541,7 @@ def test_parse_no_compress_frame_single(out: WebSocketDataQueue) -> None:
     assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
 
 
-def test_msg_too_large(out: WebSocketDataQueue) -> None:
+def test_msg_too_large(out: PatchableWebSocketReader) -> None:
     parser = WebSocketReader(out, 256, compress=False)
     data = build_frame(b"text" * 256, WSMsgType.TEXT)
     with pytest.raises(WebSocketError) as ctx:
@@ -566,7 +549,7 @@ def test_msg_too_large(out: WebSocketDataQueue) -> None:
     assert ctx.value.code == WSCloseCode.MESSAGE_TOO_BIG
 
 
-def test_msg_too_large_not_fin(out: WebSocketDataQueue) -> None:
+def test_msg_too_large_not_fin(out: PatchableWebSocketReader) -> None:
     parser = WebSocketReader(out, 256, compress=False)
     data = build_frame(b"text" * 256, WSMsgType.TEXT, is_fin=False)
     with pytest.raises(WebSocketError) as ctx:
@@ -575,7 +558,7 @@ def test_msg_too_large_not_fin(out: WebSocketDataQueue) -> None:
 
 
 @pytest.mark.usefixtures("parametrize_zlib_backend")
-def test_compressed_msg_too_large(out: WebSocketDataQueue) -> None:
+def test_compressed_msg_too_large(out: PatchableWebSocketReader) -> None:
     parser = WebSocketReader(out, 256, compress=True)
     data = build_frame(b"aaa" * 256, WSMsgType.TEXT, ZLibBackend=ZLibBackend)
     with pytest.raises(WebSocketError) as ctx:
@@ -603,16 +586,11 @@ class TestWebSocketError:
 def test_flow_control_binary(
     protocol: BaseProtocol,
     out_low_limit: WebSocketDataQueue,
-    parser_low_limit: WebSocketReader,
+    parser_low_limit: PatchableWebSocketReader,
 ) -> None:
     large_payload = b"b" * (1 + 16 * 2)
     large_payload_size = len(large_payload)
-
-    with mock.patch.object(parser_low_limit, "parse_frame", autospec=True) as m:
-        m.return_value = [(1, WSMsgType.BINARY, large_payload, False)]
-
-        parser_low_limit.feed_data(b"")
-
+    parser_low_limit._handle_frame(True, WSMsgType.BINARY, large_payload, False)
     res = out_low_limit._buffer[0]
     assert res == WSMessageBinary(data=large_payload, size=large_payload_size, extra="")
     assert protocol._reading_paused is True
@@ -621,17 +599,12 @@ def test_flow_control_binary(
 def test_flow_control_multi_byte_text(
     protocol: BaseProtocol,
     out_low_limit: WebSocketDataQueue,
-    parser_low_limit: WebSocketReader,
+    parser_low_limit: PatchableWebSocketReader,
 ) -> None:
     large_payload_text = "𒀁" * (1 + 16 * 2)
     large_payload = large_payload_text.encode("utf-8")
     large_payload_size = len(large_payload)
-
-    with mock.patch.object(parser_low_limit, "parse_frame", autospec=True) as m:
-        m.return_value = [(1, WSMsgType.TEXT, large_payload, False)]
-
-        parser_low_limit.feed_data(b"")
-
+    parser_low_limit._handle_frame(True, WSMsgType.TEXT, large_payload, False)
     res = out_low_limit._buffer[0]
     assert res == WSMessageText(
         data=large_payload_text, size=large_payload_size, extra=""

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -26,9 +26,11 @@ from aiohttp.http_websocket import (
 class PatchableWebSocketReader(WebSocketReader):
     """WebSocketReader subclass that allows for patching parse_frame."""
 
-    def parse_frame(self, data: bytes) -> list[tuple[int, int, bytes, bool]]:
+    def parse_frame(
+        self, data: bytes
+    ) -> list[tuple[int, int, Union[bytes, bytearray], bool]]:
         # This method is overridden to allow for patching in tests.
-        frames: list[tuple[int, int, bytes, int]] = []
+        frames: list[tuple[int, int, Union[bytes, bytearray], int]] = []
 
         def _handle_frame(
             fin: int,

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -28,13 +28,13 @@ class PatchableWebSocketReader(WebSocketReader):
 
     def parse_frame(self, data: bytes) -> list[tuple[int, int, bytes, bool]]:
         # This method is overridden to allow for patching in tests.
-        frames: list[tuple[int, int, bytes, bool]] = []
+        frames: list[tuple[int, int, bytes, int]] = []
 
         def _handle_frame(
-            fin: bool,
+            fin: int,
             opcode: int,
             payload: Union[bytes, bytearray],
-            compressed: bool,
+            compressed: int,
         ) -> None:
             # This method is overridden to allow for patching in tests.
             frames.append((fin, opcode, payload, compressed))


### PR DESCRIPTION
We are already putting all the data into a queue. Right now we build up a list and than transfer it into the queue. Instead reverse the flow so that each frame ends up in the queue instead of the temporary list.

This is an internal change only that does not affect the public API