### PR TITLE
Fix flakey middleware connection reuse test

### DIFF
--- a/tests/test_client_middleware.py
+++ b/tests/test_client_middleware.py
@@ -847,11 +847,12 @@ async def test_client_middleware_retry_reuses_connection(
             retry_count = 0
             while True:
                 self.attempt_count += 1
+                response = await handler(request)
                 if retry_count == 0:
                     retry_count += 1
-                    await handler(request)
+                    response.close()  # Close the response to release the connection
                     continue
-                return await handler(request)
+                return response
 
     app = web.Application()
     app.router.add_get("/", handler)

--- a/tests/test_client_middleware.py
+++ b/tests/test_client_middleware.py
@@ -850,7 +850,7 @@ async def test_client_middleware_retry_reuses_connection(
                 response = await handler(request)
                 if retry_count == 0:
                     retry_count += 1
-                    response.close()  # Close the response to release the connection
+                    response.release()  # Release the response to enable connection reuse
                     continue
                 return response
 


### PR DESCRIPTION
This test needs to explicitly release the response so the connection can get released to avoid the race.