### PR TITLE
Start building riscv64 platform wheels in CI/CD (v2 PR with upstream cibuildwheel support)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -378,6 +378,12 @@ jobs:
           qemu: ppc64le
           musl: musllinux
         - os: ubuntu-latest
+          qemu: riscv64
+          musl: ""
+        - os: ubuntu-latest
+          qemu: riscv64
+          musl: musllinux
+        - os: ubuntu-latest
           qemu: s390x
           musl: ""
         - os: ubuntu-latest

--- a/CHANGES/11425.packaging.rst
+++ b/CHANGES/11425.packaging.rst
@@ -1,0 +1,1 @@
+Add `riscv64` build to releases -- by :user:`eshattow`.

--- a/CHANGES/11425.packaging.rst
+++ b/CHANGES/11425.packaging.rst
@@ -1,1 +1,1 @@
-Add `riscv64` build to releases -- by :user:`eshattow`.
+Add ``riscv64`` build to releases -- by :user:`eshattow`.

--- a/CHANGES/11425.packaging.rst
+++ b/CHANGES/11425.packaging.rst
@@ -1,1 +1,1 @@
-Add ``riscv64`` build to releases -- by :user:`eshattow`.
+Added ``riscv64`` build to releases -- by :user:`eshattow`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -288,6 +288,7 @@ resolvehost
 resolvers
 reusage
 reuseconn
+riscv64
 Runit
 runtime
 runtimes


### PR DESCRIPTION
Build for riscv64 architecture (v2 PR)

RISC-V 64-bit Little-endian architecture is officially supported by Ubuntu and Debian Linux distro stable releases. Alpine Linux has support for riscv64 as of release 3.21; RHEL-based distros also have support such as RockyLinux Official Support for RISC-V in RL10.

Add riscv64 architecture to the ci-cd wheel builds to expand software ecosystem support for RISC-V.

Previously reverted in 616db7a due to lack of cibuildwheel support upstream for riscv64 then, and since generally available as of cibuildwheel 3.12