### PR TITLE
Fix error messages to be idiomatically correct English

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,8 +24,8 @@ entertain early in the review process. Thank you in advance!
 
 ## Related issue number
 
-<!-- Are there any issues opened that will be resolved by merging this change? -->
-<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->
+<!-- Will this resolve any open issues? -->
+<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->
 
 ## Checklist
 

--- a/CHANGES/10798.misc
+++ b/CHANGES/10798.misc
@@ -1,0 +1,1 @@
+Fix error messages to be idiomatically correct English.

--- a/CHANGES/10798.misc
+++ b/CHANGES/10798.misc
@@ -1,1 +1,0 @@
-Fix error messages to be idiomatically correct English.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -506,10 +506,10 @@ cdef class HttpParser:
         if self._payload is not None:
             if self._cparser.flags & cparser.F_CHUNKED:
                 raise TransferEncodingError(
-                    "Not enough data for satisfy transfer length header.")
+                    "Not enough data to satisfy transfer length header.")
             elif self._cparser.flags & cparser.F_CONTENT_LENGTH:
                 raise ContentLengthError(
-                    "Not enough data for satisfy content length header.")
+                    "Not enough data to satisfy content length header.")
             elif cparser.llhttp_get_errno(self._cparser) != cparser.HPE_OK:
                 desc = cparser.llhttp_get_error_reason(self._cparser)
                 raise PayloadEncodingError(desc.decode('latin-1'))

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -69,7 +69,7 @@ class TransferEncodingError(PayloadEncodingError):
 
 
 class ContentLengthError(PayloadEncodingError):
-    """Not enough data for satisfy content length header."""
+    """Not enough data to satisfy content length header."""
 
 
 class LineTooLong(BadHttpMessage):

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -792,11 +792,11 @@ class HttpPayloadParser:
             self.payload.feed_eof()
         elif self._type == ParseState.PARSE_LENGTH:
             raise ContentLengthError(
-                "Not enough data for satisfy content length header."
+                "Not enough data to satisfy content length header."
             )
         elif self._type == ParseState.PARSE_CHUNKED:
             raise TransferEncodingError(
-                "Not enough data for satisfy transfer length header."
+                "Not enough data to satisfy transfer length header."
             )
 
     def feed_data(


### PR DESCRIPTION
## What do these changes do?

Fix error messages and some instructions in PR template
to be idiomatically correct English

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?

no

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
