### PR TITLE
add example of setting network interface in custom socket creation

### DIFF
--- a/CHANGES/10962.feature.rst
+++ b/CHANGES/10962.feature.rst
@@ -1,0 +1,1 @@
+10520.feature.rst

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -721,6 +721,19 @@ make all sockets respect 9*7200 = 18 hours::
       return sock
   conn = aiohttp.TCPConnector(socket_factory=socket_factory)
 
+``socket_factory`` may also be used for binding to the specific network
+interface on supported platforms::
+
+  def socket_factory(addr_info):
+      family, type_, proto, _, _ = addr_info
+      sock = socket.socket(family=family, type=type_, proto=proto)
+      sock.setsockopt(
+          socket.SOL_SOCKET, socket.SO_BINDTODEVICE, b'eth0'
+      )
+      return sock
+
+  conn = aiohttp.TCPConnector(socket_factory=socket_factory)
+
 
 Named pipes in Windows
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## What do these changes do?

Some users may want to specific network interface used by client session (as in #6383 and #7132 ). In aiohttp 3.12, this can be done more gracefully with `socket_factory` in `TCPConnector`. I think it would be helpful to mention it in `socket_factory`'s documentation as one of its common usecases.

## Are there changes in behavior for the user?


## Is it a substantial burden for the maintainers to support this?


## Related issue number

closes #7132
<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
