### PR TITLE
Avoid creating closed futures that will never be awaited

### DIFF
--- a/CHANGES/11107.misc.rst
+++ b/CHANGES/11107.misc.rst
@@ -1,0 +1,1 @@
+Avoided creating closed futures in ``ResponseHandler`` that will never be awaited -- by :user:`bdraco`.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -462,13 +462,15 @@ class BaseConnector:
                 self._cleanup_closed_handle.cancel()
 
             for data in self._conns.values():
-                for proto, t0 in data:
+                for proto, _ in data:
                     proto.close()
-                    waiters.append(proto.closed)
+                    if closed := proto.closed:
+                        waiters.append(closed)
 
             for proto in self._acquired:
                 proto.close()
-                waiters.append(proto.closed)
+                if closed := proto.closed:
+                    waiters.append(closed)
 
             # TODO (A.Yushovskiy, 24-May-2019) collect transp. closing futures
             for transport in self._cleanup_closed_transports:

--- a/tests/test_client_proto.py
+++ b/tests/test_client_proto.py
@@ -270,8 +270,8 @@ async def test_connection_lost_exception_is_marked_retrieved(
     proto.connection_lost(ssl_error)
 
     # Verify the exception was set on the closed future
-    assert proto.closed.done()
-    exc = proto.closed.exception()
+    assert closed_future.done()
+    exc = closed_future.exception()
     assert exc is not None
     assert "Connection lost: SSL shutdown timed out" in str(exc)
     assert exc.__cause__ is ssl_error

--- a/tests/test_client_proto.py
+++ b/tests/test_client_proto.py
@@ -261,6 +261,10 @@ async def test_connection_lost_exception_is_marked_retrieved(
     proto = ResponseHandler(loop=loop)
     proto.connection_made(mock.Mock())
 
+    # Access closed property before connection_lost to ensure future is created
+    closed_future = proto.closed
+    assert closed_future is not None
+
     # Simulate an SSL shutdown timeout error
     ssl_error = TimeoutError("SSL shutdown timed out")
     proto.connection_lost(ssl_error)
@@ -271,3 +275,36 @@ async def test_connection_lost_exception_is_marked_retrieved(
     assert exc is not None
     assert "Connection lost: SSL shutdown timed out" in str(exc)
     assert exc.__cause__ is ssl_error
+
+
+async def test_closed_property_lazy_creation(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Test that closed future is created lazily."""
+    proto = ResponseHandler(loop=loop)
+
+    # Initially, the closed future should not be created
+    assert proto._closed is None
+
+    # Accessing the property should create the future
+    closed_future = proto.closed
+    assert closed_future is not None
+    assert isinstance(closed_future, asyncio.Future)
+    assert not closed_future.done()
+
+    # Subsequent access should return the same future
+    assert proto.closed is closed_future
+
+
+async def test_closed_property_after_connection_lost(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Test that closed property returns None after connection_lost if never accessed."""
+    proto = ResponseHandler(loop=loop)
+    proto.connection_made(mock.Mock())
+
+    # Don't access proto.closed before connection_lost
+    proto.connection_lost(None)
+
+    # After connection_lost, closed should return None if it was never accessed
+    assert proto.closed is None

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -326,13 +326,12 @@ async def test_close_with_proto_closed_none(key: ConnectionKey) -> None:
     # Add protocol to acquired connections
     conn._acquired.add(proto)
 
-    # Close the connector - this should handle the case where proto.closed is None
-    waiters = await conn.close()
+    # Close the connector
+    await conn.close()
 
     # Verify close was called on the protocol
     assert proto.close.called
     # Verify no waiters were added when closed is None
-    assert waiters == []
     assert conn.closed
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -315,6 +315,27 @@ async def test_close(key: ConnectionKey) -> None:
     assert conn.closed
 
 
+async def test_close_with_proto_closed_none(key: ConnectionKey) -> None:
+    """Test close when protocol.closed is None."""
+    # Create a protocol where closed property returns None
+    proto = mock.create_autospec(ResponseHandler, instance=True)
+    proto.closed = None
+    proto.close = mock.Mock()
+
+    conn = aiohttp.BaseConnector()
+    # Add protocol to acquired connections
+    conn._acquired.add(proto)
+
+    # Close the connector - this should handle the case where proto.closed is None
+    waiters = await conn.close()
+
+    # Verify close was called on the protocol
+    assert proto.close.called
+    # Verify no waiters were added when closed is None
+    assert waiters == []
+    assert conn.closed
+
+
 async def test_get(loop: asyncio.AbstractEventLoop, key: ConnectionKey) -> None:
     conn = aiohttp.BaseConnector()
     try:


### PR DESCRIPTION
## Summary

This PR is a follow-up to #11100 and #3733 that avoids creating closed futures in `ResponseHandler` that will never be awaited, preventing spurious "Future exception was never retrieved" warnings.

## Changes

### Lazy Creation of Closed Future
- Changed `ResponseHandler.closed` from eagerly creating a future in `__init__` to lazily creating it only when accessed
- The future is only created if the connection hasn't already been lost
- Returns `None` if `connection_lost()` was called before the property was ever accessed

### Connector Updates
- Updated `BaseConnector.close()` to check if `proto.closed` is not None before adding it to waiters
- This prevents waiting on futures that don't exist

## Benefits

1. **Performance**: Avoids creating futures for connections that close immediately or are never awaited
2. **Cleaner Logs**: Prevents "Future exception was never retrieved" warnings for futures that were never needed without having to manually suppress them
3. **Memory**: Reduces memory usage by not creating unnecessary future objects

## Testing

The changes include comprehensive test coverage to ensure:
- Lazy creation works correctly
- Backward compatibility is maintained
- The connector properly handles None closed futures
- Exception handling still works when the future is created

## Related Issues

- Follows up on #11100 (Fix spurious warnings for connection lost errors)
- Related to #3733 (Previous work on connection handling)

