### PR TITLE
Add benchmark requests without session and alternating clients

### DIFF
--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -4,9 +4,11 @@ import asyncio
 
 import pytest
 from pytest_codspeed import BenchmarkFixture
+from yarl import URL
 
+import aiohttp
 from aiohttp import hdrs, web
-from aiohttp.pytest_plugin import AiohttpClient
+from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
 
 
 def test_one_hundred_simple_get_requests(
@@ -28,6 +30,32 @@ def test_one_hundred_simple_get_requests(
         for _ in range(message_count):
             await client.get("/")
         await client.close()
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_client_benchmark())
+
+
+def test_one_hundred_simple_get_requests_no_session(
+    loop: asyncio.AbstractEventLoop,
+    aiohttp_server: AiohttpServer,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark 100 simple GET requests without a session."""
+    message_count = 100
+
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    server = loop.run_until_complete(aiohttp_server(app))
+    url = URL(f"http://{server.host}:{server.port}/")
+
+    async def run_client_benchmark() -> None:
+        for _ in range(message_count):
+            async with aiohttp.request("GET", url):
+                pass
 
     @benchmark
     def _run() -> None:

--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -6,8 +6,7 @@ import pytest
 from pytest_codspeed import BenchmarkFixture
 from yarl import URL
 
-import aiohttp
-from aiohttp import hdrs, web
+from aiohttp import hdrs, request, web
 from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
 
 
@@ -54,7 +53,7 @@ def test_one_hundred_simple_get_requests_no_session(
 
     async def run_client_benchmark() -> None:
         for _ in range(message_count):
-            async with aiohttp.request("GET", url):
+            async with request("GET", url):
                 pass
 
     @benchmark


### PR DESCRIPTION
This was a bit of a blind spot in our benchmarks

noticed when I was looking at resolver object churn in #10847