### PR TITLE
Add invalid content type test docs

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1472,14 +1472,13 @@ Response object
 
       .. note::
 
-         If *Content-Type* header is invalid, the value
-         is ``text/plain`` by default according to :rfc:`2045`.
-
-      .. note::
-
          Returns value is ``'application/octet-stream'`` if no
          Content-Type header present in HTTP headers according to
-         :rfc:`2616`. To make sure Content-Type header is not present in
+         :rfc:`2616`. If *Content-Type* header is invalid (e.g., ``jpg``
+         instead of ``image/jpeg``), the value is ``text/plain`` by default
+         according to :rfc:`2045`.
+
+         To make sure Content-Type header is not present in
          the server reply, use :attr:`headers` or :attr:`raw_headers`, e.g.
          ``'CONTENT-TYPE' not in resp.headers``.
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1472,6 +1472,11 @@ Response object
 
       .. note::
 
+         If *Content-Type* header is invalid, the value
+         is ``text/plain`` by default according to :rfc:`2045`.
+
+      .. note::
+
          Returns value is ``'application/octet-stream'`` if no
          Content-Type header present in HTTP headers according to
          :rfc:`2616`. To make sure Content-Type header is not present in

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1474,7 +1474,7 @@ Response object
 
          Returns value is ``'application/octet-stream'`` if no
          Content-Type header present in HTTP headers according to
-         :rfc:`2616`. If the *Content-Type* header is invalid (e.g., ``jpg``
+         :rfc:`9110`. If the *Content-Type* header is invalid (e.g., ``jpg``
          instead of ``image/jpeg``), the value is ``text/plain`` by default
          according to :rfc:`2045`. To see the original header check
          ``resp.headers['CONTENT-TYPE']``.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1474,9 +1474,10 @@ Response object
 
          Returns value is ``'application/octet-stream'`` if no
          Content-Type header present in HTTP headers according to
-         :rfc:`2616`. If *Content-Type* header is invalid (e.g., ``jpg``
+         :rfc:`2616`. If the *Content-Type* header is invalid (e.g., ``jpg``
          instead of ``image/jpeg``), the value is ``text/plain`` by default
-         according to :rfc:`2045`.
+         according to :rfc:`2045`. To see the original header check
+         ``resp.headers['CONTENT-TYPE']``.
 
          To make sure Content-Type header is not present in
          the server reply, use :attr:`headers` or :attr:`raw_headers`, e.g.

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -998,6 +998,13 @@ def test_ctor_content_type_with_extra() -> None:
     assert resp.headers["content-type"] == "text/plain; version=0.0.4; charset=utf-8"
 
 
+def test_invalid_content_type_parses_to_text_plain() -> None:
+    resp = web.Response(text="test test", content_type="jpeg")
+
+    assert resp.content_type == "text/plain"
+    assert resp.headers["content-type"] == "jpeg; charset=utf-8"
+
+
 def test_ctor_both_content_type_param_and_header_with_text() -> None:
     with pytest.raises(ValueError):
         web.Response(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
## What do these changes do?

This PR adds test coverage for invalid content type handling and documents the expected behavior. The changes include:

- A test that verifies when an invalid content type (e.g., "jpeg" without "image/") is provided to `web.Response`, the `content_type` property correctly defaults to `text/plain` as per RFC 2045
- Documentation clarifying that invalid Content-Type headers fall back to `text/plain` by default

## Are there changes in behavior for the user?

**No breaking changes.** This PR only adds test coverage and documentation for existing behavior. Users will not experience any functional changes:

- Invalid content types continue to be handled the same way as before
- The `content_type` property still defaults to `text/plain` for invalid values

## Is it a substantial burden for the maintainers to support this?

**No, this is a minimal maintenance burden.** The changes are:

- **Test-only additions**: The test is straightforward and tests existing, stable behavior
- **Documentation clarification**: Adds a simple note explaining RFC-compliant fallback behavior

The test and documentation help prevent future regressions and improve developer understanding, which actually reduces maintenance burden by making the codebase more self-documenting.

## Related issue number

<!-- Add issue number if applicable, e.g., "Fixes #123" -->
Fixes #9522

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```
    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.