### PR TITLE
Remove constraint that prevented aiodns from being installed on Windows

### DIFF
--- a/CHANGES/10823.packaging.rst
+++ b/CHANGES/10823.packaging.rst
@@ -1,3 +1,3 @@
-Removed constraint that prevented ``aiodns`` from being installed on Windows with speedups extra -- by :user:`bdraco`.
+``aiodns`` is now installed on Windows with speedups extra -- by :user:`bdraco`.
 
 As of ``aiodns`` 3.3.0, ``SelectorEventLoop`` is no longer required when using ``pycares`` 4.7.0 or later.

--- a/CHANGES/10823.packaging.rst
+++ b/CHANGES/10823.packaging.rst
@@ -1,0 +1,3 @@
+Removed constraint that prevented ``aiodns`` from being installed on Windows with speedups extra -- by :user:`bdraco`.
+
+As of ``aiodns`` 3.3.0, ``SelectorEventLoop`` is no longer required when using ``pycares`` 4.7.0 or later.

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -1,6 +1,6 @@
 # Extracted from `setup.cfg` via `make sync-direct-runtime-deps`
 
-aiodns >= 3.2.0; sys_platform=="linux" or sys_platform=="darwin"
+aiodns >= 3.2.0
 aiohappyeyeballs >= 2.5.0
 aiosignal >= 1.1.2
 async-timeout >= 4.0, < 6.0 ; python_version < "3.11"

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -1,6 +1,6 @@
 # Extracted from `setup.cfg` via `make sync-direct-runtime-deps`
 
-aiodns >= 3.2.0
+aiodns >= 3.3.0
 aiohappyeyeballs >= 2.5.0
 aiosignal >= 1.1.2
 async-timeout >= 4.0, < 6.0 ; python_version < "3.11"

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,8 +66,7 @@ install_requires =
 
 [options.extras_require]
 speedups =
-  # required c-ares (aiodns' backend) will not build on windows
-  aiodns >= 3.2.0; sys_platform=="linux" or sys_platform=="darwin"
+  aiodns >= 3.3.0
   Brotli; platform_python_implementation == 'CPython'
   brotlicffi; platform_python_implementation != 'CPython'
 


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

Remove constraint that prevented aiodns from being installed on Windows
As of aiodns 3.3.0 SelectorEventLoop is no longer required when using pycares 4.7.0 or later

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

aiodns is now available on windows

## Is it a substantial burden for the maintainers to support this?
no

## Related issue number

closes #8121


## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
