### PR TITLE
[PR #11020/852297c backport][3.12] Cleanup some type ignores in the client request tests

### DIFF
--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -751,7 +751,8 @@ async def test_post_data(loop: asyncio.AbstractEventLoop, conn: mock.Mock) -> No
         )
         resp = await req.send(conn)
         assert "/" == req.url.path
-        assert b"life=42" == req.body._value  # type: ignore[union-attr]
+        assert isinstance(req.body, payload.Payload)
+        assert b"life=42" == req.body._value
         assert "application/x-www-form-urlencoded" == req.headers["CONTENT-TYPE"]
         await req.close()
         resp.close()
@@ -788,7 +789,8 @@ async def test_get_with_data(loop) -> None:
             meth, URL("http://python.org/"), data={"life": "42"}, loop=loop
         )
         assert "/" == req.url.path
-        assert b"life=42" == req.body._value  # type: ignore[union-attr]
+        assert isinstance(req.body, payload.Payload)
+        assert b"life=42" == req.body._value
         await req.close()
 
 


### PR DESCRIPTION
(cherry picked from commit 852297cf0e3d57b855834d183bd7d87e38f9c8f2)
