### PR TITLE
Fix spurious "Future exception was never retrieved" warnings for connection lost errors

### DIFF
--- a/CHANGES/11100.bugfix.rst
+++ b/CHANGES/11100.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed spurious "Future exception was never retrieved" warnings for connection lost errors when the connector is not closed -- by :user:`bdraco`.
+
+When connections are lost, the exception is now marked as retrieved since it is always propagated through other means, preventing unnecessary warnings in logs.

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -98,6 +98,12 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
                 ),
                 original_connection_error,
             )
+            # Mark the exception as retrieved to prevent
+            # "Future exception was never retrieved" warnings
+            # The exception is always passed on through
+            # other means, so this is safe
+            with suppress(Exception):
+                self.closed.exception()
 
         if self._payload_parser is not None:
             with suppress(Exception):  # FIXME: log this somehow?

--- a/tests/test_client_proto.py
+++ b/tests/test_client_proto.py
@@ -268,5 +268,6 @@ async def test_connection_lost_exception_is_marked_retrieved(
     # Verify the exception was set on the closed future
     assert proto.closed.done()
     exc = proto.closed.exception()
+    assert exc is not None
     assert "Connection lost: SSL shutdown timed out" in str(exc)
     assert exc.__cause__ is ssl_error


### PR DESCRIPTION

## What do these changes do?

This PR fixes spurious "Future exception was never retrieved" warnings that occur when connections are lost (e.g., SSL shutdown timeouts, network errors) and the connector is not immediately closed.

The fix marks the exception on the `ResponseHandler.closed` future as retrieved after setting it, since the exception is always propagated through other means (via the waiter). This prevents Python from logging unnecessary warnings about unretrieved exceptions.

## Are there changes in behavior for the user?

No functional changes. Users will no longer see spurious "Future exception was never retrieved" warnings in their logs when connections are lost.

## Related issue number

This issue was introduced by #3733 (backported as #11074), which added proper connection closure waiting but exposed these futures that may not be awaited until the connector is closed.

