### PR TITLE
[PR #10764/e0cc020 backport][3.12] Fix WebSocket reader with fragmented masked messages

### DIFF
--- a/CHANGES/10764.bugfix.rst
+++ b/CHANGES/10764.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed reading fragmented WebSocket messages when the payload was masked -- by :user:`bdraco`.
+
+The problem first appeared in 3.11.17

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -447,8 +447,7 @@ class WebSocketReader:
                     self._payload_fragments.append(data_cstr[f_start_pos:f_end_pos])
                     if self._has_mask:
                         assert self._frame_mask is not None
-                        payload_bytearray = bytearray()
-                        payload_bytearray.join(self._payload_fragments)
+                        payload_bytearray = bytearray(b"".join(self._payload_fragments))
                         websocket_mask(self._frame_mask, payload_bytearray)
                         payload = payload_bytearray
                     else:

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -368,6 +368,51 @@ def test_fragmentation_header(
     assert res == (WSMessage(WSMsgType.TEXT, "a", ""), 1)
 
 
+def test_large_message(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
+    large_payload = b"b" * 131072
+    data = build_frame(large_payload, WSMsgType.BINARY)
+    parser._feed_data(data)
+
+    res = out._buffer[0]
+    assert res == ((WSMsgType.BINARY, large_payload, ""), 131072)
+
+
+def test_large_masked_message(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
+    large_payload = b"b" * 131072
+    data = build_frame(large_payload, WSMsgType.BINARY, use_mask=True)
+    parser._feed_data(data)
+
+    res = out._buffer[0]
+    assert res == ((WSMsgType.BINARY, large_payload, ""), 131072)
+
+
+def test_fragmented_masked_message(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
+    large_payload = b"b" * 100
+    data = build_frame(large_payload, WSMsgType.BINARY, use_mask=True)
+    for i in range(len(data)):
+        parser._feed_data(data[i : i + 1])
+
+    res = out._buffer[0]
+    assert res == ((WSMsgType.BINARY, large_payload, ""), 100)
+
+
+def test_large_fragmented_masked_message(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
+    large_payload = b"b" * 131072
+    data = build_frame(large_payload, WSMsgType.BINARY, use_mask=True)
+    for i in range(0, len(data), 16384):
+        parser._feed_data(data[i : i + 16384])
+    res = out._buffer[0]
+    assert res == ((WSMsgType.BINARY, large_payload, ""), 131072)
+
+
 def test_continuation(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:


### PR DESCRIPTION
(cherry picked from commit e0cc020d59de9267146c55dbf082805213737653)
