### PR TITLE
Update web_advanced docs

### DIFF
--- a/CHANGES/11347.doc.rst
+++ b/CHANGES/11347.doc.rst
@@ -1,0 +1,3 @@
+Remove outdated contents of aiohttp-devtools and aiohttp-swagger
+from Web_advanced docs.
+-- by :user:`Cycloctane`

--- a/CHANGES/11347.doc.rst
+++ b/CHANGES/11347.doc.rst
@@ -1,3 +1,3 @@
-Remove outdated contents of aiohttp-devtools and aiohttp-swagger
+Remove outdated contents of ``aiohttp-devtools`` and ``aiohttp-swagger``
 from Web_advanced docs.
 -- by :user:`Cycloctane`

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -1268,13 +1268,6 @@ the middleware might use :meth:`BaseRequest.clone`.
    for modifying *scheme*, *host* and *remote* attributes according
    to ``Forwarded`` and ``X-Forwarded-*`` HTTP headers.
 
-Swagger support
----------------
-
-`aiohttp-swagger <https://github.com/cr0hn/aiohttp-swagger>`_ is a
-library that allow to add Swagger documentation and embed the
-Swagger-UI into your :mod:`aiohttp.web` project.
-
 CORS support
 ------------
 

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -1274,7 +1274,7 @@ CORS support
 :mod:`aiohttp.web` itself does not support `Cross-Origin Resource
 Sharing <https://en.wikipedia.org/wiki/Cross-origin_resource_sharing>`_, but
 there is an aiohttp plugin for it:
-`aiohttp_cors <https://github.com/aio-libs/aiohttp_cors>`_.
+`aiohttp-cors <https://github.com/aio-libs/aiohttp-cors>`_.
 
 
 Debug Toolbar

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -1324,10 +1324,8 @@ Install with ``pip``:
 
     $ pip install aiohttp-devtools
 
-* ``runserver`` provides a development server with auto-reload,
-  live-reload, static file serving.
-* ``start`` is a `cookiecutter command which does the donkey work
-  of creating new :mod:`aiohttp.web` Applications.
+``adev runserver`` provides a development server with auto-reload,
+live-reload, static file serving.
 
 Documentation and a complete tutorial of creating and running an app
 locally are available at `aiohttp-devtools`_.


### PR DESCRIPTION
## What do these changes do?

Some contents in Web Server Advanced docs are outdated.

- `start` command no longer exists in aiohttp-devtools.
- third-party library aiohttp-swagger seems not maintained and has unsolved issues.

This pr removes above contents.

## Are there changes in behavior for the user?

## Is it a substantial burden for the maintainers to support this?

## Related issue number

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
