### PR TITLE
Changed static annotations and default values in helpers.py

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -585,7 +585,7 @@ class TimeoutHandle:
     def __init__(
         self,
         loop: asyncio.AbstractEventLoop,
-        timeout: Optional[Union[float,int]],
+        timeout: Optional[Union[float, int]],
         ceil_threshold: float = 5.0,
     ) -> None:
         self._timeout = timeout
@@ -719,7 +719,7 @@ class TimerContext(BaseTimerContext):
 
 
 def ceil_timeout(
-    delay: Optional[Union[float,int]], ceil_threshold: float = 5.0
+    delay: Optional[Union[float, int]], ceil_threshold: float = 5.0
 ) -> async_timeout.Timeout:
     if delay is None or delay <= 0:
         return async_timeout.timeout(None)

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -585,8 +585,8 @@ class TimeoutHandle:
     def __init__(
         self,
         loop: asyncio.AbstractEventLoop,
-        timeout: Optional[float],
-        ceil_threshold: float = 5,
+        timeout: Optional[Union[float,int]],
+        ceil_threshold: float = 5.0,
     ) -> None:
         self._timeout = timeout
         self._loop = loop
@@ -719,7 +719,7 @@ class TimerContext(BaseTimerContext):
 
 
 def ceil_timeout(
-    delay: Optional[float], ceil_threshold: float = 5
+    delay: Optional[Union[float,int]], ceil_threshold: float = 5.0
 ) -> async_timeout.Timeout:
     if delay is None or delay <= 0:
         return async_timeout.timeout(None)


### PR DESCRIPTION
There are 2 changes proposed in 2 methods `__init__` and `ceil_timeout`.

For the `ceil_threshold` parameter, an updation in the default value is done from 5 to 5.0 since the static annotation of this parameter is present as `float` but an `int` default value is being passed as runtime.

For the `timeout` parameter of the `__init__` method of the Timeout Handle class, a value of 300 is passed during runtime from the following trace of executions : 
https://github.com/aio-libs/aiohttp/blob/8767e9e042f2588b738c7364bc8705aa9510b0d0/aiohttp/client.py#L536
https://github.com/aio-libs/aiohttp/blob/8767e9e042f2588b738c7364bc8705aa9510b0d0/aiohttp/client.py#L531
https://github.com/aio-libs/aiohttp/blob/8767e9e042f2588b738c7364bc8705aa9510b0d0/aiohttp/client.py#L224

For the`delay` parameter of the `ceil_timeout` method,  a value of 30 is passed during runtime from the following trace of executions :
https://github.com/aio-libs/aiohttp/blob/8767e9e042f2588b738c7364bc8705aa9510b0d0/aiohttp/connector.py#L1219
https://github.com/aio-libs/aiohttp/blob/8767e9e042f2588b738c7364bc8705aa9510b0d0/aiohttp/connector.py#L1214
https://github.com/aio-libs/aiohttp/blob/8767e9e042f2588b738c7364bc8705aa9510b0d0/aiohttp/client.py#L224