### PR TITLE
Improved WebSocket heartbeat implementation

### DIFF
--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -88,7 +88,7 @@ class ClientWebSocketResponse:
         self._ping_task: Optional[asyncio.Task[None]] = None
 
         self._reset_heartbeat()
-        
+
         if self._heartbeat is not None:
             loop.create_task(self._repeat_heartbeat())
 

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -344,13 +344,11 @@ class ClientWebSocketResponse:
                             msg = await self._reader.read()
                     else:
                         msg = await self._reader.read()
-                    self._reset_heartbeat()
                 finally:
                     self._waiting = False
                     if self._close_wait:
                         set_result(self._close_wait, None)
             except asyncio.TimeoutError:
-                self._reset_heartbeat()
                 raise
             except asyncio.CancelledError:
                 self._close_code = WSCloseCode.ABNORMAL_CLOSURE

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -339,7 +339,9 @@ class ClientWebSocketResponse:
                     self._waiting = False
                     if self._close_wait:
                         set_result(self._close_wait, None)
-            except (asyncio.CancelledError, asyncio.TimeoutError):
+            except asyncio.TimeoutError:
+                raise
+            except asyncio.CancelledError:
                 self._close_code = WSCloseCode.ABNORMAL_CLOSURE
                 raise
             except EofStream:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -550,13 +550,11 @@ class WebSocketResponse(StreamResponse):
                             msg = await self._reader.read()
                     else:
                         msg = await self._reader.read()
-                    self._reset_heartbeat()
                 finally:
                     self._waiting = False
                     if self._close_wait:
                         set_result(self._close_wait, None)
             except asyncio.TimeoutError:
-                self._reset_heartbeat()
                 raise
             except EofStream:
                 self._close_code = WSCloseCode.OK

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -47,7 +47,6 @@ else:
 
 from asyncio import sleep
 
-
 __all__ = (
     "WebSocketResponse",
     "WebSocketReady",


### PR DESCRIPTION
Current implementation of heartbeat has drawbacks. Consider the following example:
- I had connections that only send data and not have recieve data often
- Because heartbeat send only after receive, but ignore send I often got the error 1006, because nginx closed the dead websocket

I think that if user set heartbeat timeout directly then it means heartbeat should be send anyway if client (often browser) sent data to server or not

In this implementation I mostly interested in server websocket implementation, but also adjusted client implementation