### PR TITLE
Fix failing lint jobs due to caching

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Cache PyPI
       uses: actions/cache@v4.2.3
       with:
-        key: pip-lint-${{ hashFiles('requirements/*.txt') }}
+        key: pip-lint-${{ hashFiles('requirements/*.txt') }}-v2
         path: ~/.cache/pip
         restore-keys: |
             pip-lint-


### PR DESCRIPTION
The apt mirrors are out of date and causing a failure. We need to bust the cache to fix the CI