### PR TITLE
Fix weakref garbage collection race condition in DNS resolver manager

### DIFF
--- a/CHANGES/10923.feature.rst
+++ b/CHANGES/10923.feature.rst
@@ -1,0 +1,1 @@
+10847.feature.rst

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -219,11 +219,14 @@ class _DNSResolverManager:
             loop: The event loop the resolver was using.
         """
         # Remove client from its loop's tracking
+        if loop not in self._loop_data:
+            return
         resolver, client_set = self._loop_data[loop]
         client_set.discard(client)
         # If no more clients for this loop, cancel and remove its resolver
         if not client_set:
-            resolver.cancel()
+            if resolver is not None:
+                resolver.cancel()
             del self._loop_data[loop]
 
 

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -632,7 +632,7 @@ async def test_dns_resolver_manager_weakref_garbage_collection() -> None:
 
         # Manually corrupt the data to simulate garbage collection
         # by setting the resolver to None
-        manager._loop_data[loop] = (None, manager._loop_data[loop][1])
+        manager._loop_data[loop] = (None, manager._loop_data[loop][1])  # type: ignore[assignment]
 
         # This should not raise an AttributeError: 'NoneType' object has no attribute 'cancel'
         await resolver.close()


### PR DESCRIPTION
Fix `AttributeError: NoneType object has no attribute cancel` in DNS resolver cleanup

Downstream users reported a crash during test teardown with the following error:

```
AttributeError: NoneType object has no attribute cancel
```

The issue occurs in `_DNSResolverManager.release_resolver()` when the weakref-managed resolver object gets garbage collected before it can be properly cancelled. This creates a race condition where the resolver reference becomes `None` but the cleanup code still tries to call `resolver.cancel()`.