### PR TITLE
Revert cache key change for linter

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Cache PyPI
       uses: actions/cache@v4.2.3
       with:
-        key: pip-lint-${{ hashFiles('requirements/*.txt') }}-v4
+        key: pip-lint-${{ hashFiles('requirements/*.txt') }}
         path: ~/.cache/pip
         restore-keys: |
             pip-lint-


### PR DESCRIPTION
I did not know that GitHub had added the ability to manually clear the cache since the last time I had this issue
