### PR TITLE
Correct type of ClientRequest.body

### DIFF
--- a/aiohttp/client_middleware_digest_auth.py
+++ b/aiohttp/client_middleware_digest_auth.py
@@ -193,7 +193,9 @@ class DigestAuthMiddleware:
         self._nonce_count = 0
         self._challenge: DigestAuthChallenge = {}
 
-    async def _encode(self, method: str, url: URL, body: Union[bytes, Payload]) -> str:
+    async def _encode(
+        self, method: str, url: URL, body: Union[Payload, Literal[b""]]
+    ) -> str:
         """
         Build digest authorization header for the current challenge.
 
@@ -274,7 +276,7 @@ class DigestAuthMiddleware:
         A1 = b":".join((self._login_bytes, realm_bytes, self._password_bytes))
         A2 = f"{method.upper()}:{path}".encode()
         if qop == "auth-int":
-            if isinstance(body, bytes):  # will always be empty bytes unless Payload
+            if body == b"":  # will always be empty bytes unless Payload
                 entity_bytes = body
             else:
                 entity_bytes = await body.as_bytes()  # Get bytes from Payload

--- a/aiohttp/client_middleware_digest_auth.py
+++ b/aiohttp/client_middleware_digest_auth.py
@@ -276,10 +276,10 @@ class DigestAuthMiddleware:
         A1 = b":".join((self._login_bytes, realm_bytes, self._password_bytes))
         A2 = f"{method.upper()}:{path}".encode()
         if qop == "auth-int":
-            if body == b"":  # will always be empty bytes unless Payload
-                entity_bytes = body
-            else:
+            if isinstance(body, Payload):  # will always be empty bytes unless Payload
                 entity_bytes = await body.as_bytes()  # Get bytes from Payload
+            else:
+                entity_bytes = body
             entity_hash = H(entity_bytes)
             A2 = b":".join((A2, entity_hash))
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -17,6 +17,7 @@ from typing import (
     Dict,
     Iterable,
     List,
+    Literal,
     Mapping,
     NamedTuple,
     Optional,
@@ -393,7 +394,7 @@ class ClientRequest:
         return self.url.port
 
     @property
-    def body(self) -> Union[bytes, payload.Payload]:
+    def body(self) -> Union[payload.Payload, Literal[b""]]:
         """Request body."""
         # empty body is represented as bytes for backwards compatibility
         return self._body or b""

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1868,7 +1868,7 @@ ClientRequest
    .. attribute:: body
       :type: Payload | Literal[b""]
 
-      The request body payload (defaults to ``b""``, if no body passed).
+      The request body payload (defaults to ``b""`` if no body passed).
 
    .. attribute:: chunked
       :type: bool | None

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1866,11 +1866,9 @@ ClientRequest
    For more information about using middleware, see :ref:`aiohttp-client-middleware`.
 
    .. attribute:: body
-      :type: Payload
+      :type: Payload | Literal[b""]
 
-      The request body payload. This can be:
-
-      - A :class:`Payload` object for raw data (default is empty bytes ``b""``)
+      The request body payload (defaults to ``b""``, if no body passed).
 
    .. attribute:: chunked
       :type: bool | None

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1866,12 +1866,11 @@ ClientRequest
    For more information about using middleware, see :ref:`aiohttp-client-middleware`.
 
    .. attribute:: body
-      :type: Payload | FormData
+      :type: Payload
 
       The request body payload. This can be:
 
       - A :class:`Payload` object for raw data (default is empty bytes ``b""``)
-      - A :class:`FormData` object for form submissions
 
    .. attribute:: chunked
       :type: bool | None

--- a/tests/test_client_middleware_digest_auth.py
+++ b/tests/test_client_middleware_digest_auth.py
@@ -2,7 +2,7 @@
 
 import io
 from hashlib import md5, sha1
-from typing import Generator, Union
+from typing import Generator, Literal, Union
 from unittest import mock
 
 import pytest
@@ -270,7 +270,7 @@ def compute_expected_digest(
 @pytest.mark.parametrize(
     ("body", "body_str"),
     [
-        (b"this is a body", "this is a body"),  # Bytes case
+        (b"", ""),  # Bytes case
         (
             BytesIOPayload(io.BytesIO(b"this is a body")),
             "this is a body",
@@ -280,7 +280,7 @@ def compute_expected_digest(
 async def test_digest_response_exact_match(
     qop: str,
     algorithm: str,
-    body: Union[bytes, BytesIOPayload],
+    body: Union[Literal[b""], BytesIOPayload],
     body_str: str,
     mock_sha1_digest: mock.MagicMock,
 ) -> None:

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1755,7 +1755,7 @@ async def test_warn_if_unclosed_payload_via_body_setter(
         ResourceWarning,
         match="The previous request body contains unclosed resources",
     ):
-        req.body = b"new data"
+        req.body = b"new data"  # type: ignore[assignment]  # https://github.com/python/mypy/issues/12892
 
     await req.close()
 
@@ -1773,7 +1773,7 @@ async def test_no_warn_for_autoclose_payload_via_body_setter(
     # Setting body again should not trigger warning since previous payload has autoclose=True
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
-        req.body = b"new data"
+        req.body = b"new data"  # type: ignore[assignment]  # https://github.com/python/mypy/issues/12892
 
     # Filter out any non-ResourceWarning warnings
     resource_warnings = [
@@ -1803,7 +1803,7 @@ async def test_no_warn_for_consumed_payload_via_body_setter(
     # Setting body again should not trigger warning since previous payload is consumed
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always")
-        req.body = b"new data"
+        req.body = b"new data"  # type: ignore[assignment]  # https://github.com/python/mypy/issues/12892
 
     # Filter out any non-ResourceWarning warnings
     resource_warnings = [
@@ -2051,7 +2051,7 @@ async def test_warn_stacklevel_points_to_user_code(
     with warnings.catch_warnings(record=True) as warning_list:
         warnings.simplefilter("always", ResourceWarning)
         # This line should be reported as the warning source
-        req.body = b"new data"  # LINE TO BE REPORTED
+        req.body = b"new data"  # type: ignore[assignment]  # https://github.com/python/mypy/issues/12892  # LINE TO BE REPORTED
 
     # Find the ResourceWarning
     resource_warnings = [

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1668,7 +1668,7 @@ async def test_write_bytes_with_content_length_limit(
     data = b"Hello World"
     req = ClientRequest("post", URL("http://python.org/"), loop=loop)
 
-    req.body = data
+    req.body = data  # type: ignore[assignment]  # https://github.com/python/mypy/issues/12892
 
     writer = StreamWriter(protocol=conn.protocol, loop=loop)
     # Use content_length=5 to truncate data
@@ -1705,7 +1705,7 @@ async def test_write_bytes_with_iterable_content_length_limit(
 
         req.body = gen()  # type: ignore[assignment]  # https://github.com/python/mypy/issues/12892
     else:
-        req.body = data
+        req.body = data  # type: ignore[assignment]  # https://github.com/python/mypy/issues/12892
 
     writer = StreamWriter(protocol=conn.protocol, loop=loop)
     # Use content_length=7 to truncate at the middle of Part2

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1922,7 +1922,7 @@ async def test_body_setter_closes_previous_payload(
     req._body = mock_payload
 
     # Update body with new data using setter
-    req.body = b"new body data"
+    req.body = b"new body data"  # type: ignore[assignment]  # https://github.com/python/mypy/issues/12892
 
     # Verify the previous payload was closed using _close
     mock_payload._close.assert_called_once()

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1320,7 +1320,7 @@ async def test_oserror_on_write_bytes(
     loop: asyncio.AbstractEventLoop, conn: mock.Mock
 ) -> None:
     req = ClientRequest("POST", URL("http://python.org/"), loop=loop)
-    req.body = b"test data"
+    req.body = b"test data"  # type: ignore[assignment]  # https://github.com/python/mypy/issues/12892
 
     writer = WriterMock()
     writer.write.side_effect = OSError


### PR DESCRIPTION
Having reread that code, if an instance of FormData is passed, then it is called, which produces a Payload.

The default is still weird (starts as `b""`, then goes through a special branch on write that changes it to `(b"",)`). Going to propose a refactor that removes that weird default.