### PR TITLE
Add Better Typehints using Updated aiosignal

### DIFF
--- a/CHANGES/11160.feature.rst
+++ b/CHANGES/11160.feature.rst
@@ -1,0 +1,2 @@
+Updated TraceConfig to cooperate with the newest version of aiosignal and transformed the callback protocol to a type alias
+-- by :user:`Vizonex`.

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -5,7 +5,6 @@ from aiosignal import Signal
 from multidict import CIMultiDict
 from yarl import URL
 
-
 from .client_reqrep import ClientResponse
 from .helpers import frozen_dataclass_decorator
 
@@ -13,11 +12,9 @@ _T = TypeVar("_T", covariant=True)
 
 if TYPE_CHECKING:
     from .client import ClientSession
+
     _ParamT_contra = TypeVar("_ParamT_contra", contravariant=True)
     _SignalCallback: TypeAlias = Signal[["ClientSession", _T, _ParamT_contra], None]
-
-
-
 
 
 __all__ = (
@@ -58,25 +55,51 @@ class TraceConfig(Generic[_T]):
         self._on_request_start: "_SignalCallback[_T, TraceRequestStartParams]" = Signal(
             self
         )
-        self._on_request_chunk_sent: "_SignalCallback[_T, TraceRequestChunkSentParams]" = Signal(self)
-        self._on_response_chunk_received: "_SignalCallback[_T, TraceResponseChunkReceivedParams]" = Signal(self)
-        self._on_request_end: "_SignalCallback[_T, TraceRequestEndParams]" = Signal(self)
-        self._on_request_exception: "_SignalCallback[_T, TraceRequestExceptionParams]" = (
-            Signal(self)
+        self._on_request_chunk_sent: (
+            "_SignalCallback[_T, TraceRequestChunkSentParams]"
+        ) = Signal(self)
+        self._on_response_chunk_received: (
+            "_SignalCallback[_T, TraceResponseChunkReceivedParams]"
+        ) = Signal(self)
+        self._on_request_end: "_SignalCallback[_T, TraceRequestEndParams]" = Signal(
+            self
         )
+        self._on_request_exception: (
+            "_SignalCallback[_T, TraceRequestExceptionParams]"
+        ) = Signal(self)
         self._on_request_redirect: "_SignalCallback[_T, TraceRequestRedirectParams]" = (
             Signal(self)
         )
-        self._on_connection_queued_start: "_SignalCallback[_T, TraceConnectionQueuedStartParams]" = Signal(self)
-        self._on_connection_queued_end: "_SignalCallback[_T, TraceConnectionQueuedEndParams]" = Signal(self)
-        self._on_connection_create_start: "_SignalCallback[_T, TraceConnectionCreateStartParams]" = Signal(self)
-        self._on_connection_create_end: "_SignalCallback[_T, TraceConnectionCreateEndParams]" = Signal(self)
-        self._on_connection_reuseconn: "_SignalCallback[_T, TraceConnectionReuseconnParams]" = Signal(self)
-        self._on_dns_resolvehost_start: "_SignalCallback[_T, TraceDnsResolveHostStartParams]" = Signal(self)
-        self._on_dns_resolvehost_end: "_SignalCallback[_T, TraceDnsResolveHostEndParams]" = Signal(self)
-        self._on_dns_cache_hit: "_SignalCallback[_T, TraceDnsCacheHitParams]" = Signal(self)
-        self._on_dns_cache_miss: "_SignalCallback[_T, TraceDnsCacheMissParams]" = Signal(self)
-        self._on_request_headers_sent: "_SignalCallback[_T, TraceRequestHeadersSentParams]" = Signal(self)
+        self._on_connection_queued_start: (
+            "_SignalCallback[_T, TraceConnectionQueuedStartParams]"
+        ) = Signal(self)
+        self._on_connection_queued_end: (
+            "_SignalCallback[_T, TraceConnectionQueuedEndParams]"
+        ) = Signal(self)
+        self._on_connection_create_start: (
+            "_SignalCallback[_T, TraceConnectionCreateStartParams]"
+        ) = Signal(self)
+        self._on_connection_create_end: (
+            "_SignalCallback[_T, TraceConnectionCreateEndParams]"
+        ) = Signal(self)
+        self._on_connection_reuseconn: (
+            "_SignalCallback[_T, TraceConnectionReuseconnParams]"
+        ) = Signal(self)
+        self._on_dns_resolvehost_start: (
+            "_SignalCallback[_T, TraceDnsResolveHostStartParams]"
+        ) = Signal(self)
+        self._on_dns_resolvehost_end: (
+            "_SignalCallback[_T, TraceDnsResolveHostEndParams]"
+        ) = Signal(self)
+        self._on_dns_cache_hit: "_SignalCallback[_T, TraceDnsCacheHitParams]" = Signal(
+            self
+        )
+        self._on_dns_cache_miss: "_SignalCallback[_T, TraceDnsCacheMissParams]" = (
+            Signal(self)
+        )
+        self._on_request_headers_sent: (
+            "_SignalCallback[_T, TraceRequestHeadersSentParams]"
+        ) = Signal(self)
         self._trace_config_ctx_factory: _Factory[_T] = trace_config_ctx_factory
 
     def trace_config_ctx(self, trace_request_ctx: Any = None) -> _T:
@@ -193,6 +216,7 @@ class TraceConfig(Generic[_T]):
 @frozen_dataclass_decorator
 class TraceRequestStartParams:
     """Parameters sent by the `on_request_start` signal"""
+
     method: str
     url: URL
     headers: "CIMultiDict[str]"
@@ -444,4 +468,3 @@ class Trace:
             self._trace_config_ctx,
             TraceRequestHeadersSentParams(method, url, headers),
         )
-

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -1,15 +1,13 @@
+import sys
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, overload
-import sys
 
 from aiosignal import Signal
 from multidict import CIMultiDict
 from yarl import URL
 
-
 from .client_reqrep import ClientResponse
 from .helpers import frozen_dataclass_decorator
-
 
 _T = TypeVar("_T", covariant=True)
 
@@ -18,9 +16,9 @@ if TYPE_CHECKING:
         from typing_extensions import TypeAlias
     else:
         from typing import TypeAlias
-    
-    
+
     from .client import ClientSession
+
     _ParamT_contra = TypeVar("_ParamT_contra", contravariant=True)
     _SignalCallback: TypeAlias = Signal[["ClientSession", _T, _ParamT_contra], None]
 

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -1,18 +1,26 @@
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeAlias, TypeVar, overload
+from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, overload
+import sys
 
 from aiosignal import Signal
 from multidict import CIMultiDict
 from yarl import URL
 
+
 from .client_reqrep import ClientResponse
 from .helpers import frozen_dataclass_decorator
+
 
 _T = TypeVar("_T", covariant=True)
 
 if TYPE_CHECKING:
+    if sys.version_info <= (3, 9):
+        from typing_extensions import TypeAlias
+    else:
+        from typing import TypeAlias
+    
+    
     from .client import ClientSession
-
     _ParamT_contra = TypeVar("_ParamT_contra", contravariant=True)
     _SignalCallback: TypeAlias = Signal[["ClientSession", _T, _ParamT_contra], None]
 

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -9,5 +9,5 @@ brotlicffi; platform_python_implementation != 'CPython'
 frozenlist >= 1.1.1
 multidict >=4.5, < 7.0
 propcache >= 0.2.0
-typing-extensions >= 4.13.2 ; python_version < "3.10"
+typing-extensions >= 3.10; python_version <= '3.9'
 yarl >= 1.17.0, < 2.0

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -9,4 +9,5 @@ brotlicffi; platform_python_implementation != 'CPython'
 frozenlist >= 1.1.1
 multidict >=4.5, < 7.0
 propcache >= 0.2.0
+typing-extensions >= 4.13.2 ; python_version < "3.10"
 yarl >= 1.17.0, < 2.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,7 @@ install_requires =
   frozenlist >= 1.1.1
   multidict >=4.5, < 7.0
   propcache >= 0.2.0
+  typing-extensions >= 3.10; python_version <= '3.9'
   yarl >= 1.17.0, < 2.0
 
 [options.exclude_package_data]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Adds type hinting to `TraceConfig` using the updated branch of aiosignal. I actually filmed part of this on youtube funny enough and I made sure that I ran pytest tests for `test_tracing.py` passed. This this better than my other pull requests because we no longer need to use wrappers, thank goodness no need for nested code! 


## Are there changes in behavior for the user?
Only 3 which should be the following
- `_SignalCallback` is now a `TypeAlias` as opposed to using a `Protocol` styled approach. The Benefit mainly revolves around Aiosignal's New `ParamSpec` which seems to be doing more good than I had originally thought. Originally I thought I had to use wrappers but this turns out that this is not the case and rather one of my own VS Extension's fault.
- `_T` is now inside of `_SignalCallback` so that type checkers can catch unrelated types being carried around
- Thanks to Aiosignal's new features users can now utilize the different `TraceConfig` callbacks as wrappers optionally.

## Is it a substantial burden for the maintainers to support this?
Hopefully now I can stop deleting or removing pull requests now that I have figured out the problems on my end and fixed them all. I got rid of the need for needing wrapper properties which is a real blessing. The only thing I could see maintainers maybe raising an Eyebrow for is going to be the `_T`  TypeVar being used with `_SignalCallback` which I did on purpose to ensure that if TraceConfig has passed a variable such as `TraceConfig[dict]` then `dict` should be expected by different linters to be passed.
  

## Related issue number
- Fixes #11036
- Fixes #11123
- Fixes https://github.com/aio-libs/aiosignal/pull/705
<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
