### PR TITLE
Change ClientSession middlewares default to be an empty tuple

### DIFF
--- a/CHANGES/10959.feature.rst
+++ b/CHANGES/10959.feature.rst
@@ -1,0 +1,1 @@
+9732.feature.rst

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -296,7 +296,7 @@ class ClientSession:
         max_line_size: int = 8190,
         max_field_size: int = 8190,
         fallback_charset_resolver: _CharsetResolver = lambda r, b: "utf-8",
-        middlewares: Optional[Sequence[ClientMiddlewareType]] = None,
+        middlewares: Sequence[ClientMiddlewareType] = (),
     ) -> None:
         # We initialise _connector to None immediately, as it's referenced in __del__()
         # and could cause issues if an exception occurs during initialisation.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -53,7 +53,7 @@ The client session supports the context manager protocol for self closing.
                          trust_env=False, \
                          requote_redirect_url=True, \
                          trace_configs=None, \
-                         middlewares=None, \
+                         middlewares=(), \
                          read_bufsize=2**16, \
                          max_line_size=8190, \
                          max_field_size=8190, \
@@ -216,7 +216,7 @@ The client session supports the context manager protocol for self closing.
 
    :param middlewares: A sequence of middleware instances to apply to all session requests.
                       Each middleware must match the :type:`ClientMiddlewareType` signature.
-                      ``None`` (default) is used when no middleware is needed.
+                      ``()`` (empty tuple, default) is used when no middleware is needed.
                       See :ref:`aiohttp-client-middleware` for more information.
 
       .. versionadded:: 3.12


### PR DESCRIPTION
This will avoid one breaking change in 4.0 in when we make the other change in #10890 and remove `if effective_middlewares: `

closes #10905