### PR TITLE
fix: reject HTTP/1.1 requests without Host header per RFC 9112

### DIFF
--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, Union, cast
 import yarl
 from propcache import under_cached_property
 
+from . import hdrs
 from .abc import AbstractAccessLogger, AbstractAsyncAccessLogger, AbstractStreamWriter
 from .base_protocol import BaseProtocol
 from .helpers import ceil_timeout, frozen_dataclass_decorator
@@ -25,7 +26,6 @@ from .http import (
     StreamWriter,
 )
 from .http_exceptions import BadHttpMessage, BadHttpMethod
-from . import hdrs
 from .log import access_logger, server_logger
 from .streams import EMPTY_PAYLOAD, StreamReader
 from .tcp_helpers import tcp_keepalive

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -20,10 +20,12 @@ from .http import (
     HttpProcessingError,
     HttpRequestParser,
     HttpVersion10,
+    HttpVersion11,
     RawRequestMessage,
     StreamWriter,
 )
-from .http_exceptions import BadHttpMethod
+from .http_exceptions import BadHttpMessage, BadHttpMethod
+from . import hdrs
 from .log import access_logger, server_logger
 from .streams import EMPTY_PAYLOAD, StreamReader
 from .tcp_helpers import tcp_keepalive
@@ -444,6 +446,14 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                 tail = b""
 
             for msg, payload in messages or ():
+                # RFC 9112 Section 3.2: HTTP/1.1 requests must include Host header
+                if isinstance(msg, RawRequestMessage) and msg.version == HttpVersion11:
+                    if hdrs.HOST not in msg.headers:
+                        msg = _ErrInfo(
+                            status=400,
+                            exc=BadHttpMessage("Missing Host header"),
+                            message="Missing Host header",
+                        )
                 self._request_count += 1
                 self._messages.append((msg, payload))
 


### PR DESCRIPTION
## Summary
Fixes #10600
**Root cause:** The request parser did not validate Host header presence for HTTP/1.1 requests, violating RFC 9112 Section 3.2.
**Fix:** Added Host header validation that returns 400 Bad Request for HTTP/1.1 requests missing the Host header.
## Changes
- `aiohttp/web_protocol.py`: Added Host header presence check in data_received before appending to message queue; HTTP/1.1 requests without Host are converted to 400 Bad Request per RFC 9112.
## Testing
- Verified fix rejects requests without Host header
- HTTP/1.0 requests are unaffected (Host is optional for HTTP/1.0)

Made with [Cursor](https://cursor.com)