### PR TITLE
Support using system llhttp library

### DIFF
--- a/CHANGES/10759.packaging.rst
+++ b/CHANGES/10759.packaging.rst
@@ -1,5 +1,5 @@
-Support building against system llhttp library -- by :user:`mgorny`
+Added support for building against system ``llhttp`` library -- by :user:`mgorny`.
 
-This change adds support for ``USE_SYSTEM_DEPS`` environment variable that
-can be used to build aiohttp against the system install of the llhttp library
+This change adds support for :envvar:`USE_SYSTEM_DEPS` environment variable that
+can be used to build aiohttp against the system install of the ``llhttp`` library
 rather than the vendored one.

--- a/CHANGES/10759.packaging.rst
+++ b/CHANGES/10759.packaging.rst
@@ -1,5 +1,5 @@
 Added support for building against system ``llhttp`` library -- by :user:`mgorny`.
 
-This change adds support for :envvar:`USE_SYSTEM_DEPS` environment variable that
-can be used to build aiohttp against the system install of the ``llhttp`` library
-rather than the vendored one.
+This change adds support for :envvar:`AIOHTTP_USE_SYSTEM_DEPS` environment variable that
+can be used to build aiohttp against the system install of the ``llhttp`` library rather
+than the vendored one.

--- a/CHANGES/10759.packaging.rst
+++ b/CHANGES/10759.packaging.rst
@@ -1,0 +1,5 @@
+Support building against system llhttp library -- by :user:`mgorny`
+
+This change adds support for ``USE_SYSTEM_DEPS`` environment variable that
+can be used to build aiohttp against the system install of the llhttp library
+rather than the vendored one.

--- a/aiohttp/_cparser.pxd
+++ b/aiohttp/_cparser.pxd
@@ -1,7 +1,7 @@
 from libc.stdint cimport int32_t, uint8_t, uint16_t, uint64_t
 
 
-cdef extern from "../vendor/llhttp/build/llhttp.h":
+cdef extern from "llhttp.h":
 
     struct llhttp__internal_s:
         int32_t _index

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -153,7 +153,7 @@ Environment Variables
 
 .. envvar:: AIOHTTP_NO_EXTENSIONS
 
-   If set to a non-empty value while building from source, aiohttp will be built without speedsup
+   If set to a non-empty value while building from source, aiohttp will be built without speedups
    written as C extensions. This option is primarily useful for debugging.
 
 .. envvar:: AIOHTTP_USE_SYSTEM_DEPS

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -151,6 +151,17 @@
 Environment Variables
 =====================
 
+.. envvar:: AIOHTTP_NO_EXTENSIONS
+
+   If set to a non-empty value while building from source, aiohttp will be built without speedsup
+   written as C extensions. This option is primarily useful for debugging.
+
+.. envvar:: AIOHTTP_USE_SYSTEM_DEPS
+
+   If set to a non-empty value while building from source, aiohttp will be built against
+   the system installation of llhttp rather than the vendored library. This option is primarily
+   meant to be used by downstream redistributors.
+
 .. envvar:: NETRC
 
    If set, HTTP Basic Auth will be read from the file pointed to by this environment variable,

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -176,6 +176,7 @@ kwargs
 latin
 lifecycle
 linux
+llhttp
 localhost
 Locator
 login

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "setuptools >= 46.4.0",
     "pkgconfig",
+    "setuptools >= 46.4.0",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [build-system]
 requires = [
     "setuptools >= 46.4.0",
+    "pkgconfig",
 ]
 build-backend = "setuptools.build_meta"
 

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -5,6 +5,7 @@ coverage
 freezegun
 isal
 mypy; implementation_name == "cpython"
+pkgconfig
 proxy.py >= 2.4.4rc5
 pytest
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ if sys.version_info < (3, 9):
     raise RuntimeError("aiohttp 4.x requires Python 3.9+")
 
 
+USE_SYSTEM_DEPS: bool = bool(os.environ.get("USE_SYSTEM_DEPS"))
 NO_EXTENSIONS: bool = bool(os.environ.get("AIOHTTP_NO_EXTENSIONS"))
 HERE = pathlib.Path(__file__).parent
 IS_GIT_REPO = (HERE / ".git").exists()
@@ -17,7 +18,11 @@ if sys.implementation.name != "cpython":
     NO_EXTENSIONS = True
 
 
-if IS_GIT_REPO and not (HERE / "vendor/llhttp/README.md").exists():
+if (
+    not USE_SYSTEM_DEPS
+    and IS_GIT_REPO
+    and not (HERE / "vendor/llhttp/README.md").exists()
+):
     print("Install submodules when building from git clone", file=sys.stderr)
     print("Hint:", file=sys.stderr)
     print("  git submodule update --init", file=sys.stderr)
@@ -26,6 +31,27 @@ if IS_GIT_REPO and not (HERE / "vendor/llhttp/README.md").exists():
 
 # NOTE: makefile cythonizes all Cython modules
 
+if USE_SYSTEM_DEPS:
+    import shlex
+
+    import pkgconfig
+
+    llhttp_sources = []
+    llhttp_kwargs = {
+        "extra_compile_args": shlex.split(pkgconfig.cflags("libllhttp")),
+        "extra_link_args": shlex.split(pkgconfig.libs("libllhttp")),
+    }
+else:
+    llhttp_sources = [
+        "vendor/llhttp/build/c/llhttp.c",
+        "vendor/llhttp/src/native/api.c",
+        "vendor/llhttp/src/native/http.c",
+    ]
+    llhttp_kwargs = {
+        "define_macros": [("LLHTTP_STRICT_MODE", 0)],
+        "include_dirs": ["vendor/llhttp/build"],
+    }
+
 extensions = [
     Extension("aiohttp._websocket.mask", ["aiohttp/_websocket/mask.c"]),
     Extension(
@@ -33,12 +59,9 @@ extensions = [
         [
             "aiohttp/_http_parser.c",
             "aiohttp/_find_header.c",
-            "vendor/llhttp/build/c/llhttp.c",
-            "vendor/llhttp/src/native/api.c",
-            "vendor/llhttp/src/native/http.c",
+            *llhttp_sources,
         ],
-        define_macros=[("LLHTTP_STRICT_MODE", 0)],
-        include_dirs=["vendor/llhttp/build"],
+        **llhttp_kwargs,
     ),
     Extension("aiohttp._http_writer", ["aiohttp/_http_writer.c"]),
     Extension("aiohttp._websocket.reader_c", ["aiohttp/_websocket/reader_c.c"]),

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if sys.version_info < (3, 9):
     raise RuntimeError("aiohttp 4.x requires Python 3.9+")
 
 
-USE_SYSTEM_DEPS: bool = bool(os.environ.get("USE_SYSTEM_DEPS"))
+USE_SYSTEM_DEPS = bool(os.environ.get("AIOHTTP_USE_SYSTEM_DEPS"))
 NO_EXTENSIONS: bool = bool(os.environ.get("AIOHTTP_NO_EXTENSIONS"))
 HERE = pathlib.Path(__file__).parent
 IS_GIT_REPO = (HERE / ".git").exists()

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,9 @@ if sys.version_info < (3, 9):
     raise RuntimeError("aiohttp 4.x requires Python 3.9+")
 
 
-USE_SYSTEM_DEPS = bool(os.environ.get("AIOHTTP_USE_SYSTEM_DEPS"))
+USE_SYSTEM_DEPS = bool(
+    os.environ.get("AIOHTTP_USE_SYSTEM_DEPS", os.environ.get("USE_SYSTEM_DEPS"))
+)
 NO_EXTENSIONS: bool = bool(os.environ.get("AIOHTTP_NO_EXTENSIONS"))
 HERE = pathlib.Path(__file__).parent
 IS_GIT_REPO = (HERE / ".git").exists()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add a new `USE_SYSTEM_DEPS` environment variable that can be used to enable building against the system install of llhttp library rather than the vendored one.

This is implemented using the `pkgconfig` package to query llhttp install via pkg-config.  The package is only used when `USE_SYSTEM_DEPS` is enabled, however due to limitations of `pyproject.toml` it is listed unconditionally as a build dependency.  That said, flake8 claims that the dependency is not listed and I don't really know how to solve that:

```
setup.py:36:5: I900 'pkgconfig' not listed as a requirement
```

I have also updated `aiohttp/_cparser.pxd` to reference the `llhttp.h` header via its name rather than full path.  I have poisoned the system header to confirm that the correct header is used both when building against the system library and the vendored library.

## Are there changes in behavior for the user?

- no changes for users installing from wheels
- users installing from source will see an additional `pkgconfig` build requirement
- users installing from source who enable `USE_SYSTEM_DEPS` will be using the system llhttp library

## Is it a substantial burden for the maintainers to support this?

I don't think so. The code uses `pkg-config`, so it should be pretty forward-secure to potentially nonstandard `llhttp` installs. On top of that, presumably the feature will be primarily used by downstreams / expert users, who would rather be willing to submit fixes, should any issues arise (though that implies the burden of reviewing them).

## Related issue number

Discussion #10759.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
