### PR TITLE
Ensure AsyncResolver.close() can be called multiple times

### DIFF
--- a/CHANGES/10946.feature.rst
+++ b/CHANGES/10946.feature.rst
@@ -1,0 +1,1 @@
+10847.feature.rst

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -160,7 +160,8 @@ class AsyncResolver(AbstractResolver):
             self._resolver = None  # type: ignore[assignment] # Clear reference to resolver
             return
         # Otherwise cancel our dedicated resolver
-        self._resolver.cancel()
+        if self._resolver is not None:
+            self._resolver.cancel()
         self._resolver = None  # type: ignore[assignment] # Clear reference
 
 


### PR DESCRIPTION
regressed in #10847 but never in a stable release so I linked the changelog message instead of adding a bugfix.