### PR TITLE
Refactor WebSocket reader to avoid frequent realloc when frames are fragmented

### DIFF
--- a/CHANGES/10744.misc.rst
+++ b/CHANGES/10744.misc.rst
@@ -1,0 +1,1 @@
+Improved performance of the WebSocket reader with large messages -- by :user:`bdraco`.

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -74,7 +74,7 @@ cdef class WebSocketReader:
     cdef int _opcode
     cdef bint _frame_fin
     cdef int _frame_opcode
-    cdef list _f_fragments
+    cdef list _frame_fragments
     cdef Py_ssize_t _frame_payload_len
 
     cdef bytes _tail
@@ -110,7 +110,7 @@ cdef class WebSocketReader:
         f_end_pos=Py_ssize_t,
         has_mask=bint,
         fin=bint,
-        had_existing_payload=Py_ssize_t,
-        f_payload_bytearray=bytearray,
+        had_fragments=Py_ssize_t,
+        payload_bytearray=bytearray,
     )
     cpdef void _feed_data(self, bytes data) except *

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -74,7 +74,7 @@ cdef class WebSocketReader:
     cdef int _opcode
     cdef bint _frame_fin
     cdef int _frame_opcode
-    cdef list _frame_payloads
+    cdef list _f_fragments
     cdef Py_ssize_t _frame_payload_len
 
     cdef bytes _tail

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -74,13 +74,13 @@ cdef class WebSocketReader:
     cdef int _opcode
     cdef bint _frame_fin
     cdef int _frame_opcode
-    cdef object _frame_payload
-    cdef unsigned long long _frame_payload_len
+    cdef list _frame_payloads
+    cdef Py_ssize_t _frame_payload_len
 
     cdef bytes _tail
     cdef bint _has_mask
     cdef bytes _frame_mask
-    cdef unsigned long long _payload_length
+    cdef Py_ssize_t _payload_length
     cdef unsigned int _payload_length_flag
     cdef int _compressed
     cdef object _decompressobj
@@ -97,17 +97,20 @@ cdef class WebSocketReader:
     cpdef void _handle_frame(self, bint fin, int opcode, object payload, int compressed) except *
 
     @cython.locals(
-        start_pos="unsigned int",
-        data_len="unsigned int",
-        length="unsigned int",
-        chunk_size="unsigned int",
-        chunk_len="unsigned int",
-        data_length="unsigned int",
+        start_pos=Py_ssize_t,
+        data_len=Py_ssize_t,
+        length=Py_ssize_t,
+        chunk_size=Py_ssize_t,
+        chunk_len=Py_ssize_t,
+        data_length=Py_ssize_t,
         data_cstr="const unsigned char *",
         first_byte="unsigned char",
         second_byte="unsigned char",
-        end_pos="unsigned int",
+        f_start_pos=Py_ssize_t,
+        f_end_pos=Py_ssize_t,
         has_mask=bint,
         fin=bint,
+        had_existing_payload=Py_ssize_t,
+        f_payload_bytearray=bytearray,
     )
     cpdef void _feed_data(self, bytes data) except *

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -74,7 +74,7 @@ cdef class WebSocketReader:
     cdef int _opcode
     cdef bint _frame_fin
     cdef int _frame_opcode
-    cdef list _frame_fragments
+    cdef list _payload_fragments
     cdef Py_ssize_t _frame_payload_len
 
     cdef bytes _tail
@@ -111,6 +111,6 @@ cdef class WebSocketReader:
         has_mask=bint,
         fin=bint,
         had_fragments=Py_ssize_t,
-        frame_bytearray=bytearray,
+        payload_bytearray=bytearray,
     )
     cpdef void _feed_data(self, bytes data) except *

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -81,7 +81,7 @@ cdef class WebSocketReader:
     cdef bint _has_mask
     cdef bytes _frame_mask
     cdef Py_ssize_t _remaing_payload_len
-    cdef unsigned int _remaing_payload_len_flag
+    cdef unsigned int _payload_len_flag
     cdef int _compressed
     cdef object _decompressobj
     cdef bint _compress

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -80,7 +80,7 @@ cdef class WebSocketReader:
     cdef bytes _tail
     cdef bint _has_mask
     cdef bytes _frame_mask
-    cdef Py_ssize_t _remaing_payload_len
+    cdef Py_ssize_t _frame_bytes_left
     cdef unsigned int _payload_len_flag
     cdef int _compressed
     cdef object _decompressobj

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -80,7 +80,7 @@ cdef class WebSocketReader:
     cdef bytes _tail
     cdef bint _has_mask
     cdef bytes _frame_mask
-    cdef Py_ssize_t _frame_bytes_left
+    cdef Py_ssize_t _payload_bytes_to_read
     cdef unsigned int _payload_len_flag
     cdef int _compressed
     cdef object _decompressobj

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -111,6 +111,6 @@ cdef class WebSocketReader:
         has_mask=bint,
         fin=bint,
         had_fragments=Py_ssize_t,
-        payload_bytearray=bytearray,
+        frame_bytearray=bytearray,
     )
     cpdef void _feed_data(self, bytes data) except *

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -102,7 +102,7 @@ cdef class WebSocketReader:
         length=Py_ssize_t,
         chunk_size=Py_ssize_t,
         chunk_len=Py_ssize_t,
-        data_length=Py_ssize_t,
+        data_len=Py_ssize_t,
         data_cstr="const unsigned char *",
         first_byte="unsigned char",
         second_byte="unsigned char",

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -80,8 +80,8 @@ cdef class WebSocketReader:
     cdef bytes _tail
     cdef bint _has_mask
     cdef bytes _frame_mask
-    cdef Py_ssize_t _payload_length
-    cdef unsigned int _payload_length_flag
+    cdef Py_ssize_t _remaing_payload_len
+    cdef unsigned int _remaing_payload_len_flag
     cdef int _compressed
     cdef object _decompressobj
     cdef bint _compress

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -468,9 +468,10 @@ class WebSocketReader:
                 elif self._has_mask:
                     assert self._frame_mask is not None
                     f_payload_bytearray = data_cstr[f_start_pos:f_end_pos]  # type: ignore[assignment]
-                    if type(f_payload_bytearray) is not bytearray:
+                    if type(f_payload_bytearray) is not bytearray:  # pragma: no branch
                         # Cython will do the conversion for us
-                        # but we need to do it for Python
+                        # but we need to do it for Python and we
+                        # will always get here in Python
                         f_payload_bytearray = bytearray(f_payload_bytearray)
                     websocket_mask(self._frame_mask, f_payload_bytearray)
                     f_payload = f_payload_bytearray

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -454,7 +454,7 @@ class WebSocketReader:
 
                 payload: Union[bytes, bytearray]
                 if had_fragments:
-                    # We have to merge the payloads if we have a fragmented message
+                    # We have to join the frame fragments get the payload
                     self._frame_fragments.append(data_cstr[f_start_pos:f_end_pos])
                     if self._has_mask:
                         assert self._frame_mask is not None

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -157,8 +157,8 @@ class WebSocketReader:
         self._tail: bytes = b""
         self._has_mask = False
         self._frame_mask: Optional[bytes] = None
-        self._payload_length = 0
-        self._payload_length_flag = 0
+        self._remaing_payload_len = 0
+        self._remaing_payload_len_flag = 0
         self._compressed: int = COMPRESSED_NOT_SET
         self._decompressobj: Optional[ZLibDecompressor] = None
         self._compress = compress
@@ -401,26 +401,26 @@ class WebSocketReader:
                 self._frame_fin = bool(fin)
                 self._frame_opcode = opcode
                 self._has_mask = bool(has_mask)
-                self._payload_length_flag = length
+                self._remaing_payload_len_flag = length
                 self._state = READ_PAYLOAD_LENGTH
 
             # read payload length
             if self._state == READ_PAYLOAD_LENGTH:
-                length_flag = self._payload_length_flag
+                length_flag = self._remaing_payload_len_flag
                 if length_flag == 126:
                     if data_len - start_pos < 2:
                         break
                     first_byte = data_cstr[start_pos]
                     second_byte = data_cstr[start_pos + 1]
                     start_pos += 2
-                    self._payload_length = first_byte << 8 | second_byte
+                    self._remaing_payload_len = first_byte << 8 | second_byte
                 elif length_flag > 126:
                     if data_len - start_pos < 8:
                         break
-                    self._payload_length = UNPACK_LEN3(data, start_pos)[0]
+                    self._remaing_payload_len = UNPACK_LEN3(data, start_pos)[0]
                     start_pos += 8
                 else:
-                    self._payload_length = length_flag
+                    self._remaing_payload_len = length_flag
 
                 self._state = READ_PAYLOAD_MASK if self._has_mask else READ_PAYLOAD
 
@@ -434,19 +434,19 @@ class WebSocketReader:
 
             if self._state == READ_PAYLOAD:
                 chunk_len = data_len - start_pos
-                if self._payload_length >= chunk_len:
+                if self._remaing_payload_len >= chunk_len:
                     f_end_pos = data_len
-                    self._payload_length -= chunk_len
+                    self._remaing_payload_len -= chunk_len
                 else:
-                    f_end_pos = start_pos + self._payload_length
-                    self._payload_length = 0
+                    f_end_pos = start_pos + self._remaing_payload_len
+                    self._remaing_payload_len = 0
 
                 had_fragments = self._frame_payload_len
                 self._frame_payload_len += f_end_pos - start_pos
                 f_start_pos = start_pos
                 start_pos = f_end_pos
 
-                if self._payload_length != 0:
+                if self._remaing_payload_len != 0:
                     # If we don't have a complete payload, we need to save the
                     # data for the next call to feed_data.
                     self._frame_fragments.append(data_cstr[f_start_pos:f_end_pos])

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -447,39 +447,39 @@ class WebSocketReader:
                 start_pos = f_end_pos
 
                 if self._frame_bytes_left != 0:
-                    # If we don't have a complete payload, we need to save the
+                    # If we don't have a complete frame, we need to save the
                     # data for the next call to feed_data.
                     self._frame_fragments.append(data_cstr[f_start_pos:f_end_pos])
                     break
 
-                payload: Union[bytes, bytearray]
+                frame: Union[bytes, bytearray]
                 if had_fragments:
-                    # We have to join the frame fragments get the payload
+                    # We have to join the frame fragments get the frame
                     self._frame_fragments.append(data_cstr[f_start_pos:f_end_pos])
                     if self._has_mask:
                         assert self._frame_mask is not None
-                        payload_bytearray = bytearray()
-                        payload_bytearray.join(self._frame_fragments)
-                        websocket_mask(self._frame_mask, payload_bytearray)
-                        payload = payload_bytearray
+                        frame_bytearray = bytearray()
+                        frame_bytearray.join(self._frame_fragments)
+                        websocket_mask(self._frame_mask, frame_bytearray)
+                        frame = frame_bytearray
                     else:
-                        payload = b"".join(self._frame_fragments)
+                        frame = b"".join(self._frame_fragments)
                     self._frame_fragments.clear()
                 elif self._has_mask:
                     assert self._frame_mask is not None
-                    payload_bytearray = data_cstr[f_start_pos:f_end_pos]  # type: ignore[assignment]
-                    if type(payload_bytearray) is not bytearray:  # pragma: no branch
+                    frame_bytearray = data_cstr[f_start_pos:f_end_pos]  # type: ignore[assignment]
+                    if type(frame_bytearray) is not bytearray:  # pragma: no branch
                         # Cython will do the conversion for us
                         # but we need to do it for Python and we
                         # will always get here in Python
-                        payload_bytearray = bytearray(payload_bytearray)
-                    websocket_mask(self._frame_mask, payload_bytearray)
-                    payload = payload_bytearray
+                        frame_bytearray = bytearray(frame_bytearray)
+                    websocket_mask(self._frame_mask, frame_bytearray)
+                    frame = frame_bytearray
                 else:
-                    payload = data_cstr[f_start_pos:f_end_pos]
+                    frame = data_cstr[f_start_pos:f_end_pos]
 
                 self._handle_frame(
-                    self._frame_fin, self._frame_opcode, payload, self._compressed
+                    self._frame_fin, self._frame_opcode, frame, self._compressed
                 )
                 self._frame_payload_len = 0
                 self._state = READ_HEADER

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -157,7 +157,7 @@ class WebSocketReader:
         self._tail: bytes = b""
         self._has_mask = False
         self._frame_mask: Optional[bytes] = None
-        self._remaing_payload_len = 0
+        self._remaining_payload_len = 0
         self._payload_len_flag = 0
         self._compressed: int = COMPRESSED_NOT_SET
         self._decompressobj: Optional[ZLibDecompressor] = None
@@ -413,14 +413,14 @@ class WebSocketReader:
                     first_byte = data_cstr[start_pos]
                     second_byte = data_cstr[start_pos + 1]
                     start_pos += 2
-                    self._remaing_payload_len = first_byte << 8 | second_byte
+                    self._remaining_payload_len = first_byte << 8 | second_byte
                 elif len_flag > 126:
                     if data_len - start_pos < 8:
                         break
-                    self._remaing_payload_len = UNPACK_LEN3(data, start_pos)[0]
+                    self._remaining_payload_len = UNPACK_LEN3(data, start_pos)[0]
                     start_pos += 8
                 else:
-                    self._remaing_payload_len = len_flag
+                    self._remaining_payload_len = len_flag
 
                 self._state = READ_PAYLOAD_MASK if self._has_mask else READ_PAYLOAD
 
@@ -434,19 +434,19 @@ class WebSocketReader:
 
             if self._state == READ_PAYLOAD:
                 chunk_len = data_len - start_pos
-                if self._remaing_payload_len >= chunk_len:
+                if self._remaining_payload_len >= chunk_len:
                     f_end_pos = data_len
-                    self._remaing_payload_len -= chunk_len
+                    self._remaining_payload_len -= chunk_len
                 else:
-                    f_end_pos = start_pos + self._remaing_payload_len
-                    self._remaing_payload_len = 0
+                    f_end_pos = start_pos + self._remaining_payload_len
+                    self._remaining_payload_len = 0
 
                 had_fragments = self._frame_payload_len
                 self._frame_payload_len += f_end_pos - start_pos
                 f_start_pos = start_pos
                 start_pos = f_end_pos
 
-                if self._remaing_payload_len != 0:
+                if self._remaining_payload_len != 0:
                     # If we don't have a complete payload, we need to save the
                     # data for the next call to feed_data.
                     self._frame_fragments.append(data_cstr[f_start_pos:f_end_pos])

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -157,7 +157,7 @@ class WebSocketReader:
         self._tail: bytes = b""
         self._has_mask = False
         self._frame_mask: Optional[bytes] = None
-        self._frame_bytes_left = 0
+        self._payload_bytes_to_read = 0
         self._payload_len_flag = 0
         self._compressed: int = COMPRESSED_NOT_SET
         self._decompressobj: Optional[ZLibDecompressor] = None
@@ -413,14 +413,14 @@ class WebSocketReader:
                     first_byte = data_cstr[start_pos]
                     second_byte = data_cstr[start_pos + 1]
                     start_pos += 2
-                    self._frame_bytes_left = first_byte << 8 | second_byte
+                    self._payload_bytes_to_read = first_byte << 8 | second_byte
                 elif len_flag > 126:
                     if data_len - start_pos < 8:
                         break
-                    self._frame_bytes_left = UNPACK_LEN3(data, start_pos)[0]
+                    self._payload_bytes_to_read = UNPACK_LEN3(data, start_pos)[0]
                     start_pos += 8
                 else:
-                    self._frame_bytes_left = len_flag
+                    self._payload_bytes_to_read = len_flag
 
                 self._state = READ_PAYLOAD_MASK if self._has_mask else READ_PAYLOAD
 
@@ -434,19 +434,19 @@ class WebSocketReader:
 
             if self._state == READ_PAYLOAD:
                 chunk_len = data_len - start_pos
-                if self._frame_bytes_left >= chunk_len:
+                if self._payload_bytes_to_read >= chunk_len:
                     f_end_pos = data_len
-                    self._frame_bytes_left -= chunk_len
+                    self._payload_bytes_to_read -= chunk_len
                 else:
-                    f_end_pos = start_pos + self._frame_bytes_left
-                    self._frame_bytes_left = 0
+                    f_end_pos = start_pos + self._payload_bytes_to_read
+                    self._payload_bytes_to_read = 0
 
                 had_fragments = self._frame_payload_len
                 self._frame_payload_len += f_end_pos - start_pos
                 f_start_pos = start_pos
                 start_pos = f_end_pos
 
-                if self._frame_bytes_left != 0:
+                if self._payload_bytes_to_read != 0:
                     # If we don't have a complete frame, we need to save the
                     # data for the next call to feed_data.
                     self._payload_fragments.append(data_cstr[f_start_pos:f_end_pos])

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -454,7 +454,7 @@ class WebSocketReader:
 
                 payload: Union[bytes, bytearray]
                 if had_fragments:
-                    # We have to join the payload fragments get the frame
+                    # We have to join the payload fragments get the payload
                     self._payload_fragments.append(data_cstr[f_start_pos:f_end_pos])
                     if self._has_mask:
                         assert self._frame_mask is not None

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -158,7 +158,7 @@ class WebSocketReader:
         self._has_mask = False
         self._frame_mask: Optional[bytes] = None
         self._remaing_payload_len = 0
-        self._remaing_payload_len_flag = 0
+        self._payload_len_flag = 0
         self._compressed: int = COMPRESSED_NOT_SET
         self._decompressobj: Optional[ZLibDecompressor] = None
         self._compress = compress
@@ -401,12 +401,12 @@ class WebSocketReader:
                 self._frame_fin = bool(fin)
                 self._frame_opcode = opcode
                 self._has_mask = bool(has_mask)
-                self._remaing_payload_len_flag = length
+                self._payload_len_flag = length
                 self._state = READ_PAYLOAD_LENGTH
 
             # read payload length
             if self._state == READ_PAYLOAD_LENGTH:
-                length_flag = self._remaing_payload_len_flag
+                length_flag = self._payload_len_flag
                 if length_flag == 126:
                     if data_len - start_pos < 2:
                         break

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -157,7 +157,7 @@ class WebSocketReader:
         self._tail: bytes = b""
         self._has_mask = False
         self._frame_mask: Optional[bytes] = None
-        self._remaining_payload_len = 0
+        self._frame_bytes_left = 0
         self._payload_len_flag = 0
         self._compressed: int = COMPRESSED_NOT_SET
         self._decompressobj: Optional[ZLibDecompressor] = None
@@ -413,14 +413,14 @@ class WebSocketReader:
                     first_byte = data_cstr[start_pos]
                     second_byte = data_cstr[start_pos + 1]
                     start_pos += 2
-                    self._remaining_payload_len = first_byte << 8 | second_byte
+                    self._frame_bytes_left = first_byte << 8 | second_byte
                 elif len_flag > 126:
                     if data_len - start_pos < 8:
                         break
-                    self._remaining_payload_len = UNPACK_LEN3(data, start_pos)[0]
+                    self._frame_bytes_left = UNPACK_LEN3(data, start_pos)[0]
                     start_pos += 8
                 else:
-                    self._remaining_payload_len = len_flag
+                    self._frame_bytes_left = len_flag
 
                 self._state = READ_PAYLOAD_MASK if self._has_mask else READ_PAYLOAD
 
@@ -434,19 +434,19 @@ class WebSocketReader:
 
             if self._state == READ_PAYLOAD:
                 chunk_len = data_len - start_pos
-                if self._remaining_payload_len >= chunk_len:
+                if self._frame_bytes_left >= chunk_len:
                     f_end_pos = data_len
-                    self._remaining_payload_len -= chunk_len
+                    self._frame_bytes_left -= chunk_len
                 else:
-                    f_end_pos = start_pos + self._remaining_payload_len
-                    self._remaining_payload_len = 0
+                    f_end_pos = start_pos + self._frame_bytes_left
+                    self._frame_bytes_left = 0
 
                 had_fragments = self._frame_payload_len
                 self._frame_payload_len += f_end_pos - start_pos
                 f_start_pos = start_pos
                 start_pos = f_end_pos
 
-                if self._remaining_payload_len != 0:
+                if self._frame_bytes_left != 0:
                     # If we don't have a complete payload, we need to save the
                     # data for the next call to feed_data.
                     self._frame_fragments.append(data_cstr[f_start_pos:f_end_pos])

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -406,21 +406,21 @@ class WebSocketReader:
 
             # read payload length
             if self._state == READ_PAYLOAD_LENGTH:
-                length_flag = self._payload_len_flag
-                if length_flag == 126:
+                len_flag = self._payload_len_flag
+                if len_flag == 126:
                     if data_len - start_pos < 2:
                         break
                     first_byte = data_cstr[start_pos]
                     second_byte = data_cstr[start_pos + 1]
                     start_pos += 2
                     self._remaing_payload_len = first_byte << 8 | second_byte
-                elif length_flag > 126:
+                elif len_flag > 126:
                     if data_len - start_pos < 8:
                         break
                     self._remaing_payload_len = UNPACK_LEN3(data, start_pos)[0]
                     start_pos += 8
                 else:
-                    self._remaing_payload_len = length_flag
+                    self._remaing_payload_len = len_flag
 
                 self._state = READ_PAYLOAD_MASK if self._has_mask else READ_PAYLOAD
 


### PR DESCRIPTION
Instead of reallocating memory to extend a bytearray on every part of the payload we read, put the payload into a list and join them when we have the full payload.