### PR TITLE
Add missing prepared method for WebSocketResponse to docs

### DIFF
--- a/CHANGES/10988.bugfix.rst
+++ b/CHANGES/10988.bugfix.rst
@@ -1,0 +1,1 @@
+6009.bugfix.rst

--- a/CHANGES/6009.bugfix.rst
+++ b/CHANGES/6009.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed :py:meth:`~aiohttp.web.WebSocketResponse.prepared` property to correctly reflect the prepared state, especially during timeout scenarios -- by :user:`bdraco`
+Fixed :py:attr:`~aiohttp.web.WebSocketResponse.prepared` property to correctly reflect the prepared state, especially during timeout scenarios -- by :user:`bdraco`

--- a/CHANGES/6009.bugfix.rst
+++ b/CHANGES/6009.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``WebSocketResponse.prepared`` property to correctly reflect the prepared state, especially during timeout scenarios -- by :user:`bdraco`
+Fixed :py:attr:`~aiohttp.web.WebSocketResponse.prepared` property to correctly reflect the prepared state, especially during timeout scenarios -- by :user:`bdraco`

--- a/CHANGES/6009.bugfix.rst
+++ b/CHANGES/6009.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed :py:attr:`~aiohttp.web.WebSocketResponse.prepared` property to correctly reflect the prepared state, especially during timeout scenarios -- by :user:`bdraco`
+Fixed :py:meth:`~aiohttp.web.WebSocketResponse.prepared` property to correctly reflect the prepared state, especially during timeout scenarios -- by :user:`bdraco`

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1045,6 +1045,11 @@ and :ref:`aiohttp-web-signals` handlers::
       of closing.
       :const:`~aiohttp.WSMsgType.CLOSE` message has been received from peer.
 
+   .. attribute:: prepared
+
+      Read-only :class:`bool` property, ``True`` if :meth:`prepare` has
+      been called, ``False`` otherwise.
+
    .. attribute:: close_code
 
       Read-only property, close code from peer. It is set to ``None`` on


### PR DESCRIPTION
We now override this method so we should document it. I should have used :py:attr:`~aiohttp.web.WebSocketResponse.prepared` 
