### PR TITLE
Downgrade connector close error to debug

### DIFF
--- a/CHANGES/11114.misc.rst
+++ b/CHANGES/11114.misc.rst
@@ -1,0 +1,1 @@
+Downgraded the logging level for connector close errors from ERROR to DEBUG, as these are expected behavior with TLS 1.3 connections -- by :user:`bdraco`.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -439,7 +439,7 @@ class BaseConnector:
             for res in results:
                 if isinstance(res, Exception):
                     err_msg = "Error while closing connector: " + repr(res)
-                    logging.error(err_msg)
+                    logging.debug(err_msg)
 
     def _close_immediately(self) -> List[Awaitable[object]]:
         waiters: List[Awaitable[object]] = []

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1,6 +1,5 @@
 import asyncio
 import functools
-import logging
 import random
 import socket
 import sys
@@ -60,6 +59,7 @@ from .helpers import (
     set_exception,
     set_result,
 )
+from .log import client_logger
 from .resolver import DefaultResolver
 
 if sys.version_info >= (3, 12):
@@ -439,7 +439,7 @@ class BaseConnector:
             for res in results:
                 if isinstance(res, Exception):
                     err_msg = "Error while closing connector: " + repr(res)
-                    logging.debug(err_msg)
+                    client_logger.debug(err_msg)
 
     def _close_immediately(self) -> List[Awaitable[object]]:
         waiters: List[Awaitable[object]] = []


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Downgrade connector close error to debug
This is going to be expected with TLS 1.3. Error is too aggressive for something that is expected to happen.
Also send the message to the client_logger as the original PR (#3733) sent it to the root logger which was likely not intended


## Are there changes in behavior for the user?

We never logged this before we backported waiting for connection closed in #11077 so there is likely no reason to log this at error level as there is nothing that can be done about it. Its purely needed for debugging.

fixes #11113

## Is it a substantial burden for the maintainers to support this?
no