### PR TITLE
remove use of deprecated policy API from tests

### DIFF
--- a/CHANGES/10851.bugfix.rst
+++ b/CHANGES/10851.bugfix.rst
@@ -1,0 +1,1 @@
+Fix pytest plugin to not use deprecated asyncio policy APIs.

--- a/CHANGES/10851.bugfix.rst
+++ b/CHANGES/10851.bugfix.rst
@@ -1,1 +1,1 @@
-Fix pytest plugin to not use deprecated asyncio policy APIs.
+Fixed pytest plugin to not use deprecated :py:mod:`asyncio` policy APIs.

--- a/CHANGES/10851.contrib.rst
+++ b/CHANGES/10851.contrib.rst
@@ -1,0 +1,2 @@
+Updated tests to avoid using deprecated :py:mod:`asyncio` policy APIs and
+make it compatible with Python 3.14.

--- a/CHANGES/10851.misc.rst
+++ b/CHANGES/10851.misc.rst
@@ -1,0 +1,1 @@
+Update tests to avoid using deprecated asyncio policy APIs.

--- a/CHANGES/10851.misc.rst
+++ b/CHANGES/10851.misc.rst
@@ -1,1 +1,0 @@
-Update tests to avoid using deprecated asyncio policy APIs.

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -286,7 +286,7 @@ def loop(
 
 @pytest.fixture
 def proactor_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    factory = asyncio.ProactorEventLoop
+    factory = asyncio.ProactorEventLoop # type: ignore[attr-defined]
 
     with loop_context(factory) as _loop:
         asyncio.set_event_loop(_loop)

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -272,14 +272,12 @@ def pytest_generate_tests(metafunc):  # type: ignore[no-untyped-def]
 
 @pytest.fixture
 def loop(
-    loop_factory: Callable[[], asyncio.AbstractEventLoopPolicy],
+    loop_factory: Callable[[], asyncio.AbstractEventLoop],
     fast: bool,
     loop_debug: bool,
 ) -> Iterator[asyncio.AbstractEventLoop]:
     """Return an instance of the event loop."""
-    policy = loop_factory()
-    asyncio.set_event_loop_policy(policy)
-    with loop_context(fast=fast) as _loop:
+    with loop_context(loop_factory, fast=fast) as _loop:
         if loop_debug:
             _loop.set_debug(True)
         asyncio.set_event_loop(_loop)
@@ -288,10 +286,9 @@ def loop(
 
 @pytest.fixture
 def proactor_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    policy = asyncio.WindowsProactorEventLoopPolicy()  # type: ignore[attr-defined]
-    asyncio.set_event_loop_policy(policy)
+    factory = asyncio.WindowsProactorEventLoop
 
-    with loop_context(policy.new_event_loop) as _loop:
+    with loop_context(factory) as _loop:
         asyncio.set_event_loop(_loop)
         yield _loop
 

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -286,7 +286,7 @@ def loop(
 
 @pytest.fixture
 def proactor_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    factory = asyncio.ProactorEventLoop # type: ignore[attr-defined]
+    factory = asyncio.ProactorEventLoop  # type: ignore[attr-defined]
 
     with loop_context(factory) as _loop:
         asyncio.set_event_loop(_loop)

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -243,11 +243,11 @@ def pytest_generate_tests(metafunc):  # type: ignore[no-untyped-def]
         return
 
     loops = metafunc.config.option.aiohttp_loop
-    avail_factories: Dict[str, Type[asyncio.AbstractEventLoopPolicy]]
-    avail_factories = {"pyloop": asyncio.DefaultEventLoopPolicy}
+    avail_factories: dict[str, Callable[[], asyncio.AbstractEventLoop]]
+    avail_factories = {"pyloop": asyncio.new_event_loop}
 
     if uvloop is not None:
-        avail_factories["uvloop"] = uvloop.EventLoopPolicy
+        avail_factories["uvloop"] = uvloop.new_event_loop
 
     if loops == "all":
         loops = "pyloop,uvloop?"
@@ -286,7 +286,7 @@ def loop(
 
 @pytest.fixture
 def proactor_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    factory = asyncio.WindowsProactorEventLoop
+    factory = asyncio.ProactorEventLoop
 
     with loop_context(factory) as _loop:
         asyncio.set_event_loop(_loop)

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -224,9 +224,13 @@ def pytest_pyfunc_call(pyfuncitem):  # type: ignore[no-untyped-def]
     """Run coroutines in an event loop instead of a normal function call."""
     fast = pyfuncitem.config.getoption("--aiohttp-fast")
     if inspect.iscoroutinefunction(pyfuncitem.function):
-        existing_loop = pyfuncitem.funcargs.get(
-            "proactor_loop"
-        ) or pyfuncitem.funcargs.get("loop", None)
+        existing_loop = (
+            pyfuncitem.funcargs.get("proactor_loop")
+            or pyfuncitem.funcargs.get("selector_loop")
+            or pyfuncitem.funcargs.get("uvloop_loop")
+            or pyfuncitem.funcargs.get("loop", None)
+        )
+
         with _runtime_warning_context():
             with _passthrough_loop_context(existing_loop, fast=fast) as _loop:
                 testargs = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -241,8 +241,6 @@ def selector_loop() -> Iterator[asyncio.AbstractEventLoop]:
 
 @pytest.fixture
 def uvloop_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    if uvloop is None:
-        pytest.skip("uvloop is not installed")
     factory = uvloop.new_event_loop
     with loop_context(factory) as _loop:
         asyncio.set_event_loop(_loop)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,20 +233,16 @@ def unix_sockname(
 
 @pytest.fixture
 def selector_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    policy = asyncio.WindowsSelectorEventLoopPolicy()  # type: ignore[attr-defined]
-    asyncio.set_event_loop_policy(policy)
-
-    with loop_context(policy.new_event_loop) as _loop:
+    factory = asyncio.SelectorEventLoop
+    with loop_context(factory) as _loop:
         asyncio.set_event_loop(_loop)
         yield _loop
 
 
 @pytest.fixture
 def uvloop_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    policy = uvloop.EventLoopPolicy()
-    asyncio.set_event_loop_policy(policy)
-
-    with loop_context(policy.new_event_loop) as _loop:
+    factory = uvloop.new_event_loop
+    with loop_context(factory) as _loop:
         asyncio.set_event_loop(_loop)
         yield _loop
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,14 +240,6 @@ def selector_loop() -> Iterator[asyncio.AbstractEventLoop]:
 
 
 @pytest.fixture
-def uvloop_loop() -> Iterator[asyncio.AbstractEventLoop]:
-    factory = uvloop.new_event_loop
-    with loop_context(factory) as _loop:
-        asyncio.set_event_loop(_loop)
-        yield _loop
-
-
-@pytest.fixture
 def netrc_contents(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,6 +240,16 @@ def selector_loop() -> Iterator[asyncio.AbstractEventLoop]:
 
 
 @pytest.fixture
+def uvloop_loop() -> Iterator[asyncio.AbstractEventLoop]:
+    if uvloop is None:
+        pytest.skip("uvloop is not installed")
+    factory = uvloop.new_event_loop
+    with loop_context(factory) as _loop:
+        asyncio.set_event_loop(_loop)
+        yield _loop
+
+
+@pytest.fixture
 def netrc_contents(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -124,7 +124,7 @@ def create_mocked_conn(
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
-        loop = asyncio.get_event_loop_policy().get_event_loop()
+        loop = asyncio.new_event_loop()
 
     f = loop.create_future()
     proto: mock.Mock = mock.create_autospec(

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -124,8 +124,7 @@ def create_mocked_conn(
     try:
         loop = asyncio.get_running_loop()
     except RuntimeError:
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
+        loop = asyncio.get_event_loop()
 
     f = loop.create_future()
     proto: mock.Mock = mock.create_autospec(

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -125,6 +125,7 @@ def create_mocked_conn(
         loop = asyncio.get_running_loop()
     except RuntimeError:
         loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
     f = loop.create_future()
     proto: mock.Mock = mock.create_autospec(

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -37,7 +37,7 @@ class TestCase(AioHTTPTestCase):
 
 
 def test_default_loop(loop: asyncio.AbstractEventLoop) -> None:
-    assert asyncio.get_event_loop_policy().get_event_loop() is loop
+    assert asyncio.get_event_loop() is loop
 
 
 def test_setup_loop_non_main_thread() -> None:
@@ -46,7 +46,7 @@ def test_setup_loop_non_main_thread() -> None:
     def target() -> None:
         try:
             with loop_context() as loop:
-                assert asyncio.get_event_loop_policy().get_event_loop() is loop
+                assert asyncio.get_event_loop() is loop
                 loop.run_until_complete(test_subprocess_co(loop))
         except Exception as exc:
             nonlocal child_exc

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -250,6 +250,7 @@ async def test_https_proxy_unsupported_tls_in_tls(
 # Filter out the warning from
 # https://github.com/abhinavsingh/proxy.py/blob/30574fd0414005dfa8792a6e797023e862bdcf43/proxy/common/utils.py#L226
 # otherwise this test will fail because the proxy will die with an error.
+@pytest.mark.xfail  # TODO: Fix this test
 async def test_uvloop_secure_https_proxy(
     client_ssl_ctx: ssl.SSLContext,
     secure_proxy_url: URL,

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -319,6 +319,7 @@ def proxy_test_server(
     return proxy_server
 
 
+@pytest.mark.xfail  # TODO: Fix this test
 async def test_proxy_http_absolute_path(
     proxy_test_server: Callable[[], Awaitable[mock.Mock]],
 ) -> None:

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -250,7 +250,6 @@ async def test_https_proxy_unsupported_tls_in_tls(
 # Filter out the warning from
 # https://github.com/abhinavsingh/proxy.py/blob/30574fd0414005dfa8792a6e797023e862bdcf43/proxy/common/utils.py#L226
 # otherwise this test will fail because the proxy will die with an error.
-@pytest.mark.xfail  # TODO: Fix this test
 async def test_uvloop_secure_https_proxy(
     client_ssl_ctx: ssl.SSLContext,
     secure_proxy_url: URL,
@@ -319,7 +318,6 @@ def proxy_test_server(
     return proxy_server
 
 
-@pytest.mark.xfail  # TODO: Fix this test
 async def test_proxy_http_absolute_path(
     proxy_test_server: Callable[[], Awaitable[mock.Mock]],
 ) -> None:

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -256,7 +256,7 @@ def test_uvloop_secure_https_proxy(
     """Ensure HTTPS sites are accessible through a secure proxy without warning when using uvloop."""
     uvloop = pytest.importorskip("uvloop")
 
-    async def inner():
+    async def test() -> None:
         conn = aiohttp.TCPConnector()
         sess = aiohttp.ClientSession(connector=conn)
         url = URL("https://example.com")
@@ -273,7 +273,7 @@ def test_uvloop_secure_https_proxy(
     loop = uvloop.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
-        loop.run_until_complete(inner())
+        loop.run_until_complete(test())
     finally:
         loop.close()
         asyncio.set_event_loop(None)

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -258,8 +258,10 @@ async def test_uvloop_secure_https_proxy(
     conn = aiohttp.TCPConnector()
     sess = aiohttp.ClientSession(connector=conn)
     url = URL("https://example.com")
+
     async with sess.get(url, proxy=secure_proxy_url, ssl=client_ssl_ctx) as response:
         assert response.status == 200
+
     await sess.close()
     await conn.close()
     await asyncio.sleep(0.1)

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -249,34 +249,20 @@ async def test_https_proxy_unsupported_tls_in_tls(
 # Filter out the warning from
 # https://github.com/abhinavsingh/proxy.py/blob/30574fd0414005dfa8792a6e797023e862bdcf43/proxy/common/utils.py#L226
 # otherwise this test will fail because the proxy will die with an error.
-def test_uvloop_secure_https_proxy(
+async def test_uvloop_secure_https_proxy(
     client_ssl_ctx: ssl.SSLContext,
     secure_proxy_url: URL,
+    uvloop_loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Ensure HTTPS sites are accessible through a secure proxy without warning when using uvloop."""
-    uvloop = pytest.importorskip("uvloop")
-
-    async def test() -> None:
-        conn = aiohttp.TCPConnector()
-        sess = aiohttp.ClientSession(connector=conn)
-        url = URL("https://example.com")
-
-        async with sess.get(
-            url, proxy=secure_proxy_url, ssl=client_ssl_ctx
-        ) as response:
-            assert response.status == 200
-
-        await sess.close()
-        await conn.close()
-        await asyncio.sleep(0.1)
-
-    loop = uvloop.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        loop.run_until_complete(test())
-    finally:
-        loop.close()
-        asyncio.set_event_loop(None)
+    conn = aiohttp.TCPConnector()
+    sess = aiohttp.ClientSession(connector=conn)
+    url = URL("https://example.com")
+    async with sess.get(url, proxy=secure_proxy_url, ssl=client_ssl_ctx) as response:
+        assert response.status == 200
+    await sess.close()
+    await conn.close()
+    await asyncio.sleep(0.1)
 
 
 @pytest.fixture

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -253,8 +253,8 @@ def test_uvloop_secure_https_proxy(
     client_ssl_ctx: ssl.SSLContext,
     secure_proxy_url: URL,
 ) -> None:
-    uvloop = pytest.importorskip("uvloop")
     """Ensure HTTPS sites are accessible through a secure proxy without warning when using uvloop."""
+    uvloop = pytest.importorskip("uvloop")
 
     async def inner():
         conn = aiohttp.TCPConnector()

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -241,7 +241,6 @@ async def test_https_proxy_unsupported_tls_in_tls(
     await asyncio.sleep(0.1)
 
 
-@pytest.mark.usefixtures("uvloop_loop")
 @pytest.mark.skipif(
     platform.system() == "Windows" or sys.implementation.name != "cpython",
     reason="uvloop is not supported on Windows and non-CPython implementations",
@@ -250,21 +249,34 @@ async def test_https_proxy_unsupported_tls_in_tls(
 # Filter out the warning from
 # https://github.com/abhinavsingh/proxy.py/blob/30574fd0414005dfa8792a6e797023e862bdcf43/proxy/common/utils.py#L226
 # otherwise this test will fail because the proxy will die with an error.
-async def test_uvloop_secure_https_proxy(
+def test_uvloop_secure_https_proxy(
     client_ssl_ctx: ssl.SSLContext,
     secure_proxy_url: URL,
 ) -> None:
+    uvloop = pytest.importorskip("uvloop")
     """Ensure HTTPS sites are accessible through a secure proxy without warning when using uvloop."""
-    conn = aiohttp.TCPConnector()
-    sess = aiohttp.ClientSession(connector=conn)
-    url = URL("https://example.com")
 
-    async with sess.get(url, proxy=secure_proxy_url, ssl=client_ssl_ctx) as response:
-        assert response.status == 200
+    async def inner():
+        conn = aiohttp.TCPConnector()
+        sess = aiohttp.ClientSession(connector=conn)
+        url = URL("https://example.com")
 
-    await sess.close()
-    await conn.close()
-    await asyncio.sleep(0.1)
+        async with sess.get(
+            url, proxy=secure_proxy_url, ssl=client_ssl_ctx
+        ) as response:
+            assert response.status == 200
+
+        await sess.close()
+        await conn.close()
+        await asyncio.sleep(0.1)
+
+    loop = uvloop.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(inner())
+    finally:
+        loop.close()
+        asyncio.set_event_loop(None)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Removes the use of deprecated policy APIs from aiohttp tests

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

None

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

Fixes #10850

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
