### PR TITLE
Fix unclosed resources in proxy xfail tests

### DIFF
--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -512,7 +512,8 @@ async def test_proxy_http_multi_conn_limit(
     responses = await asyncio.gather(*requests)
 
     assert len(responses) == multi_conn_num
-    assert {resp.status for resp in responses} == {200}
+    actual_responses = [resp for resp in responses if isinstance(resp, ClientResponse)]
+    assert {resp.status for resp in actual_responses} == {200}
 
     await sess.close()
 

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -512,8 +512,7 @@ async def test_proxy_http_multi_conn_limit(
     responses = await asyncio.gather(*requests)
 
     assert len(responses) == multi_conn_num
-    actual_responses = [resp for resp in responses if isinstance(resp, ClientResponse)]
-    assert {resp.status for resp in actual_responses} == {200}
+    assert {resp.status for resp in responses} == {200}
 
     await sess.close()
 
@@ -738,7 +737,7 @@ async def test_proxy_https_multi_conn_limit(
         responses = await asyncio.gather(*requests, return_exceptions=True)
 
         # Filter out exceptions to count actual responses
-        actual_responses = [r for r in responses if not isinstance(r, Exception)]
+        actual_responses = [r for r in responses if isinstance(r, ClientResponse)]
         assert len(actual_responses) == multi_conn_num
         assert {resp.status for resp in actual_responses} == {200}
     finally:

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -559,15 +559,17 @@ async def test_proxy_https_send_body(
     loop: asyncio.AbstractEventLoop,
 ) -> None:
     sess = aiohttp.ClientSession()
-    proxy = await proxy_test_server()
-    proxy.return_value = {"status": 200, "body": b"1" * (2**20)}
-    url = "https://www.google.com.ua/search?q=aiohttp proxy"
+    try:
+        proxy = await proxy_test_server()
+        proxy.return_value = {"status": 200, "body": b"1" * (2**20)}
+        url = "https://www.google.com.ua/search?q=aiohttp proxy"
 
-    async with sess.get(url, proxy=proxy.url) as resp:
-        body = await resp.read()
-    await sess.close()
+        async with sess.get(url, proxy=proxy.url) as resp:
+            body = await resp.read()
 
-    assert body == b"1" * (2**20)
+        assert body == b"1" * (2**20)
+    finally:
+        await sess.close()
 
 
 @pytest.mark.xfail
@@ -662,19 +664,21 @@ async def test_proxy_https_acquired_cleanup(
 
     conn = aiohttp.TCPConnector()
     sess = aiohttp.ClientSession(connector=conn)
-    proxy = await proxy_test_server()
+    try:
+        proxy = await proxy_test_server()
 
-    assert 0 == len(conn._acquired)
+        assert 0 == len(conn._acquired)
 
-    async def request() -> None:
-        async with sess.get(url, proxy=proxy.url):
-            assert 1 == len(conn._acquired)
+        async def request() -> None:
+            async with sess.get(url, proxy=proxy.url):
+                assert 1 == len(conn._acquired)
 
-    await request()
+        await request()
 
-    assert 0 == len(conn._acquired)
-
-    await sess.close()
+        assert 0 == len(conn._acquired)
+    finally:
+        await sess.close()
+        await conn.close()
 
 
 @pytest.mark.xfail
@@ -686,19 +690,21 @@ async def test_proxy_https_acquired_cleanup_force(
 
     conn = aiohttp.TCPConnector(force_close=True)
     sess = aiohttp.ClientSession(connector=conn)
-    proxy = await proxy_test_server()
+    try:
+        proxy = await proxy_test_server()
 
-    assert 0 == len(conn._acquired)
+        assert 0 == len(conn._acquired)
 
-    async def request() -> None:
-        async with sess.get(url, proxy=proxy.url):
-            assert 1 == len(conn._acquired)
+        async def request() -> None:
+            async with sess.get(url, proxy=proxy.url):
+                assert 1 == len(conn._acquired)
 
-    await request()
+        await request()
 
-    assert 0 == len(conn._acquired)
-
-    await sess.close()
+        assert 0 == len(conn._acquired)
+    finally:
+        await sess.close()
+        await conn.close()
 
 
 @pytest.mark.xfail
@@ -713,26 +719,30 @@ async def test_proxy_https_multi_conn_limit(
     sess = aiohttp.ClientSession(connector=conn)
     proxy = await proxy_test_server()
 
-    current_pid = None
+    try:
+        current_pid = None
 
-    async def request(pid: int) -> ClientResponse:
-        # process requests only one by one
-        nonlocal current_pid
+        async def request(pid: int) -> ClientResponse:
+            # process requests only one by one
+            nonlocal current_pid
 
-        async with sess.get(url, proxy=proxy.url) as resp:
-            current_pid = pid
-            await asyncio.sleep(0.2)
-            assert current_pid == pid
+            async with sess.get(url, proxy=proxy.url) as resp:
+                current_pid = pid
+                await asyncio.sleep(0.2)
+                assert current_pid == pid
 
-        return resp
+            return resp
 
-    requests = [request(pid) for pid in range(multi_conn_num)]
-    responses = await asyncio.gather(*requests)
+        requests = [request(pid) for pid in range(multi_conn_num)]
+        responses = await asyncio.gather(*requests, return_exceptions=True)
 
-    assert len(responses) == multi_conn_num
-    assert {resp.status for resp in responses} == {200}
-
-    await sess.close()
+        # Filter out exceptions to count actual responses
+        actual_responses = [r for r in responses if not isinstance(r, Exception)]
+        assert len(actual_responses) == multi_conn_num
+        assert {resp.status for resp in actual_responses} == {200}
+    finally:
+        await sess.close()
+        await conn.close()
 
 
 def _patch_ssl_transport(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -900,7 +910,7 @@ async def test_proxy_from_env_https(
     url = "https://aiohttp.io/path"
     proxy = await proxy_test_server()
     mocker.patch.dict(os.environ, {"https_proxy": str(proxy.url)})
-    mock.patch("pathlib.Path.is_file", mock_is_file)
+    mocker.patch("pathlib.Path.is_file", mock_is_file)
 
     await get_request(url=url, trust_env=True)
 


### PR DESCRIPTION


## What do these changes do?

Fixes some flakey tests that would cause subsequent tests to fail because they didn't cleanup resources.

It became more noticeable in https://github.com/aio-libs/aiohttp/pull/9732

## Are there changes in behavior for the user?

no
## Is it a substantial burden for the maintainers to support this?
no