### PR TITLE
Release 3.11.18

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,34 @@
 
 .. towncrier release notes start
 
+3.11.18 (2025-04-20)
+====================
+
+Bug fixes
+---------
+
+- Disabled TLS in TLS warning (when using HTTPS proxies) for uvloop and newer Python versions -- by :user:`lezgomatt`.
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`7686`.
+
+
+
+- Fixed reading fragmented WebSocket messages when the payload was masked -- by :user:`bdraco`.
+
+  The problem first appeared in 3.11.17
+
+
+  *Related issues and pull requests on GitHub:*
+  :issue:`10764`.
+
+
+
+
+----
+
+
 3.11.17 (2025-04-19)
 ====================
 

--- a/CHANGES/10764.bugfix.rst
+++ b/CHANGES/10764.bugfix.rst
@@ -1,3 +1,0 @@
-Fixed reading fragmented WebSocket messages when the payload was masked -- by :user:`bdraco`.
-
-The problem first appeared in 3.11.17

--- a/CHANGES/7686.bugfix.rst
+++ b/CHANGES/7686.bugfix.rst
@@ -1,1 +1,0 @@
-Disabled TLS in TLS warning (when using HTTPS proxies) for uvloop and newer Python versions -- by :user:`lezgomatt`.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.11.18.dev0"
+__version__ = "3.11.18"
 
 from typing import TYPE_CHECKING, Tuple
 


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/actions/runs/14570663661

<img width="683" alt="Screenshot 2025-04-20 at 10 44 45 PM" src="https://github.com/user-attachments/assets/39631184-4526-4a88-95e9-2e395a737ff0" />


pre-release testing
- [x] production 1
- [x] production 2
- [x] check last 3.11 run for new errors
- [x] Review diff against v3.11.17 for obvious errors

post merge tasks https://docs.aiohttp.org/en/stable/contributing-admins.html#id1

- [x] baby sit
- [x] retest on HA https://github.com/home-assistant/core/pull/143392
- [x] 3.12 merge + change cleanup
- [x] master merge + change cleanup https://github.com/aio-libs/aiohttp/pull/10776
- [x] socials
- [x] increment 3.11 version to .19.dev0  https://github.com/aio-libs/aiohttp/pull/10775