### PR TITLE
Avoid memcpy on WebSocket write if there is no trailer

### DIFF
--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -97,7 +97,10 @@ class WebSocketWriter:
                 if self.notakeover
                 else ZLibBackend.Z_SYNC_FLUSH
             ):
-                message += trailer
+                if message:
+                    message += trailer
+                else:
+                    message = trailer
             if message.endswith(WS_DEFLATE_TRAILING):
                 message = message.removesuffix(WS_DEFLATE_TRAILING)
             # Its critical that we do not return control to the event


### PR DESCRIPTION
All our websocket compression tests are testing messages with 1300 byte lengths so this likely won't show much improvement. We need a test for large messages before considering this PR