### PR TITLE
Mark the removal of make_mocked_coro as a breaking change

### DIFF
--- a/CHANGES/9212.breaking.rst
+++ b/CHANGES/9212.breaking.rst
@@ -1,0 +1,1 @@
+9212.packaging.rst


### PR DESCRIPTION
Adds a symlink for the change note in https://github.com/aio-libs/aiohttp/pull/10910 to also mark it breaking.

The backports done to 3.11 will be partial to leave the function in but we will remove all usage in our tests.