### PR TITLE
Add trailer parsing logic

### DIFF
--- a/CHANGES/11269.feature.rst
+++ b/CHANGES/11269.feature.rst
@@ -1,1 +1,1 @@
-Added initial trailer parsing logic to Python parser -- by :user:`Dreamsorcerer`.
+Added initial trailer parsing logic to Python HTTP parser -- by :user:`Dreamsorcerer`.

--- a/CHANGES/11269.feature.rst
+++ b/CHANGES/11269.feature.rst
@@ -1,1 +1,1 @@
-Added initial trailer parsing logic -- by :user:`Dreamsorcerer`.
+Added initial trailer parsing logic to Python parser -- by :user:`Dreamsorcerer`.

--- a/CHANGES/11269.feature.rst
+++ b/CHANGES/11269.feature.rst
@@ -1,0 +1,1 @@
+Added initial trailer parsing logic -- by :user:`Dreamsorcerer`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -913,7 +913,9 @@ class HttpPayloadParser:
                         # Headers and trailers are defined the same way,
                         # so we reuse the HeadersParser here.
                         try:
-                            trailers, raw_trailers = self._headers_parser.parse_headers(self._trailer_lines)
+                            trailers, raw_trailers = self._headers_parser.parse_headers(
+                                self._trailer_lines
+                            )
                         finally:
                             self._trailer_lines.clear()
                         self.payload.feed_eof()

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -470,7 +470,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
 
                     eof = True
                     data = b""
-                    if isinstance(underlying_exc, BadHttpMessage):
+                    if isinstance(underlying_exc, (InvalidHeader, TransferEncodingError)):
                         raise
 
                 if eof:
@@ -843,7 +843,7 @@ class HttpPayloadParser:
                             size_b = chunk[:i]  # strip chunk-extensions
                             # Verify no LF in the chunk-extension
                             if b"\n" in (ext := chunk[i:pos]):
-                                exc = BadHttpMessage(
+                                exc = TransferEncodingError(
                                     f"Unexpected LF in chunk-extension: {ext!r}"
                                 )
                                 set_exception(self.payload, exc)

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -142,8 +142,8 @@ class HeadersParser:
         # note: "raw" does not mean inclusion of OWS before/after the field value
         raw_headers = []
 
-        lines_idx = 1
-        line = lines[1]
+        lines_idx = 0
+        line = lines[lines_idx]
         line_count = len(lines)
 
         while line:
@@ -634,7 +634,7 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
             compression,
             upgrade,
             chunked,
-        ) = self.parse_headers(lines)
+        ) = self.parse_headers(lines[1:])
 
         if close is None:  # then the headers weren't set in the request
             if version_o <= HttpVersion10:  # HTTP 1.0 must asks to not close
@@ -720,7 +720,7 @@ class HttpResponseParser(HttpParser[RawResponseMessage]):
             compression,
             upgrade,
             chunked,
-        ) = self.parse_headers(lines)
+        ) = self.parse_headers(lines[1:])
 
         if close is None:
             if version_o <= HttpVersion10:
@@ -774,8 +774,7 @@ class HttpPayloadParser:
         self._auto_decompress = auto_decompress
         self._lax = lax
         self._headers_parser = headers_parser
-        # HeadersParser expects status/request line first, so skips the first line.
-        self._trailer_lines: list[bytes] = [b""]
+        self._trailer_lines: list[bytes] = []
         self.done = False
 
         # payload decompression wrapper

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -470,6 +470,8 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
 
                     eof = True
                     data = b""
+                    if isinstance(underlying_exc, BadHttpMessage):
+                        raise
 
                 if eof:
                     start_pos = 0

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -394,6 +394,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                                 response_with_body=self.response_with_body,
                                 auto_decompress=self._auto_decompress,
                                 lax=self.lax,
+                                headers_parser=self._headers_parser,
                             )
                             if not payload_parser.done:
                                 self._payload_parser = payload_parser
@@ -412,6 +413,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                                 compression=msg.compression,
                                 auto_decompress=self._auto_decompress,
                                 lax=self.lax,
+                                headers_parser=self._headers_parser,
                             )
                         elif not empty_body and length is None and self.read_until_eof:
                             payload = StreamReader(
@@ -430,6 +432,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                                 response_with_body=self.response_with_body,
                                 auto_decompress=self._auto_decompress,
                                 lax=self.lax,
+                                headers_parser=self._headers_parser,
                             )
                             if not payload_parser.done:
                                 self._payload_parser = payload_parser
@@ -758,6 +761,8 @@ class HttpPayloadParser:
         response_with_body: bool = True,
         auto_decompress: bool = True,
         lax: bool = False,
+        *,
+        headers_parser: HeadersParser,
     ) -> None:
         self._length = 0
         self._type = ParseState.PARSE_UNTIL_EOF
@@ -766,6 +771,9 @@ class HttpPayloadParser:
         self._chunk_tail = b""
         self._auto_decompress = auto_decompress
         self._lax = lax
+        self._headers_parser = headers_parser
+        # HeadersParser expects status/request line first, so skips the first line.
+        self._trailer_lines: list[bytes] = [b""]
         self.done = False
 
         # payload decompression wrapper
@@ -854,7 +862,7 @@ class HttpPayloadParser:
 
                         chunk = chunk[pos + len(SEP) :]
                         if size == 0:  # eof marker
-                            self._chunk = ChunkState.PARSE_MAYBE_TRAILERS
+                            self._chunk = ChunkState.PARSE_TRAILERS
                             if self._lax and chunk.startswith(b"\r"):
                                 chunk = chunk[1:]
                         else:
@@ -888,37 +896,28 @@ class HttpPayloadParser:
                         self._chunk_tail = chunk
                         return False, b""
 
-                # if stream does not contain trailer, after 0\r\n
-                # we should get another \r\n otherwise
-                # trailers needs to be skipped until \r\n\r\n
-                if self._chunk == ChunkState.PARSE_MAYBE_TRAILERS:
-                    head = chunk[: len(SEP)]
-                    if head == SEP:
-                        # end of stream
-                        self.payload.feed_eof()
-                        return True, chunk[len(SEP) :]
-                    # Both CR and LF, or only LF may not be received yet. It is
-                    # expected that CRLF or LF will be shown at the very first
-                    # byte next time, otherwise trailers should come. The last
-                    # CRLF which marks the end of response might not be
-                    # contained in the same TCP segment which delivered the
-                    # size indicator.
-                    if not head:
-                        return False, b""
-                    if head == SEP[:1]:
-                        self._chunk_tail = head
-                        return False, b""
-                    self._chunk = ChunkState.PARSE_TRAILERS
-
-                # read and discard trailer up to the CRLF terminator
                 if self._chunk == ChunkState.PARSE_TRAILERS:
                     pos = chunk.find(SEP)
-                    if pos >= 0:
-                        chunk = chunk[pos + len(SEP) :]
-                        self._chunk = ChunkState.PARSE_MAYBE_TRAILERS
-                    else:
+                    if pos < 0:  # No line found
                         self._chunk_tail = chunk
                         return False, b""
+
+                    line = chunk[:pos]
+                    chunk = chunk[pos + len(SEP) :]
+                    if SEP == b"\n":  # For lax response parsing
+                        line = line.rstrip(b"\r")
+                    self._trailer_lines.append(line)
+
+                    # \r\n\r\n found, end of stream
+                    if self._trailer_lines[-1] == b"":
+                        # Headers and trailers are defined the same way,
+                        # so we reuse the HeadersParser here.
+                        try:
+                            trailers, raw_trailers = self._headers_parser.parse_headers(self._trailer_lines)
+                        finally:
+                            self._trailer_lines.clear()
+                        self.payload.feed_eof()
+                        return True, chunk
 
         # Read all bytes until eof
         elif self._type == ParseState.PARSE_UNTIL_EOF:

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -470,7 +470,9 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
 
                     eof = True
                     data = b""
-                    if isinstance(underlying_exc, (InvalidHeader, TransferEncodingError)):
+                    if isinstance(
+                        underlying_exc, (InvalidHeader, TransferEncodingError)
+                    ):
                         raise
 
                 if eof:

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -781,7 +781,7 @@ class MultipartReader:
             raise ValueError(f"Invalid boundary {chunk!r}, expected {self._boundary!r}")
 
     async def _read_headers(self) -> "CIMultiDictProxy[str]":
-        lines = [b""]
+        lines = []
         while True:
             chunk = await self._content.readline()
             chunk = chunk.strip()

--- a/setup.cfg
+++ b/setup.cfg
@@ -124,7 +124,7 @@ exclude_lines =
 [tool:pytest]
 addopts =
     # `pytest-xdist`:
-    --numprocesses=auto
+    #--numprocesses=auto
 
     # show 10 slowest invocations:
     --durations=10

--- a/setup.cfg
+++ b/setup.cfg
@@ -124,7 +124,7 @@ exclude_lines =
 [tool:pytest]
 addopts =
     # `pytest-xdist`:
-    #--numprocesses=auto
+    --numprocesses=auto
 
     # show 10 slowest invocations:
     --durations=10

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1370,7 +1370,7 @@ async def test_request_chunked_reject_bad_trailer(parser: HttpRequestParser) -> 
     messages, upgraded, tail = parser.feed_data(text)
     assert not tail
     msg, payload = messages[0]
-    with pytest.raises(http_exceptions.InvalidHeader, match=r"b'bad\\ntrailer'"):
+    with pytest.raises(http_exceptions.BadHttpMessage, match=r"b'bad\\ntrailer'"):
         await payload.read()
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1535,7 +1535,7 @@ async def test_parse_chunked_payload_split_chunks(response: HttpResponseParser) 
 
 
 async def test_parse_chunked_payload_with_lf_in_extensions(
-    parser: HttpRequestParser
+    parser: HttpRequestParser,
 ) -> None:
     """Test chunked payload that has a LF in the chunk extensions."""
     payload = (

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1179,7 +1179,7 @@ async def test_http_response_parser_bad_chunked_strict_py(
         b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5 \r\nabcde\r\n0\r\n\r\n"
     )
     with pytest.raises(http_exceptions.TransferEncodingError, match="5"):
-        messages, upgrade, tail = response.feed_data(text)
+        response.feed_data(text)
 
 
 @pytest.mark.dev_mode

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1178,8 +1178,8 @@ async def test_http_response_parser_bad_chunked_strict_py(
     text = (
         b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5 \r\nabcde\r\n0\r\n\r\n"
     )
-    messages, upgrade, tail = response.feed_data(text)
-    assert isinstance(messages[0][1].exception(), http_exceptions.TransferEncodingError)
+    with pytest.raises(http_exceptions.TransferEncodingError, match="5"):
+        messages, upgrade, tail = response.feed_data(text)
 
 
 @pytest.mark.dev_mode

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1367,10 +1367,11 @@ async def test_request_chunked_with_trailer(parser: HttpRequestParser) -> None:
 
 async def test_request_chunked_reject_bad_trailer(parser: HttpRequestParser) -> None:
     text = b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\nbad\ntrailer\r\n\r\n"
-    messages, upgraded, tail = parser.feed_data(text)
-    assert not tail
-    msg, payload = messages[0]
+    # This raises on feed_data() or .read() depending on parser used.
     with pytest.raises(http_exceptions.BadHttpMessage, match=r"b'bad\\ntrailer'"):
+        messages, upgraded, tail = parser.feed_data(text)
+        assert not tail
+        msg, payload = messages[0]
         await payload.read()
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1812,7 +1812,9 @@ class TestParsePayload:
 
         length = len(COMPRESSED)
         out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
-        p = HttpPayloadParser(out, length=length, compression="deflate", headers_parser=HeadersParser())
+        p = HttpPayloadParser(
+            out, length=length, compression="deflate", headers_parser=HeadersParser()
+        )
         p.feed_data(COMPRESSED)
         assert b"data" == out._buffer[0]
         assert out.is_eof()
@@ -1826,7 +1828,9 @@ class TestParsePayload:
 
         length = len(COMPRESSED)
         out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
-        p = HttpPayloadParser(out, length=length, compression="deflate", headers_parser=HeadersParser())
+        p = HttpPayloadParser(
+            out, length=length, compression="deflate", headers_parser=HeadersParser()
+        )
         p.feed_data(COMPRESSED)
         assert b"data" == out._buffer[0]
         assert out.is_eof()
@@ -1839,7 +1843,9 @@ class TestParsePayload:
 
         length = len(COMPRESSED)
         out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
-        p = HttpPayloadParser(out, length=length, compression="deflate", headers_parser=HeadersParser())
+        p = HttpPayloadParser(
+            out, length=length, compression="deflate", headers_parser=HeadersParser()
+        )
         p.feed_data(COMPRESSED)
 
         assert b"data" == out._buffer[0]
@@ -1849,7 +1855,9 @@ class TestParsePayload:
         self, protocol: BaseProtocol
     ) -> None:
         out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
-        p = HttpPayloadParser(out, compression="deflate", headers_parser=HeadersParser())
+        p = HttpPayloadParser(
+            out, compression="deflate", headers_parser=HeadersParser()
+        )
         # Feeding one correct byte should be enough to choose exact
         # deflate decompressor
         p.feed_data(b"x")
@@ -1861,7 +1869,9 @@ class TestParsePayload:
         self, protocol: BaseProtocol
     ) -> None:
         out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
-        p = HttpPayloadParser(out, compression="deflate", headers_parser=HeadersParser())
+        p = HttpPayloadParser(
+            out, compression="deflate", headers_parser=HeadersParser()
+        )
         # Feeding one wrong byte should be enough to choose exact
         # deflate decompressor
         p.feed_data(b"K")
@@ -1881,7 +1891,12 @@ class TestParsePayload:
     async def test_http_payload_brotli(self, protocol: BaseProtocol) -> None:
         compressed = brotli.compress(b"brotli data")
         out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
-        p = HttpPayloadParser(out, length=len(compressed), compression="br", headers_parser=HeadersParser())
+        p = HttpPayloadParser(
+            out,
+            length=len(compressed),
+            compression="br",
+            headers_parser=HeadersParser(),
+        )
         p.feed_data(compressed)
         assert b"brotli data" == out._buffer[0]
         assert out.is_eof()
@@ -1890,7 +1905,12 @@ class TestParsePayload:
     async def test_http_payload_zstandard(self, protocol: BaseProtocol) -> None:
         compressed = zstandard.compress(b"zstd data")
         out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
-        p = HttpPayloadParser(out, length=len(compressed), compression="zstd", headers_parser=HeadersParser())
+        p = HttpPayloadParser(
+            out,
+            length=len(compressed),
+            compression="zstd",
+            headers_parser=HeadersParser(),
+        )
         p.feed_data(compressed)
         assert b"zstd data" == out._buffer[0]
         assert out.is_eof()


### PR DESCRIPTION
This adds trailer parsing to the parsing logic. First step towards #1652.

It does not yet expose the trailers, so there are no visible user changes, but paves the way for a future PR to add the public API to these.