### PR TITLE
small speedup by avoiding redundant `IOBasePayload.size` calls

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -980,7 +980,8 @@ class MultipartWriter(Payload):
         """Size of the payload."""
         total = 0
         for part, encoding, te_encoding in self._parts:
-            if encoding or te_encoding or (part_size := part.size) is None:
+            part_size = part.size
+            if encoding or te_encoding or part_size is None:
                 return None
 
             total += int(

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -980,8 +980,7 @@ class MultipartWriter(Payload):
         """Size of the payload."""
         total = 0
         for part, encoding, te_encoding in self._parts:
-            part_size = part.size
-            if encoding or te_encoding or part_size is None:
+            if encoding or te_encoding or (part_size := part.size) is None:
                 return None
 
             total += int(

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -980,14 +980,15 @@ class MultipartWriter(Payload):
         """Size of the payload."""
         total = 0
         for part, encoding, te_encoding in self._parts:
-            if encoding or te_encoding or part.size is None:
+            part_size = part.size
+            if encoding or te_encoding or part_size is None:
                 return None
 
             total += int(
                 2
                 + len(self._boundary)
                 + 2
-                + part.size  # b'--'+self._boundary+b'\r\n'
+                + part_size  # b'--'+self._boundary+b'\r\n'
                 + len(part._binary_headers)
                 + 2  # b'\r\n'
             )

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -690,8 +690,8 @@ class Response(StreamResponse):
                 del self._headers[hdrs.CONTENT_LENGTH]
         elif not self._chunked:
             if isinstance(self._body, Payload):
-                if self._body.size is not None:
-                    self._headers[hdrs.CONTENT_LENGTH] = str(self._body.size)
+                if (size := self._body.size) is not None:
+                    self._headers[hdrs.CONTENT_LENGTH] = str(size)
             else:
                 body_len = len(self._body) if self._body else "0"
                 # https://www.rfc-editor.org/rfc/rfc9110.html#section-8.6-7


### PR DESCRIPTION
## What do these changes do?

`Payload.size` is always called twice in multipart encoding and Response. `IOBasePayload`'s `size()` property implementation contains potential syscall. This pr reduces `Payload.size` calls to cut down syscall overhead.

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?

no

## Related issue number

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new news fragment into the `CHANGES/` folder
