### PR TITLE
Add a test to the WebSocket parser for sending one byte at a time

### DIFF
--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -333,6 +333,7 @@ def test_simple_binary(
 def test_one_byte_at_a_time(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
+    """Send one byte at a time to the parser."""
     data = build_frame(b"binary", WSMsgType.BINARY)
     for i in range(len(data)):
         parser._feed_data(data[i : i + 1])

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -330,6 +330,16 @@ def test_simple_binary(
     assert res == WSMessageBinary(data=b"binary", size=6, extra="")
 
 
+def test_one_byte_at_a_time(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
+    data = build_frame(b"binary", WSMsgType.BINARY)
+    for i in range(len(data)):
+        parser._feed_data(data[i : i + 1])
+    res = out._buffer[0]
+    assert res == WSMessageBinary(data=b"binary", size=6, extra="")
+
+
 def test_fragmentation_header(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:


### PR DESCRIPTION
These type of tests are good for catching buffer (over|under)runs
