### PR TITLE
[3.12] Update to Cython 3.1.1

### DIFF
--- a/CHANGES/10877.packaging.rst
+++ b/CHANGES/10877.packaging.rst
@@ -1,0 +1,1 @@
+Fixed compatibility issue with Cython 3.1.1 -- by :user:`bdraco`

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -79,7 +79,7 @@ class WebSocketDataQueue:
 
     def set_exception(
         self,
-        exc: "BaseException",
+        exc: BaseException,
         exc_cause: builtins.BaseException = _EXC_SENTINEL,
     ) -> None:
         self._eof = True

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -62,7 +62,7 @@ cryptography==45.0.2
     # via
     #   pyjwt
     #   trustme
-cython==3.0.12
+cython==3.1.1
     # via -r requirements/cython.in
 distlib==0.3.9
     # via virtualenv

--- a/requirements/cython.in
+++ b/requirements/cython.in
@@ -1,3 +1,3 @@
 -r multidict.in
 
-Cython
+Cython >= 3.1.1

--- a/requirements/cython.txt
+++ b/requirements/cython.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --allow-unsafe --output-file=requirements/cython.txt --resolver=backtracking --strip-extras requirements/cython.in
 #
-cython==3.0.12
+cython==3.1.1
     # via -r requirements/cython.in
 multidict==6.4.3
     # via -r requirements/multidict.in


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

## Overview
This commit fixes compilation issues with Cython 3.1.1 for the 3.12 branch.

## Changes Made

### 1. Updated Cython Version
- Upgraded from Cython 3.0.12 to 3.1.1 in:
  - `requirements/cython.txt`
  - `requirements/constraints.txt`

### 2. Fixed Type Annotation
- Modified `aiohttp/_websocket/reader_py.py`:
  - Changed `exc: "BaseException"` to `exc: BaseException`
  - Removed quotes around BaseException type annotation to comply with Cython 3.1.1

## Purpose
This is a compatibility fix to ensure the project can compile successfully with the newer version of Cython 3.1.1.



## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?
no


replaces and closes #10849