### PR TITLE
fix tests due  "module asyncio has no attribute Server"

### DIFF
--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -11,6 +11,13 @@ from aiohttp.abc import AbstractAccessLogger
 from aiohttp.test_utils import get_unused_port_socket
 from aiohttp.web_log import AccessLogger
 
+try:
+    Server = asyncio.Server
+except AttributeError:
+    import asyncio.base_events
+
+    Server = asyncio.base_events.Server
+
 
 class _RunnerMaker(Protocol):
     def __call__(self, handle_signals: bool = ..., **kwargs: Any) -> web.AppRunner: ...
@@ -265,7 +272,7 @@ async def test_tcpsite_default_host(make_runner: _RunnerMaker) -> None:
     assert site.name == "http://0.0.0.0:8080"
 
     m = mock.create_autospec(asyncio.AbstractEventLoop, spec_set=True, instance=True)
-    m.create_server.return_value = mock.create_autospec(asyncio.Server, spec_set=True)
+    m.create_server.return_value = mock.create_autospec(Server, spec_set=True)
     with mock.patch(
         "asyncio.get_event_loop", autospec=True, spec_set=True, return_value=m
     ):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Server class isn't explicitly exposed in the asyncio module in some versions.

<img width="859" height="330" alt="Captura de pantalla 2025-10-05 a las 23 54 18" src="https://github.com/user-attachments/assets/14170d8e-18b6-4a8b-9806-a2d3e0f0de72" />

i'm currently using python 3.9 and i'm in MacOs

## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?

no

## Related issue number

i'm not sure if it was reported already

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
