### PR TITLE
Clean up redundant code and stale comments from PR #11290

### DIFF
--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -557,11 +557,7 @@ class IOBasePayload(Payload):
             # By storing the start position, we ensure the size calculation always
             # returns the correct total size for any subsequent use.
             if self._start_position is None:
-                try:
-                    self._start_position = self._value.tell()
-                except (OSError, AttributeError):
-                    # Can't get position, can't determine size
-                    return None
+                self._start_position = self._value.tell()
 
             # Return the total size from the start position
             # This ensures Content-Length is correct even after reading

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -5365,8 +5365,8 @@ async def test_file_upload_307_308_redirect(
 ) -> None:
     """Test that file uploads work correctly with 307/308 redirects.
 
-    This demonstrates the bug where file payloads get incorrect Content-Length
-    on redirect because the file position isn't reset.
+    This verifies that file payloads maintain correct Content-Length
+    on redirect by properly handling the file position.
     """
     received_bodies: list[bytes] = []
 

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1281,8 +1281,9 @@ async def test_text_io_payload_size_utf16(tmp_path: Path) -> None:
 async def test_iobase_payload_size_after_reading(tmp_path: Path) -> None:
     """Test that IOBasePayload.size returns correct size after file has been read.
 
-    This demonstrates the bug where size calculation doesn't account for
-    the current file position, causing issues with 307/308 redirects.
+    This verifies that size calculation properly accounts for the initial
+    file position, which is critical for 307/308 redirects where the same
+    payload instance is reused.
     """
     # Create a test file with known content
     test_file = tmp_path / "test.txt"
@@ -1304,14 +1305,12 @@ async def test_iobase_payload_size_after_reading(tmp_path: Path) -> None:
         assert len(writer.buffer) == expected_size
 
         # Second size check - should still return full file size
-        # but currently returns 0 because file position is at EOF
-        assert p.size == expected_size  # This assertion fails!
+        assert p.size == expected_size
 
         # Attempting to write again should write the full content
-        # but currently writes nothing because file is at EOF
         writer2 = BufferWriter()
         await p.write(writer2)
-        assert len(writer2.buffer) == expected_size  # This also fails!
+        assert len(writer2.buffer) == expected_size
     finally:
         await asyncio.to_thread(f.close)
 


### PR DESCRIPTION
## What do these changes do?

This PR addresses review comments from PR #11290 by:
- Removing redundant inner try-except block in `IOBasePayload.size` property - the exceptions are already handled by the outer try-except
- Updating stale test comments that referenced the bug as if it was still present
- Improving test docstrings to reflect that they verify the fix rather than demonstrate a bug

## Are there changes in behavior for the user?

No behavioral changes. This is purely a code cleanup that removes redundancy while maintaining the exact same functionality.

## Is it a substantial burden for the maintainers to support this?

No, this actually reduces maintenance burden by:
- Removing redundant code that could cause confusion
- Making the code flow clearer and easier to understand
- Ensuring test documentation accurately reflects the current state

## Related issue number

Follow-up to #11290 (addressing review comments)
Related to #11270 (original bug fix)

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (all existing tests pass)
- [ ] Documentation reflects the changes (no user-facing docs needed)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new news fragment into the `CHANGES/` folder

## Summary of Changes

### 1. Removed redundant code in `aiohttp/payload.py`:
```python
# Before:
if self._start_position is None:
    try:
        self._start_position = self._value.tell()
    except (OSError, AttributeError):
        # Can't get position, can't determine size
        return None

# After:
if self._start_position is None:
    self._start_position = self._value.tell()
```

The inner try-except was redundant because:
- The outer try-except block in the `size` property already catches `AttributeError` and `OSError`
- Any exception raised by `self._value.tell()` will be caught by the outer handler
- Having nested try-except blocks for the same exceptions adds unnecessary complexity

### 2. Updated test comments in `tests/test_payload.py`:
- Removed comments claiming "This assertion fails!" and "This also fails!" from `test_iobase_payload_size_after_reading`
- Updated docstring from "demonstrates the bug" to "verifies that size calculation properly accounts for the initial file position"

### 3. Updated test comments in `tests/test_client_functional.py`:
- Updated docstring in `test_file_upload_307_308_redirect` from "demonstrates the bug" to "verifies that file payloads maintain correct Content-Length"

All tests continue to pass, confirming the redundant code was indeed unnecessary.