### PR TITLE
Add preemptive authentication support to DigestAuthMiddleware

### DIFF
--- a/CHANGES/11128.feature.rst
+++ b/CHANGES/11128.feature.rst
@@ -3,7 +3,7 @@ Added preemptive digest authentication to :class:`~aiohttp.DigestAuthMiddleware`
 The middleware now reuses authentication credentials for subsequent requests to the same
 protection space, improving efficiency by avoiding extra authentication round trips.
 This behavior matches how web browsers handle digest authentication and follows
-`RFC 7616 Section 3.6 <https://datatracker.ietf.org/doc/html/rfc7616#section-3.6>`_.
+:rfc:`7616#section-3.6`.
 
 Preemptive authentication is enabled by default but can be disabled by passing
 ``preemptive=False`` to the middleware constructor.

--- a/CHANGES/11128.feature.rst
+++ b/CHANGES/11128.feature.rst
@@ -1,0 +1,9 @@
+Added preemptive digest authentication to :class:`~aiohttp.DigestAuthMiddleware` -- by :user:`bdraco`.
+
+The middleware now reuses authentication credentials for subsequent requests to the same
+protection space, improving efficiency by avoiding extra authentication round trips.
+This behavior matches how web browsers handle digest authentication and follows
+`RFC 7616 Section 3.6 <https://datatracker.ietf.org/doc/html/rfc7616#section-3.6>`_.
+
+Preemptive authentication is enabled by default but can be disabled by passing
+``preemptive=False`` to the middleware constructor.

--- a/CHANGES/11129.feature.rst
+++ b/CHANGES/11129.feature.rst
@@ -1,0 +1,1 @@
+11128.feature.rst

--- a/aiohttp/client_middleware_digest_auth.py
+++ b/aiohttp/client_middleware_digest_auth.py
@@ -422,25 +422,23 @@ class DigestAuthMiddleware:
                 self._challenge[field] = value
 
         # Update protection space based on domain parameter or default to origin
-        if self._challenge:
-            response_url = response.url
-            origin = response_url.origin()
+        origin = response.url.origin()
 
-            if domain := self._challenge.get("domain"):
-                # Parse space-separated list of URIs
-                self._protection_space = set()
-                for uri in domain.split():
-                    # Remove quotes if present
-                    uri = uri.strip('"')
-                    if uri.startswith("/"):
-                        # Path-absolute, relative to origin
-                        self._protection_space.add(origin.join(URL(uri)))
-                    else:
-                        # Absolute URI
-                        self._protection_space.add(URL(uri))
-            else:
-                # No domain specified, protection space is entire origin
-                self._protection_space = {origin}
+        if domain := self._challenge.get("domain"):
+            # Parse space-separated list of URIs
+            self._protection_space = set()
+            for uri in domain.split():
+                # Remove quotes if present
+                uri = uri.strip('"')
+                if uri.startswith("/"):
+                    # Path-absolute, relative to origin
+                    self._protection_space.add(origin.join(URL(uri)))
+                else:
+                    # Absolute URI
+                    self._protection_space.add(URL(uri))
+        else:
+            # No domain specified, protection space is entire origin
+            self._protection_space = {origin}
 
         # Return True only if we found at least one challenge parameter
         return bool(self._challenge)

--- a/aiohttp/client_middleware_digest_auth.py
+++ b/aiohttp/client_middleware_digest_auth.py
@@ -374,9 +374,6 @@ class DigestAuthMiddleware:
         According to RFC 7616, a URI is in the protection space if any URI
         in the protection space is a prefix of it (after both have been made absolute).
         """
-        if not self._protection_space:
-            return False
-
         # Check if any protection space URI is a prefix of the request URL
         request_str = str(url)
         for space_url in self._protection_space:

--- a/aiohttp/client_middleware_digest_auth.py
+++ b/aiohttp/client_middleware_digest_auth.py
@@ -18,7 +18,6 @@ from typing import (
     FrozenSet,
     List,
     Literal,
-    Set,
     Tuple,
     TypedDict,
     Union,
@@ -203,7 +202,7 @@ class DigestAuthMiddleware:
         self._challenge: DigestAuthChallenge = {}
         self._preemptive: bool = preemptive
         # Set of URLs defining the protection space
-        self._protection_space: Set[str] = set()
+        self._protection_space: List[str] = []
 
     async def _encode(
         self, method: str, url: URL, body: Union[Payload, Literal[b""]]
@@ -428,19 +427,19 @@ class DigestAuthMiddleware:
 
         if domain := self._challenge.get("domain"):
             # Parse space-separated list of URIs
-            self._protection_space = set()
+            self._protection_space = []
             for uri in domain.split():
                 # Remove quotes if present
                 uri = uri.strip('"')
                 if uri.startswith("/"):
                     # Path-absolute, relative to origin
-                    self._protection_space.add(str(origin.join(URL(uri))))
+                    self._protection_space.append(str(origin.join(URL(uri))))
                 else:
                     # Absolute URI
-                    self._protection_space.add(str(URL(uri)))
+                    self._protection_space.append(str(URL(uri)))
         else:
             # No domain specified, protection space is entire origin
-            self._protection_space = {str(origin)}
+            self._protection_space = [str(origin)]
 
         # Return True only if we found at least one challenge parameter
         return bool(self._challenge)

--- a/tests/test_client_middleware_digest_auth.py
+++ b/tests/test_client_middleware_digest_auth.py
@@ -1193,7 +1193,7 @@ def test_in_protection_space(
     expected: bool,
 ) -> None:
     """Test _in_protection_space method with various URL patterns."""
-    digest_auth_mw._protection_space = {protection_space_url}
+    digest_auth_mw._protection_space = [protection_space_url]
     result = digest_auth_mw._in_protection_space(URL(request_url))
     assert result == expected
 
@@ -1202,11 +1202,11 @@ def test_in_protection_space_multiple_spaces(
     digest_auth_mw: DigestAuthMiddleware,
 ) -> None:
     """Test _in_protection_space with multiple protection spaces."""
-    digest_auth_mw._protection_space = {
+    digest_auth_mw._protection_space = [
         "http://example.com/api",
         "http://example.com/admin/",
         "http://example.com/secure/area",
-    }
+    ]
 
     # Test various URLs
     assert digest_auth_mw._in_protection_space(URL("http://example.com/api")) is True

--- a/tests/test_client_middleware_digest_auth.py
+++ b/tests/test_client_middleware_digest_auth.py
@@ -913,9 +913,8 @@ async def test_preemptive_auth_updates_nonce_count(
             )
 
         # Extract nc (nonce count) from auth header
-        if "nc=" in auth_header:
-            nc_match = auth_header.split("nc=")[1].split(",")[0].strip()
-            nonce_counts.append(nc_match)
+        nc_match = auth_header.split("nc=")[1].split(",")[0].strip()
+        nonce_counts.append(nc_match)
 
         return Response(text="OK")
 

--- a/tests/test_client_middleware_digest_auth.py
+++ b/tests/test_client_middleware_digest_auth.py
@@ -778,6 +778,333 @@ async def test_no_retry_on_second_401(
     assert request_count == 2
 
 
+async def test_preemptive_auth_disabled(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Test that preemptive authentication can be disabled."""
+    digest_auth_mw = DigestAuthMiddleware("user", "pass", preemptive=False)
+    request_count = 0
+    auth_headers = []
+
+    async def handler(request: Request) -> Response:
+        nonlocal request_count
+        request_count += 1
+        auth_headers.append(request.headers.get(hdrs.AUTHORIZATION))
+
+        if not request.headers.get(hdrs.AUTHORIZATION):
+            # Return 401 with digest challenge
+            challenge = 'Digest realm="test", nonce="abc123", qop="auth", algorithm=MD5'
+            return Response(
+                status=401,
+                headers={"WWW-Authenticate": challenge},
+                text="Unauthorized",
+            )
+
+        return Response(text="OK")
+
+    app = Application()
+    app.router.add_get("/", handler)
+    server = await aiohttp_server(app)
+
+    async with ClientSession(middlewares=(digest_auth_mw,)) as session:
+        # First request will get 401 and store challenge
+        async with session.get(server.make_url("/")) as resp:
+            assert resp.status == 200
+            text = await resp.text()
+            assert text == "OK"
+
+        # Second request should NOT send auth preemptively (preemptive=False)
+        async with session.get(server.make_url("/")) as resp:
+            assert resp.status == 200
+            text = await resp.text()
+            assert text == "OK"
+
+    # With preemptive disabled, each request needs 401 challenge first
+    assert request_count == 4  # 2 requests * 2 (401 + retry)
+    assert auth_headers[0] is None  # First request has no auth
+    assert auth_headers[1] is not None  # Second request has auth after 401
+    assert auth_headers[2] is None  # Third request has no auth (preemptive disabled)
+    assert auth_headers[3] is not None  # Fourth request has auth after 401
+
+
+async def test_preemptive_auth_with_stale_nonce(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Test preemptive auth handles stale nonce responses correctly."""
+    digest_auth_mw = DigestAuthMiddleware("user", "pass", preemptive=True)
+    request_count = 0
+    current_nonce = 0
+
+    async def handler(request: Request) -> Response:
+        nonlocal request_count, current_nonce
+        request_count += 1
+
+        auth_header = request.headers.get(hdrs.AUTHORIZATION)
+
+        if not auth_header:
+            # First request without auth
+            current_nonce = 1
+            challenge = f'Digest realm="test", nonce="nonce{current_nonce}", qop="auth", algorithm=MD5'
+            return Response(
+                status=401,
+                headers={"WWW-Authenticate": challenge},
+                text="Unauthorized",
+            )
+
+        # For the second set of requests, always consider the first nonce stale
+        if request_count == 3 and current_nonce == 1:
+            # Stale nonce - request new auth with stale=true
+            current_nonce = 2
+            challenge = f'Digest realm="test", nonce="nonce{current_nonce}", qop="auth", algorithm=MD5, stale=true'
+            return Response(
+                status=401,
+                headers={"WWW-Authenticate": challenge},
+                text="Unauthorized - Stale nonce",
+            )
+
+        return Response(text="OK")
+
+    app = Application()
+    app.router.add_get("/", handler)
+    server = await aiohttp_server(app)
+
+    async with ClientSession(middlewares=(digest_auth_mw,)) as session:
+        # First request - will get 401, then retry with auth
+        async with session.get(server.make_url("/")) as resp:
+            assert resp.status == 200
+            text = await resp.text()
+            assert text == "OK"
+
+        # Second request - will use preemptive auth with nonce1, get 401 stale, retry with nonce2
+        async with session.get(server.make_url("/")) as resp:
+            assert resp.status == 200
+            text = await resp.text()
+            assert text == "OK"
+
+    # Verify the expected flow:
+    # Request 1: no auth -> 401
+    # Request 2: retry with auth -> 200
+    # Request 3: preemptive auth with old nonce -> 401 stale
+    # Request 4: retry with new nonce -> 200
+    assert request_count == 4
+
+
+async def test_preemptive_auth_updates_nonce_count(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Test that preemptive auth properly increments nonce count."""
+    digest_auth_mw = DigestAuthMiddleware("user", "pass", preemptive=True)
+    request_count = 0
+    nonce_counts = []
+
+    async def handler(request: Request) -> Response:
+        nonlocal request_count
+        request_count += 1
+
+        auth_header = request.headers.get(hdrs.AUTHORIZATION)
+
+        if not auth_header:
+            # First request without auth
+            challenge = 'Digest realm="test", nonce="abc123", qop="auth", algorithm=MD5'
+            return Response(
+                status=401,
+                headers={"WWW-Authenticate": challenge},
+                text="Unauthorized",
+            )
+
+        # Extract nc (nonce count) from auth header
+        if "nc=" in auth_header:
+            nc_match = auth_header.split("nc=")[1].split(",")[0].strip()
+            nonce_counts.append(nc_match)
+
+        return Response(text="OK")
+
+    app = Application()
+    app.router.add_get("/", handler)
+    server = await aiohttp_server(app)
+
+    async with ClientSession(middlewares=(digest_auth_mw,)) as session:
+        # Make multiple requests to see nonce count increment
+        for _ in range(3):
+            async with session.get(server.make_url("/")) as resp:
+                assert resp.status == 200
+                await resp.text()
+
+    # First request has no auth, then gets 401 and retries with nc=00000001
+    # Second and third requests use preemptive auth with nc=00000002 and nc=00000003
+    assert len(nonce_counts) == 3
+    assert nonce_counts[0] == "00000001"
+    assert nonce_counts[1] == "00000002"
+    assert nonce_counts[2] == "00000003"
+
+
+async def test_preemptive_auth_respects_protection_space(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Test that preemptive auth only applies to URLs within the protection space."""
+    digest_auth_mw = DigestAuthMiddleware("user", "pass", preemptive=True)
+    request_count = 0
+    auth_headers = []
+    requested_paths = []
+
+    async def handler(request: Request) -> Response:
+        nonlocal request_count
+        request_count += 1
+        auth_headers.append(request.headers.get(hdrs.AUTHORIZATION))
+        requested_paths.append(request.path)
+
+        if not request.headers.get(hdrs.AUTHORIZATION):
+            # Return 401 with digest challenge including domain parameter
+            challenge = 'Digest realm="test", nonce="abc123", qop="auth", algorithm=MD5, domain="/api /admin"'
+            return Response(
+                status=401,
+                headers={"WWW-Authenticate": challenge},
+                text="Unauthorized",
+            )
+
+        return Response(text="OK")
+
+    app = Application()
+    app.router.add_get("/api/endpoint", handler)
+    app.router.add_get("/admin/panel", handler)
+    app.router.add_get("/public/page", handler)
+    server = await aiohttp_server(app)
+
+    async with ClientSession(middlewares=(digest_auth_mw,)) as session:
+        # First request to /api/endpoint - should get 401 and retry with auth
+        async with session.get(server.make_url("/api/endpoint")) as resp:
+            assert resp.status == 200
+
+        # Second request to /api/endpoint - should use preemptive auth (in protection space)
+        async with session.get(server.make_url("/api/endpoint")) as resp:
+            assert resp.status == 200
+
+        # Third request to /admin/panel - should use preemptive auth (in protection space)
+        async with session.get(server.make_url("/admin/panel")) as resp:
+            assert resp.status == 200
+
+        # Fourth request to /public/page - should NOT use preemptive auth (outside protection space)
+        async with session.get(server.make_url("/public/page")) as resp:
+            assert resp.status == 200
+
+    # Verify auth headers
+    assert auth_headers[0] is None  # First request to /api/endpoint - no auth
+    assert auth_headers[1] is not None  # Retry with auth
+    assert (
+        auth_headers[2] is not None
+    )  # Second request to /api/endpoint - preemptive auth
+    assert auth_headers[3] is not None  # Request to /admin/panel - preemptive auth
+    assert auth_headers[4] is None  # First request to /public/page - no preemptive auth
+    assert auth_headers[5] is not None  # Retry with auth
+
+    # Verify paths
+    assert requested_paths == [
+        "/api/endpoint",  # Initial request
+        "/api/endpoint",  # Retry with auth
+        "/api/endpoint",  # Second request with preemptive auth
+        "/admin/panel",  # Request with preemptive auth
+        "/public/page",  # Initial request (no preemptive auth)
+        "/public/page",  # Retry with auth
+    ]
+
+
+async def test_preemptive_auth_with_absolute_domain_uris(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Test preemptive auth with absolute URIs in domain parameter."""
+    digest_auth_mw = DigestAuthMiddleware("user", "pass", preemptive=True)
+    request_count = 0
+    auth_headers = []
+
+    async def handler(request: Request) -> Response:
+        nonlocal request_count
+        request_count += 1
+        auth_headers.append(request.headers.get(hdrs.AUTHORIZATION))
+
+        if not request.headers.get(hdrs.AUTHORIZATION):
+            # Return 401 with digest challenge including absolute URI in domain
+            server_url = str(request.url.with_path("/protected"))
+            challenge = f'Digest realm="test", nonce="abc123", qop="auth", algorithm=MD5, domain="{server_url}"'
+            return Response(
+                status=401,
+                headers={"WWW-Authenticate": challenge},
+                text="Unauthorized",
+            )
+
+        return Response(text="OK")
+
+    app = Application()
+    app.router.add_get("/protected/resource", handler)
+    app.router.add_get("/unprotected/resource", handler)
+    server = await aiohttp_server(app)
+
+    async with ClientSession(middlewares=(digest_auth_mw,)) as session:
+        # First request to protected resource
+        async with session.get(server.make_url("/protected/resource")) as resp:
+            assert resp.status == 200
+
+        # Second request to protected resource - should use preemptive auth
+        async with session.get(server.make_url("/protected/resource")) as resp:
+            assert resp.status == 200
+
+        # Request to unprotected resource - should NOT use preemptive auth
+        async with session.get(server.make_url("/unprotected/resource")) as resp:
+            assert resp.status == 200
+
+    # Verify auth pattern
+    assert auth_headers[0] is None  # First request - no auth
+    assert auth_headers[1] is not None  # Retry with auth
+    assert auth_headers[2] is not None  # Second request - preemptive auth
+    assert auth_headers[3] is None  # Unprotected resource - no preemptive auth
+    assert auth_headers[4] is not None  # Retry with auth
+
+
+async def test_preemptive_auth_without_domain_uses_origin(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Test that preemptive auth without domain parameter applies to entire origin."""
+    digest_auth_mw = DigestAuthMiddleware("user", "pass", preemptive=True)
+    request_count = 0
+    auth_headers = []
+
+    async def handler(request: Request) -> Response:
+        nonlocal request_count
+        request_count += 1
+        auth_headers.append(request.headers.get(hdrs.AUTHORIZATION))
+
+        if not request.headers.get(hdrs.AUTHORIZATION):
+            # Return 401 with digest challenge without domain parameter
+            challenge = 'Digest realm="test", nonce="abc123", qop="auth", algorithm=MD5'
+            return Response(
+                status=401,
+                headers={"WWW-Authenticate": challenge},
+                text="Unauthorized",
+            )
+
+        return Response(text="OK")
+
+    app = Application()
+    app.router.add_get("/path1", handler)
+    app.router.add_get("/path2", handler)
+    server = await aiohttp_server(app)
+
+    async with ClientSession(middlewares=(digest_auth_mw,)) as session:
+        # First request
+        async with session.get(server.make_url("/path1")) as resp:
+            assert resp.status == 200
+
+        # Second request to different path - should still use preemptive auth
+        async with session.get(server.make_url("/path2")) as resp:
+            assert resp.status == 200
+
+    # Verify auth pattern
+    assert auth_headers[0] is None  # First request - no auth
+    assert auth_headers[1] is not None  # Retry with auth
+    assert (
+        auth_headers[2] is not None
+    )  # Second request - preemptive auth (entire origin)
+
+
 @pytest.mark.parametrize(
     ("status", "headers", "expected"),
     [


### PR DESCRIPTION
## What do these changes do?

It was discovered that `DigestAuthMiddleware` doesn't work for some servers because the original implementation didn't implement preemptive support.

This PR adds preemptive authentication support to `DigestAuthMiddleware`, following RFC 7616 Section 3.6. The middleware now remembers successful authentication challenges and automatically includes the Authorization header in subsequent requests to the same protection space.

### Key changes:
- Added `preemptive` parameter to `DigestAuthMiddleware` constructor (default: `True`)
- Implemented protection space tracking based on the `domain` parameter from server challenges
- When no `domain` is specified, the entire origin becomes the protection space
- Added support for the `stale` parameter to handle expired nonces
- The middleware only sends preemptive auth to URLs within the same protection space

## Are there changes in behavior for the user?

Yes, but backwards compatible:
- By default, the middleware now uses preemptive authentication (can be disabled with `preemptive=False`)
- Subsequent requests to the same protection space will include the Authorization header automatically
- This improves performance by avoiding unnecessary 401 round trips
- Matches how modern web browsers handle digest authentication

## Related issue number

Fixes #11128