### PR TITLE
Fix DNS resolver object churn for multiple sessions

### DIFF
--- a/CHANGES/10847.feature.rst
+++ b/CHANGES/10847.feature.rst
@@ -1,0 +1,5 @@
+Implemented shared DNS resolver management to fix excessive resolver object creation
+when using multiple client sessions. The new ``_DNSResolverManager`` singleton ensures
+only one ``DNSResolver`` object is created for default configurations, significantly
+reducing resource usage and improving performance for applications using multiple
+client sessions simultaneously -- by :user:`bdraco`.

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -180,11 +180,11 @@ class _DNSResolverManager:
         return cls._instance
 
     def _init(self) -> None:
-        # Map event loops to (resolver, client_set) tuples
-        self._loop_data: dict[
+        # Use WeakKeyDictionary to allow event loops to be garbage collected
+        self._loop_data: weakref.WeakKeyDictionary[
             asyncio.AbstractEventLoop,
             tuple["aiodns.DNSResolver", weakref.WeakSet["AsyncResolver"]],
-        ] = {}
+        ] = weakref.WeakKeyDictionary()
 
     def get_resolver(
         self, client: "AsyncResolver", loop: asyncio.AbstractEventLoop

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -156,9 +156,12 @@ class AsyncResolver(AbstractResolver):
         if self._manager:
             # Release the resolver from the manager if using the shared resolver
             self._manager.release_resolver(self, self._loop)
+            self._manager = None  # Clear reference to manager
+            self._resolver = None  # Clear reference to resolver
             return
         # Otherwise cancel our dedicated resolver
         self._resolver.cancel()
+        self._resolver = None  # Clear reference
 
 
 class _DNSResolverManager:

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -157,11 +157,11 @@ class AsyncResolver(AbstractResolver):
             # Release the resolver from the manager if using the shared resolver
             self._manager.release_resolver(self, self._loop)
             self._manager = None  # Clear reference to manager
-            self._resolver = None  # Clear reference to resolver
+            self._resolver = None  # type: ignore[assignment] # Clear reference to resolver
             return
         # Otherwise cancel our dedicated resolver
         self._resolver.cancel()
-        self._resolver = None  # Clear reference
+        self._resolver = None  # type: ignore[assignment] # Clear reference
 
 
 class _DNSResolverManager:

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -196,7 +196,7 @@ class _DNSResolverManager:
         # Create a new resolver and client set for this loop if it doesn't exist
         if loop not in self._loop_data:
             resolver = aiodns.DNSResolver(loop=loop)
-            client_set = weakref.WeakSet()
+            client_set: weakref.WeakSet["AsyncResolver"] = weakref.WeakSet()
             self._loop_data[loop] = (resolver, client_set)
         else:
             # Get the existing resolver and client set

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -169,15 +169,15 @@ class _DNSResolverManager:
 
     _instance: Optional["_DNSResolverManager"] = None
 
-    def __new__(cls):
+    def __new__(cls) -> "_DNSResolverManager":
         if cls._instance is None:
             cls._instance = super().__new__(cls)
             cls._instance._init()
         return cls._instance
 
     def _init(self) -> None:
-        self._resolver = None
-        self._clients = weakref.WeakSet()
+        self._resolver: Optional["aiodns.DNSResolver"] = None
+        self._clients: weakref.WeakSet["AsyncResolver"] = weakref.WeakSet()
         if aiodns is None:
             raise RuntimeError("DNSResolverManager requires aiodns library")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def check_no_lingering_resolvers() -> Generator[None, None, None]:
     AsyncResolver or directly uses _DNSResolverManager.
     """
     yield
-    if aiodns is None:
+    if not aiodns:
         return
     manager = _DNSResolverManager()
     if manager._loop_data:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def check_no_lingering_resolvers() -> Generator[None, None, None]:
     AsyncResolver or directly uses _DNSResolverManager.
     """
     yield
-    if not aiodns:
+    if aiodns is None:
         return
     manager = _DNSResolverManager()
     if manager._loop_data:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import gc
 import os
 import socket
 import ssl
@@ -20,6 +21,7 @@ from blockbuster import blockbuster_ctx
 from aiohttp.client_proto import ResponseHandler
 from aiohttp.compression_utils import ZLibBackend, ZLibBackendProtocol, set_zlib_backend
 from aiohttp.http import WS_KEY
+from aiohttp.resolver import _DNSResolverManager
 from aiohttp.test_utils import get_unused_port_socket, loop_context
 
 try:
@@ -34,6 +36,12 @@ except ImportError:
 
 
 try:
+    import aiodns
+except ImportError:
+    aiodns = None  # type: ignore[assignment]
+
+
+try:
     import uvloop
 except ImportError:
     uvloop = None  # type: ignore[assignment]
@@ -43,6 +51,27 @@ pytest_plugins = ("aiohttp.pytest_plugin", "pytester")
 
 IS_HPUX = sys.platform.startswith("hp-ux")
 IS_LINUX = sys.platform.startswith("linux")
+
+
+@pytest.fixture()
+def check_no_lingering_resolvers() -> Generator[None, None, None]:
+    """Verify no resolvers remain after the test.
+
+    This fixture should be used in any test that creates instances of
+    AsyncResolver or directly uses _DNSResolverManager.
+    """
+    yield
+    if not aiodns:
+        return
+    manager = _DNSResolverManager()
+    if manager._loop_data:
+        # Force garbage collection to ensure weak references are updated
+        gc.collect()
+        if manager._loop_data:
+            pytest.fail(
+                f"Lingering resolvers found: {len(manager._loop_data)}. "
+                "Some AsyncResolver instances were not properly closed."
+            )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ IS_HPUX = sys.platform.startswith("hp-ux")
 IS_LINUX = sys.platform.startswith("linux")
 
 
-@pytest.fixture()
+@pytest.fixture(autouse=True)
 def check_no_lingering_resolvers() -> Generator[None, None, None]:
     """Verify no resolvers remain after the test.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,7 @@ IS_HPUX = sys.platform.startswith("hp-ux")
 IS_LINUX = sys.platform.startswith("linux")
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def check_no_lingering_resolvers() -> Generator[None, None, None]:
     """Verify no resolvers remain after the test.
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -500,7 +500,7 @@ async def test_dns_resolver_manager_resolver_lifecycle(
     assert manager._resolver is resolver
 
     # Getting it again should return the same instance
-    assert manager.get_resolver(mock_client) is resolver
+    assert manager.get_resolver(mock_client) is resolver  # type: ignore[unreachable]
 
     # Clean up
     manager.release_resolver(mock_client)
@@ -527,20 +527,25 @@ async def test_dns_resolver_manager_client_registration(
         # The manager should be tracking both clients
         assert resolver1._manager is resolver2._manager
         manager = resolver1._manager
+        assert manager is not None
         assert len(manager._clients) == 2
 
         # Close one resolver
         await resolver1.close()
+        assert manager is not None
         assert len(manager._clients) == 1
 
         # Resolver should still exist
+        assert manager is not None
         assert manager._resolver is not None
 
         # Close the second resolver
         await resolver2.close()
+        assert manager is not None
         assert len(manager._clients) == 0
 
         # Now the resolver should be canceled and removed
+        assert manager is not None
         assert manager._resolver is None
         mock().cancel.assert_called_once()
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -55,15 +55,18 @@ def check_no_lingering_resolvers() -> Generator[None, None, None]:
     This fixture should be used in any test that creates instances of
     AsyncResolver or directly uses _DNSResolverManager.
     """
-    yield
     manager = _DNSResolverManager()
-    if manager._loop_data:
+    before = len(manager._loop_data)
+    yield
+    after = len(manager._loop_data)
+    if after > before:
         # Force garbage collection to ensure weak references are updated
         gc.collect()
-        if manager._loop_data:
+        after = len(manager._loop_data)
+        if after > before:
             pytest.fail(
-                f"Lingering resolvers found: {len(manager._loop_data)}. "
-                "Some AsyncResolver instances were not properly closed."
+                f"Lingering resolvers found: {(after - before)} "
+                "new AsyncResolver instances were not properly closed."
             )
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -22,6 +22,7 @@ from aiohttp.resolver import (
     AsyncResolver,
     DefaultResolver,
     ThreadedResolver,
+    _DNSResolverManager,
 )
 
 try:
@@ -389,3 +390,103 @@ def test_aio_dns_is_default() -> None:
 @pytest.mark.skipif(getaddrinfo, reason="aiodns <3.2.0 required")
 def test_threaded_resolver_is_default() -> None:
     assert DefaultResolver is ThreadedResolver
+
+
+@pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")
+async def test_dns_resolver_manager_sharing(loop: asyncio.AbstractEventLoop) -> None:
+    """Test that the DNSResolverManager shares a resolver among AsyncResolver instances."""
+    # Create two default AsyncResolver instances
+    resolver1 = AsyncResolver()
+    resolver2 = AsyncResolver()
+
+    # Check that they share the same underlying resolver
+    assert resolver1._resolver is resolver2._resolver
+
+    # Create an AsyncResolver with custom args
+    resolver3 = AsyncResolver(nameservers=["8.8.8.8"])
+
+    # Check that it has its own resolver
+    assert resolver1._resolver is not resolver3._resolver
+
+    # Cleanup
+    await resolver1.close()
+    await resolver2.close()
+    await resolver3.close()
+
+
+@pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")
+async def test_dns_resolver_manager_singleton(loop: asyncio.AbstractEventLoop) -> None:
+    """Test that DNSResolverManager is a singleton."""
+    # Create two managers and check they're the same instance
+    manager1 = _DNSResolverManager()
+    manager2 = _DNSResolverManager()
+
+    assert manager1 is manager2
+
+
+@pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")
+async def test_dns_resolver_manager_resolver_lifecycle(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Test that DNSResolverManager creates and destroys resolver correctly."""
+    manager = _DNSResolverManager()
+
+    # Initially there should be no resolver
+    assert manager._resolver is None
+
+    # Getting resolver should create one
+    resolver = manager.get_resolver()
+    assert resolver is not None
+    assert manager._resolver is resolver
+
+    # Getting it again should return the same instance
+    assert manager.get_resolver() is resolver
+
+
+@pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")
+async def test_dns_resolver_manager_client_registration(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Test client registration and unregistration logic."""
+    with patch("aiodns.DNSResolver") as mock:
+        # Create resolver instances
+        resolver1 = AsyncResolver()
+        resolver2 = AsyncResolver()
+
+        # Both should use the same resolver from the manager
+        assert resolver1._resolver is resolver2._resolver
+
+        # The manager should be tracking both clients
+        assert resolver1._manager is resolver2._manager
+        manager = resolver1._manager
+        assert len(manager._clients) == 2
+
+        # Close one resolver
+        await resolver1.close()
+        assert len(manager._clients) == 1
+
+        # Resolver should still exist
+        assert manager._resolver is not None
+
+        # Close the second resolver
+        await resolver2.close()
+        assert len(manager._clients) == 0
+
+        # Now the resolver should be canceled and removed
+        assert manager._resolver is None
+        mock().cancel.assert_called_once()
+
+
+@pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")
+async def test_dns_resolver_manager_error_without_aiodns(
+    loop: asyncio.AbstractEventLoop, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that DNSResolverManager raises an error when aiodns is not available."""
+    # Simulate aiodns not being installed
+    monkeypatch.setattr("aiohttp.resolver.aiodns", None)
+
+    # Should raise RuntimeError when initialized
+    with pytest.raises(
+        RuntimeError, match="DNSResolverManager requires aiodns library"
+    ):
+        _DNSResolverManager()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -547,7 +547,7 @@ async def test_dns_resolver_manager_client_registration(
         # Now the resolver should be canceled and removed
         assert manager is not None
         assert manager._resolver is None
-        mock().cancel.assert_called_once()
+        mock().cancel.assert_called_once()  # type: ignore[unreachable]
 
 
 @pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -55,20 +55,16 @@ def check_no_lingering_resolvers() -> Generator[None, None, None]:
     This fixture should be used in any test that creates instances of
     AsyncResolver or directly uses _DNSResolverManager.
     """
-    try:
-        yield
-    finally:
-        # We need to check in a finally block to ensure the check runs
-        # even if the test fails
-        manager = _DNSResolverManager()
+    yield
+    manager = _DNSResolverManager()
+    if manager._loop_data:
+        # Force garbage collection to ensure weak references are updated
+        gc.collect()
         if manager._loop_data:
-            # Force garbage collection to ensure weak references are updated
-            gc.collect()
-            if manager._loop_data:
-                pytest.fail(
-                    f"Lingering resolvers found: {len(manager._loop_data)}. "
-                    "Some AsyncResolver instances were not properly closed."
-                )
+            pytest.fail(
+                f"Lingering resolvers found: {len(manager._loop_data)}. "
+                "Some AsyncResolver instances were not properly closed."
+            )
 
 
 @pytest.fixture()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -59,12 +59,12 @@ def check_no_lingering_resolvers() -> Generator[None, None, None]:
     before = len(manager._loop_data)
     yield
     after = len(manager._loop_data)
-    if after > before:
+    if after > before:  # pragma: no branch
         # Force garbage collection to ensure weak references are updated
-        gc.collect()
-        after = len(manager._loop_data)
-        if after > before:
-            pytest.fail(
+        gc.collect()  # pragma: no cover
+        after = len(manager._loop_data)  # pragma: no cover
+        if after > before:  # pragma: no cover
+            pytest.fail(  # pragma: no cover
                 f"Lingering resolvers found: {(after - before)} "
                 "new AsyncResolver instances were not properly closed."
             )
@@ -76,9 +76,6 @@ def dns_resolver_manager() -> Generator[_DNSResolverManager, None, None]:
 
     Saves and restores the singleton state to avoid affecting other tests.
     """
-    if aiodns is None:
-        pytest.skip("aiodns is required")
-
     # Save the original instance
     original_instance = _DNSResolverManager._instance
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -555,7 +555,7 @@ async def test_dns_resolver_manager_client_registration(
 
         # Now all resolvers should be canceled and removed
         assert not manager._loop_data  # Should be empty
-        mock().cancel.assert_called_once()  # type: ignore[unreachable]
+        mock().cancel.assert_called_once()
 
 
 @pytest.mark.skipif(not getaddrinfo, reason="aiodns >=3.2.0 required")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,5 +1,4 @@
 import asyncio
-import gc
 import ipaddress
 import socket
 from collections.abc import Generator
@@ -46,25 +45,6 @@ _AddrInfo6 = List[
 _UnknownAddrInfo = List[
     Tuple[socket.AddressFamily, socket.SocketKind, int, str, Tuple[int, bytes]]
 ]
-
-
-@pytest.fixture()
-def check_no_lingering_resolvers() -> Generator[None, None, None]:
-    """Verify no resolvers remain after the test.
-
-    This fixture should be used in any test that creates instances of
-    AsyncResolver or directly uses _DNSResolverManager.
-    """
-    yield
-    manager = _DNSResolverManager()
-    if manager._loop_data:
-        # Force garbage collection to ensure weak references are updated
-        gc.collect()
-        if manager._loop_data:
-            pytest.fail(
-                f"Lingering resolvers found: {len(manager._loop_data)}. "
-                "Some AsyncResolver instances were not properly closed."
-            )
 
 
 @pytest.fixture()

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -57,6 +57,11 @@ def check_no_lingering_resolvers() -> Generator[None, None, None]:
     try:
         yield
     finally:
+        # Force garbage collection to ensure weak references are updated
+        import gc
+
+        gc.collect()
+
         # We need to check in a finally block to ensure the check runs
         # even if the test fails
         if aiodns is not None:  # Only when aiodns is available


### PR DESCRIPTION
## Problem

As reported in [#10847](https://github.com/aio-libs/aiohttp/issues/10847), aiohttp currently creates a new `DNSResolver` object for each `AsyncResolver` instance, leading to excessive resolver object churn when using multiple sessions. This causes unnecessary resource usage and potential performance degradation, as the c-ares library documentation indicates that a single resolver can handle unlimited queries.

## Solution

This PR introduces a shared resolver management system:

1. Created a new `_DNSResolverManager` singleton class that maintains a single shared `aiodns.DNSResolver` instance
2. Modified `AsyncResolver` to use the shared resolver for default arguments while still supporting custom resolver configurations
3. Implemented proper client tracking and cleanup through the `get_resolver` and `release_resolver` methods
4. Added comprehensive tests to ensure correct behavior

The key design point is requiring clients to be explicitly passed to `get_resolver`, ensuring that the manager can track all users of the shared resolver and properly clean up when they're done.

## Implementation Details

- `_DNSResolverManager` is a singleton that ensures only one shared resolver exists
- Custom resolver configurations still create dedicated resolver instances 
- Client tracking uses `weakref.WeakSet` to avoid reference cycles
- The shared resolver is automatically canceled and cleaned up when the last client is released
- All resolvers are properly cleaned up after tests

## Benefits

- Drastically reduces the number of DNSResolver objects created for multiple sessions
- Decreases memory and resource usage
- Improves performance by avoiding unnecessary resolver creation and destruction
- Properly leverages c-ares's ability to handle unlimited queries with a single resolver
## Related issue number


fixes #10847
