### PR TITLE
Ensure that application/octet-stream is the default content_type

### DIFF
--- a/CHANGES/10889.bugfix.rst
+++ b/CHANGES/10889.bugfix.rst
@@ -1,4 +1,4 @@
-Updated ``Content-Type`` header parsing to return ``application/octet-stream`` when empty or wrong.
+Updated ``Content-Type`` header parsing to return ``application/octet-stream`` when header contains invalid syntax.
 See :rfc:`9110#section-8.3-5`.
 
 -- by :user:`sgaist`.

--- a/CHANGES/10889.bugfix.rst
+++ b/CHANGES/10889.bugfix.rst
@@ -1,0 +1,4 @@
+Updated ``Content-Type`` header parsing to return ``application/octet-stream`` when empty or wrong.
+See `RFC9110 <https://www.rfc-editor.org/rfc/rfc9110#section-8.3-5>`_
+
+-- by :user:`sgaist`.

--- a/CHANGES/10889.bugfix.rst
+++ b/CHANGES/10889.bugfix.rst
@@ -1,4 +1,4 @@
 Updated ``Content-Type`` header parsing to return ``application/octet-stream`` when empty or wrong.
-See `RFC9110 <https://www.rfc-editor.org/rfc/rfc9110#section-8.3-5>`_
+See :rfc:`9110#section-8.3-5`.
 
 -- by :user:`sgaist`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -318,6 +318,7 @@ Roman Postnov
 Rong Zhang
 Samir Akarioh
 Samuel Colvin
+Samuel Gaist
 Sean Hunt
 Sebastian Acuna
 Sebastian Hanula

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -19,7 +19,6 @@ import warnings
 import weakref
 from collections import namedtuple
 from contextlib import suppress
-from email.message import _splitparam  # type: ignore[attr-defined]
 from email.message import Message
 from email.parser import HeaderParser
 from email.utils import parsedate
@@ -383,8 +382,12 @@ class EnsureOctetStream(Message):
         The way this class is used guarantees that content-type will
         be present so simplify the checks wrt to the base implementation.
         """
-        value = self.get("content-type")
-        ctype = _splitparam(value)[0].lower()
+        value = self.get("content-type").lower()
+
+        # Based on the implementation of _splitparam in the standard library
+        ctype, sep, _ = value.partition(";")
+        if not sep:
+            ctype = ctype.strip()
         if ctype.count("/") != 1:
             return self.get_default_type()
         return ctype

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -22,6 +22,7 @@ from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import suppress
 from email.message import Message
 from email.parser import HeaderParser
+from email.policy import HTTP
 from email.utils import parsedate
 from http.cookies import SimpleCookie
 from math import ceil
@@ -389,7 +390,7 @@ def parse_content_type(raw: str) -> tuple[str, MappingProxyType[str, str]]:
     MappingProxyType of parameters. The default returned value
     is `application/octet-stream`
     """
-    msg = HeaderParser(EnsureOctetStream).parsestr(f"Content-Type: {raw}")
+    msg = HeaderParser(EnsureOctetStream, policy=HTTP).parsestr(f"Content-Type: {raw}")
     content_type = msg.get_content_type()
     params = msg.get_params(())
     content_dict = dict(params[1:])  # First element is content type again

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -371,12 +371,11 @@ class EnsureOctetStream(Message):
         The way this class is used guarantees that content-type will
         be present so simplify the checks wrt to the base implementation.
         """
-        value = str(self.get("content-type")).lower()
+        value = self.get("content-type", "").lower()
 
         # Based on the implementation of _splitparam in the standard library
         ctype, sep, _ = value.partition(";")
-        if not sep:
-            ctype = ctype.strip()
+        ctype = ctype.strip()
         if ctype.count("/") != 1:
             return self.get_default_type()
         return ctype

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -375,7 +375,7 @@ class EnsureOctetStream(EmailMessage):
         value = self.get("content-type", "").lower()
 
         # Based on the implementation of _splitparam in the standard library
-        ctype, sep, _ = value.partition(";")
+        ctype, _, _ = value.partition(";")
         ctype = ctype.strip()
         if ctype.count("/") != 1:
             return self.get_default_type()

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -371,7 +371,7 @@ class EnsureOctetStream(Message):
         The way this class is used guarantees that content-type will
         be present so simplify the checks wrt to the base implementation.
         """
-        value = self.get("content-type").lower()
+        value = str(self.get("content-type")).lower()
 
         # Based on the implementation of _splitparam in the standard library
         ctype, sep, _ = value.partition(";")

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -377,13 +377,13 @@ class EnsureOctetStream(Message):
     def get_content_type(self) -> Any:
         """Re-implementation from Message
 
-        In this case, return application/octet-stream in all
-        bad cases
+        Returns application/octet-stream in place of plain/text when
+        value is wrong.
+
+        The way this class is used guarantees that content-type will
+        be present so simplify the checks wrt to the base implementation.
         """
-        missing = object()
-        value = self.get("content-type", missing)
-        if value is missing:
-            return self.get_default_type()
+        value = self.get("content-type")
         ctype = _splitparam(value)[0].lower()
         if ctype.count("/") != 1:
             return self.get_default_type()

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -361,6 +361,7 @@ def parse_mimetype(mimetype: str) -> MimeType:
 class EnsureOctetStream(EmailMessage):
     def __init__(self) -> None:
         super().__init__()
+        # https://www.rfc-editor.org/rfc/rfc9110#section-8.3-5
         self.set_default_type("application/octet-stream")
 
     def get_content_type(self) -> Any:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -20,7 +20,7 @@ import weakref
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Iterator, Mapping
 from contextlib import suppress
-from email.message import Message
+from email.message import EmailMessage
 from email.parser import HeaderParser
 from email.policy import HTTP
 from email.utils import parsedate
@@ -358,7 +358,7 @@ def parse_mimetype(mimetype: str) -> MimeType:
     )
 
 
-class EnsureOctetStream(Message):
+class EnsureOctetStream(EmailMessage):
     def __init__(self) -> None:
         super().__init__()
         self.set_default_type("application/octet-stream")

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1552,10 +1552,9 @@ Response object
 
          Returns value is ``'application/octet-stream'`` if no
          Content-Type header present in HTTP headers according to
-         :rfc:`9110`. If the *Content-Type* header is invalid (e.g., ``jpg``
-         instead of ``image/jpeg``), the value is ``text/plain`` by default
-         according to :rfc:`2045`. To see the original header check
-         ``resp.headers['CONTENT-TYPE']``.
+         :rfc:`9110`. The same applies if the *Content-Type* header is
+         invalid (e.g., ``jpg`` instead of ``image/jpeg``). To see the
+         original header check ``resp.headers['CONTENT-TYPE']``.
 
          To make sure Content-Type header is not present in
          the server reply, use :attr:`headers` or :attr:`raw_headers`, e.g.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1550,15 +1550,14 @@ Response object
 
       .. note::
 
-         Returns value is ``'application/octet-stream'`` if no
-         Content-Type header present in HTTP headers according to
-         :rfc:`9110`. The same applies if the *Content-Type* header is
-         invalid (e.g., ``jpg`` instead of ``image/jpeg``). To see the
-         original header check ``resp.headers['CONTENT-TYPE']``.
+         Returns ``'application/octet-stream'`` if no Content-Type header
+         is present or the value contains invalid syntax according to
+         :rfc:`9110`. To see the original header check
+         ``resp.headers["Content-Type"]``.
 
          To make sure Content-Type header is not present in
          the server reply, use :attr:`headers` or :attr:`raw_headers`, e.g.
-         ``'CONTENT-TYPE' not in resp.headers``.
+         ``'Content-Type' not in resp.headers``.
 
    .. attribute:: charset
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -6,7 +6,8 @@ import sys
 import weakref
 from math import ceil, modf
 from pathlib import Path
-from typing import Dict, Iterator, Optional, Union
+from types import MappingProxyType
+from typing import Dict, Iterator, Optional, Tuple, Union
 from unittest import mock
 from urllib.request import getproxies_environment
 
@@ -78,6 +79,30 @@ def test_parse_mimetype(mimetype: str, expected: helpers.MimeType) -> None:
     result = helpers.parse_mimetype(mimetype)
 
     assert isinstance(result, helpers.MimeType)
+    assert result == expected
+
+
+# ------------------- parse_content_type ------------------------------
+
+
+@pytest.mark.parametrize(
+    "content_type, expected",
+    [
+        (
+            "text/plain",
+            ("text/plain", MultiDictProxy(MultiDict())),
+        ),
+        (
+            "wrong",
+            ("application/octet-stream", MultiDictProxy(MultiDict())),
+        ),
+    ],
+)
+def test_parse_content_type(
+    content_type: str, expected: Tuple[str, MappingProxyType[str, str]]
+) -> None:
+    result = helpers.parse_content_type(content_type)
+
     assert result == expected
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -8,7 +8,6 @@ from collections.abc import Iterator
 from math import ceil, modf
 from pathlib import Path
 from types import MappingProxyType
-from typing import Tuple
 from unittest import mock
 from urllib.request import getproxies_environment
 
@@ -100,7 +99,7 @@ def test_parse_mimetype(mimetype: str, expected: helpers.MimeType) -> None:
     ],
 )
 def test_parse_content_type(
-    content_type: str, expected: Tuple[str, MappingProxyType[str, str]]
+    content_type: str, expected: tuple[str, MappingProxyType[str, str]]
 ) -> None:
     result = helpers.parse_content_type(content_type)
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -1023,10 +1023,10 @@ def test_ctor_content_type_with_extra() -> None:
     assert resp.headers["content-type"] == "text/plain; version=0.0.4; charset=utf-8"
 
 
-def test_invalid_content_type_parses_to_text_plain() -> None:
+def test_invalid_content_type_parses_to_application_octect_stream() -> None:
     resp = web.Response(text="test test", content_type="jpeg")
 
-    assert resp.content_type == "text/plain"
+    assert resp.content_type == "application/octet-stream"
     assert resp.headers["content-type"] == "jpeg; charset=utf-8"
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
The implementation of HeaderParser returns text/plain in case of issues as it's following mail based RFCs.

This PR makes the application/octet-stream the default in all "wrong" cases.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Users will get `application/octet-stream` in place of `plain/text`

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

The new code is based on the std library and should be of minimal impact.

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->
Fixes #10889

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [X] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
