### PR TITLE
Pin CI Python version to 3.13.3

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -138,7 +138,11 @@ jobs:
     needs: gen_llhttp
     strategy:
       matrix:
-        pyver: [3.9, '3.10', '3.11', '3.12', '3.13']
+        # Note that 3.13.4 is broken on Windows which
+        # is why 3.13.5 was rushed out. When 3.13.5 is fully
+        # available, we can remove 3.13.4 from the matrix
+        # and switch it back to 3.13
+        pyver: [3.9, '3.10', '3.11', '3.12', '3.13.3']
         no-extensions: ['', 'Y']
         os: [ubuntu, macos, windows]
         experimental: [false]


### PR DESCRIPTION
Python 3.13.4 build for Windows are broken. 3.13.5 was rushed out to fix it but its not available yet. Pin to 3.13.3 to fix the CI.

https://github.com/actions/setup-python/issues/1123#issuecomment-2967884782
