### PR TITLE
[PR #10851/e5d1240 backport][3.13] remove use of deprecated policy API from tests (#10851)

### DIFF
--- a/CHANGES/10851.bugfix.rst
+++ b/CHANGES/10851.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed pytest plugin to not use deprecated :py:mod:`asyncio` policy APIs.

--- a/CHANGES/10851.contrib.rst
+++ b/CHANGES/10851.contrib.rst
@@ -1,0 +1,2 @@
+Updated tests to avoid using deprecated :py:mod:`asyncio` policy APIs and
+make it compatible with Python 3.14.

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -33,9 +33,6 @@ class TestCase(AioHTTPTestCase):
     async def test_on_startup_hook(self) -> None:
         self.assertTrue(self.on_startup_called)
 
-    def test_default_loop(self) -> None:
-        self.assertIs(self.loop, asyncio.get_event_loop_policy().get_event_loop())
-
 
 def test_default_loop(loop: asyncio.AbstractEventLoop) -> None:
     assert asyncio.get_event_loop() is loop


### PR DESCRIPTION
(cherry picked from commit e5d1240babff6db6297e0d92f174446de19cf76d)

First backport missed a line due to a bad conflict resolution