### PR TITLE
Remove update of libenchant from linter workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Cache PyPI
       uses: actions/cache@v4.2.3
       with:
-        key: pip-lint-${{ hashFiles('requirements/*.txt') }}-v3
+        key: pip-lint-${{ hashFiles('requirements/*.txt') }}-v4
         path: ~/.cache/pip
         restore-keys: |
             pip-lint-
@@ -77,10 +77,6 @@ jobs:
         # can be scanned by slotscheck.
         pip install -r requirements/base.in -c requirements/base.txt
         slotscheck -v -m aiohttp
-    - name: Install libenchant
-      run: |
-        sudo apt-get update
-        sudo apt install libenchant-2-dev
     - name: Install spell checker
       run: |
         pip install -r requirements/doc-spelling.in -c requirements/doc-spelling.txt


### PR DESCRIPTION
This is no longer needed per https://github.com/aio-libs/aiohttp/pull/11060#discussion_r2112576163
