### PR TITLE
Remove manual release call in middleware

### DIFF
--- a/CHANGES/10952.feature.rst
+++ b/CHANGES/10952.feature.rst
@@ -1,0 +1,1 @@
+9732.feature.rst

--- a/aiohttp/client_middleware_digest_auth.py
+++ b/aiohttp/client_middleware_digest_auth.py
@@ -408,8 +408,6 @@ class DigestAuthMiddleware:
             # Check if we need to authenticate
             if not self._authenticate(response):
                 break
-            elif retry_count < 1:
-                response.release()  # Release the response to enable connection reuse on retry
 
         # At this point, response is guaranteed to be defined
         assert response is not None

--- a/tests/test_client_middleware.py
+++ b/tests/test_client_middleware.py
@@ -891,7 +891,6 @@ async def test_client_middleware_retry_reuses_connection(
                 response = await handler(request)
                 if retry_count == 0:
                     retry_count += 1
-                    response.release()  # Release the response to enable connection reuse
                     continue
                 return response
 


### PR DESCRIPTION
This should no longer be needed now that we have resolved the root cause.

closes #10901
