### PR TITLE
[PR #11148/86a9a38 backport][3.12] Abort ssl connections on close when ssl_shutdown_timeout is 0

### DIFF
--- a/CHANGES/11148.deprecation.rst
+++ b/CHANGES/11148.deprecation.rst
@@ -1,0 +1,1 @@
+11148.feature.rst

--- a/CHANGES/11148.feature.rst
+++ b/CHANGES/11148.feature.rst
@@ -1,0 +1,10 @@
+Improved SSL connection handling by changing the default ``ssl_shutdown_timeout``
+from ``0.1`` to ``0`` seconds. SSL connections now use Python's default graceful
+shutdown during normal operation but are aborted immediately when the connector
+is closed, providing optimal behavior for both cases. Also added support for
+``ssl_shutdown_timeout=0`` on all Python versions. Previously, this value was
+rejected on Python 3.11+ and ignored on earlier versions. Non-zero values on
+Python < 3.11 now trigger a ``RuntimeWarning`` -- by :user:`bdraco`.
+
+The ``ssl_shutdown_timeout`` parameter is now deprecated and will be removed in
+aiohttp 4.0 as there is no clear use case for changing the default.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -303,7 +303,7 @@ class ClientSession:
         max_field_size: int = 8190,
         fallback_charset_resolver: _CharsetResolver = lambda r, b: "utf-8",
         middlewares: Sequence[ClientMiddlewareType] = (),
-        ssl_shutdown_timeout: Optional[float] = 0.1,
+        ssl_shutdown_timeout: Union[_SENTINEL, None, float] = sentinel,
     ) -> None:
         # We initialise _connector to None immediately, as it's referenced in __del__()
         # and could cause issues if an exception occurs during initialisation.
@@ -360,6 +360,13 @@ class ClientSession:
                     "conflict, please setup "
                     "timeout.connect"
                 )
+
+        if ssl_shutdown_timeout is not sentinel:
+            warnings.warn(
+                "The ssl_shutdown_timeout parameter is deprecated and will be removed in aiohttp 4.0",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         if connector is None:
             connector = TCPConnector(ssl_shutdown_timeout=ssl_shutdown_timeout)

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -95,6 +95,15 @@ class ResponseHandler(BaseProtocol, DataQueue[Tuple[RawResponseMessage, StreamRe
             self._payload = None
             self._drop_timeout()
 
+    def abort(self) -> None:
+        self._exception = None  # Break cyclic references
+        transport = self.transport
+        if transport is not None:
+            transport.abort()
+            self.transport = None
+            self._payload = None
+            self._drop_timeout()
+
     def is_connected(self) -> bool:
         return self.transport is not None and not self.transport.is_closing()
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -58,7 +58,7 @@ The client session supports the context manager protocol for self closing.
                          max_line_size=8190, \
                          max_field_size=8190, \
                          fallback_charset_resolver=lambda r, b: "utf-8", \
-                         ssl_shutdown_timeout=0.1)
+                         ssl_shutdown_timeout=0)
 
    The class for creating client sessions and making requests.
 
@@ -257,15 +257,30 @@ The client session supports the context manager protocol for self closing.
 
       .. versionadded:: 3.8.6
 
-   :param float ssl_shutdown_timeout: Grace period for SSL shutdown handshake on TLS
-      connections (``0.1`` seconds by default). This usually provides sufficient time
-      to notify the remote peer of connection closure, helping prevent broken
-      connections on the server side, while minimizing delays during connector
-      cleanup. This timeout is passed to the underlying :class:`TCPConnector`
-      when one is created automatically. Note: This parameter only takes effect
-      on Python 3.11+.
+   :param float ssl_shutdown_timeout: **(DEPRECATED)** This parameter is deprecated
+      and will be removed in aiohttp 4.0. Grace period for SSL shutdown handshake on
+      TLS connections when the connector is closed (``0`` seconds by default).
+      By default (``0``), SSL connections are aborted immediately when the
+      connector is closed, without performing the shutdown handshake. During
+      normal operation, SSL connections use Python's default SSL shutdown
+      behavior. Setting this to a positive value (e.g., ``0.1``) will perform
+      a graceful shutdown when closing the connector, notifying the remote
+      peer which can help prevent "connection reset" errors at the cost of
+      additional cleanup time. This timeout is passed to the underlying
+      :class:`TCPConnector` when one is created automatically.
+      Note: On Python versions prior to 3.11, only a value of ``0`` is supported;
+      other values will trigger a warning.
 
       .. versionadded:: 3.12.5
+
+      .. versionchanged:: 3.12.11
+         Changed default from ``0.1`` to ``0`` to abort SSL connections
+         immediately when the connector is closed. Added support for
+         ``ssl_shutdown_timeout=0`` on all Python versions. A :exc:`RuntimeWarning`
+         is issued when non-zero values are passed on Python < 3.11.
+
+      .. deprecated:: 3.12.11
+         This parameter is deprecated and will be removed in aiohttp 4.0.
 
    .. attribute:: closed
 
@@ -1196,7 +1211,7 @@ is controlled by *force_close* constructor's parameter).
                  force_close=False, limit=100, limit_per_host=0, \
                  enable_cleanup_closed=False, timeout_ceil_threshold=5, \
                  happy_eyeballs_delay=0.25, interleave=None, loop=None, \
-                 socket_factory=None, ssl_shutdown_timeout=0.1)
+                 socket_factory=None, ssl_shutdown_timeout=0)
 
    Connector for working with *HTTP* and *HTTPS* via *TCP* sockets.
 
@@ -1323,15 +1338,28 @@ is controlled by *force_close* constructor's parameter).
 
         .. versionadded:: 3.12
 
-   :param float ssl_shutdown_timeout: Grace period for SSL shutdown on TLS
-      connections (``0.1`` seconds by default). This parameter balances two
-      important considerations: usually providing sufficient time to notify
-      the remote server (which helps prevent "connection reset" errors),
-      while avoiding unnecessary delays during connector cleanup.
-      The default value provides a reasonable compromise for most use cases.
-      Note: This parameter only takes effect on Python 3.11+.
+   :param float ssl_shutdown_timeout: **(DEPRECATED)** This parameter is deprecated
+      and will be removed in aiohttp 4.0. Grace period for SSL shutdown on TLS
+      connections when the connector is closed (``0`` seconds by default).
+      By default (``0``), SSL connections are aborted immediately when the
+      connector is closed, without performing the shutdown handshake. During
+      normal operation, SSL connections use Python's default SSL shutdown
+      behavior. Setting this to a positive value (e.g., ``0.1``) will perform
+      a graceful shutdown when closing the connector, notifying the remote
+      server which can help prevent "connection reset" errors at the cost of
+      additional cleanup time. Note: On Python versions prior to 3.11, only
+      a value of ``0`` is supported; other values will trigger a warning.
 
         .. versionadded:: 3.12.5
+
+        .. versionchanged:: 3.12.11
+           Changed default from ``0.1`` to ``0`` to abort SSL connections
+           immediately when the connector is closed. Added support for
+           ``ssl_shutdown_timeout=0`` on all Python versions. A :exc:`RuntimeWarning`
+           is issued when non-zero values are passed on Python < 3.11.
+
+        .. deprecated:: 3.12.11
+           This parameter is deprecated and will be removed in aiohttp 4.0.
 
    .. attribute:: family
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -698,7 +698,10 @@ async def test_ssl_client_shutdown_timeout(
 ) -> None:
     # Test that ssl_shutdown_timeout is properly used during connection closure
 
-    connector = aiohttp.TCPConnector(ssl=client_ssl_ctx, ssl_shutdown_timeout=0.1)
+    with pytest.warns(
+        DeprecationWarning, match="ssl_shutdown_timeout parameter is deprecated"
+    ):
+        connector = aiohttp.TCPConnector(ssl=client_ssl_ctx, ssl_shutdown_timeout=0.1)
 
     async def streaming_handler(request: web.Request) -> NoReturn:
         # Create a streaming response that continuously sends data

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -3,6 +3,8 @@ import contextlib
 import gc
 import io
 import json
+import sys
+import warnings
 from collections import deque
 from http.cookies import BaseCookie, SimpleCookie
 from typing import Any, Awaitable, Callable, Iterator, List, Optional, cast
@@ -310,32 +312,91 @@ async def test_create_connector(create_session, loop, mocker) -> None:
     assert connector.close.called
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="Use test_ssl_shutdown_timeout_passed_to_connector_pre_311 for Python < 3.11",
+)
 async def test_ssl_shutdown_timeout_passed_to_connector() -> None:
-    # Test default value
+    # Test default value (no warning expected)
     async with ClientSession() as session:
         assert isinstance(session.connector, TCPConnector)
-        assert session.connector._ssl_shutdown_timeout == 0.1
+        assert session.connector._ssl_shutdown_timeout == 0
 
-    # Test custom value
-    async with ClientSession(ssl_shutdown_timeout=1.0) as session:
-        assert isinstance(session.connector, TCPConnector)
-        assert session.connector._ssl_shutdown_timeout == 1.0
+    # Test custom value - expect deprecation warning
+    with pytest.warns(
+        DeprecationWarning, match="ssl_shutdown_timeout parameter is deprecated"
+    ):
+        async with ClientSession(ssl_shutdown_timeout=1.0) as session:
+            assert isinstance(session.connector, TCPConnector)
+            assert session.connector._ssl_shutdown_timeout == 1.0
 
-    # Test None value
-    async with ClientSession(ssl_shutdown_timeout=None) as session:
-        assert isinstance(session.connector, TCPConnector)
-        assert session.connector._ssl_shutdown_timeout is None
+    # Test None value - expect deprecation warning
+    with pytest.warns(
+        DeprecationWarning, match="ssl_shutdown_timeout parameter is deprecated"
+    ):
+        async with ClientSession(ssl_shutdown_timeout=None) as session:
+            assert isinstance(session.connector, TCPConnector)
+            assert session.connector._ssl_shutdown_timeout is None
 
     # Test that it doesn't affect when custom connector is provided
-    custom_conn = TCPConnector(ssl_shutdown_timeout=2.0)
-    async with ClientSession(
-        connector=custom_conn, ssl_shutdown_timeout=1.0
-    ) as session:
-        assert session.connector is not None
-        assert isinstance(session.connector, TCPConnector)
-        assert (
-            session.connector._ssl_shutdown_timeout == 2.0
-        )  # Should use connector's value
+    with pytest.warns(
+        DeprecationWarning, match="ssl_shutdown_timeout parameter is deprecated"
+    ):
+        custom_conn = TCPConnector(ssl_shutdown_timeout=2.0)
+    with pytest.warns(
+        DeprecationWarning, match="ssl_shutdown_timeout parameter is deprecated"
+    ):
+        async with ClientSession(
+            connector=custom_conn, ssl_shutdown_timeout=1.0
+        ) as session:
+            assert session.connector is not None
+            assert isinstance(session.connector, TCPConnector)
+            assert (
+                session.connector._ssl_shutdown_timeout == 2.0
+            )  # Should use connector's value
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11),
+    reason="This test is for Python < 3.11 runtime warning behavior",
+)
+async def test_ssl_shutdown_timeout_passed_to_connector_pre_311() -> None:
+    """Test that both deprecation and runtime warnings are issued on Python < 3.11."""
+    # Test custom value - expect both deprecation and runtime warnings
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        async with ClientSession(ssl_shutdown_timeout=1.0) as session:
+            assert isinstance(session.connector, TCPConnector)
+            assert session.connector._ssl_shutdown_timeout == 1.0
+        # Should have deprecation warnings (from ClientSession and TCPConnector) and runtime warning
+        # ClientSession emits 1 DeprecationWarning, TCPConnector emits 1 DeprecationWarning + 1 RuntimeWarning = 3 total
+        assert len(w) == 3
+        deprecation_count = sum(
+            1 for warn in w if issubclass(warn.category, DeprecationWarning)
+        )
+        runtime_count = sum(
+            1 for warn in w if issubclass(warn.category, RuntimeWarning)
+        )
+        assert deprecation_count == 2  # One from ClientSession, one from TCPConnector
+        assert runtime_count == 1  # One from TCPConnector
+
+    # Test with custom connector
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        custom_conn = TCPConnector(ssl_shutdown_timeout=2.0)
+        # Should have both deprecation and runtime warnings
+        assert len(w) == 2
+    with pytest.warns(
+        DeprecationWarning, match="ssl_shutdown_timeout parameter is deprecated"
+    ):
+        async with ClientSession(
+            connector=custom_conn, ssl_shutdown_timeout=1.0
+        ) as session:
+            assert session.connector is not None
+            assert isinstance(session.connector, TCPConnector)
+            assert (
+                session.connector._ssl_shutdown_timeout == 2.0
+            )  # Should use connector's value
 
 
 def test_connector_loop(loop: asyncio.AbstractEventLoop) -> None:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -935,24 +935,14 @@ class TestProxy(unittest.TestCase):
         self.loop.run_until_complete(
             connector._create_connection(req, None, aiohttp.ClientTimeout())
         )
-
-        if sys.version_info >= (3, 11):
-            self.loop.start_tls.assert_called_with(
-                mock.ANY,
-                mock.ANY,
-                _SSL_CONTEXT_VERIFIED,
-                server_hostname="www.python.org",
-                ssl_handshake_timeout=mock.ANY,
-                ssl_shutdown_timeout=0.1,
-            )
-        else:
-            self.loop.start_tls.assert_called_with(
-                mock.ANY,
-                mock.ANY,
-                _SSL_CONTEXT_VERIFIED,
-                server_hostname="www.python.org",
-                ssl_handshake_timeout=mock.ANY,
-            )
+        # ssl_shutdown_timeout=0 is not passed to start_tls
+        self.loop.start_tls.assert_called_with(
+            mock.ANY,
+            mock.ANY,
+            _SSL_CONTEXT_VERIFIED,
+            server_hostname="www.python.org",
+            ssl_handshake_timeout=mock.ANY,
+        )
 
         self.assertEqual(req.url.path, "/")
         self.assertEqual(proxy_req.method, "CONNECT")


### PR DESCRIPTION
(cherry picked from commit 86a9a3827c876acfd32886bd51b49df7f5f1925e)
