### PR TITLE
remove use of deprecated policy API from tests (#10851)

### DIFF
--- a/CHANGES/10851.bugfix.rst
+++ b/CHANGES/10851.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed pytest plugin to not use deprecated :py:mod:`asyncio` policy APIs.

--- a/CHANGES/10851.contrib.rst
+++ b/CHANGES/10851.contrib.rst
@@ -1,0 +1,2 @@
+Updated tests to avoid using deprecated :py:mod:`asyncio` policy APIs and
+make it compatible with Python 3.14.


### PR DESCRIPTION
(cherry picked from commit e5d1240babff6db6297e0d92f174446de19cf76d)
