### PR TITLE
Do not assume Python 3.14 has stdlib zstd

### DIFF
--- a/CHANGES/11603.bugfix.rst
+++ b/CHANGES/11603.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed invalid assumption that Python 3.14 is built with zstd support -- by :user:`JacobHenner`.

--- a/CHANGES/11603.bugfix.rst
+++ b/CHANGES/11603.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed invalid assumption that Python 3.14 is built with zstd support -- by :user:`JacobHenner`.
+Fixed Python 3.14 support when built without ``zstd`` support -- by :user:`JacobHenner`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -177,6 +177,7 @@ Ivan Lakovic
 Ivan Larin
 J. Nick Koston
 Jacob Champion
+Jacob Henner
 Jaesung Lee
 Jake Davis
 Jakob Ackermann

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -22,7 +22,7 @@ except ImportError:
     HAS_BROTLI = False
 
 try:
-    from compression.zstd import ZstdDecompressor  # noqa: I900
+    from compression.zstd import ZstdDecompressor  # type: ignore[import-not-found]  # noqa: I900
 
     HAS_ZSTD = True
 except ImportError:
@@ -301,7 +301,7 @@ class ZSTDDecompressor:
         self._obj = ZstdDecompressor()
 
     def decompress_sync(self, data: bytes) -> bytes:
-        return self._obj.decompress(data)
+        return self._obj.decompress(data)  # type: ignore[no-any-return]
 
     def flush(self) -> bytes:
         return b""

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -22,9 +22,9 @@ except ImportError:
     HAS_BROTLI = False
 
 try:
-    from compression.zstd import (
+    from compression.zstd import (  # type: ignore[import-not-found]  # noqa: I900
         ZstdDecompressor,
-    )  # type: ignore[import-not-found]  # noqa: I900
+    )
 
     HAS_ZSTD = True
 except ImportError:

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -22,7 +22,9 @@ except ImportError:
     HAS_BROTLI = False
 
 try:
-    from compression.zstd import ZstdDecompressor  # type: ignore[import-not-found]  # noqa: I900
+    from compression.zstd import (
+        ZstdDecompressor,
+    )  # type: ignore[import-not-found]  # noqa: I900
 
     HAS_ZSTD = True
 except ImportError:

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -21,17 +21,18 @@ try:
 except ImportError:
     HAS_BROTLI = False
 
-if sys.version_info >= (3, 14):
-    import compression.zstd  # noqa: I900
+try:
+    from compression.zstd import ZstdDecompressor  # noqa: I900
 
     HAS_ZSTD = True
-else:
+except ImportError:
     try:
-        import zstandard
+        from zstandard import ZstdDecompressor
 
         HAS_ZSTD = True
     except ImportError:
         HAS_ZSTD = False
+
 
 MAX_SYNC_CHUNK_SIZE = 1024
 
@@ -297,10 +298,7 @@ class ZSTDDecompressor:
                 "The zstd decompression is not available. "
                 "Please install `zstandard` module"
             )
-        if sys.version_info >= (3, 14):
-            self._obj = compression.zstd.ZstdDecompressor()
-        else:
-            self._obj = zstandard.ZstdDecompressor()
+        self._obj = ZstdDecompressor()
 
     def decompress_sync(self, data: bytes) -> bytes:
         return self._obj.decompress(data)


### PR DESCRIPTION
Do not assume Python 3.14 has compression.zstd available, as that module depends on a shared library version that is not available on all platforms and distributions (e.g. Rocky Linux 8).

<!-- Thank you for your contribution! -->

## What do these changes do?

Prevents errors when using aiohttp from a Python 3.14 build that does not include `compression.zstd` support. 

## Are there changes in behavior for the user?

Fixes bug.

## Is it a substantial burden for the maintainers to support this?

No

## Related issue number

Fixes #11603

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
