### PR TITLE
[3.12] Fix AsyncResolver not using the loop argument

### DIFF
--- a/CHANGES/10951.bugfix.rst
+++ b/CHANGES/10951.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :py:class:`~aiohttp.resolver.AsyncResolver` not using the ``loop`` argument in versions 3.x where it should still be supported -- by :user:`bdraco`.

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -94,7 +94,7 @@ class AsyncResolver(AbstractResolver):
         if aiodns is None:
             raise RuntimeError("Resolver requires aiodns library")
 
-        self._loop = asyncio.get_running_loop()
+        self._loop = loop or asyncio.get_running_loop()
         self._manager: Optional[_DNSResolverManager] = None
         # If custom args are provided, create a dedicated resolver instance
         # This means each AsyncResolver with custom args gets its own


### PR DESCRIPTION
This PR is to 3.12 since we have dropped the loop argument on master

The loop argument was being ignored in AsyncResolver in 3.12/3.11 where it should still be supported

fixes #10787