### PR TITLE
Fix cookie header parser ignoring reserved names

### DIFF
--- a/CHANGES/11178.bugfix.rst
+++ b/CHANGES/11178.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed Cookie header parsing to treat attribute names as regular cookies per RFC 6265 -- by :user:`bdraco`.

--- a/CHANGES/11178.bugfix.rst
+++ b/CHANGES/11178.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed Cookie header parsing to treat attribute names as regular cookies per RFC 6265 -- by :user:`bdraco`.
+Fixed ``Cookie`` header parsing to treat attribute names as regular cookies per :rfc:`6265#section-5.4` -- by :user:`bdraco`.

--- a/aiohttp/_cookie_helpers.py
+++ b/aiohttp/_cookie_helpers.py
@@ -13,7 +13,7 @@ from typing import List, Optional, Sequence, Tuple, cast
 from .log import internal_logger
 
 __all__ = (
-    "parse_cookie_headers",
+    "parse_set_cookie_headers",
     "parse_cookie_header",
     "preserve_morsel_with_coded_value",
 )
@@ -136,7 +136,7 @@ def parse_cookie_header(header: str) -> List[Tuple[str, Morsel[str]]]:
     There are no attributes in Cookie headers - even names that match
     attribute names (like 'path' or 'secure') should be treated as cookies.
 
-    This parser uses the same regex-based approach as parse_cookie_headers
+    This parser uses the same regex-based approach as parse_set_cookie_headers
     to properly handle quoted values that may contain semicolons.
 
     Args:
@@ -153,7 +153,7 @@ def parse_cookie_header(header: str) -> List[Tuple[str, Morsel[str]]]:
     n = len(header)
 
     while i < n:
-        # Use the same pattern as parse_cookie_headers to find cookies
+        # Use the same pattern as parse_set_cookie_headers to find cookies
         match = _COOKIE_PATTERN.match(header, i)
         if not match:
             break
@@ -183,7 +183,7 @@ def parse_cookie_header(header: str) -> List[Tuple[str, Morsel[str]]]:
     return cookies
 
 
-def parse_cookie_headers(headers: Sequence[str]) -> List[Tuple[str, Morsel[str]]]:
+def parse_set_cookie_headers(headers: Sequence[str]) -> List[Tuple[str, Morsel[str]]]:
     """
     Parse cookie headers using a vendored version of SimpleCookie parsing.
 

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -22,7 +22,7 @@ from typing import (
 from multidict import CIMultiDict
 from yarl import URL
 
-from ._cookie_helpers import parse_cookie_headers
+from ._cookie_helpers import parse_set_cookie_headers
 from .typedefs import LooseCookies
 
 if TYPE_CHECKING:
@@ -194,7 +194,7 @@ class AbstractCookieJar(Sized, IterableBase):
         self, headers: Sequence[str], response_url: URL
     ) -> None:
         """Update cookies from raw Set-Cookie headers."""
-        if headers and (cookies_to_update := parse_cookie_headers(headers)):
+        if headers and (cookies_to_update := parse_set_cookie_headers(headers)):
             self.update_cookies(cookies_to_update, response_url)
 
     @abstractmethod

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -30,7 +30,11 @@ from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL
 
 from . import hdrs, helpers, http, multipart, payload
-from ._cookie_helpers import parse_cookie_headers, preserve_morsel_with_coded_value
+from ._cookie_helpers import (
+    parse_cookie_header,
+    parse_cookie_headers,
+    preserve_morsel_with_coded_value,
+)
 from .abc import AbstractStreamWriter
 from .client_exceptions import (
     ClientConnectionError,
@@ -1014,8 +1018,8 @@ class ClientRequest:
 
         c = SimpleCookie()
         if hdrs.COOKIE in self.headers:
-            # parse_cookie_headers already preserves coded values
-            c.update(parse_cookie_headers((self.headers.get(hdrs.COOKIE, ""),)))
+            # parse_cookie_header for RFC 6265 compliant Cookie header parsing
+            c.update(parse_cookie_header(self.headers.get(hdrs.COOKIE, "")))
             del self.headers[hdrs.COOKIE]
 
         if isinstance(cookies, Mapping):

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -32,7 +32,7 @@ from yarl import URL
 from . import hdrs, helpers, http, multipart, payload
 from ._cookie_helpers import (
     parse_cookie_header,
-    parse_cookie_headers,
+    parse_set_cookie_headers,
     preserve_morsel_with_coded_value,
 )
 from .abc import AbstractStreamWriter
@@ -317,9 +317,9 @@ class ClientResponse(HeadersMixin):
             if self._raw_cookie_headers is not None:
                 # Parse cookies for response.cookies (SimpleCookie for backward compatibility)
                 cookies = SimpleCookie()
-                # Use parse_cookie_headers for more lenient parsing that handles
+                # Use parse_set_cookie_headers for more lenient parsing that handles
                 # malformed cookies better than SimpleCookie.load
-                cookies.update(parse_cookie_headers(self._raw_cookie_headers))
+                cookies.update(parse_set_cookie_headers(self._raw_cookie_headers))
                 self._cookies = cookies
             else:
                 self._cookies = SimpleCookie()

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -28,7 +28,7 @@ from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL
 
 from . import hdrs
-from ._cookie_helpers import parse_cookie_headers
+from ._cookie_helpers import parse_cookie_header
 from .abc import AbstractStreamWriter
 from .helpers import (
     _SENTINEL,
@@ -556,9 +556,10 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
 
         A read-only dictionary-like object.
         """
-        # Use parse_cookie_headers for more lenient parsing that accepts
-        # special characters in cookie names (fixes #2683)
-        parsed = parse_cookie_headers((self.headers.get(hdrs.COOKIE, ""),))
+        # Use parse_cookie_header for RFC 6265 compliant Cookie header parsing
+        # that accepts special characters in cookie names (fixes #2683)
+        parsed = parse_cookie_header(self.headers.get(hdrs.COOKIE, ""))
+        # Extract values from Morsel objects
         return MappingProxyType({name: morsel.value for name, morsel in parsed})
 
     @reify

--- a/tests/test_cookie_helpers.py
+++ b/tests/test_cookie_helpers.py
@@ -11,9 +11,9 @@ import pytest
 
 from aiohttp import _cookie_helpers as helpers
 from aiohttp._cookie_helpers import (
+    _unquote,
     parse_cookie_header,
     parse_set_cookie_headers,
-    _unquote,
     preserve_morsel_with_coded_value,
 )
 
@@ -1039,7 +1039,6 @@ def test_parse_set_cookie_headers_date_formats_with_attributes() -> None:
     assert result[1][1]["domain"] == ".example.com"
     assert result[1][1]["samesite"] == "Strict"
 
-    
 
 @pytest.mark.parametrize(
     ("header", "expected_name", "expected_value", "expected_coded"),
@@ -1081,9 +1080,10 @@ def test_parse_cookie_headers_uses_unquote_with_octal(
 
     # Check that coded_value preserves the original quoted string
     assert morsel.coded_value == expected_coded
-    
+
 
 # Tests for parse_cookie_header (RFC 6265 compliant Cookie header parser)
+
 
 def test_parse_cookie_header_simple() -> None:
     """Test parse_cookie_header with simple cookies."""
@@ -1368,8 +1368,8 @@ def test_parse_cookie_header_issue_7993() -> None:
     assert result[1][1].value == '"qux'
     assert result[2][0] == "foo2"
     assert result[2][1].value == "bar2"
-    
-    
+
+
 @pytest.mark.parametrize(
     ("input_str", "expected"),
     [
@@ -1558,4 +1558,3 @@ def test_unquote_compatibility_with_simplecookie(test_value: str) -> None:
         f"our={_unquote(test_value)!r}, "
         f"SimpleCookie={simplecookie_unquote(test_value)!r}"
     )
-

--- a/tests/test_cookie_helpers.py
+++ b/tests/test_cookie_helpers.py
@@ -1370,6 +1370,20 @@ def test_parse_cookie_header_issue_7993() -> None:
     assert result[2][1].value == "bar2"
 
 
+def test_parse_cookie_header_illegal_names(caplog: pytest.LogCaptureFixture) -> None:
+    """Test parse_cookie_header warns about illegal cookie names."""
+    # Cookie name with comma (not allowed in _COOKIE_NAME_RE)
+    header = "good=value; invalid,cookie=bad; another=test"
+    result = parse_cookie_header(header)
+    # Should skip the invalid cookie but continue parsing
+    assert len(result) == 2
+    assert result[0][0] == "good"
+    assert result[0][1].value == "value"
+    assert result[1][0] == "another"
+    assert result[1][1].value == "test"
+    assert "Can not load cookie: Illegal cookie name 'invalid,cookie'" in caplog.text
+
+
 @pytest.mark.parametrize(
     ("input_str", "expected"),
     [

--- a/tests/test_cookie_helpers.py
+++ b/tests/test_cookie_helpers.py
@@ -1065,11 +1065,11 @@ def test_parse_set_cookie_headers_date_formats_with_attributes() -> None:
         ),
     ],
 )
-def test_parse_cookie_headers_uses_unquote_with_octal(
+def test_parse_set_cookie_headers_uses_unquote_with_octal(
     header: str, expected_name: str, expected_value: str, expected_coded: str
 ) -> None:
-    """Test that parse_cookie_headers correctly unquotes values with octal sequences and preserves coded_value."""
-    result = parse_cookie_headers([header])
+    """Test that parse_set_cookie_headers correctly unquotes values with octal sequences and preserves coded_value."""
+    result = parse_set_cookie_headers([header])
 
     assert len(result) == 1
     name, morsel = result[0]

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -407,27 +407,35 @@ def test_request_cookies_quoted_values() -> None:
 
 
 def test_request_cookies_with_attributes() -> None:
-    """Test that cookie attributes don't affect value parsing.
+    """Test that cookie attributes are parsed as cookies per RFC 6265.
 
-    Related to issue #5397 - ensures that the presence of domain or other
-    attributes doesn't change how cookie values are parsed.
+    Per RFC 6265 Section 5.4, Cookie headers contain only name-value pairs.
+    Names that match attribute names (Domain, Path, etc.) should be treated
+    as regular cookies, not as attributes.
     """
-    # Cookie with domain attribute - quotes should still be removed
+    # Cookie with domain - both should be parsed as cookies
     headers = CIMultiDict(COOKIE='sess="quoted_value"; Domain=.example.com')
     req = make_mocked_request("GET", "/", headers=headers)
-    assert req.cookies == {"sess": "quoted_value"}
+    assert req.cookies == {"sess": "quoted_value", "Domain": ".example.com"}
 
-    # Cookie with multiple attributes
+    # Cookie with multiple attribute names - all parsed as cookies
     headers = CIMultiDict(COOKIE='token="abc123"; Path=/; Secure; HttpOnly')
     req = make_mocked_request("GET", "/", headers=headers)
-    assert req.cookies == {"token": "abc123"}
+    assert req.cookies == {"token": "abc123", "Path": "/", "Secure": "", "HttpOnly": ""}
 
-    # Multiple cookies with different attributes
+    # Multiple cookies with attribute names mixed in
     headers = CIMultiDict(
         COOKIE='c1="v1"; Domain=.example.com; c2="v2"; Path=/api; c3=v3; Secure'
     )
     req = make_mocked_request("GET", "/", headers=headers)
-    assert req.cookies == {"c1": "v1", "c2": "v2", "c3": "v3"}
+    assert req.cookies == {
+        "c1": "v1",
+        "Domain": ".example.com",
+        "c2": "v2",
+        "Path": "/api",
+        "c3": "v3",
+        "Secure": "",
+    }
 
 
 def test_match_info() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR fixes the Cookie header parser to correctly handle reserved attribute names (like `path`, `domain`, `secure`) as regular cookies, per [RFC 6265 Section 5.4](https://datatracker.ietf.org/doc/html/rfc6265#section-5.4).

Previously, Cookie headers like `session=abc123; path=/api; secure=true` would only parse `session=abc123`, incorrectly ignoring `path` and `secure`. Now all three are correctly parsed as cookies.

The fix:
- Adds a new `parse_cookie_header()` function specifically for RFC 6265 compliant Cookie header parsing
- Renames the existing `parse_cookie_headers()` to `parse_set_cookie_headers()` for clarity
- Updates all Cookie header parsing locations to use the new parser

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Yes, Cookie headers containing reserved attribute names will now be parsed differently:

**Before:**
```python
# Cookie: "session=abc123; path=/api; secure=true"
request.cookies == {"session": "abc123"}  # path and secure ignored
```

**After:**
```python
# Cookie: "session=abc123; path=/api; secure=true"
request.cookies == {"session": "abc123", "path": "/api", "secure": "true"}
```

This is the correct behavior per RFC 6265 and matches what web browsers do.

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

No. This change:
- Simplifies the cookie parsing logic by having separate parsers for different header types
- Makes the code more RFC compliant and easier to understand
- Uses the same robust regex-based parsing approach as the existing parser
- Has comprehensive test coverage

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

This has likely been an issue since the beginning, as we previously used Python's `SimpleCookie` which has the same incorrect behavior. Now that we have our own parser (from PR #11112), we can fix this RFC compliance issue.

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.