### PR TITLE
Only import blockbuster if we will actually use it

### DIFF
--- a/CHANGES/11363.packaging
+++ b/CHANGES/11363.packaging
@@ -1,0 +1,2 @@
+Tests no longer import the blockbuster module when it will not be used, e.g. if the skip_blockbuster mark is set
+-- by :user:`musicinybrain`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,6 @@ from uuid import uuid4
 import isal.isal_zlib
 import pytest
 import zlib_ng.zlib_ng
-from blockbuster import blockbuster_ctx
 
 from aiohttp import payload
 from aiohttp.client_proto import ResponseHandler
@@ -64,6 +63,9 @@ def blockbuster(request: pytest.FixtureRequest) -> Iterator[None]:
             yield
             return
         node = node.parent
+
+    from blockbuster import blockbuster_ctx
+
     with blockbuster_ctx(
         "aiohttp", excluded_modules=["aiohttp.pytest_plugin", "aiohttp.test_utils"]
     ) as bb:


### PR DESCRIPTION
This makes blockbuster an *actually optional* test dependency, as suggested in https://github.com/cbornet/blockbuster/issues/46#issuecomment-3070096881, assuming the `skip_blockbuster` mark is set when the dependency is unavailable.

<!-- Thank you for your contribution! -->

## What do these changes do?

Only import the `blockbuster` module inside the `blockbuster` fixture, rather than at the top level of `tests/conftest.py`, and even then, only after we have ruled out the cases in which it would not actually be used.

The result is that the `blockbuster` module is never imported at all when the `skip_blockbuster` mark is set; before, it was unconditionally imported no matter what, so it wasn’t really an optional test dependency in practice.

This is useful in Fedora, where we package [`python-aiohttp`](https://src.fedoraproject.org/rpms/python-aiohttp) but we would rather avoid packaging `python-blockbuster` and its dependency `python-forbiddenfruit` if possible – see https://github.com/cbornet/blockbuster/issues/46 for context. It is likely to be useful for other distribution packagers as well.

## Are there changes in behavior for the user?

No, only for people running the tests under certain conditions.
<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

It should be no burden at all.

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist **N/A, the change is in test code**
- [x] Documentation reflects the changes **No documentation changes are required**
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

https://github.com/aio-libs/aiohttp/blob/f42b73a47ce22e325a09c1797bcfad147aa101b8/CONTRIBUTORS.txt#L62

- [x] Add a new news fragment into the `CHANGES/` folder