### PR TITLE
Update a regex in test_aiohttp_request_coroutine for Python 3.14

### DIFF
--- a/CHANGES/11271.bugfix
+++ b/CHANGES/11271.bugfix
@@ -1,1 +1,0 @@
-Update a regex in `test_aiohttp_request_coroutine` for Python 3.14

--- a/CHANGES/11271.bugfix
+++ b/CHANGES/11271.bugfix
@@ -1,0 +1,1 @@
+Update a regex in `test_aiohttp_request_coroutine` for Python 3.14

--- a/CHANGES/11271.contrib.rst
+++ b/CHANGES/11271.contrib.rst
@@ -1,0 +1,1 @@
+Updated a regex in `test_aiohttp_request_coroutine` for Python 3.14.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -59,6 +59,7 @@ Arthur Darcet
 Austin Scola
 Bai Haoran
 Ben Bader
+Ben Beasley
 Ben Greiner
 Ben Kallus
 Ben Timby

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3670,8 +3670,12 @@ async def test_aiohttp_request_coroutine(aiohttp_server: AiohttpServer) -> None:
     not_an_awaitable = aiohttp.request("GET", server.make_url("/"))
     with pytest.raises(
         TypeError,
-        match="^object _SessionRequestContextManager "
-        "can't be used in 'await' expression$",
+        match=(
+            "^'_SessionRequestContextManager' object can't be awaited$"
+            if sys.version_info >= (3, 14)
+            else "^object _SessionRequestContextManager "
+            "can't be used in 'await' expression$"
+        ),
     ):
         await not_an_awaitable  # type: ignore[misc]
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Based on downstream testing in Fedora Rawhide, the expected message associated with the `TypeError` in `test_aiohttp_request_coroutine` has changed for Python 3.14, which results in a test regression on Python 3.14.

```
E       AssertionError: Regex pattern did not match.
E        Regex: "^object _SessionRequestContextManager can't be used in 'await' expression$"
E        Input: "'_SessionRequestContextManager' object can't be awaited"
```

This PR conditionalizes the message regex on the Python interpreter version, fixing the regression.

This can’t easily be reproduced in a virtualenv yet: I have to work around Pydantic and uvloop not being installable for Python 3.14, and even after that, `pytest` segfaults. However, I have tested the patch with Python 3.14 in Fedora.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No; users running tests on Python 3.14 will see one fewer failure.

## Is it a substantial burden for the maintainers to support this?

No. It may be desirable to remove the `if/else` and the old regex once Python 3.14 is the oldest supported Python version.
<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->
N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist **The change fixes a test.**
- [x] Documentation reflects the changes **Nothing to document**
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` **This was an awfully trivial change, but OK.**
- [x] Add a new news fragment into the `CHANGES/` folder