### PR TITLE
Fix flakey test_aiohttp_request_ctx_manager_close_sess_on_error test

### DIFF
--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3409,6 +3409,7 @@ async def test_aiohttp_request_ctx_manager_close_sess_on_error(
 
     assert cm._session.closed
     # Allow event loop to process transport cleanup
+    # on Python < 3.11
     await asyncio.sleep(0)
 
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3408,6 +3408,8 @@ async def test_aiohttp_request_ctx_manager_close_sess_on_error(
             pass
 
     assert cm._session.closed
+    # Allow event loop to process transport cleanup
+    await asyncio.sleep(0)
 
 
 async def test_aiohttp_request_ctx_manager_not_found() -> None:


### PR DESCRIPTION
SSL cleanup still needs one sleep of the event loop to fully cleanup
on older python versions