### PR TITLE
Increase benchmark timeout to 9 minutes in the CI

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -260,7 +260,7 @@ jobs:
     needs: gen_llhttp
 
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 9
     steps:
     - name: Checkout project
       uses: actions/checkout@v4


### PR DESCRIPTION
Sometimes these take a bit more than 7m which causes the CI timeout
