### PR TITLE
allow tests to run without `trustme`

### DIFF
--- a/CHANGES/11465.contrib.rst
+++ b/CHANGES/11465.contrib.rst
@@ -1,0 +1,1 @@
+Fixed tests to run without trustme installed -- by :user:`kumaraditya303`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -127,7 +127,9 @@ def client_ssl_ctx(tls_certificate_authority: "trustme.CA") -> ssl.SSLContext:
 
 
 @pytest.fixture
-def tls_ca_certificate_pem_path(tls_certificate_authority: "trustme.CA") -> Iterator[str]:
+def tls_ca_certificate_pem_path(
+    tls_certificate_authority: "trustme.CA",
+) -> Iterator[str]:
     with tls_certificate_authority.cert_pem.tempfile() as ca_cert_pem:
         yield ca_cert_pem
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,14 +96,14 @@ def blockbuster(request: pytest.FixtureRequest) -> Iterator[None]:
 
 
 @pytest.fixture
-def tls_certificate_authority() -> trustme.CA:
+def tls_certificate_authority() -> "trustme.CA":
     if not TRUSTME:
         pytest.xfail("trustme is not supported")
     return trustme.CA()
 
 
 @pytest.fixture
-def tls_certificate(tls_certificate_authority: trustme.CA) -> trustme.LeafCert:
+def tls_certificate(tls_certificate_authority: "trustme.CA") -> "trustme.LeafCert":
     return tls_certificate_authority.issue_cert(
         "localhost",
         "xn--prklad-4va.localhost",
@@ -113,33 +113,33 @@ def tls_certificate(tls_certificate_authority: trustme.CA) -> trustme.LeafCert:
 
 
 @pytest.fixture
-def ssl_ctx(tls_certificate: trustme.LeafCert) -> ssl.SSLContext:
+def ssl_ctx(tls_certificate: "trustme.LeafCert") -> ssl.SSLContext:
     ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
     tls_certificate.configure_cert(ssl_ctx)
     return ssl_ctx
 
 
 @pytest.fixture
-def client_ssl_ctx(tls_certificate_authority: trustme.CA) -> ssl.SSLContext:
+def client_ssl_ctx(tls_certificate_authority: "trustme.CA") -> ssl.SSLContext:
     ssl_ctx = ssl.create_default_context(purpose=ssl.Purpose.SERVER_AUTH)
     tls_certificate_authority.configure_trust(ssl_ctx)
     return ssl_ctx
 
 
 @pytest.fixture
-def tls_ca_certificate_pem_path(tls_certificate_authority: trustme.CA) -> Iterator[str]:
+def tls_ca_certificate_pem_path(tls_certificate_authority: "trustme.CA") -> Iterator[str]:
     with tls_certificate_authority.cert_pem.tempfile() as ca_cert_pem:
         yield ca_cert_pem
 
 
 @pytest.fixture
-def tls_certificate_pem_path(tls_certificate: trustme.LeafCert) -> Iterator[str]:
+def tls_certificate_pem_path(tls_certificate: "trustme.LeafCert") -> Iterator[str]:
     with tls_certificate.private_key_and_cert_chain_pem.tempfile() as cert_pem:
         yield cert_pem
 
 
 @pytest.fixture
-def tls_certificate_pem_bytes(tls_certificate: trustme.LeafCert) -> bytes:
+def tls_certificate_pem_bytes(tls_certificate: "trustme.LeafCert") -> bytes:
     return tls_certificate.cert_chain_pems[0].bytes()
 
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -15,6 +15,7 @@ import time
 import zipfile
 from contextlib import suppress
 from typing import (
+    TYPE_CHECKING,
     Any,
     AsyncIterator,
     Awaitable,
@@ -29,7 +30,6 @@ from typing import (
 from unittest import mock
 
 import pytest
-import trustme
 from multidict import MultiDict
 from pytest_mock import MockerFixture
 from yarl import URL
@@ -61,6 +61,9 @@ from aiohttp.payload import (
 from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
 from aiohttp.test_utils import TestClient, TestServer, unused_port
 from aiohttp.typedefs import Handler, Query
+
+if TYPE_CHECKING:
+    import trustme
 
 
 @pytest.fixture(autouse=True)
@@ -3259,7 +3262,7 @@ async def test_creds_in_auth_and_redirect_url(
 
 @pytest.fixture
 def create_server_for_url_and_handler(
-    aiohttp_server: AiohttpServer, tls_certificate_authority: trustme.CA
+    aiohttp_server: AiohttpServer, tls_certificate_authority: "trustme.CA"
 ) -> Callable[[URL, Handler], Awaitable[TestServer]]:
     def create(url: URL, srv: Handler) -> Awaitable[TestServer]:
         app = web.Application()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
`trustme` is an optional test only dependency, however it is used for annotations which requires it to be installed. This PR fixes the annotations so that tests can be run without trustme.  
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No change.
<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?
No
<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
