### PR TITLE
making content_length really optinal as intended

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1258,7 +1258,7 @@ class ClientRequest:
         self,
         writer: AbstractStreamWriter,
         conn: "Connection",
-        content_length: Optional[int],
+        content_length: Optional[int] = None,
     ) -> None:
         """
         Write the request body to the connection stream.


### PR DESCRIPTION
## What do these changes do?
Fix issue made on version 3.12.0
Where content_length argument in function write_bytes supposed to be optional but it's not because it's a positional argument and not keyword argument.

