### PR TITLE
Fix IOBasePayload reading entire files into memory instead of chunking

### DIFF
--- a/CHANGES/11138.bugfix.rst
+++ b/CHANGES/11138.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``IOBasePayload`` and ``TextIOPayload`` reading entire files into memory when streaming large files -- by :user:`bdraco`.
+
+When using file-like objects with the aiohttp client, the entire file would be read into memory if the file size was provided in the ``Content-Length`` header. This could cause out-of-memory errors when uploading large files. The payload classes now correctly read data in chunks of ``READ_SIZE`` (64KB) regardless of the total content length.

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -512,7 +512,7 @@ class IOBasePayload(Payload):
         self._set_or_restore_start_position()
         size = self.size  # Call size only once since it does I/O
         return size, self._value.read(
-            min(size or READ_SIZE, remaining_content_len or READ_SIZE)
+            min(READ_SIZE, size or READ_SIZE, remaining_content_len or READ_SIZE)
         )
 
     def _read(self, remaining_content_len: Optional[int]) -> bytes:
@@ -615,7 +615,15 @@ class IOBasePayload(Payload):
                 return
 
             # Read next chunk
-            chunk = await loop.run_in_executor(None, self._read, remaining_content_len)
+            chunk = await loop.run_in_executor(
+                None,
+                self._read,
+                (
+                    min(READ_SIZE, remaining_content_len)
+                    if remaining_content_len is not None
+                    else READ_SIZE
+                ),
+            )
 
     def _should_stop_writing(
         self,
@@ -757,7 +765,7 @@ class TextIOPayload(IOBasePayload):
         self._set_or_restore_start_position()
         size = self.size
         chunk = self._value.read(
-            min(size or READ_SIZE, remaining_content_len or READ_SIZE)
+            min(READ_SIZE, size or READ_SIZE, remaining_content_len or READ_SIZE)
         )
         return size, chunk.encode(self._encoding) if self._encoding else chunk.encode()
 

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -377,7 +377,7 @@ async def test_iobase_payload_reads_in_chunks() -> None:
     # Track the sizes of read() calls
     read_sizes = []
 
-    def mock_read(size):
+    def mock_read(size: int) -> bytes:
         read_sizes.append(size)
         # Return data based on how many times read was called
         call_count = len(read_sizes)
@@ -412,12 +412,12 @@ async def test_iobase_payload_large_content_length() -> None:
 
     # Create a custom file-like object that tracks read sizes
     class TrackingBytesIO(io.BytesIO):
-        def __init__(self, data):
+        def __init__(self, data: bytes) -> None:
             super().__init__(data)
-            self.read_sizes = []
+            self.read_sizes: List[int] = []
 
-        def read(self, size=-1):
-            self.read_sizes.append(size)
+        def read(self, size: Optional[int] = -1) -> bytes:
+            self.read_sizes.append(size if size is not None else -1)
             return super().read(size)
 
     tracking_file = TrackingBytesIO(data)
@@ -452,7 +452,7 @@ async def test_textio_payload_reads_in_chunks() -> None:
     # Track the sizes of read() calls
     read_sizes = []
 
-    def mock_read(size):
+    def mock_read(size: int) -> str:
         read_sizes.append(size)
         # Return data based on how many times read was called
         call_count = len(read_sizes)
@@ -487,12 +487,12 @@ async def test_textio_payload_large_content_length() -> None:
 
     # Create a custom file-like object that tracks read sizes
     class TrackingStringIO(io.StringIO):
-        def __init__(self, data):
+        def __init__(self, data: str) -> None:
             super().__init__(data)
-            self.read_sizes = []
+            self.read_sizes: List[int] = []
 
-        def read(self, size=-1):
-            self.read_sizes.append(size)
+        def read(self, size: Optional[int] = -1) -> str:
+            self.read_sizes.append(size if size is not None else -1)
             return super().read(size)
 
     tracking_file = TrackingStringIO(text_data)

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -12,6 +12,7 @@ from multidict import CIMultiDict
 
 from aiohttp import payload
 from aiohttp.abc import AbstractStreamWriter
+from aiohttp.payload import READ_SIZE
 
 
 class BufferWriter(AbstractStreamWriter):
@@ -361,6 +362,155 @@ async def test_iobase_payload_exact_chunk_size_limit() -> None:
     written = writer.get_written_bytes()
     assert len(written) == chunk_size
     assert written == data[:chunk_size]
+
+
+async def test_iobase_payload_reads_in_chunks() -> None:
+    """Test IOBasePayload reads data in chunks of READ_SIZE, not all at once."""
+    # Create a large file that's multiple times larger than READ_SIZE
+    large_data = b"x" * (READ_SIZE * 3 + 1000)  # ~192KB + 1000 bytes
+
+    # Mock the file-like object to track read calls
+    mock_file = unittest.mock.Mock(spec=io.BytesIO)
+    mock_file.tell.return_value = 0
+    mock_file.fileno.side_effect = AttributeError  # Make size return None
+
+    # Track the sizes of read() calls
+    read_sizes = []
+
+    def mock_read(size):
+        read_sizes.append(size)
+        # Return data based on how many times read was called
+        call_count = len(read_sizes)
+        if call_count == 1:
+            return large_data[:size]
+        elif call_count == 2:
+            return large_data[READ_SIZE : READ_SIZE + size]
+        elif call_count == 3:
+            return large_data[READ_SIZE * 2 : READ_SIZE * 2 + size]
+        else:
+            return large_data[READ_SIZE * 3 :]
+
+    mock_file.read.side_effect = mock_read
+
+    payload_obj = payload.IOBasePayload(mock_file)
+    writer = MockStreamWriter()
+
+    # Write with a large content_length
+    await payload_obj.write_with_length(writer, len(large_data))
+
+    # Verify that reads were limited to READ_SIZE
+    assert len(read_sizes) > 1  # Should have multiple reads
+    for read_size in read_sizes:
+        assert (
+            read_size <= READ_SIZE
+        ), f"Read size {read_size} exceeds READ_SIZE {READ_SIZE}"
+
+
+async def test_iobase_payload_large_content_length() -> None:
+    """Test IOBasePayload with very large content_length doesn't read all at once."""
+    data = b"x" * (READ_SIZE + 1000)
+
+    # Create a custom file-like object that tracks read sizes
+    class TrackingBytesIO(io.BytesIO):
+        def __init__(self, data):
+            super().__init__(data)
+            self.read_sizes = []
+
+        def read(self, size=-1):
+            self.read_sizes.append(size)
+            return super().read(size)
+
+    tracking_file = TrackingBytesIO(data)
+    payload_obj = payload.IOBasePayload(tracking_file)
+    writer = MockStreamWriter()
+
+    # Write with a very large content_length (simulating the bug scenario)
+    large_content_length = 10 * 1024 * 1024  # 10MB
+    await payload_obj.write_with_length(writer, large_content_length)
+
+    # Verify no single read exceeded READ_SIZE
+    for read_size in tracking_file.read_sizes:
+        assert (
+            read_size <= READ_SIZE
+        ), f"Read size {read_size} exceeds READ_SIZE {READ_SIZE}"
+
+    # Verify the correct amount of data was written
+    assert writer.get_written_bytes() == data
+
+
+async def test_textio_payload_reads_in_chunks() -> None:
+    """Test TextIOPayload reads data in chunks of READ_SIZE, not all at once."""
+    # Create a large text file that's multiple times larger than READ_SIZE
+    large_text = "x" * (READ_SIZE * 3 + 1000)  # ~192KB + 1000 chars
+
+    # Mock the file-like object to track read calls
+    mock_file = unittest.mock.Mock(spec=io.StringIO)
+    mock_file.tell.return_value = 0
+    mock_file.fileno.side_effect = AttributeError  # Make size return None
+    mock_file.encoding = "utf-8"
+
+    # Track the sizes of read() calls
+    read_sizes = []
+
+    def mock_read(size):
+        read_sizes.append(size)
+        # Return data based on how many times read was called
+        call_count = len(read_sizes)
+        if call_count == 1:
+            return large_text[:size]
+        elif call_count == 2:
+            return large_text[READ_SIZE : READ_SIZE + size]
+        elif call_count == 3:
+            return large_text[READ_SIZE * 2 : READ_SIZE * 2 + size]
+        else:
+            return large_text[READ_SIZE * 3 :]
+
+    mock_file.read.side_effect = mock_read
+
+    payload_obj = payload.TextIOPayload(mock_file)
+    writer = MockStreamWriter()
+
+    # Write with a large content_length
+    await payload_obj.write_with_length(writer, len(large_text.encode("utf-8")))
+
+    # Verify that reads were limited to READ_SIZE
+    assert len(read_sizes) > 1  # Should have multiple reads
+    for read_size in read_sizes:
+        assert (
+            read_size <= READ_SIZE
+        ), f"Read size {read_size} exceeds READ_SIZE {READ_SIZE}"
+
+
+async def test_textio_payload_large_content_length() -> None:
+    """Test TextIOPayload with very large content_length doesn't read all at once."""
+    text_data = "x" * (READ_SIZE + 1000)
+
+    # Create a custom file-like object that tracks read sizes
+    class TrackingStringIO(io.StringIO):
+        def __init__(self, data):
+            super().__init__(data)
+            self.read_sizes = []
+
+        def read(self, size=-1):
+            self.read_sizes.append(size)
+            return super().read(size)
+
+    tracking_file = TrackingStringIO(text_data)
+    payload_obj = payload.TextIOPayload(tracking_file)
+    writer = MockStreamWriter()
+
+    # Write with a very large content_length (simulating the bug scenario)
+    large_content_length = 10 * 1024 * 1024  # 10MB
+    await payload_obj.write_with_length(writer, large_content_length)
+
+    # Verify no single read exceeded READ_SIZE
+    for read_size in tracking_file.read_sizes:
+        assert (
+            read_size <= READ_SIZE
+        ), f"Read size {read_size} exceeds READ_SIZE {READ_SIZE}"
+
+    # Verify the correct amount of data was written
+    assert writer.get_written_bytes() == text_data.encode("utf-8")
 
 
 async def test_async_iterable_payload_write_with_length_no_limit() -> None:


### PR DESCRIPTION
## What do these changes do?

This PR fixes a memory consumption issue where `IOBasePayload` and `TextIOPayload` would read entire files into memory when streaming large files. The bug was introduced in #10915 and caused the payload classes to read `remaining_content_length` bytes at once instead of chunking the reads.

The fix ensures that both payload classes never read more than `READ_SIZE` (64KB) at a time, regardless of the file size or content length. This prevents out-of-memory errors when uploading large files using file-like objects with the aiohttp client.

## Are there changes in behavior for the user?

No behavioral changes for users. The fix is transparent and only affects memory usage during file streaming. Files are still uploaded correctly, but now they're read in 64KB chunks instead of potentially reading gigabytes into memory at once.

## Is it a substantial burden for the maintainers to support this?

No, this is a minimal fix that restores the original intended behavior. The changes are:
- Adding `READ_SIZE` as the first parameter to `min()` in `_read_and_available_len()` for both `IOBasePayload` and `TextIOPayload`
- Ensuring the `_read()` method is called with appropriate chunk sizes
- Comprehensive test coverage to prevent regression

The fix is straightforward and maintains backward compatibility while fixing a critical memory issue.

## Related issue number

Fixes #11138

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.