### PR TITLE
Fix cookie unquoting regression

### DIFF
--- a/CHANGES/11173.bugfix.rst
+++ b/CHANGES/11173.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed cookie unquoting to properly handle octal escape sequences in cookie values (e.g., ``\012`` for newline) by vendoring the correct ``_unquote`` implementation from Python's ``http.cookies`` module -- by :user:`bdraco`.

--- a/aiohttp/_cookie_helpers.py
+++ b/aiohttp/_cookie_helpers.py
@@ -124,30 +124,33 @@ def _unquote_replace(m: re.Match[str]) -> str:
     return m[2]
 
 
-def _unquote(str: str) -> str:
+def _unquote(value: str) -> str:
     """
     Unquote a cookie value.
 
     Vendored from http.cookies._unquote to ensure compatibility.
+
+    Note: The original implementation checked for None, but we've removed
+    that check since all callers already ensure the value is not None.
     """
     # If there aren't any doublequotes,
     # then there can't be any special characters.  See RFC 2109.
-    if str is None or len(str) < 2:
-        return str
-    if str[0] != '"' or str[-1] != '"':
-        return str
+    if len(value) < 2:
+        return value
+    if value[0] != '"' or value[-1] != '"':
+        return value
 
     # We have to assume that we must decode this string.
     # Down to work.
 
     # Remove the "s
-    str = str[1:-1]
+    value = value[1:-1]
 
     # Check for special sequences.  Examples:
     #    \012 --> \n
     #    \"   --> "
     #
-    return _unquote_sub(_unquote_replace, str)
+    return _unquote_sub(_unquote_replace, value)
 
 
 def parse_cookie_headers(headers: Sequence[str]) -> List[Tuple[str, Morsel[str]]]:

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -363,6 +363,7 @@ uvloop
 uWSGI
 vcvarsall
 vendored
+vendoring
 waituntil
 wakeup
 wakeups

--- a/tests/test_cookie_helpers.py
+++ b/tests/test_cookie_helpers.py
@@ -1054,11 +1054,6 @@ def test_unquote_basic(input_str: str, expected: str) -> None:
     assert _unquote(input_str) == expected
 
 
-def test_unquote_none() -> None:
-    """Test _unquote with None input."""
-    assert _unquote(None) is None  # type: ignore[arg-type]
-
-
 @pytest.mark.parametrize(
     ("input_str", "expected"),
     [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR fixes a regression I introduced when vendoring SimpleCookie - I accidentally copied the wrong `_unquote` function. The correct implementation from Python's `http.cookies` module is now vendored, which properly handles:
- Octal escape sequences in cookie values (e.g., `\012` for newline, `\011` for tab)
- Escaped quotes (`\"`) and backslashes (`\\`)
- All edge cases that the standard library handles

Comprehensive tests have been added to ensure the vendored function behaves identically to SimpleCookie's implementation.

## Are there changes in behavior for the user?

Cookie parsing will now correctly handle cookies with octal escape sequences in their values, restoring compatibility with servers that send such cookies. This fixes a regression where these cookies were not being decoded properly.

## Is it a substantial burden for the maintainers to support this?

No. This is a straightforward vendoring of a stable function from Python's standard library that has remained unchanged for years. The implementation is well-tested and matches Python's cookie handling behavior exactly. The comprehensive test suite ensures any future changes will be caught.

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.