### PR TITLE
[PR #10910/36a2567 backport][3.11] Remove mocked coro from tests

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -284,6 +284,7 @@ Pavol Vargovčík
 Pawel Kowalski
 Pawel Miech
 Pepe Osca
+Phebe Polk
 Philipp A.
 Pierre-Louis Peeters
 Pieter van Beek

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -24,7 +24,6 @@ from aiohttp.client_reqrep import (
     _merge_ssl_params,
 )
 from aiohttp.http import HttpVersion10, HttpVersion11
-from aiohttp.test_utils import make_mocked_coro
 
 
 class WriterMock(mock.AsyncMock):
@@ -805,7 +804,7 @@ async def test_content_encoding(loop, conn) -> None:
         "post", URL("http://python.org/"), data="foo", compress="deflate", loop=loop
     )
     with mock.patch("aiohttp.client_reqrep.StreamWriter") as m_writer:
-        m_writer.return_value.write_headers = make_mocked_coro()
+        m_writer.return_value.write_headers = mock.AsyncMock()
         resp = await req.send(conn)
     assert req.headers["TRANSFER-ENCODING"] == "chunked"
     assert req.headers["CONTENT-ENCODING"] == "deflate"
@@ -835,7 +834,7 @@ async def test_content_encoding_header(loop, conn) -> None:
         loop=loop,
     )
     with mock.patch("aiohttp.client_reqrep.StreamWriter") as m_writer:
-        m_writer.return_value.write_headers = make_mocked_coro()
+        m_writer.return_value.write_headers = mock.AsyncMock()
         resp = await req.send(conn)
 
     assert not m_writer.return_value.enable_compression.called
@@ -885,7 +884,7 @@ async def test_chunked2(loop, conn) -> None:
 async def test_chunked_explicit(loop, conn) -> None:
     req = ClientRequest("post", URL("http://python.org/"), chunked=True, loop=loop)
     with mock.patch("aiohttp.client_reqrep.StreamWriter") as m_writer:
-        m_writer.return_value.write_headers = make_mocked_coro()
+        m_writer.return_value.write_headers = mock.AsyncMock()
         resp = await req.send(conn)
 
     assert "chunked" == req.headers["TRANSFER-ENCODING"]

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -14,7 +14,6 @@ import aiohttp
 from aiohttp import ClientSession, http
 from aiohttp.client_reqrep import ClientResponse, RequestInfo
 from aiohttp.helpers import TimerNoop
-from aiohttp.test_utils import make_mocked_coro
 
 
 class WriterMock(mock.AsyncMock):
@@ -1104,7 +1103,7 @@ def test_redirect_history_in_exception() -> None:
 
 async def test_response_read_triggers_callback(loop, session) -> None:
     trace = mock.Mock()
-    trace.send_response_chunk_received = make_mocked_coro()
+    trace.send_response_chunk_received = mock.AsyncMock()
     response_method = "get"
     response_url = URL("http://def-cl-resp.org")
     response_body = b"This is response"

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -23,7 +23,6 @@ from aiohttp.connector import BaseConnector, Connection, TCPConnector, UnixConne
 from aiohttp.helpers import DEBUG
 from aiohttp.http import RawResponseMessage
 from aiohttp.pytest_plugin import AiohttpServer
-from aiohttp.test_utils import make_mocked_coro
 from aiohttp.tracing import Trace
 
 
@@ -738,10 +737,10 @@ async def test_request_tracing(loop: asyncio.AbstractEventLoop, aiohttp_client) 
     trace_config_ctx = mock.Mock()
     trace_request_ctx = {}
     body = "This is request body"
-    gathered_req_headers = CIMultiDict()
-    on_request_start = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_request_redirect = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_request_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
+    gathered_req_headers: CIMultiDict[str] = CIMultiDict()
+    on_request_start = mock.AsyncMock()
+    on_request_redirect = mock.AsyncMock()
+    on_request_end = mock.AsyncMock()
 
     with io.BytesIO() as gathered_req_body, io.BytesIO() as gathered_res_body:
 
@@ -809,7 +808,7 @@ async def test_request_tracing_url_params(loop: Any, aiohttp_client: Any) -> Non
     app.router.add_get("/", root_handler)
     app.router.add_get("/redirect", redirect_handler)
 
-    mocks = [mock.Mock(side_effect=make_mocked_coro(mock.Mock())) for _ in range(7)]
+    mocks = [mock.AsyncMock() for _ in range(7)]
     (
         on_request_start,
         on_request_redirect,
@@ -900,8 +899,8 @@ async def test_request_tracing_url_params(loop: Any, aiohttp_client: Any) -> Non
 
 async def test_request_tracing_exception() -> None:
     loop = asyncio.get_event_loop()
-    on_request_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_request_exception = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
+    on_request_end = mock.AsyncMock()
+    on_request_exception = mock.AsyncMock()
 
     trace_config = aiohttp.TraceConfig()
     trace_config.on_request_end.append(on_request_end)

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -11,7 +11,6 @@ import aiohttp
 from aiohttp import ClientConnectionResetError, ServerDisconnectedError, client, hdrs
 from aiohttp.http import WS_KEY
 from aiohttp.streams import EofStream
-from aiohttp.test_utils import make_mocked_coro
 
 
 async def test_ws_connect(ws_key: Any, loop: Any, key_data: Any) -> None:
@@ -352,7 +351,7 @@ async def test_close(loop, ws_key, key_data) -> None:
                 m_req.return_value.set_result(resp)
                 writer = mock.Mock()
                 WebSocketWriter.return_value = writer
-                writer.close = make_mocked_coro()
+                writer.close = mock.AsyncMock()
 
                 session = aiohttp.ClientSession(loop=loop)
                 resp = await session.ws_connect("http://test.org")
@@ -461,7 +460,7 @@ async def test_close_exc(
                 m_req.return_value.set_result(mresp)
                 writer = mock.Mock()
                 WebSocketWriter.return_value = writer
-                writer.close = make_mocked_coro()
+                writer.close = mock.AsyncMock()
 
                 session = aiohttp.ClientSession(loop=loop)
                 resp = await session.ws_connect("http://test.org")
@@ -595,7 +594,7 @@ async def test_reader_read_exception(ws_key, key_data, loop) -> None:
 
                 writer = mock.Mock()
                 WebSocketWriter.return_value = writer
-                writer.close = make_mocked_coro()
+                writer.close = mock.AsyncMock()
 
                 session = aiohttp.ClientSession(loop=loop)
                 resp = await session.ws_connect("http://test.org")
@@ -731,7 +730,7 @@ async def test_ws_connect_deflate_per_message(loop, ws_key, key_data) -> None:
                 m_req.return_value = loop.create_future()
                 m_req.return_value.set_result(resp)
                 writer = WebSocketWriter.return_value = mock.Mock()
-                send_frame = writer.send_frame = make_mocked_coro()
+                send_frame = writer.send_frame = mock.AsyncMock()
 
                 session = aiohttp.ClientSession(loop=loop)
                 resp = await session.ws_connect("http://test.org")

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -19,7 +19,6 @@ from aiohttp.hdrs import (
 from aiohttp.helpers import parse_mimetype
 from aiohttp.multipart import MultipartResponseWrapper
 from aiohttp.streams import StreamReader
-from aiohttp.test_utils import make_mocked_coro
 
 BOUNDARY = b"--:"
 
@@ -97,21 +96,21 @@ class TestMultipartResponseWrapper:
 
     async def test_next(self) -> None:
         wrapper = MultipartResponseWrapper(mock.Mock(), mock.Mock())
-        wrapper.stream.next = make_mocked_coro(b"")
+        wrapper.stream.next = mock.AsyncMock(b"")
         wrapper.stream.at_eof.return_value = False
         await wrapper.next()
         assert wrapper.stream.next.called
 
     async def test_release(self) -> None:
         wrapper = MultipartResponseWrapper(mock.Mock(), mock.Mock())
-        wrapper.resp.release = make_mocked_coro(None)
+        wrapper.resp.release = mock.AsyncMock(None)
         await wrapper.release()
         assert wrapper.resp.release.called
 
     async def test_release_when_stream_at_eof(self) -> None:
         wrapper = MultipartResponseWrapper(mock.Mock(), mock.Mock())
-        wrapper.resp.release = make_mocked_coro(None)
-        wrapper.stream.next = make_mocked_coro(b"")
+        wrapper.resp.release = mock.AsyncMock(None)
+        wrapper.stream.next = mock.AsyncMock(b"")
         wrapper.stream.at_eof.return_value = True
         await wrapper.next()
         assert wrapper.stream.next.called

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -14,7 +14,6 @@ import aiohttp
 from aiohttp.client_reqrep import ClientRequest, ClientResponse, Fingerprint
 from aiohttp.connector import _SSL_CONTEXT_VERIFIED
 from aiohttp.helpers import TimerNoop
-from aiohttp.test_utils import make_mocked_coro
 
 pytestmark = pytest.mark.skipif(
     sys.platform == "win32", reason="Proxy tests are unstable on Windows"
@@ -27,7 +26,9 @@ class TestProxy(unittest.TestCase):
     }
     mocked_response = mock.Mock(**response_mock_attrs)
     clientrequest_mock_attrs = {
-        "return_value.send.return_value.start": make_mocked_coro(mocked_response),
+        "return_value.send.return_value.start": mock.AsyncMock(
+            return_value=mocked_response
+        ),
     }
 
     def setUp(self):
@@ -61,8 +62,8 @@ class TestProxy(unittest.TestCase):
             return aiohttp.TCPConnector()
 
         connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
+        connector._resolve_host = mock.AsyncMock(
+            return_value=[
                 {
                     "hostname": "hostname",
                     "host": "127.0.0.1",
@@ -79,7 +80,9 @@ class TestProxy(unittest.TestCase):
                 "transport.get_extra_info.return_value": False,
             }
         )
-        self.loop.create_connection = make_mocked_coro((proto.transport, proto))
+        self.loop.create_connection = mock.AsyncMock(
+            return_value=(proto.transport, proto)
+        )
         conn = self.loop.run_until_complete(
             connector.connect(req, None, aiohttp.ClientTimeout())
         )
@@ -119,8 +122,8 @@ class TestProxy(unittest.TestCase):
             return aiohttp.TCPConnector()
 
         connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
+        connector._resolve_host = mock.AsyncMock(
+            return_value=[
                 {
                     "hostname": "hostname",
                     "host": "127.0.0.1",
@@ -137,7 +140,9 @@ class TestProxy(unittest.TestCase):
                 "transport.get_extra_info.return_value": False,
             }
         )
-        self.loop.create_connection = make_mocked_coro((proto.transport, proto))
+        self.loop.create_connection = mock.AsyncMock(
+            return_value=(proto.transport, proto)
+        )
         conn = self.loop.run_until_complete(
             connector.connect(req, None, aiohttp.ClientTimeout())
         )
@@ -185,8 +190,8 @@ class TestProxy(unittest.TestCase):
             return aiohttp.TCPConnector()
 
         connector: aiohttp.TCPConnector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            raise_exception=OSError("dont take it serious")
+        connector._resolve_host = mock.AsyncMock(
+            side_effect=OSError("dont take it serious")
         )
 
         req = ClientRequest(
@@ -214,8 +219,8 @@ class TestProxy(unittest.TestCase):
             return aiohttp.TCPConnector()
 
         connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
+        connector._resolve_host = mock.AsyncMock(
+            return_value=[
                 {
                     "hostname": "www.python.org",
                     "host": "127.0.0.1",
@@ -226,8 +231,8 @@ class TestProxy(unittest.TestCase):
                 }
             ]
         )
-        connector._loop.create_connection = make_mocked_coro(
-            raise_exception=OSError("dont take it serious")
+        connector._loop.create_connection = mock.AsyncMock(
+            side_effect=OSError("dont take it serious")
         )
 
         req = ClientRequest(
@@ -266,15 +271,15 @@ class TestProxy(unittest.TestCase):
             loop=self.loop,
             session=mock.Mock(),
         )
-        proxy_req.send = make_mocked_coro(proxy_resp)
-        proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
+        proxy_req.send = mock.AsyncMock(return_value=proxy_resp)
+        proxy_resp.start = mock.AsyncMock(return_value=mock.Mock(status=200))
 
         async def make_conn():
             return aiohttp.TCPConnector()
 
         connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
+        connector._resolve_host = mock.AsyncMock(
+            return_value=[
                 {
                     "hostname": "hostname",
                     "host": "127.0.0.1",
@@ -287,8 +292,8 @@ class TestProxy(unittest.TestCase):
         )
 
         tr, proto = mock.Mock(), mock.Mock()
-        self.loop.create_connection = make_mocked_coro((tr, proto))
-        self.loop.start_tls = make_mocked_coro(mock.Mock())
+        self.loop.create_connection = mock.AsyncMock(return_value=(tr, proto))
+        self.loop.start_tls = mock.AsyncMock(return_value=mock.Mock())
 
         req = ClientRequest(
             "GET",
@@ -335,15 +340,15 @@ class TestProxy(unittest.TestCase):
             loop=self.loop,
             session=mock.Mock(),
         )
-        proxy_req.send = make_mocked_coro(proxy_resp)
-        proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
+        proxy_req.send = mock.AsyncMock(return_value=proxy_resp)
+        proxy_resp.start = mock.AsyncMock(return_value=mock.Mock(status=200))
 
         async def make_conn():
             return aiohttp.TCPConnector()
 
         connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
+        connector._resolve_host = mock.AsyncMock(
+            return_value=[
                 {
                     "hostname": "hostname",
                     "host": "127.0.0.1",
@@ -356,8 +361,8 @@ class TestProxy(unittest.TestCase):
         )
 
         tr, proto = mock.Mock(), mock.Mock()
-        self.loop.create_connection = make_mocked_coro((tr, proto))
-        self.loop.start_tls = make_mocked_coro(mock.Mock())
+        self.loop.create_connection = mock.AsyncMock(return_value=(tr, proto))
+        self.loop.start_tls = mock.AsyncMock(return_value=mock.Mock())
 
         req = ClientRequest(
             "GET",
@@ -513,15 +518,15 @@ class TestProxy(unittest.TestCase):
             loop=self.loop,
             session=mock.Mock(),
         )
-        proxy_req.send = make_mocked_coro(proxy_resp)
-        proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
+        proxy_req.send = mock.AsyncMock(return_value=proxy_resp)
+        proxy_resp.start = mock.AsyncMock(return_value=mock.Mock(status=200))
 
         async def make_conn():
             return aiohttp.TCPConnector()
 
         connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
+        connector._resolve_host = mock.AsyncMock(
+            return_value=[
                 {
                     "hostname": "hostname",
                     "host": "127.0.0.1",
@@ -534,8 +539,8 @@ class TestProxy(unittest.TestCase):
         )
 
         tr, proto = mock.Mock(), mock.Mock()
-        self.loop.create_connection = make_mocked_coro((tr, proto))
-        self.loop.start_tls = make_mocked_coro(mock.Mock())
+        self.loop.create_connection = mock.AsyncMock(return_value=(tr, proto))
+        self.loop.start_tls = mock.AsyncMock(return_value=mock.Mock())
 
         req = ClientRequest(
             "GET",
@@ -580,15 +585,15 @@ class TestProxy(unittest.TestCase):
             loop=self.loop,
             session=mock.Mock(),
         )
-        proxy_req.send = make_mocked_coro(proxy_resp)
-        proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
+        proxy_req.send = mock.AsyncMock(return_value=proxy_resp)
+        proxy_resp.start = mock.AsyncMock(return_value=mock.Mock(status=200))
 
         async def make_conn():
             return aiohttp.TCPConnector()
 
         connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
+        connector._resolve_host = mock.AsyncMock(
+            return_value=[
                 {
                     "hostname": "hostname",
                     "host": "127.0.0.1",
@@ -601,9 +606,11 @@ class TestProxy(unittest.TestCase):
         )
 
         # Called on connection to http://proxy.example.com
-        self.loop.create_connection = make_mocked_coro((mock.Mock(), mock.Mock()))
+        self.loop.create_connection = mock.AsyncMock(
+            return_value=(mock.Mock(), mock.Mock())
+        )
         # Called on connection to https://www.python.org
-        self.loop.start_tls = make_mocked_coro(raise_exception=ssl.CertificateError)
+        self.loop.start_tls = mock.AsyncMock(side_effect=ssl.CertificateError)
 
         req = ClientRequest(
             "GET",
@@ -641,15 +648,15 @@ class TestProxy(unittest.TestCase):
             loop=self.loop,
             session=mock.Mock(),
         )
-        proxy_req.send = make_mocked_coro(proxy_resp)
-        proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
+        proxy_req.send = mock.AsyncMock(return_value=proxy_resp)
+        proxy_resp.start = mock.AsyncMock(return_value=mock.Mock(status=200))
 
         async def make_conn():
             return aiohttp.TCPConnector()
 
         connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
+        connector._resolve_host = mock.AsyncMock(
+            return_value=[
                 {
                     "hostname": "hostname",
                     "host": "127.0.0.1",
@@ -662,11 +669,11 @@ class TestProxy(unittest.TestCase):
         )
 
         # Called on connection to http://proxy.example.com
-        self.loop.create_connection = make_mocked_coro(
-            (mock.Mock(), mock.Mock()),
+        self.loop.create_connection = mock.AsyncMock(
+            return_value=(mock.Mock(), mock.Mock()),
         )
         # Called on connection to https://www.python.org
-        self.loop.start_tls = make_mocked_coro(raise_exception=ssl.SSLError)
+        self.loop.start_tls = mock.AsyncMock(side_effect=ssl.SSLError)
 
         req = ClientRequest(
             "GET",
@@ -704,15 +711,17 @@ class TestProxy(unittest.TestCase):
             loop=self.loop,
             session=mock.Mock(),
         )
-        proxy_req.send = make_mocked_coro(proxy_resp)
-        proxy_resp.start = make_mocked_coro(mock.Mock(status=400, reason="bad request"))
+        proxy_req.send = mock.AsyncMock(return_value=proxy_resp)
+        proxy_resp.start = mock.AsyncMock(
+            return_value=mock.Mock(status=400, reason="bad request")
+        )
 
         async def make_conn():
             return aiohttp.TCPConnector()
 
         connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
+        connector._resolve_host = mock.AsyncMock(
+            return_value=[
                 {
                     "hostname": "hostname",
                     "host": "127.0.0.1",
@@ -726,7 +735,7 @@ class TestProxy(unittest.TestCase):
 
         tr, proto = mock.Mock(), mock.Mock()
         tr.get_extra_info.return_value = None
-        self.loop.create_connection = make_mocked_coro((tr, proto))
+        self.loop.create_connection = mock.AsyncMock(return_value=(tr, proto))
 
         req = ClientRequest(
             "GET",
@@ -770,15 +779,15 @@ class TestProxy(unittest.TestCase):
             loop=self.loop,
             session=mock.Mock(),
         )
-        proxy_req.send = make_mocked_coro(proxy_resp)
-        proxy_resp.start = make_mocked_coro(raise_exception=OSError("error message"))
+        proxy_req.send = mock.AsyncMock(return_value=proxy_resp)
+        proxy_resp.start = mock.AsyncMock(side_effect=OSError("error message"))
 
         async def make_conn():
             return aiohttp.TCPConnector()
 
         connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
+        connector._resolve_host = mock.AsyncMock(
+            return_value=[
                 {
                     "hostname": "hostname",
                     "host": "127.0.0.1",
@@ -792,7 +801,7 @@ class TestProxy(unittest.TestCase):
 
         tr, proto = mock.Mock(), mock.Mock()
         tr.get_extra_info.return_value = None
-        self.loop.create_connection = make_mocked_coro((tr, proto))
+        self.loop.create_connection = mock.AsyncMock(return_value=(tr, proto))
 
         req = ClientRequest(
             "GET",
@@ -821,8 +830,8 @@ class TestProxy(unittest.TestCase):
             return aiohttp.TCPConnector()
 
         connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
+        connector._resolve_host = mock.AsyncMock(
+            return_value=[
                 {
                     "hostname": "hostname",
                     "host": "127.0.0.1",
@@ -836,7 +845,7 @@ class TestProxy(unittest.TestCase):
 
         tr, proto = mock.Mock(), mock.Mock()
         tr.get_extra_info.return_value = None
-        self.loop.create_connection = make_mocked_coro((tr, proto))
+        self.loop.create_connection = mock.AsyncMock(return_value=(tr, proto))
 
         req = ClientRequest(
             "GET",
@@ -893,15 +902,15 @@ class TestProxy(unittest.TestCase):
             loop=self.loop,
             session=mock.Mock(),
         )
-        proxy_req.send = make_mocked_coro(proxy_resp)
-        proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
+        proxy_req.send = mock.AsyncMock(return_value=proxy_resp)
+        proxy_resp.start = mock.AsyncMock(return_value=mock.Mock(status=200))
 
         async def make_conn():
             return aiohttp.TCPConnector()
 
         connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
+        connector._resolve_host = mock.AsyncMock(
+            return_value=[
                 {
                     "hostname": "hostname",
                     "host": "127.0.0.1",
@@ -914,8 +923,8 @@ class TestProxy(unittest.TestCase):
         )
 
         tr, proto = mock.Mock(), mock.Mock()
-        self.loop.create_connection = make_mocked_coro((tr, proto))
-        self.loop.start_tls = make_mocked_coro(mock.Mock())
+        self.loop.create_connection = mock.AsyncMock(return_value=(tr, proto))
+        self.loop.start_tls = mock.AsyncMock(return_value=mock.Mock())
 
         req = ClientRequest(
             "GET",
@@ -969,15 +978,15 @@ class TestProxy(unittest.TestCase):
             loop=self.loop,
             session=mock.Mock(),
         )
-        proxy_req.send = make_mocked_coro(proxy_resp)
-        proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
+        proxy_req.send = mock.AsyncMock(return_value=proxy_resp)
+        proxy_resp.start = mock.AsyncMock(return_value=mock.Mock(status=200))
 
         async def make_conn():
             return aiohttp.TCPConnector()
 
         connector = self.loop.run_until_complete(make_conn())
-        connector._resolve_host = make_mocked_coro(
-            [
+        connector._resolve_host = mock.AsyncMock(
+            return_value=[
                 {
                     "hostname": "hostname",
                     "host": "127.0.0.1",
@@ -990,8 +999,8 @@ class TestProxy(unittest.TestCase):
         )
 
         tr, proto = mock.Mock(), mock.Mock()
-        self.loop.create_connection = make_mocked_coro((tr, proto))
-        self.loop.start_tls = make_mocked_coro(mock.Mock())
+        self.loop.create_connection = mock.AsyncMock(return_value=(tr, proto))
+        self.loop.start_tls = mock.AsyncMock(return_value=mock.Mock())
 
         self.assertIn("AUTHORIZATION", proxy_req.headers)
         self.assertNotIn("PROXY-AUTHORIZATION", proxy_req.headers)

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -14,6 +14,7 @@ from typing import (
     Awaitable,
     Callable,
     Coroutine,
+    Iterator,
     NoReturn,
     Optional,
     Set,
@@ -25,7 +26,6 @@ from uuid import uuid4
 import pytest
 
 from aiohttp import ClientConnectorError, ClientSession, ClientTimeout, WSCloseCode, web
-from aiohttp.test_utils import make_mocked_coro
 from aiohttp.web_runner import BaseRunner
 
 # Test for features of OS' socket support
@@ -65,15 +65,25 @@ def skip_if_on_windows():
 
 
 @pytest.fixture
-def patched_loop(loop):
-    server = mock.Mock()
-    server.wait_closed = make_mocked_coro(None)
-    loop.create_server = make_mocked_coro(server)
-    unix_server = mock.Mock()
-    unix_server.wait_closed = make_mocked_coro(None)
-    loop.create_unix_server = make_mocked_coro(unix_server)
-    asyncio.set_event_loop(loop)
-    return loop
+def patched_loop(
+    loop: asyncio.AbstractEventLoop,
+) -> Iterator[asyncio.AbstractEventLoop]:
+    server = mock.create_autospec(asyncio.Server, spec_set=True, instance=True)
+    server.wait_closed.return_value = None
+    unix_server = mock.create_autospec(asyncio.Server, spec_set=True, instance=True)
+    unix_server.wait_closed.return_value = None
+    with mock.patch.object(
+        loop, "create_server", autospec=True, spec_set=True, return_value=server
+    ):
+        with mock.patch.object(
+            loop,
+            "create_unix_server",
+            autospec=True,
+            spec_set=True,
+            return_value=unix_server,
+        ):
+            asyncio.set_event_loop(loop)
+            yield loop
 
 
 def stopper(loop):
@@ -88,9 +98,9 @@ def stopper(loop):
 
 def test_run_app_http(patched_loop) -> None:
     app = web.Application()
-    startup_handler = make_mocked_coro()
+    startup_handler = mock.AsyncMock()
     app.on_startup.append(startup_handler)
-    cleanup_handler = make_mocked_coro()
+    cleanup_handler = mock.AsyncMock()
     app.on_cleanup.append(cleanup_handler)
 
     web.run_app(app, print=stopper(patched_loop), loop=patched_loop)
@@ -693,9 +703,9 @@ def test_startup_cleanup_signals_even_on_failure(patched_loop) -> None:
     patched_loop.create_server = mock.Mock(side_effect=RuntimeError())
 
     app = web.Application()
-    startup_handler = make_mocked_coro()
+    startup_handler = mock.AsyncMock()
     app.on_startup.append(startup_handler)
-    cleanup_handler = make_mocked_coro()
+    cleanup_handler = mock.AsyncMock()
     app.on_cleanup.append(cleanup_handler)
 
     with pytest.raises(RuntimeError):
@@ -711,9 +721,9 @@ def test_run_app_coro(patched_loop) -> None:
     async def make_app():
         nonlocal startup_handler, cleanup_handler
         app = web.Application()
-        startup_handler = make_mocked_coro()
+        startup_handler = mock.AsyncMock()
         app.on_startup.append(startup_handler)
-        cleanup_handler = make_mocked_coro()
+        cleanup_handler = mock.AsyncMock()
         app.on_cleanup.append(cleanup_handler)
         return app
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,9 +1,9 @@
 from types import SimpleNamespace
+from unittest import mock
 from unittest.mock import Mock
 
 import pytest
 
-from aiohttp.test_utils import make_mocked_coro
 from aiohttp.tracing import (
     Trace,
     TraceConfig,
@@ -104,7 +104,7 @@ class TestTrace:
     async def test_send(self, signal, params, param_obj) -> None:
         session = Mock()
         trace_request_ctx = Mock()
-        callback = Mock(side_effect=make_mocked_coro(Mock()))
+        callback = mock.AsyncMock()
 
         trace_config = TraceConfig()
         getattr(trace_config, "on_%s" % signal).append(callback)

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -8,7 +8,6 @@ import pytest
 from aiohttp import log, web
 from aiohttp.abc import AbstractAccessLogger, AbstractRouter
 from aiohttp.helpers import DEBUG
-from aiohttp.test_utils import make_mocked_coro
 from aiohttp.typedefs import Handler
 
 
@@ -167,8 +166,8 @@ async def test_app_make_handler_raises_deprecation_warning() -> None:
 
 async def test_app_register_on_finish() -> None:
     app = web.Application()
-    cb1 = make_mocked_coro(None)
-    cb2 = make_mocked_coro(None)
+    cb1 = mock.AsyncMock(return_value=None)
+    cb2 = mock.AsyncMock(return_value=None)
     app.on_cleanup.append(cb1)
     app.on_cleanup.append(cb2)
     app.freeze()

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -23,8 +23,7 @@ from aiohttp import (
     web,
 )
 from aiohttp.hdrs import CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING
-from aiohttp.pytest_plugin import AiohttpClient
-from aiohttp.test_utils import make_mocked_coro
+from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
 from aiohttp.typedefs import Handler
 from aiohttp.web_protocol import RequestHandler
 
@@ -2014,15 +2013,14 @@ async def test_iter_any(aiohttp_server) -> None:
             assert resp.status == 200
 
 
-async def test_request_tracing(aiohttp_server) -> None:
-
-    on_request_start = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_request_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_dns_resolvehost_start = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_dns_resolvehost_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_request_redirect = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_connection_create_start = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
-    on_connection_create_end = mock.Mock(side_effect=make_mocked_coro(mock.Mock()))
+async def test_request_tracing(aiohttp_server: AiohttpServer) -> None:
+    on_request_start = mock.AsyncMock()
+    on_request_end = mock.AsyncMock()
+    on_dns_resolvehost_start = mock.AsyncMock()
+    on_dns_resolvehost_end = mock.AsyncMock()
+    on_request_redirect = mock.AsyncMock()
+    on_connection_create_start = mock.AsyncMock()
+    on_connection_create_end = mock.AsyncMock()
 
     async def redirector(request):
         raise web.HTTPFound(location=URL("/redirected"))

--- a/tests/test_web_request_handler.py
+++ b/tests/test_web_request_handler.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 from aiohttp import web
-from aiohttp.test_utils import make_mocked_coro
 
 
 async def serve(request: web.BaseRequest) -> web.Response:
@@ -37,7 +36,7 @@ async def test_shutdown_no_timeout() -> None:
 
     handler = mock.Mock(spec_set=web.RequestHandler)
     handler._task_handler = None
-    handler.shutdown = make_mocked_coro(mock.Mock())
+    handler.shutdown = mock.AsyncMock(return_value=mock.Mock())
     transport = mock.Mock()
     manager.connection_made(handler, transport)
 
@@ -52,7 +51,7 @@ async def test_shutdown_timeout() -> None:
     manager = web.Server(serve)
 
     handler = mock.Mock()
-    handler.shutdown = make_mocked_coro(mock.Mock())
+    handler.shutdown = mock.AsyncMock(return_value=mock.Mock())
     transport = mock.Mock()
     manager.connection_made(handler, transport)
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -18,7 +18,7 @@ from aiohttp.helpers import ETag
 from aiohttp.http_writer import StreamWriter, _serialize_headers
 from aiohttp.multipart import BodyPartReader, MultipartWriter
 from aiohttp.payload import BytesPayload, StringPayload
-from aiohttp.test_utils import make_mocked_coro, make_mocked_request
+from aiohttp.test_utils import make_mocked_request
 from aiohttp.web import ContentCoding, Response, StreamResponse, json_response
 
 
@@ -829,8 +829,8 @@ async def test_cannot_write_eof_twice() -> None:
     resp = StreamResponse()
     writer = mock.Mock()
     resp_impl = await resp.prepare(make_request("GET", "/"))
-    resp_impl.write = make_mocked_coro(None)
-    resp_impl.write_eof = make_mocked_coro(None)
+    resp_impl.write = mock.AsyncMock(None)
+    resp_impl.write_eof = mock.AsyncMock(None)
 
     await resp.write(b"data")
     assert resp_impl.write.called
@@ -1023,7 +1023,7 @@ async def test_prepare_twice() -> None:
 
 async def test_prepare_calls_signal() -> None:
     app = mock.Mock()
-    sig = make_mocked_coro()
+    sig = mock.AsyncMock()
     on_response_prepare = aiosignal.Signal(app)
     on_response_prepare.append(sig)
     req = make_request("GET", "/", app=app, on_response_prepare=on_response_prepare)
@@ -1294,8 +1294,8 @@ async def test_send_set_cookie_header(buf, writer) -> None:
 
 async def test_consecutive_write_eof() -> None:
     writer = mock.Mock()
-    writer.write_eof = make_mocked_coro()
-    writer.write_headers = make_mocked_coro()
+    writer.write_eof = mock.AsyncMock()
+    writer.write_headers = mock.AsyncMock()
     req = make_request("GET", "/", writer=writer)
     data = b"data"
     resp = Response(body=data)

--- a/tests/test_web_sendfile.py
+++ b/tests/test_web_sendfile.py
@@ -3,7 +3,7 @@ from stat import S_IFREG, S_IRUSR, S_IWUSR
 from unittest import mock
 
 from aiohttp import hdrs
-from aiohttp.test_utils import make_mocked_coro, make_mocked_request
+from aiohttp.test_utils import make_mocked_request
 from aiohttp.web_fileresponse import FileResponse
 
 MOCK_MODE = S_IFREG | S_IRUSR | S_IWUSR
@@ -28,7 +28,7 @@ def test_using_gzip_if_header_present_and_file_available(loop) -> None:
 
     file_sender = FileResponse(filepath)
     file_sender._path = filepath
-    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]
+    file_sender._sendfile = mock.AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     loop.run_until_complete(file_sender.prepare(request))
 
@@ -53,7 +53,7 @@ def test_gzip_if_header_not_present_and_file_available(loop) -> None:
 
     file_sender = FileResponse(filepath)
     file_sender._path = filepath
-    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]
+    file_sender._sendfile = mock.AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     loop.run_until_complete(file_sender.prepare(request))
 
@@ -76,7 +76,7 @@ def test_gzip_if_header_not_present_and_file_not_available(loop) -> None:
 
     file_sender = FileResponse(filepath)
     file_sender._path = filepath
-    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]
+    file_sender._sendfile = mock.AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     loop.run_until_complete(file_sender.prepare(request))
 
@@ -101,7 +101,7 @@ def test_gzip_if_header_present_and_file_not_available(loop) -> None:
 
     file_sender = FileResponse(filepath)
     file_sender._path = filepath
-    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]
+    file_sender._sendfile = mock.AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     loop.run_until_complete(file_sender.prepare(request))
 
@@ -120,7 +120,7 @@ def test_status_controlled_by_user(loop) -> None:
 
     file_sender = FileResponse(filepath, status=203)
     file_sender._path = filepath
-    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]
+    file_sender._sendfile = mock.AsyncMock(return_value=None)  # type: ignore[method-assign]
 
     loop.run_until_complete(file_sender.prepare(request))
 

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -8,13 +8,12 @@ import pytest
 from aiohttp import WSMsgType
 from aiohttp._websocket.reader import WebSocketDataQueue
 from aiohttp.http import WebSocketReader, WebSocketWriter
-from aiohttp.test_utils import make_mocked_coro
 
 
 @pytest.fixture
 def protocol():
     ret = mock.Mock()
-    ret._drain_helper = make_mocked_coro()
+    ret._drain_helper = mock.AsyncMock()
     return ret
 
 


### PR DESCRIPTION
This is a partial backport of 36a2567d96903007a2b6ff6c10af9392767bfe0f, `make_mocked_coro` is still left in the test utils for backwards compat, and only the internal tests are updated.

(cherry picked from commit 36a2567d96903007a2b6ff6c10af9392767bfe0f)
