### PR TITLE
Refractor TraceConfig with a wrapper styled approach.

### DIFF
--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 # Due to wanting to prevent an XZ-utils Styled Attack it was decided by the aiocallback's main 
 # mainter to let aiohttp borrow a copy of the main member descriptor, it is given with permission 
 # from it's founder & owner to use else-where. If your looking for a better solution
-# And want to write one of these yourself you can use aiocallback for that.
+# and you want to write one of these yourself you can use aiocallback for that.
 
 class signal_event(Generic[P, R]):
     """An internal member descriptor made for helping to better define signals"""

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -3,11 +3,11 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Awaitable,
+    Callable,
     Generic,
     Protocol,
     TypeVar,
     overload,
-    Callable,
 )
 
 from aiosignal import Signal
@@ -16,8 +16,7 @@ from yarl import URL
 
 from .client_reqrep import ClientResponse
 from .helpers import frozen_dataclass_decorator
-
-from .typedefs import P, R, Concatenate
+from .typedefs import Concatenate, P, R
 
 if TYPE_CHECKING:
     from .client import ClientSession
@@ -106,9 +105,9 @@ class _Factory(Protocol[_T]):
 
 class TraceConfig(Generic[_T]):
     """First-class used to trace requests launched via ClientSession objects."""
-    
+
     # TODO: Maybe see about giving TraceConfig some __slots__ to be faster and discourage subclassing it?
-    
+
     @overload
     def __init__(self: "TraceConfig[SimpleNamespace]") -> None: ...
     @overload
@@ -124,7 +123,7 @@ class TraceConfig(Generic[_T]):
         return self._trace_config_ctx_factory(trace_request_ctx=trace_request_ctx)
 
     def freeze(self) -> None:
-        # NOTE: __get__ will be sure all these signals are made at somepoint. 
+        # NOTE: __get__ will be sure all these signals are made at somepoint.
         self.on_request_start.freeze()
         self.on_request_chunk_sent.freeze()
         self.on_response_chunk_received.freeze()
@@ -148,8 +147,7 @@ class TraceConfig(Generic[_T]):
         client_session: ClientSession,
         trace_config_ctx: _T,
         params: "TraceRequestStartParams",
-    ) -> None:...
-
+    ) -> None: ...
 
     @signal_event
     def on_request_chunk_sent(
@@ -157,8 +155,8 @@ class TraceConfig(Generic[_T]):
         client_session: ClientSession,
         trace_config_ctx: _T,
         params: "TraceRequestChunkSentParams",
-    ) -> None:...
-    
+    ) -> None: ...
+
     # TraceResponseChunkReceivedParams
     @signal_event
     def on_response_chunk_received(
@@ -166,48 +164,47 @@ class TraceConfig(Generic[_T]):
         client_session: ClientSession,
         trace_config_ctx: _T,
         params: "TraceResponseChunkReceivedParams",
-    ) -> None:...
-    
+    ) -> None: ...
+
     @signal_event
     def on_request_end(
         self,
         client_session: ClientSession,
         trace_config_ctx: _T,
-        params: "TraceRequestEndParams"
-    ) -> None:...
+        params: "TraceRequestEndParams",
+    ) -> None: ...
 
     @signal_event
     def on_request_exception(
         self,
         client_session: ClientSession,
         trace_config_ctx: _T,
-        params: "TraceRequestExceptionParams"
-    ) -> None:...
+        params: "TraceRequestExceptionParams",
+    ) -> None: ...
 
     @signal_event
     def on_request_redirect(
         self,
         client_session: ClientSession,
         trace_config_ctx: _T,
-        params: "TraceRequestRedirectParams"
-    ) -> None:...
+        params: "TraceRequestRedirectParams",
+    ) -> None: ...
 
     @signal_event
     def on_connection_queued_start(
         self,
         client_session: ClientSession,
         trace_config_ctx: _T,
-        params: "TraceConnectionQueuedStartParams"
-    ) -> None:...
-
+        params: "TraceConnectionQueuedStartParams",
+    ) -> None: ...
 
     @signal_event
     def on_connection_queued_end(
         self,
         client_session: ClientSession,
         trace_config_ctx: _T,
-        params: "TraceConnectionQueuedEndParams"
-    ) -> None:...
+        params: "TraceConnectionQueuedEndParams",
+    ) -> None: ...
 
     @signal_event
     def on_connection_create_start(
@@ -215,8 +212,7 @@ class TraceConfig(Generic[_T]):
         client_session: ClientSession,
         trace_config_ctx: _T,
         params: "TraceConnectionCreateStartParams",
-    ) -> None:...
-
+    ) -> None: ...
 
     @signal_event
     def on_connection_create_end(
@@ -224,7 +220,7 @@ class TraceConfig(Generic[_T]):
         client_session: ClientSession,
         trace_config_ctx: _T,
         params: "TraceConnectionCreateEndParams",
-    ) -> None:...
+    ) -> None: ...
 
     @signal_event
     def on_connection_reuseconn(
@@ -232,48 +228,47 @@ class TraceConfig(Generic[_T]):
         client_session: ClientSession,
         trace_config_ctx: _T,
         params: "TraceConnectionReuseconnParams",
-    ) -> None:...
+    ) -> None: ...
 
     @signal_event
     def on_dns_resolvehost_start(
         self,
         client_session: ClientSession,
         trace_config_ctx: _T,
-        params: "TraceDnsResolveHostStartParams"
-    ) -> None:...
-    
+        params: "TraceDnsResolveHostStartParams",
+    ) -> None: ...
+
     @signal_event
     def on_dns_resolvehost_end(
         self,
         client_session: ClientSession,
         trace_config_ctx: _T,
         params: "TraceDnsResolveHostEndParams",
-    ) -> None:...
-    
+    ) -> None: ...
+
     @signal_event
     def on_dns_cache_hit(
         self,
         client_session: ClientSession,
         trace_config_ctx: _T,
-        params: "TraceDnsCacheHitParams"
-    ) -> None:...
-
+        params: "TraceDnsCacheHitParams",
+    ) -> None: ...
 
     @signal_event
     def on_dns_cache_miss(
         self,
         client_session: ClientSession,
         trace_config_ctx: _T,
-        params: "TraceDnsCacheMissParams"
-    ) -> None:...
-        
+        params: "TraceDnsCacheMissParams",
+    ) -> None: ...
+
     @signal_event
     def on_request_headers_sent(
         self,
         client_session: ClientSession,
         trace_config_ctx: _T,
-        params: "TraceDnsCacheMissParams"
-    ) -> None:...
+        params: "TraceDnsCacheMissParams",
+    ) -> None: ...
 
 
 @frozen_dataclass_decorator
@@ -531,4 +526,3 @@ class Trace:
             self._trace_config_ctx,
             TraceRequestHeadersSentParams(method, url, headers),
         )
-

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -106,7 +106,9 @@ class _Factory(Protocol[_T]):
 
 class TraceConfig(Generic[_T]):
     """First-class used to trace requests launched via ClientSession objects."""
-
+    
+    # TODO: Maybe see about giving TraceConfig some __slots__ to be faster and discourage subclassing it?
+    
     @overload
     def __init__(self: "TraceConfig[SimpleNamespace]") -> None: ...
     @overload

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -175,6 +175,7 @@ class TraceConfig(Generic[_T]):
         self._on_dns_cache_miss.freeze()
         self._on_request_headers_sent.freeze()
 
+    # TODO: Transform from properties to signal events. 
     @property
     def on_request_start(self) -> "Signal[_SignalCallback[TraceRequestStartParams]]":
         return self._on_request_start
@@ -399,7 +400,7 @@ class Trace:
         self._trace_config = trace_config
         self._trace_config_ctx = trace_config_ctx
         self._session = session
-
+    
     async def send_request_start(
         self, method: str, url: URL, headers: "CIMultiDict[str]"
     ) -> None:

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
 # from it's founder & owner to use else-where. If your looking for a better solution
 # and you want to write one of these yourself you can use aiocallback for that.
 
+# SEE: https://github.com/aio-libs/aiohttp/issues/11036
+
 class signal_event(Generic[P, R]):
     """An internal member descriptor made for helping to better define signals"""
     __slots__ = ("_func", "_name", "_signal",)

--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -10,6 +11,7 @@ from typing import (
     Protocol,
     Tuple,
     Union,
+    TypeVar
 )
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy, istr
@@ -19,6 +21,16 @@ Query = _Query
 
 DEFAULT_JSON_ENCODER = json.dumps
 DEFAULT_JSON_DECODER = json.loads
+
+# TODO: Import ParamSpec & Concatenate  Directly when Python 3.9 support is Dropped.
+if sys.version_info >= (3, 10):
+    from typing import Concatenate, ParamSpec
+else:
+    from typing_extensions import Concatenate, ParamSpec
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
 
 if TYPE_CHECKING:
     _CIMultiDict = CIMultiDict[str]
@@ -67,3 +79,4 @@ class Middleware(Protocol):
 
 
 PathLike = Union[str, "os.PathLike[str]"]
+

--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -10,8 +10,8 @@ from typing import (
     Mapping,
     Protocol,
     Tuple,
+    TypeVar,
     Union,
-    TypeVar
 )
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy, istr
@@ -79,4 +79,3 @@ class Middleware(Protocol):
 
 
 PathLike = Union[str, "os.PathLike[str]"]
-


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These Changes make `TraceConfig` more definable and are based off ideas from [this proposal](https://github.com/aio-libs/aiohttp/issues/11036) it was made with the new wrapper functionality that I helped to create for aiosignal version `1.3.3` which isn't out at the time of making this pull-request.

- Since my library known as `aiocallback` utilizes functionality from `aiosignal` Changes were made to `aiosignal` that ultimately lead to it not being deprecated and you can thank me for that. 

- Due to `aiocallback` being so new and to prevent an XZ-Utils Situation from happening (AKA Supply-chain attack) it was my decision to instead donate my code instead of making it into a new dependency. This way I get to keep my library that I plan on maintaining for many more years and `aiocallback` will be able to grow and remain maintained and have new features added to it without it becoming a burden. 

- Added some comments about where it came from so that people could understand and give credit where credit is due.

- By using member descriptors and transforming class methods. It is now possible to type-hint without needing the protocol setup. Users who need help with setting up and understanding `TraceConfig` will be able to copy and paste the callback parameters from over there if help is needed. Otherwise I plan to make some documentation around each of these along with a code snippet or example of how each of them could used or utilized.


With that all said and done I will wait for `aiosignal` __1.3.3__ to release first and then work can move forward. I am very happy that I could help maintain a library that I spent years with working with in my early ages of learning how to program. It even played a part in me to developing of the `uvloop` brother `winloop` for windows operating systems. I am glad I was able to share my input and contribute to making it better and I can't wait to see what these new features will inspire for future generations.

## Are there changes in behavior for the user?
Users should expect to see some added functionality to `TraceConfig` and now it can be optionally used in a fastapi/discord-py styled approach where callbacks can now be both wrapped and appended.

```python
from aiohttp import TraceConfig, ClientSession

trace = TraceConfig()

# I plan to add a better example in the aiohttp documentation in the future...
# NOTE: You can call this on_request_start multiple times and it isn't limited to just once...
@trace.on_request_start
async def on_request_start(session:ClientSession, trace, params:TraceRequestStartParams):
    print("[DEBUG]: Starting Request....")
```

## Is it a substantial burden for the maintainers to support this?
I really felt the need to make sure it benefitted both maintainers and developers using it. It was my hope that developers would understand why I made these changes as well as understand why I felt that member descriptors were better in this case 
scenario. Know that I added a comment to `freeze` that getting all the events plays a role in making sure all signals have been initialized before freezing.

The `aiocallback` Library was inspired by `TraceConfig` and it was ultimately decided by me that complaining about
it's approach in aiocallback's repo was not a healthy idea and it helped lead me to not only reviving the `aiosignal` library that 
I had stopped using out of [fear of it's removal](https://github.com/aio-libs/aiosignal/issues/671) but also in improving upon
`TraceConfig`

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number
Fixes #11036
<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
