### PR TITLE
[PR #10764/e0cc020 backport][3.11] Fix WebSocket reader with fragmented masked messages

### DIFF
--- a/CHANGES/10764.bugfix.rst
+++ b/CHANGES/10764.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed reading fragmented WebSocket messages when the payload was masked -- by :user:`bdraco`.
+
+The problem first appeared in 3.11.17

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -439,8 +439,7 @@ class WebSocketReader:
                     self._payload_fragments.append(data_cstr[f_start_pos:f_end_pos])
                     if self._has_mask:
                         assert self._frame_mask is not None
-                        payload_bytearray = bytearray()
-                        payload_bytearray.join(self._payload_fragments)
+                        payload_bytearray = bytearray(b"".join(self._payload_fragments))
                         websocket_mask(self._frame_mask, payload_bytearray)
                         payload = payload_bytearray
                     else:


### PR DESCRIPTION
(cherry picked from commit e0cc020d59de9267146c55dbf082805213737653)
