### PR TITLE
Fix WebSocket reader with fragmented masked messages

### DIFF
--- a/CHANGES/10764.bugfix.rst
+++ b/CHANGES/10764.bugfix.rst
@@ -1,3 +1,3 @@
 Fixed reading fragmented WebSocket messages when the payload was masked -- by :user:`bdraco`.
 
-The problem first appeared in 3.11.16
+The problem first appeared in 3.11.17

--- a/CHANGES/10764.bugfix.rst
+++ b/CHANGES/10764.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed reading fragmented WebSocket messages when the payload was masked -- by :user:`bdraco`.
+
+The problem first appeared in 3.11.16

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -458,10 +458,7 @@ class WebSocketReader:
                     self._payload_fragments.append(data_cstr[f_start_pos:f_end_pos])
                     if self._has_mask:
                         assert self._frame_mask is not None
-                        payload_bytearray = bytearray()
-                        payload_bytearray = payload_bytearray.join(
-                            self._payload_fragments
-                        )
+                        payload_bytearray = bytearray(b"".join(self._payload_fragments))
                         websocket_mask(self._frame_mask, payload_bytearray)
                         payload = payload_bytearray
                     else:

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -458,7 +458,10 @@ class WebSocketReader:
                     self._payload_fragments.append(data_cstr[f_start_pos:f_end_pos])
                     if self._has_mask:
                         assert self._frame_mask is not None
-                        payload_bytearray = bytearray().join(self._payload_fragments)
+                        payload_bytearray = bytearray()
+                        payload_bytearray = payload_bytearray.join(
+                            self._payload_fragments
+                        )
                         websocket_mask(self._frame_mask, payload_bytearray)
                         payload = payload_bytearray
                     else:

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -458,8 +458,7 @@ class WebSocketReader:
                     self._payload_fragments.append(data_cstr[f_start_pos:f_end_pos])
                     if self._has_mask:
                         assert self._frame_mask is not None
-                        payload_bytearray = bytearray()
-                        payload_bytearray.join(self._payload_fragments)
+                        payload_bytearray = bytearray().join(self._payload_fragments)
                         websocket_mask(self._frame_mask, payload_bytearray)
                         payload = payload_bytearray
                     else:

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -92,10 +92,10 @@ def build_frame(
 
     if mask:
         assert not noheader
-        mask = PACK_RANDBITS(random.getrandbits(32))
+        mask_bytes = PACK_RANDBITS(random.getrandbits(32))
         message_arr = bytearray(message)
-        websocket_mask(mask, message_arr)
-        return header + mask + message_arr
+        websocket_mask(mask_bytes, message_arr)
+        return header + mask_bytes + message_arr
 
     if noheader:
         return message

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -144,11 +144,6 @@ def parser(out: WebSocketDataQueue) -> PatchableWebSocketReader:
     return PatchableWebSocketReader(out, 4 * 1024 * 1024)
 
 
-@pytest.fixture()
-def parser_with_large_limit(out: WebSocketDataQueue) -> PatchableWebSocketReader:
-    return PatchableWebSocketReader(out, 1024 * 1024 * 1024)
-
-
 def test_feed_data_remembers_exception(parser: WebSocketReader) -> None:
     """Verify that feed_data remembers an exception was already raised internally."""
     error, data = parser.feed_data(struct.pack("!BB", 0b01100000, 0b00000000))
@@ -377,22 +372,22 @@ def test_fragmentation_header(
 
 
 def test_large_message(
-    out: WebSocketDataQueue, parser_with_large_limit: PatchableWebSocketReader
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
     large_payload = b"b" * 131072
     data = build_frame(large_payload, WSMsgType.BINARY)
-    parser_with_large_limit._feed_data(data)
+    parser._feed_data(data)
 
     res = out._buffer[0]
     assert res == WSMessageBinary(data=large_payload, size=131072, extra="")
 
 
 def test_large_masked_message(
-    out: WebSocketDataQueue, parser_with_large_limit: PatchableWebSocketReader
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
     large_payload = b"b" * 131072
     data = build_frame(large_payload, WSMsgType.BINARY, mask=True)
-    parser_with_large_limit._feed_data(data)
+    parser._feed_data(data)
 
     res = out._buffer[0]
     assert res == WSMessageBinary(data=large_payload, size=131072, extra="")


### PR DESCRIPTION
Fix WebSocket reader with fragmented masked messages

We didn't have proper coverage for these cases. Add mask and large payload coverage for the reported cases since they would come through as 0 instead of the correct size.

fixes #10763
regressed in #10747

