### PR TITLE
Fix ClientSession.close() hanging with HTTPS proxy connections

### DIFF
--- a/CHANGES/11273.bugfix.rst
+++ b/CHANGES/11273.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :py:meth:`ClientSession.close() <aiohttp.ClientSession.close>` hanging indefinitely when using HTTPS requests through HTTP proxies -- by :user:`bdraco`.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -202,6 +202,14 @@ class Connection:
         return self._protocol is None or not self._protocol.is_connected()
 
 
+class _ConnectTunnelConnection(Connection):
+    """Special connection for CONNECT tunnels that doesn't pool on release."""
+
+    def release(self) -> None:
+        """Do nothing - don't pool or close the connection."""
+        # The connection will be used for TLS upgrade and cleaned up later
+
+
 class _TransportPlaceholder:
     """placeholder for BaseConnector.connect function"""
 
@@ -1496,7 +1504,7 @@ class TCPConnector(BaseConnector):
             key = req.connection_key._replace(
                 proxy=None, proxy_auth=None, proxy_headers_hash=None
             )
-            conn = Connection(self, key, proto, self._loop)
+            conn = _ConnectTunnelConnection(self, key, proto, self._loop)
             proxy_resp = await proxy_req.send(conn)
             try:
                 protocol = conn._protocol

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -47,6 +47,7 @@ from aiohttp.connector import (
     AddrInfoType,
     Connection,
     TCPConnector,
+    _ConnectTunnelConnection,
     _DNSCacheTable,
 )
 from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
@@ -4460,8 +4461,6 @@ async def test_connect_tunnel_connection_release(
     loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Test _ConnectTunnelConnection.release() does not pool the connection."""
-    from aiohttp.connector import _ConnectTunnelConnection
-
     connector = mock.Mock()
     key = mock.Mock()
     protocol = mock.Mock()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -4461,9 +4461,11 @@ async def test_connect_tunnel_connection_release(
     loop: asyncio.AbstractEventLoop,
 ) -> None:
     """Test _ConnectTunnelConnection.release() does not pool the connection."""
-    connector = mock.Mock()
-    key = mock.Mock()
-    protocol = mock.Mock()
+    connector = mock.create_autospec(
+        aiohttp.BaseConnector, spec_set=True, instance=True
+    )
+    key = mock.create_autospec(ConnectionKey, spec_set=True, instance=True)
+    protocol = mock.create_autospec(ResponseHandler, spec_set=True, instance=True)
 
     # Create a connect tunnel connection
     conn = _ConnectTunnelConnection(connector, key, protocol, loop)

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -982,15 +982,9 @@ async def test_https_proxy_connect_tunnel_session_close_no_hang(
     """Test that CONNECT tunnel connections are not pooled."""
     # Regression test for issue #11273.
 
-    # Create a simple proxy server that responds to CONNECT
-    async def proxy_handler(request: web.Request) -> web.Response:
-        if request.method == "CONNECT":
-            # Return 200 OK for CONNECT
-            return web.Response(status=200)
-        return web.Response(text="proxy response")
-
+    # Create a minimal proxy server
+    # The CONNECT method is handled at the protocol level, not by the handler
     proxy_app = web.Application()
-    proxy_app.router.add_route("*", "/{path:.*}", proxy_handler)
     proxy_server = await aiohttp_server(proxy_app)
     proxy_url = f"http://{proxy_server.host}:{proxy_server.port}"
 

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -4,6 +4,7 @@ import pathlib
 import platform
 import ssl
 import sys
+from contextlib import suppress
 from re import match as match_regex
 from typing import (
     TYPE_CHECKING,
@@ -973,3 +974,52 @@ async def test_proxy_auth() -> None:
                 proxy_auth=("user", "pass"),  # type: ignore[arg-type]
             ):
                 pass
+
+
+async def test_https_proxy_connect_tunnel_session_close_no_hang(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Test that CONNECT tunnel connections are not pooled."""
+    # Regression test for issue #11273.
+
+    # Create a simple proxy server that responds to CONNECT
+    async def proxy_handler(request: web.Request) -> web.Response:
+        if request.method == "CONNECT":
+            # Return 200 OK for CONNECT
+            return web.Response(status=200)
+        return web.Response(text="proxy response")
+
+    proxy_app = web.Application()
+    proxy_app.router.add_route("*", "/{path:.*}", proxy_handler)
+    proxy_server = await aiohttp_server(proxy_app)
+    proxy_url = f"http://{proxy_server.host}:{proxy_server.port}"
+
+    # Create session and make HTTPS request through proxy
+    session = aiohttp.ClientSession()
+
+    try:
+        # This will fail during TLS upgrade because proxy doesn't establish tunnel
+        with suppress(aiohttp.ClientError):
+            async with session.get("https://example.com/test", proxy=proxy_url) as resp:
+                await resp.read()
+
+        # The critical test: Check if any connections were pooled with proxy=None
+        # This is the root cause of the hang - CONNECT tunnel connections
+        # should NOT be pooled
+        connector = session.connector
+        assert connector is not None
+
+        # Count connections with proxy=None in the pool
+        proxy_none_keys = [key for key in connector._conns if key.proxy is None]
+        proxy_none_count = len(proxy_none_keys)
+
+        # Before the fix, there would be a connection with proxy=None
+        # After the fix, CONNECT tunnel connections are not pooled
+        assert proxy_none_count == 0, (
+            f"Found {proxy_none_count} connections with proxy=None in pool. "
+            f"CONNECT tunnel connections should not be pooled - this is bug #11273"
+        )
+
+    finally:
+        # Clean close
+        await session.close()


### PR DESCRIPTION
## What do these changes do?

This PR fixes a regression where `ClientSession.close()` would hang indefinitely when HTTPS requests were made through an HTTP proxy. The issue was caused by CONNECT tunnel connections being pooled with `proxy=None` in the connection key, and their `closed` futures never completing. The leaking connections have been an issue for some time, but only became apparent when we fixed the waiting issue in 3.12.4.

The fix introduces a special `_ConnectTunnelConnection` class that overrides the `release()` method to prevent these connections from being pooled. This allows the connections to be properly used for TLS upgrade without interfering with session cleanup.

## Are there changes in behavior for the user?

Users will no longer experience hanging when calling `session.close()` after making HTTPS requests through HTTP proxies. The behavior is restored to how it worked before we started waiting for the connections to close. They had been leaking into the connection pool for some time.

## Is it a substantial burden for the maintainers to support this?

No. The fix is minimal and isolated:
- Adds a small subclass of `Connection` with a single method override
- Only affects CONNECT tunnel connections for HTTPS through HTTP proxies
- Includes comprehensive tests to prevent regression
- The special handling is clearly documented in the code

## Related issue number

Fixes #11273

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (no user-facing API changes)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new news fragment into the `CHANGES/` folder

