### PR TITLE
Remove mocked coro

### DIFF
--- a/CHANGES/9212.packaging.rst
+++ b/CHANGES/9212.packaging.rst
@@ -1,0 +1,1 @@
+Removed remaining `make_mocked_coro` in the test suite -- by :user:`polkapolka`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -295,6 +295,7 @@ Pavol Vargovčík
 Pawel Kowalski
 Pawel Miech
 Pepe Osca
+Phebe Polk
 Philipp A.
 Pierre-Louis Peeters
 Pieter van Beek

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -682,10 +682,10 @@ def make_mocked_request(
 
     if writer is None:
         writer = mock.Mock()
-        writer.write_headers = make_mocked_coro(None)
-        writer.write = make_mocked_coro(None)
-        writer.write_eof = make_mocked_coro(None)
-        writer.drain = make_mocked_coro(None)
+        writer.write_headers = mock.AsyncMock(return_value=None)
+        writer.write = mock.AsyncMock(return_value=None)
+        writer.write_eof = mock.AsyncMock(return_value=None)
+        writer.drain = mock.AsyncMock(return_value=None)
         writer.transport = transport
 
     protocol.transport = transport
@@ -701,18 +701,3 @@ def make_mocked_request(
     req._match_info = match_info
 
     return req
-
-
-def make_mocked_coro(
-    return_value: Any = sentinel, raise_exception: Any = sentinel
-) -> Any:
-    """Creates a coroutine mock."""
-
-    async def mock_coro(*args: Any, **kwargs: Any) -> Any:
-        if raise_exception is not sentinel:
-            raise raise_exception
-        if not inspect.isawaitable(return_value):
-            return return_value
-        await return_value
-
-    return mock.Mock(wraps=mock_coro)

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -3,7 +3,6 @@
 import asyncio
 import contextlib
 import gc
-import inspect
 import ipaddress
 import os
 import socket
@@ -42,7 +41,6 @@ from . import ClientSession, hdrs
 from .abc import AbstractCookieJar, AbstractStreamWriter
 from .client_reqrep import ClientResponse
 from .client_ws import ClientWebSocketResponse
-from .helpers import sentinel
 from .http import HttpVersion, RawRequestMessage
 from .streams import EMPTY_PAYLOAD, StreamReader
 from .typedefs import LooseHeaders, StrOrURL

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -793,25 +793,6 @@ Test Client
 Utilities
 ~~~~~~~~~
 
-.. function:: make_mocked_coro(return_value)
-
-  Creates a coroutine mock.
-
-  Behaves like a coroutine which returns *return_value*.  But it is
-  also a mock object, you might test it as usual
-  :class:`~unittest.mock.Mock`::
-
-      mocked = make_mocked_coro(1)
-      assert 1 == await mocked(1, 2)
-      mocked.assert_called_with(1, 2)
-
-
-  :param return_value: A value that the mock object will return when
-      called.
-  :returns: A mock object that behaves as a coroutine which returns
-      *return_value* when called.
-
-
 .. function:: unused_port()
 
    Return an unused port number for IPv4 TCP protocol.

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -34,7 +34,6 @@ from aiohttp.client_reqrep import (
 from aiohttp.compression_utils import ZLibBackend
 from aiohttp.connector import Connection
 from aiohttp.http import HttpVersion10, HttpVersion11
-from aiohttp.test_utils import make_mocked_coro
 from aiohttp.typedefs import LooseCookies
 
 
@@ -831,7 +830,7 @@ async def test_content_encoding(
         "post", URL("http://python.org/"), data="foo", compress="deflate", loop=loop
     )
     with mock.patch("aiohttp.client_reqrep.StreamWriter") as m_writer:
-        m_writer.return_value.write_headers = make_mocked_coro()
+        m_writer.return_value.write_headers = mock.AsyncMock()
         resp = await req.send(conn)
     assert req.headers["TRANSFER-ENCODING"] == "chunked"
     assert req.headers["CONTENT-ENCODING"] == "deflate"
@@ -867,7 +866,7 @@ async def test_content_encoding_header(
         loop=loop,
     )
     with mock.patch("aiohttp.client_reqrep.StreamWriter") as m_writer:
-        m_writer.return_value.write_headers = make_mocked_coro()
+        m_writer.return_value.write_headers = mock.AsyncMock()
         resp = await req.send(conn)
 
     assert not m_writer.return_value.enable_compression.called
@@ -940,7 +939,7 @@ async def test_chunked_explicit(
 ) -> None:
     req = ClientRequest("post", URL("http://python.org/"), chunked=True, loop=loop)
     with mock.patch("aiohttp.client_reqrep.StreamWriter") as m_writer:
-        m_writer.return_value.write_headers = make_mocked_coro()
+        m_writer.return_value.write_headers = mock.AsyncMock()
         resp = await req.send(conn)
 
     assert "chunked" == req.headers["TRANSFER-ENCODING"]

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -16,7 +16,6 @@ from aiohttp import ClientSession, http
 from aiohttp.client_reqrep import ClientResponse, RequestInfo
 from aiohttp.connector import Connection
 from aiohttp.helpers import TimerNoop
-from aiohttp.test_utils import make_mocked_coro
 
 
 class WriterMock(mock.AsyncMock):
@@ -1142,7 +1141,7 @@ async def test_response_read_triggers_callback(
     loop: asyncio.AbstractEventLoop, session: ClientSession
 ) -> None:
     trace = mock.Mock()
-    trace.send_response_chunk_received = make_mocked_coro()
+    trace.send_response_chunk_received = mock.AsyncMock()
     response_method = "get"
     response_url = URL("http://def-cl-resp.org")
     response_body = b"This is response"

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -33,7 +33,6 @@ from aiohttp.connector import BaseConnector, Connection, TCPConnector, UnixConne
 from aiohttp.cookiejar import CookieJar
 from aiohttp.http import RawResponseMessage
 from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
-from aiohttp.test_utils import make_mocked_coro
 from aiohttp.tracing import Trace
 
 
@@ -791,9 +790,9 @@ async def test_request_tracing(
     trace_config_ctx = mock.Mock()
     body = "This is request body"
     gathered_req_headers: CIMultiDict[str] = CIMultiDict()
-    on_request_start = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_request_redirect = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_request_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
+    on_request_start = mock.AsyncMock()
+    on_request_redirect = mock.AsyncMock()
+    on_request_end = mock.AsyncMock()
 
     with io.BytesIO() as gathered_req_body, io.BytesIO() as gathered_res_body:
 
@@ -872,7 +871,7 @@ async def test_request_tracing_url_params(
     app.router.add_get("/", root_handler)
     app.router.add_get("/redirect", redirect_handler)
 
-    mocks = [mock.Mock(side_effect=make_mocked_coro(mock.Mock())) for _ in range(7)]
+    mocks = [mock.AsyncMock() for _ in range(7)]
     (
         on_request_start,
         on_request_redirect,
@@ -963,8 +962,8 @@ async def test_request_tracing_url_params(
 
 
 async def test_request_tracing_exception() -> None:
-    on_request_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_request_exception = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
+    on_request_end = mock.AsyncMock()
+    on_request_exception = mock.AsyncMock()
 
     trace_config = aiohttp.TraceConfig()
     trace_config.on_request_end.append(on_request_end)

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -18,7 +18,6 @@ from aiohttp import (
 from aiohttp.http import WS_KEY
 from aiohttp.http_websocket import WSMessageClose
 from aiohttp.streams import EofStream
-from aiohttp.test_utils import make_mocked_coro
 
 
 async def test_ws_connect(
@@ -383,7 +382,7 @@ async def test_close(
                 m_req.return_value.set_result(mresp)
                 writer = mock.Mock()
                 WebSocketWriter.return_value = writer
-                writer.close = make_mocked_coro()
+                writer.close = mock.AsyncMock()
 
                 session = aiohttp.ClientSession()
                 resp = await session.ws_connect("http://test.org")
@@ -492,7 +491,7 @@ async def test_close_exc(
                 m_req.return_value.set_result(mresp)
                 writer = mock.Mock()
                 WebSocketWriter.return_value = writer
-                writer.close = make_mocked_coro()
+                writer.close = mock.AsyncMock()
 
                 session = aiohttp.ClientSession()
                 resp = await session.ws_connect("http://test.org")
@@ -628,7 +627,7 @@ async def test_reader_read_exception(
 
                 writer = mock.Mock()
                 WebSocketWriter.return_value = writer
-                writer.close = make_mocked_coro()
+                writer.close = mock.AsyncMock()
 
                 session = aiohttp.ClientSession()
                 resp = await session.ws_connect("http://test.org")
@@ -780,7 +779,7 @@ async def test_ws_connect_deflate_per_message(
                 m_req.return_value = loop.create_future()
                 m_req.return_value.set_result(mresp)
                 writer = WebSocketWriter.return_value = mock.Mock()
-                send_frame = writer.send_frame = make_mocked_coro()
+                send_frame = writer.send_frame = mock.AsyncMock()
 
                 session = aiohttp.ClientSession()
                 resp = await session.ws_connect("http://test.org")

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -49,7 +49,7 @@ from aiohttp.connector import (
     _DNSCacheTable,
 )
 from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
-from aiohttp.test_utils import make_mocked_coro, unused_port
+from aiohttp.test_utils import unused_port
 from aiohttp.tracing import Trace
 
 
@@ -1423,10 +1423,10 @@ async def test_tcp_connector_dns_tracing(
 ) -> None:
     session = mock.Mock()
     trace_config_ctx = mock.Mock()
-    on_dns_resolvehost_start = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_dns_resolvehost_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_dns_cache_hit = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_dns_cache_miss = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
+    on_dns_resolvehost_start = mock.AsyncMock()
+    on_dns_resolvehost_end = mock.AsyncMock()
+    on_dns_cache_hit = mock.AsyncMock()
+    on_dns_cache_miss = mock.AsyncMock()
 
     trace_config = aiohttp.TraceConfig(
         trace_config_ctx_factory=mock.Mock(return_value=trace_config_ctx)
@@ -1470,8 +1470,8 @@ async def test_tcp_connector_dns_tracing_cache_disabled(
 ) -> None:
     session = mock.Mock()
     trace_config_ctx = mock.Mock()
-    on_dns_resolvehost_start = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_dns_resolvehost_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
+    on_dns_resolvehost_start = mock.AsyncMock()
+    on_dns_resolvehost_end = mock.AsyncMock()
 
     trace_config = aiohttp.TraceConfig(
         trace_config_ctx_factory=mock.Mock(return_value=trace_config_ctx)
@@ -1527,8 +1527,8 @@ async def test_tcp_connector_dns_tracing_throttle_requests(
 ) -> None:
     session = mock.Mock()
     trace_config_ctx = mock.Mock()
-    on_dns_cache_hit = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_dns_cache_miss = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
+    on_dns_cache_hit = mock.AsyncMock()
+    on_dns_cache_miss = mock.AsyncMock()
 
     trace_config = aiohttp.TraceConfig(
         trace_config_ctx_factory=mock.Mock(return_value=trace_config_ctx)
@@ -1671,8 +1671,8 @@ async def test_connect(loop: asyncio.AbstractEventLoop, key: ConnectionKey) -> N
 async def test_connect_tracing(loop: asyncio.AbstractEventLoop) -> None:
     session = mock.Mock()
     trace_config_ctx = mock.Mock()
-    on_connection_create_start = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_connection_create_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
+    on_connection_create_start = mock.AsyncMock()
+    on_connection_create_end = mock.AsyncMock()
 
     trace_config = aiohttp.TraceConfig(
         trace_config_ctx_factory=mock.Mock(return_value=trace_config_ctx)
@@ -2677,8 +2677,8 @@ async def test_connect_queued_operation_tracing(
 ) -> None:
     session = mock.Mock()
     trace_config_ctx = mock.Mock()
-    on_connection_queued_start = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_connection_queued_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
+    on_connection_queued_start = mock.AsyncMock()
+    on_connection_queued_end = mock.AsyncMock()
 
     trace_config = aiohttp.TraceConfig(
         trace_config_ctx_factory=mock.Mock(return_value=trace_config_ctx)
@@ -2724,7 +2724,7 @@ async def test_connect_reuseconn_tracing(
 ) -> None:
     session = mock.Mock()
     trace_config_ctx = mock.Mock()
-    on_connection_reuseconn = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
+    on_connection_reuseconn = mock.AsyncMock()
 
     trace_config = aiohttp.TraceConfig(
         trace_config_ctx_factory=mock.Mock(return_value=trace_config_ctx)
@@ -3228,7 +3228,7 @@ async def test_unix_connector_not_found(loop: asyncio.AbstractEventLoop) -> None
 
 @pytest.mark.skipif(not hasattr(socket, "AF_UNIX"), reason="requires UNIX sockets")
 async def test_unix_connector_permission(loop: asyncio.AbstractEventLoop) -> None:
-    m = make_mocked_coro(raise_exception=PermissionError())
+    m = mock.AsyncMock(side_effect=PermissionError())
     with mock.patch.object(loop, "create_unix_connection", m):
         connector = aiohttp.UnixConnector("/" + uuid.uuid4().hex)
 
@@ -3267,7 +3267,7 @@ async def test_named_pipe_connector_not_found(
 async def test_named_pipe_connector_permission(
     proactor_loop: asyncio.AbstractEventLoop, pipe_name: str
 ) -> None:
-    m = make_mocked_coro(raise_exception=PermissionError())
+    m = mock.AsyncMock(side_effect=PermissionError())
     with mock.patch.object(proactor_loop, "create_pipe_connection", m):
         asyncio.set_event_loop(proactor_loop)
         connector = aiohttp.NamedPipeConnector(pipe_name)

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -12,7 +12,6 @@ from aiohttp import ClientConnectionResetError, hdrs, http
 from aiohttp.base_protocol import BaseProtocol
 from aiohttp.compression_utils import ZLibBackend
 from aiohttp.http_writer import _serialize_headers
-from aiohttp.test_utils import make_mocked_coro
 
 
 @pytest.fixture
@@ -787,7 +786,7 @@ async def test_write_calls_callback(
     transport: asyncio.Transport,
     loop: asyncio.AbstractEventLoop,
 ) -> None:
-    on_chunk_sent = make_mocked_coro()
+    on_chunk_sent = mock.AsyncMock()
     msg = http.StreamWriter(protocol, loop, on_chunk_sent=on_chunk_sent)
     chunk = b"1"
     await msg.write(chunk)
@@ -800,7 +799,7 @@ async def test_write_eof_calls_callback(
     transport: asyncio.Transport,
     loop: asyncio.AbstractEventLoop,
 ) -> None:
-    on_chunk_sent = make_mocked_coro()
+    on_chunk_sent = mock.AsyncMock()
     msg = http.StreamWriter(protocol, loop, on_chunk_sent=on_chunk_sent)
     chunk = b"1"
     await msg.write_eof(chunk=chunk)

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -12,7 +12,6 @@ import aiohttp
 from aiohttp.client_reqrep import ClientRequest, ClientResponse, Fingerprint
 from aiohttp.connector import _SSL_CONTEXT_VERIFIED
 from aiohttp.helpers import TimerNoop
-from aiohttp.test_utils import make_mocked_coro
 
 
 class TestProxy(unittest.TestCase):
@@ -21,7 +20,9 @@ class TestProxy(unittest.TestCase):
     }
     mocked_response = mock.Mock(**response_mock_attrs)
     clientrequest_mock_attrs = {
-        "return_value.send.return_value.start": make_mocked_coro(mocked_response),
+        "return_value.send.return_value.start": mock.AsyncMock(
+            return_value=mocked_response
+        ),
     }
 
     def setUp(self) -> None:

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -31,7 +31,6 @@ from pytest_mock import MockerFixture
 
 from aiohttp import ClientConnectorError, ClientSession, ClientTimeout, WSCloseCode, web
 from aiohttp.log import access_logger
-from aiohttp.test_utils import make_mocked_coro
 from aiohttp.web_protocol import RequestHandler
 from aiohttp.web_runner import BaseRunner
 
@@ -108,9 +107,9 @@ def stopper(loop: asyncio.AbstractEventLoop) -> Callable[[], None]:
 
 def test_run_app_http(patched_loop: asyncio.AbstractEventLoop) -> None:
     app = web.Application()
-    startup_handler = make_mocked_coro()
+    startup_handler = mock.AsyncMock()
     app.on_startup.append(startup_handler)
-    cleanup_handler = make_mocked_coro()
+    cleanup_handler = mock.AsyncMock()
     app.on_cleanup.append(cleanup_handler)
 
     web.run_app(app, print=stopper(patched_loop), loop=patched_loop)
@@ -734,9 +733,9 @@ def test_startup_cleanup_signals_even_on_failure(
     patched_loop.create_server.side_effect = RuntimeError()  # type: ignore[attr-defined]
 
     app = web.Application()
-    startup_handler = make_mocked_coro()
+    startup_handler = mock.AsyncMock()
     app.on_startup.append(startup_handler)
-    cleanup_handler = make_mocked_coro()
+    cleanup_handler = mock.AsyncMock()
     app.on_cleanup.append(cleanup_handler)
 
     with pytest.raises(RuntimeError):
@@ -752,9 +751,9 @@ def test_run_app_coro(patched_loop: asyncio.AbstractEventLoop) -> None:
     async def make_app() -> web.Application:
         nonlocal startup_handler, cleanup_handler
         app = web.Application()
-        startup_handler = make_mocked_coro()
+        startup_handler = mock.AsyncMock()
         app.on_startup.append(startup_handler)
-        cleanup_handler = make_mocked_coro()
+        cleanup_handler = mock.AsyncMock()
         app.on_cleanup.append(cleanup_handler)
         return app
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,10 +1,10 @@
 from types import SimpleNamespace
 from typing import Any, Tuple
+from unittest import mock
 from unittest.mock import Mock
 
 import pytest
 
-from aiohttp.test_utils import make_mocked_coro
 from aiohttp.tracing import (
     Trace,
     TraceConfig,
@@ -107,7 +107,7 @@ class TestTrace:
     ) -> None:
         session = Mock()
         trace_request_ctx = Mock()
-        callback = Mock(side_effect=make_mocked_coro(Mock()))
+        callback = mock.AsyncMock()
 
         trace_config = TraceConfig()
         getattr(trace_config, "on_%s" % signal).append(callback)

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -6,7 +6,6 @@ import pytest
 
 from aiohttp import log, web
 from aiohttp.pytest_plugin import AiohttpClient
-from aiohttp.test_utils import make_mocked_coro
 from aiohttp.typedefs import Handler
 
 
@@ -22,8 +21,8 @@ def test_app_call() -> None:
 
 async def test_app_register_on_finish() -> None:
     app = web.Application()
-    cb1 = make_mocked_coro(None)
-    cb2 = make_mocked_coro(None)
+    cb1 = mock.AsyncMock(return_value=None)
+    cb2 = mock.AsyncMock(return_value=None)
     app.on_cleanup.append(cb1)
     app.on_cleanup.append(cb2)
     app.freeze()

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -36,7 +36,6 @@ from aiohttp.abc import AbstractResolver, ResolveResult
 from aiohttp.compression_utils import ZLibBackend, ZLibCompressObjProtocol
 from aiohttp.hdrs import CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING
 from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
-from aiohttp.test_utils import make_mocked_coro
 from aiohttp.typedefs import Handler, Middleware
 from aiohttp.web_protocol import RequestHandler
 
@@ -2018,13 +2017,13 @@ async def test_iter_any(aiohttp_server: AiohttpServer) -> None:
 
 
 async def test_request_tracing(aiohttp_server: AiohttpServer) -> None:
-    on_request_start = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_request_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_dns_resolvehost_start = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_dns_resolvehost_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_request_redirect = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_connection_create_start = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_connection_create_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
+    on_request_start = mock.AsyncMock()
+    on_request_end = mock.AsyncMock()
+    on_dns_resolvehost_start = mock.AsyncMock()
+    on_dns_resolvehost_end = mock.AsyncMock()
+    on_request_redirect = mock.AsyncMock()
+    on_connection_create_start = mock.AsyncMock()
+    on_connection_create_end = mock.AsyncMock()
 
     async def redirector(request: web.Request) -> NoReturn:
         raise web.HTTPFound(location=URL("/redirected"))

--- a/tests/test_web_request_handler.py
+++ b/tests/test_web_request_handler.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 from aiohttp import web
-from aiohttp.test_utils import make_mocked_coro
 
 
 async def serve(request: web.BaseRequest) -> web.Response:
@@ -37,7 +36,7 @@ async def test_shutdown_no_timeout() -> None:
 
     handler = mock.Mock(spec_set=web.RequestHandler)
     handler._task_handler = None
-    handler.shutdown = make_mocked_coro(mock.Mock())
+    handler.shutdown = mock.AsyncMock(return_value=mock.Mock())
     transport = mock.Mock()
     manager.connection_made(handler, transport)
 
@@ -52,7 +51,7 @@ async def test_shutdown_timeout() -> None:
     manager = web.Server(serve)
 
     handler = mock.Mock()
-    handler.shutdown = make_mocked_coro(mock.Mock())
+    handler.shutdown = mock.AsyncMock(return_value=mock.Mock())
     transport = mock.Mock()
     manager.connection_made(handler, transport)
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -19,7 +19,7 @@ from aiohttp.helpers import ETag
 from aiohttp.http_writer import StreamWriter, _serialize_headers
 from aiohttp.multipart import BodyPartReader, MultipartWriter
 from aiohttp.payload import BytesPayload, StringPayload
-from aiohttp.test_utils import make_mocked_coro, make_mocked_request
+from aiohttp.test_utils import make_mocked_request
 from aiohttp.typedefs import LooseHeaders
 
 
@@ -899,7 +899,7 @@ async def test_prepare_twice() -> None:
 
 async def test_prepare_calls_signal() -> None:
     app = mock.create_autospec(web.Application, spec_set=True)
-    sig = make_mocked_coro()
+    sig = mock.AsyncMock()
     app.on_response_prepare = aiosignal.Signal(app)
     app.on_response_prepare.append(sig)
     req = make_request("GET", "/", app=app)
@@ -1171,8 +1171,8 @@ async def test_send_set_cookie_header(
 
 async def test_consecutive_write_eof() -> None:
     writer = mock.Mock()
-    writer.write_eof = make_mocked_coro()
-    writer.write_headers = make_mocked_coro()
+    writer.write_eof = mock.AsyncMock()
+    writer.write_headers = mock.AsyncMock()
     req = make_request("GET", "/", writer=writer)
     data = b"data"
     resp = web.Response(body=data)

--- a/tests/test_web_sendfile.py
+++ b/tests/test_web_sendfile.py
@@ -4,7 +4,7 @@ from stat import S_IFREG, S_IRUSR, S_IWUSR
 from unittest import mock
 
 from aiohttp import hdrs
-from aiohttp.test_utils import make_mocked_coro, make_mocked_request
+from aiohttp.test_utils import make_mocked_request
 from aiohttp.web_fileresponse import FileResponse
 
 MOCK_MODE = S_IFREG | S_IRUSR | S_IWUSR
@@ -31,7 +31,7 @@ def test_using_gzip_if_header_present_and_file_available(
 
     file_sender = FileResponse(filepath)
     file_sender._path = filepath
-    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[method-assign]
+    file_sender._sendfile = mock.AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     loop.run_until_complete(file_sender.prepare(request))
 
@@ -58,7 +58,7 @@ def test_gzip_if_header_not_present_and_file_available(
 
     file_sender = FileResponse(filepath)
     file_sender._path = filepath
-    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[method-assign]
+    file_sender._sendfile = mock.AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     loop.run_until_complete(file_sender.prepare(request))
 
@@ -83,7 +83,7 @@ def test_gzip_if_header_not_present_and_file_not_available(
 
     file_sender = FileResponse(filepath)
     file_sender._path = filepath
-    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[method-assign]
+    file_sender._sendfile = mock.AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     loop.run_until_complete(file_sender.prepare(request))
 
@@ -110,7 +110,7 @@ def test_gzip_if_header_present_and_file_not_available(
 
     file_sender = FileResponse(filepath)
     file_sender._path = filepath
-    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[method-assign]
+    file_sender._sendfile = mock.AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     loop.run_until_complete(file_sender.prepare(request))
 
@@ -129,7 +129,7 @@ def test_status_controlled_by_user(loop: asyncio.AbstractEventLoop) -> None:
 
     file_sender = FileResponse(filepath, status=203)
     file_sender._path = filepath
-    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[method-assign]
+    file_sender._sendfile = mock.AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     loop.run_until_complete(file_sender.prepare(request))
 

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -12,7 +12,7 @@ from aiohttp import WSMessageTypeError, WSMsgType, web
 from aiohttp.http import WS_CLOSED_MESSAGE, WS_CLOSING_MESSAGE
 from aiohttp.http_websocket import WSMessageClose
 from aiohttp.streams import EofStream
-from aiohttp.test_utils import make_mocked_coro, make_mocked_request
+from aiohttp.test_utils import make_mocked_request
 from aiohttp.web_ws import WebSocketReady
 
 
@@ -421,9 +421,7 @@ async def test_receive_eofstream_in_reader(
 
     ws._reader = mock.Mock()
     exc = EofStream()
-    res = loop.create_future()
-    res.set_exception(exc)
-    ws._reader.read = make_mocked_coro(res)
+    ws._reader.read = mock.AsyncMock(side_effect=exc)
     assert ws._payload_writer is not None
     f = loop.create_future()
     f.set_result(True)
@@ -442,9 +440,7 @@ async def test_receive_exception_in_reader(
 
     ws._reader = mock.Mock()
     exc = Exception()
-    res = loop.create_future()
-    res.set_exception(exc)
-    ws._reader.read = make_mocked_coro(res)
+    ws._reader.read = mock.AsyncMock(side_effect=exc)
 
     f = loop.create_future()
     assert ws._payload_writer is not None
@@ -545,9 +541,7 @@ async def test_receive_timeouterror(
     assert len(req.transport.close.mock_calls) == 0  # type: ignore[attr-defined]
 
     ws._reader = mock.Mock()
-    res = loop.create_future()
-    res.set_exception(asyncio.TimeoutError())
-    ws._reader.read = make_mocked_coro(res)
+    ws._reader.read = mock.AsyncMock(side_effect=asyncio.TimeoutError())
 
     with pytest.raises(asyncio.TimeoutError):
         await ws.receive()

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -9,13 +9,12 @@ from aiohttp import WSMsgType
 from aiohttp._websocket.reader import WebSocketDataQueue
 from aiohttp.base_protocol import BaseProtocol
 from aiohttp.http import WebSocketReader, WebSocketWriter
-from aiohttp.test_utils import make_mocked_coro
 
 
 @pytest.fixture
 def protocol() -> mock.Mock:
     ret = mock.Mock()
-    ret._drain_helper = make_mocked_coro()
+    ret._drain_helper = mock.AsyncMock()
     return ret
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Removed a function that was redundant to AsyncMock functionality.

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Fixes #9212 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
